### PR TITLE
Feature: #0856 - Crafting Terminal requires Crafting Permissions to open

### DIFF
--- a/src/main/java/appeng/parts/reporting/PartCraftingTerminal.java
+++ b/src/main/java/appeng/parts/reporting/PartCraftingTerminal.java
@@ -2,6 +2,9 @@ package appeng.parts.reporting;
 
 import java.util.List;
 
+import appeng.api.networking.security.ISecurityGrid;
+import appeng.util.Platform;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -10,6 +13,8 @@ import appeng.core.sync.GuiBridge;
 import appeng.tile.inventory.AppEngInternalInventory;
 import appeng.tile.inventory.IAEAppEngInventory;
 import appeng.tile.inventory.InvOperation;
+import net.minecraft.util.Vec3;
+import net.minecraftforge.common.util.ForgeDirection;
 
 public class PartCraftingTerminal extends PartTerminal implements IAEAppEngInventory
 {
@@ -48,9 +53,19 @@ public class PartCraftingTerminal extends PartTerminal implements IAEAppEngInven
 		// frontSolid = CableBusTextures.PartCraftingTerm_Solid;
 	}
 
-	public GuiBridge getGui()
+	public GuiBridge getGui( EntityPlayer p )
 	{
-		return GuiBridge.GUI_CRAFTING_TERMINAL;
+		int x = (int) p.posX, y = (int) p.posY, z = (int) p.posZ;
+		if ( getHost().getTile() != null )
+		{
+			x = tile.xCoord;
+			y = tile.yCoord;
+			z = tile.zCoord;
+		}
+
+		if( GuiBridge.GUI_CRAFTING_TERMINAL.hasPermissions( getHost().getTile(), x, y, z, side, p ) )
+			return GuiBridge.GUI_CRAFTING_TERMINAL;
+		return GuiBridge.GUI_ME;
 	}
 
 	@Override

--- a/src/main/java/appeng/parts/reporting/PartPatternTerminal.java
+++ b/src/main/java/appeng/parts/reporting/PartPatternTerminal.java
@@ -2,6 +2,7 @@ package appeng.parts.reporting;
 
 import java.util.List;
 
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -58,9 +59,19 @@ public class PartPatternTerminal extends PartTerminal implements IAEAppEngInvent
 		frontDark = CableBusTextures.PartPatternTerm_Dark;
 	}
 
-	public GuiBridge getGui()
+	public GuiBridge getGui( EntityPlayer p )
 	{
-		return GuiBridge.GUI_PATTERN_TERMINAL;
+		int x = (int) p.posX, y = (int) p.posY, z = (int) p.posZ;
+		if ( getHost().getTile() != null )
+		{
+			x = tile.xCoord;
+			y = tile.yCoord;
+			z = tile.zCoord;
+		}
+
+		if( GuiBridge.GUI_PATTERN_TERMINAL.hasPermissions( getHost().getTile(), x, y, z, side, p ) )
+			return GuiBridge.GUI_PATTERN_TERMINAL;
+		return GuiBridge.GUI_ME;
 	}
 
 	@Override

--- a/src/main/java/appeng/parts/reporting/PartTerminal.java
+++ b/src/main/java/appeng/parts/reporting/PartTerminal.java
@@ -77,7 +77,7 @@ public class PartTerminal extends PartMonitor implements ITerminalHost, IConfigM
 		cm.registerSetting( Settings.SORT_DIRECTION, SortDir.ASCENDING );
 	}
 
-	public GuiBridge getGui()
+	public GuiBridge getGui( EntityPlayer player )
 	{
 		return GuiBridge.GUI_ME;
 	}
@@ -92,7 +92,7 @@ public class PartTerminal extends PartMonitor implements ITerminalHost, IConfigM
 				if ( Platform.isClient() )
 					return true;
 
-				Platform.openGUI( player, getHost().getTile(), side, getGui() );
+				Platform.openGUI( player, getHost().getTile(), side, getGui( player ) );
 
 				return true;
 			}
@@ -151,5 +151,4 @@ public class PartTerminal extends PartMonitor implements ITerminalHost, IConfigM
 	{
 		host.markForSave();
 	}
-
 }


### PR DESCRIPTION
Whenever a player without "craft"-ing permissions attempts to open a crafting or pattern terminal, they will open the normal terminal GUI instead
