### PR TITLE
Update TileSpatialIOPort.java

### DIFF
--- a/src/main/java/appeng/tile/spatial/TileSpatialIOPort.java
+++ b/src/main/java/appeng/tile/spatial/TileSpatialIOPort.java
@@ -94,7 +94,7 @@ public class TileSpatialIOPort extends AENetworkInvTile implements Callable
 			IGrid gi = gridProxy.getGrid();
 			IEnergyGrid energy = gridProxy.getEnergy();
 
-			ItemSpatialStorageCell sc = (ItemSpatialStorageCell) cell.getItem();
+			ISpatialStorageCell sc = (ISpatialStorageCell) cell.getItem();
 
 			SpatialPylonCache spc = gi.getCache( ISpatialCache.class );
 			if ( spc.hasRegion() && spc.isValidRegion() )


### PR DESCRIPTION
Made TileSpatialIOPort compliant to the API by changing cast to ISpatialStorageCell instead of cast to ItemSpatialStorageCell.
