### PR TITLE
Added a checkstyle xml

### DIFF
--- a/codeformat/checkstyle.xml
+++ b/codeformat/checkstyle.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN" "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<!--
+    This configuration file was written by the eclipse-cs plugin configuration editor
+-->
+<!--
+    Checkstyle-Configuration: AE2
+    Description: none
+-->
+<module name="Checker">
+  <property name="severity" value="warning"/>
+  <module name="TreeWalker">
+    <property name="tabWidth" value="4"/>
+    <module name="ConstantName"/>
+    <module name="LocalFinalVariableName"/>
+    <module name="LocalVariableName"/>
+    <module name="MemberName"/>
+    <module name="MethodName"/>
+    <module name="PackageName"/>
+    <module name="ParameterName"/>
+    <module name="StaticVariableName"/>
+    <module name="TypeName"/>
+    <module name="AvoidStarImport"/>
+    <module name="IllegalImport"/>
+    <module name="RedundantImport"/>
+    <module name="UnusedImports"/>
+    <module name="EmptyForIteratorPad"/>
+    <module name="MethodParamPad"/>
+    <module name="NoWhitespaceAfter">
+      <property name="tokens" value="BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS,UNARY_PLUS"/>
+    </module>
+    <module name="NoWhitespaceBefore"/>
+    <module name="OperatorWrap"/>
+    <module name="ParenPad">
+      <property name="option" value="space"/>
+    </module>
+    <module name="TypecastParenPad">
+      <property name="option" value="space"/>
+      <property name="tokens" value="RPAREN,TYPECAST"/>
+    </module>
+    <module name="WhitespaceAfter"/>
+    <module name="WhitespaceAround"/>
+    <module name="ModifierOrder"/>
+    <module name="RedundantModifier"/>
+    <module name="AvoidNestedBlocks"/>
+    <module name="EmptyBlock">
+      <property name="severity" value="ignore"/>
+      <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
+    </module>
+    <module name="LeftCurly">
+      <property name="option" value="nl"/>
+    </module>
+    <module name="NeedBraces"/>
+    <module name="RightCurly">
+      <property name="option" value="alone"/>
+    </module>
+    <module name="AvoidInlineConditionals">
+      <property name="severity" value="ignore"/>
+      <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
+    </module>
+    <module name="EmptyStatement"/>
+    <module name="EqualsHashCode"/>
+    <module name="HiddenField"/>
+    <module name="IllegalInstantiation"/>
+    <module name="InnerAssignment"/>
+    <module name="MagicNumber"/>
+    <module name="MissingSwitchDefault"/>
+    <module name="RedundantThrows">
+      <property name="suppressLoadErrors" value="true"/>
+    </module>
+    <module name="SimplifyBooleanExpression"/>
+    <module name="SimplifyBooleanReturn"/>
+    <module name="FinalClass"/>
+    <module name="HideUtilityClassConstructor"/>
+    <module name="InterfaceIsType"/>
+    <module name="VisibilityModifier"/>
+    <module name="ArrayTypeStyle"/>
+    <module name="FinalParameters"/>
+    <module name="UpperEll"/>
+  </module>
+  <module name="Translation"/>
+  <module name="RegexpSingleline">
+    <property name="format" value="\s+$"/>
+    <property name="message" value="Line has trailing spaces."/>
+  </module>
+  <module name="Header">
+    <property name="severity" value="error"/>
+    <property name="headerFile" value="${config_loc}/copyright.txt"/>
+    <property name="fileExtensions" value="java"/>
+  </module>
+</module>

--- a/codeformat/consistent.importorder
+++ b/codeformat/consistent.importorder
@@ -1,6 +1,10 @@
 #Organize Import Order
-#Tue Oct 07 11:47:29 CEST 2014
-3=com
+#Thu Oct 09 12:52:21 CEST 2014
+6=
+5=cpw
+4=net
+3=io
 2=org
-1=javax
+1=com
 0=java
+7=appeng


### PR DESCRIPTION
**This should be an ongoing discussion and not merged immediately!**
## Overview

This PR adds checkstyle rules based on the default ones with the AE2 specific formatting as well as a more refined import order definition.
## Import order

I have added a more project specific one.
The order in general:
1. java
2. com/org/io (usually large libs, but did not encounter io, could maybe be dropped)
3. net (minecrat and forge mainly)
4. cpw (...)
5. \* wildcard, it catches anything else. Like mods._, buildcraft._ etc
6. appeng
## Rules to highlight (current violations, not default, etc)
### Header

Plain simple, it enforces every .java file to contain the copyright.txt as header.
### All rules related to formatting

Rules like conditionals always need {}, { on newline, etc are still creating a large number of violations.
I would estimate about 50%. **But** (at least eclipse) can solve them automatically.
### Naming conventions

These are probably the second largest one and cannot really be solved automatically.
Mostly these are variables name like `int ThisIsAnInteger = 1` instead of `int thisIsAnInteger = 1` or parameters starting with `_` (Mostly used to prevent hiding fields, but that is another violation).
I see these as the most time consuming ones, but at least java refactoring works great in this cases.
##### PascalCase naming
- Classes
- Interfaces
##### camelCase naming
- Fields
- Variables
- Methods
##### CAPITALIZATION_NAMING
- Constants (public static final)
### Other notable ones
- Hidden fields (same parameter as already present field)
- Final parameter/fields (make everything immutable if possible)
## Possible rules to consider adding
### indentation

I would highly suggest it to keep a consistent formatting.
By itself this rule allows for tabs as well as spaces to indent the code.
**But** checkstyle cannot enforce using tabs. Only not using tabs.
So it is either use spaces or have the problem of dealing with mixed spaces and tabs.
### import order

Also would suggest it, but the general import order should be finalized before adding it.
## Disabled rules
### empty blocks

This rule could be considered to be used, as empty blocks should be avoided.
Currently these are mostly empty catch blocks, so adding at least some logging could be an idea.
On the other hand, all the launchers don't really care about severity levels, so logs might get spammed to much.
### avoid ternary operators

Probably not worth keeping.
## Gradle Integration

Currently not included, but this should be on a high priority.
But i would suggest to set `ignoreFailures true` either until every violation is resolved **OR** a fixed date like 2014-11-01 is reached.
