### PR TITLE
Changed the iron facade to the general one, fixes #332

### DIFF
--- a/src/main/java/appeng/core/stats/Achievements.java
+++ b/src/main/java/appeng/core/stats/Achievements.java
@@ -1,93 +1,111 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
 package appeng.core.stats;
 
+
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.stats.Achievement;
+
 import appeng.api.AEApi;
 import appeng.api.util.AEColor;
 import appeng.api.util.AEColoredItemDefinition;
 import appeng.api.util.AEItemDefinition;
-import appeng.items.parts.ItemFacade;
+
 
 public enum Achievements
 {
 
 	// done
-	Compass(-2, -4, AEApi.instance().blocks().blockSkyCompass, AchievementType.Craft),
+	Compass( -2, -4, AEApi.instance().blocks().blockSkyCompass, AchievementType.Craft ),
 
 	// done
-	Presses(-2, -2, AEApi.instance().materials().materialLogicProcessorPress, AchievementType.Custom),
+	Presses( -2, -2, AEApi.instance().materials().materialLogicProcessorPress, AchievementType.Custom ),
 
 	// done
-	SpatialIO(-4, -4, AEApi.instance().blocks().blockSpatialIOPort, AchievementType.Craft),
+	SpatialIO( -4, -4, AEApi.instance().blocks().blockSpatialIOPort, AchievementType.Craft ),
 
 	// done
-	SpatialIOExplorer(-4, -2, AEApi.instance().items().itemSpatialCell128, AchievementType.Custom),
+	SpatialIOExplorer( -4, -2, AEApi.instance().items().itemSpatialCell128, AchievementType.Custom ),
 
 	// done
-	StorageCell(-6, -4, AEApi.instance().items().itemCell64k, AchievementType.CraftItem),
+	StorageCell( -6, -4, AEApi.instance().items().itemCell64k, AchievementType.CraftItem ),
 
 	// done
-	IOPort(-6, -2, AEApi.instance().blocks().blockIOPort, AchievementType.Craft),
+	IOPort( -6, -2, AEApi.instance().blocks().blockIOPort, AchievementType.Craft ),
 
 	// done
-	CraftingTerminal(-8, -4, AEApi.instance().parts().partCraftingTerminal, AchievementType.Craft),
+	CraftingTerminal( -8, -4, AEApi.instance().parts().partCraftingTerminal, AchievementType.Craft ),
 
 	// done
-	PatternTerminal(-8, -2, AEApi.instance().parts().partPatternTerminal, AchievementType.Craft),
+	PatternTerminal( -8, -2, AEApi.instance().parts().partPatternTerminal, AchievementType.Craft ),
 
 	// done
-	ChargedQuartz(0, -4, AEApi.instance().materials().materialCertusQuartzCrystalCharged, AchievementType.Pickup),
+	ChargedQuartz( 0, -4, AEApi.instance().materials().materialCertusQuartzCrystalCharged, AchievementType.Pickup ),
 
 	// done
-	Fluix(0, -2, AEApi.instance().materials().materialFluixCrystal, AchievementType.Pickup),
+	Fluix( 0, -2, AEApi.instance().materials().materialFluixCrystal, AchievementType.Pickup ),
 
 	// done
-	Charger(0, 0, AEApi.instance().blocks().blockCharger, AchievementType.Craft),
+	Charger( 0, 0, AEApi.instance().blocks().blockCharger, AchievementType.Craft ),
 
 	// done
-	CrystalGrowthAccelerator(-2, 0, AEApi.instance().blocks().blockQuartzGrowthAccelerator, AchievementType.Craft),
+	CrystalGrowthAccelerator( -2, 0, AEApi.instance().blocks().blockQuartzGrowthAccelerator, AchievementType.Craft ),
 
 	// done
-	GlassCable(2, 0, AEApi.instance().parts().partCableGlass, AchievementType.Craft),
+	GlassCable( 2, 0, AEApi.instance().parts().partCableGlass, AchievementType.Craft ),
 
 	// done
-	Networking1(4, -6, AEApi.instance().parts().partCableCovered, AchievementType.Custom),
+	Networking1( 4, -6, AEApi.instance().parts().partCableCovered, AchievementType.Custom ),
 
 	// done
-	Controller(4, -4, AEApi.instance().blocks().blockController, AchievementType.Craft),
+	Controller( 4, -4, AEApi.instance().blocks().blockController, AchievementType.Craft ),
 
 	// done
-	Networking2(4, 0, AEApi.instance().parts().partCableSmart, AchievementType.Custom),
+	Networking2( 4, 0, AEApi.instance().parts().partCableSmart, AchievementType.Custom ),
 
 	// done
-	Networking3(4, 2, AEApi.instance().parts().partCableDense, AchievementType.Custom),
+	Networking3( 4, 2, AEApi.instance().parts().partCableDense, AchievementType.Custom ),
 
 	// done
-	P2P(2, -2, AEApi.instance().parts().partP2PTunnelME, AchievementType.Craft),
+	P2P( 2, -2, AEApi.instance().parts().partP2PTunnelME, AchievementType.Craft ),
 
 	// done
-	Recursive(6, -2, AEApi.instance().blocks().blockInterface, AchievementType.Craft),
+	Recursive( 6, -2, AEApi.instance().blocks().blockInterface, AchievementType.Craft ),
 
 	// done
-	CraftingCPU(6, 0, AEApi.instance().blocks().blockCraftingStorage64k, AchievementType.CraftItem),
+	CraftingCPU( 6, 0, AEApi.instance().blocks().blockCraftingStorage64k, AchievementType.CraftItem ),
 
 	// done
-	Facade(6, 2, ((ItemFacade) AEApi.instance().items().itemFacade.item()).createFacadeForItem( new ItemStack( Blocks.iron_block ), false ),
-			AchievementType.CraftItem),
+	Facade( 6, 2, AEApi.instance().items().itemFacade, AchievementType.CraftItem ),
 
 	// done
-	NetworkTool(8, 0, AEApi.instance().items().itemNetworkTool, AchievementType.Craft),
+	NetworkTool( 8, 0, AEApi.instance().items().itemNetworkTool, AchievementType.Craft ),
 
 	// done
-	PortableCell(8, 2, AEApi.instance().items().itemPortableCell, AchievementType.Craft),
+	PortableCell( 8, 2, AEApi.instance().items().itemPortableCell, AchievementType.Craft ),
 
 	// done
-	StorageBus(10, 0, AEApi.instance().parts().partStorageBus, AchievementType.Craft),
+	StorageBus( 10, 0, AEApi.instance().parts().partStorageBus, AchievementType.Craft ),
 
 	// done
-	QNB(10, 2, AEApi.instance().blocks().blockQuantumLink, AchievementType.Craft);
+	QNB( 10, 2, AEApi.instance().blocks().blockQuantumLink, AchievementType.Craft );
 
 	public final ItemStack stack;
 	public final AchievementType type;
@@ -96,7 +114,7 @@ public enum Achievements
 	private Achievement parent;
 	private Achievement stat;
 
-	public void setParent(Achievements parent)
+	public void setParent( Achievements parent )
 	{
 		this.parent = parent.getAchievement();
 	}
@@ -112,7 +130,7 @@ public enum Achievements
 		return stat;
 	}
 
-	private Achievements(int x, int y, AEColoredItemDefinition which, AchievementType type)
+	private Achievements( int x, int y, AEColoredItemDefinition which, AchievementType type )
 	{
 		stack = which.stack( AEColor.Transparent, 1 );
 		this.type = type;
@@ -120,7 +138,7 @@ public enum Achievements
 		this.y = y;
 	}
 
-	private Achievements(int x, int y, AEItemDefinition which, AchievementType type)
+	private Achievements( int x, int y, AEItemDefinition which, AchievementType type )
 	{
 		stack = which.stack( 1 );
 		this.type = type;
@@ -128,7 +146,7 @@ public enum Achievements
 		this.y = y;
 	}
 
-	private Achievements(int x, int y, ItemStack which, AchievementType type)
+	private Achievements( int x, int y, ItemStack which, AchievementType type )
 	{
 		stack = which;
 		this.type = type;
@@ -136,7 +154,7 @@ public enum Achievements
 		this.y = y;
 	}
 
-	public void addToPlayer(EntityPlayer player)
+	public void addToPlayer( EntityPlayer player )
 	{
 		player.addStat( getAchievement(), 1 );
 	}


### PR DESCRIPTION
If the facades feature is disabled it will cause a NPE because it is trying to create the specific iron block facade, which is not possible under this conditions.

For whatever reasons it chooses the glass facade. Which I personally find more convenient, because it shows the anchor clearly instead of hiding it like a opaque version is doing.
This might chance depending on the installed mods, but I would consider a possible changing icon the better solution to crashing.

The achievment tab itself is already sophisticated enough to hide disabled features.
So I do not see any reasons currently to split it up and disable them explicitly if the specific feature is disabled.

Fixes #332 
