### PR TITLE
Fixes condenser dupe bug

### DIFF
--- a/src/main/java/appeng/me/storage/VoidFluidInventory.java
+++ b/src/main/java/appeng/me/storage/VoidFluidInventory.java
@@ -1,4 +1,23 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
 package appeng.me.storage;
+
 
 import appeng.api.config.AccessRestriction;
 import appeng.api.config.Actionable;
@@ -9,18 +28,23 @@ import appeng.api.storage.data.IAEFluidStack;
 import appeng.api.storage.data.IItemList;
 import appeng.tile.misc.TileCondenser;
 
+
 public class VoidFluidInventory implements IMEInventoryHandler<IAEFluidStack>
 {
 
 	final TileCondenser target;
 
-	public VoidFluidInventory(TileCondenser te) {
+	public VoidFluidInventory( TileCondenser te )
+	{
 		target = te;
 	}
 
 	@Override
-	public IAEFluidStack injectItems(IAEFluidStack input, Actionable mode, BaseActionSource src)
+	public IAEFluidStack injectItems( IAEFluidStack input, Actionable mode, BaseActionSource src )
 	{
+		if ( mode == Actionable.SIMULATE )
+			return null;
+
 		if ( input != null )
 			target.addPower( input.getStackSize() / 1000.0 );
 		return null;
@@ -33,13 +57,13 @@ public class VoidFluidInventory implements IMEInventoryHandler<IAEFluidStack>
 	}
 
 	@Override
-	public IAEFluidStack extractItems(IAEFluidStack request, Actionable mode, BaseActionSource src)
+	public IAEFluidStack extractItems( IAEFluidStack request, Actionable mode, BaseActionSource src )
 	{
 		return null;
 	}
 
 	@Override
-	public IItemList<IAEFluidStack> getAvailableItems(IItemList out)
+	public IItemList<IAEFluidStack> getAvailableItems( IItemList out )
 	{
 		return out;
 	}
@@ -51,13 +75,13 @@ public class VoidFluidInventory implements IMEInventoryHandler<IAEFluidStack>
 	}
 
 	@Override
-	public boolean isPrioritized(IAEFluidStack input)
+	public boolean isPrioritized( IAEFluidStack input )
 	{
 		return false;
 	}
 
 	@Override
-	public boolean canAccept(IAEFluidStack input)
+	public boolean canAccept( IAEFluidStack input )
 	{
 		return true;
 	}
@@ -75,7 +99,7 @@ public class VoidFluidInventory implements IMEInventoryHandler<IAEFluidStack>
 	}
 
 	@Override
-	public boolean validForPass(int i)
+	public boolean validForPass( int i )
 	{
 		return i == 2;
 	}

--- a/src/main/java/appeng/me/storage/VoidItemInventory.java
+++ b/src/main/java/appeng/me/storage/VoidItemInventory.java
@@ -1,4 +1,23 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
 package appeng.me.storage;
+
 
 import appeng.api.config.AccessRestriction;
 import appeng.api.config.Actionable;
@@ -9,18 +28,23 @@ import appeng.api.storage.data.IAEItemStack;
 import appeng.api.storage.data.IItemList;
 import appeng.tile.misc.TileCondenser;
 
+
 public class VoidItemInventory implements IMEInventoryHandler<IAEItemStack>
 {
 
 	final TileCondenser target;
 
-	public VoidItemInventory(TileCondenser te) {
+	public VoidItemInventory( TileCondenser te )
+	{
 		target = te;
 	}
 
 	@Override
-	public IAEItemStack injectItems(IAEItemStack input, Actionable mode, BaseActionSource src)
+	public IAEItemStack injectItems( IAEItemStack input, Actionable mode, BaseActionSource src )
 	{
+		if ( mode == Actionable.SIMULATE )
+			return null;
+
 		if ( input != null )
 			target.addPower( input.getStackSize() );
 		return null;
@@ -33,13 +57,13 @@ public class VoidItemInventory implements IMEInventoryHandler<IAEItemStack>
 	}
 
 	@Override
-	public IAEItemStack extractItems(IAEItemStack request, Actionable mode, BaseActionSource src)
+	public IAEItemStack extractItems( IAEItemStack request, Actionable mode, BaseActionSource src )
 	{
 		return null;
 	}
 
 	@Override
-	public IItemList<IAEItemStack> getAvailableItems(IItemList out)
+	public IItemList<IAEItemStack> getAvailableItems( IItemList out )
 	{
 		return out;
 	}
@@ -51,13 +75,13 @@ public class VoidItemInventory implements IMEInventoryHandler<IAEItemStack>
 	}
 
 	@Override
-	public boolean isPrioritized(IAEItemStack input)
+	public boolean isPrioritized( IAEItemStack input )
 	{
 		return false;
 	}
 
 	@Override
-	public boolean canAccept(IAEItemStack input)
+	public boolean canAccept( IAEItemStack input )
 	{
 		return true;
 	}
@@ -75,7 +99,7 @@ public class VoidItemInventory implements IMEInventoryHandler<IAEItemStack>
 	}
 
 	@Override
-	public boolean validForPass(int i)
+	public boolean validForPass( int i )
 	{
 		return i == 2;
 	}


### PR DESCRIPTION
Both `VoidFluidInventory` and `VoidItemInventory` will already add the stored power in the simulation phase.
Resulting in adding the full cell inventory to it instead of only the extracted items from the cell.
