### PR TITLE
Fixes #473, catches outdated player names and checks if all entries are UUIDs before converted and thus prevents the server crashing.

### DIFF
--- a/gradle/scripts/dependencies.gradle
+++ b/gradle/scripts/dependencies.gradle
@@ -1,3 +1,23 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+
+
 repositories {
 
     maven {
@@ -41,4 +61,6 @@ dependencies {
 
     // add hacked buildcraft jar to compile time (for facades)
     compile fileTree(dir: 'libs', include: '*.jar')
+
+    testCompile "junit:junit:4.11"
 }

--- a/src/main/java/appeng/core/PlayerMappings.java
+++ b/src/main/java/appeng/core/PlayerMappings.java
@@ -1,0 +1,79 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.core;
+
+
+import java.util.Map;
+import java.util.UUID;
+
+import net.minecraftforge.common.config.ConfigCategory;
+
+import cpw.mods.fml.relauncher.FMLRelaunchLog;
+
+import com.google.common.base.Optional;
+
+
+/**
+ * Wrapper class for the player mappings.
+ * Will grant access to a pre initialized player map
+ * based on the "players" category in the settings.cfg
+ */
+public class PlayerMappings
+{
+	/**
+	 * View of player mappings, is not immutable,
+	 * since it needs to be edited upon runtime,
+	 * cause new players can join
+	 */
+	private final Map<Integer, UUID> mappings;
+
+	public PlayerMappings( ConfigCategory category, FMLRelaunchLog log )
+	{
+		final PlayerMappingsInitializer init = new PlayerMappingsInitializer( category, log );
+
+		this.mappings = init.getPlayerMappings();
+	}
+
+	/**
+	 * Tries to retrieve the UUID of a player.
+	 * Might not be stored inside of the map.
+	 * Should not happen though.
+	 *
+	 * @param id ID of the to be searched player
+	 *
+	 * @return maybe the UUID of the searched player
+	 */
+	public Optional<UUID> get( int id )
+	{
+		final UUID maybe = this.mappings.get( id );
+
+		return Optional.fromNullable( maybe );
+	}
+
+	/**
+	 * Put in new players when they join the server
+	 *
+	 * @param id   id of new player
+	 * @param uuid UUID of new player
+	 */
+	public void put( int id, UUID uuid )
+	{
+		this.mappings.put( id, uuid );
+	}
+}

--- a/src/main/java/appeng/core/PlayerMappingsInitializer.java
+++ b/src/main/java/appeng/core/PlayerMappingsInitializer.java
@@ -1,0 +1,94 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.core;
+
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import net.minecraftforge.common.config.ConfigCategory;
+import net.minecraftforge.common.config.Property;
+
+import cpw.mods.fml.relauncher.FMLRelaunchLog;
+
+import appeng.util.UUIDMatcher;
+
+
+/**
+ * Initializes a map of ID to UUID from the player list in the settings.cfg
+ */
+public class PlayerMappingsInitializer
+{
+	/**
+	 * Internal immutable mapping
+	 */
+	private final Map<Integer, UUID> playerMappings;
+
+	/**
+	 * Creates the initializer for the player mappings.
+	 * The map will be filled upon construction
+	 * and will only be filled with valid entries.
+	 * If an invalid entry is found, an warning is printed,
+	 * mostly due to migration problems from 1.7.2 to 1.7.10
+	 * where the UUIDs were introduced.
+	 *
+	 * @param playerList the category for the player list, generally extracted using the "players" tag
+	 * @param log        the logger used to warn the server or user of faulty entries
+	 */
+	public PlayerMappingsInitializer( ConfigCategory playerList, FMLRelaunchLog log )
+	{
+		// Matcher for UUIDs
+		final UUIDMatcher matcher = new UUIDMatcher();
+
+		// Initial capacity for mappings
+		final int capacity = playerList.size();
+
+		// Mappings for the IDs is a regular HashMap
+		this.playerMappings = new HashMap<Integer, UUID>( capacity );
+
+		// Iterates through every pair of UUID to ID
+		for ( Map.Entry<String, Property> entry : playerList.getValues().entrySet() )
+		{
+			final String maybeUUID = entry.getKey();
+			final int id = entry.getValue().getInt();
+
+			if ( matcher.isUUID( maybeUUID ) )
+			{
+				final UUID UUIDString = UUID.fromString( maybeUUID );
+
+				this.playerMappings.put( id, UUIDString );
+			}
+			else
+			{
+				AELog.warning( "The configuration for players contained an outdated entry instead an expected UUID " + maybeUUID + " for the player " + id + ". Please clean this up." );
+			}
+		}
+	}
+
+	/**
+	 * Getter
+	 *
+	 * @return Immutable map of the players mappings of their ID to their UUID
+	 */
+	public Map<Integer, UUID> getPlayerMappings()
+	{
+		return this.playerMappings;
+	}
+}

--- a/src/main/java/appeng/util/UUIDMatcher.java
+++ b/src/main/java/appeng/util/UUIDMatcher.java
@@ -1,0 +1,43 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.util;
+
+
+/**
+ * Regex wrapper for UUIDs to not rely on try catch
+ */
+public final class UUIDMatcher
+{
+	/**
+	 * String which is the regular expression for UUIDs
+	 */
+	private static final String UUID_REGEX = "[0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}";
+
+	/**
+	 * Checks if a potential UUID is an UUID by applying a regular expression on it.
+	 *
+	 * @param potential to be checked potential UUID
+	 *
+	 * @return true, if the potential UUID is indeed an UUID
+	 */
+	public boolean isUUID( String potential )
+	{
+		return potential.matches( UUID_REGEX );
+	}
+}

--- a/src/test/java/appeng/util/UUIDMatcherTest.java
+++ b/src/test/java/appeng/util/UUIDMatcherTest.java
@@ -1,0 +1,61 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.util;
+
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+
+/**
+ * Tests for {@link UUIDMatcher}
+ */
+public class UUIDMatcherTest
+{
+	private static final String isUUID = "03ba29a1-d6bd-32ba-90b2-375e4d65abc9";
+	private static final String noUUID = "no";
+	private static final String invalidUUID = "g3ba29a1-d6bd-32ba-90b2-375e4d65abc9";
+
+	private final UUIDMatcher matcher;
+
+	public UUIDMatcherTest()
+	{
+		this.matcher = new UUIDMatcher();
+	}
+
+	@Test
+	public void testUUID_shouldPass()
+	{
+		assertTrue( this.matcher.isUUID( isUUID ) );
+	}
+
+	@Test
+	public void testNoUUD_shouldPass()
+	{
+		assertFalse( this.matcher.isUUID( noUUID ) );
+	}
+
+	@Test
+	public void testInvalidUUID_shouldPass()
+	{
+		assertFalse( this.matcher.isUUID( invalidUUID ) );
+	}
+}


### PR DESCRIPTION
Split off logic into single responsibilities for storing, initializing and matching the UUID mappings. 
Added JUnit to create tests for the UUID Matcher to see if its legit. 
It tests against simple problems like unconform UUIDs and also tests against a valid UUID.
