### PR TITLE
#470 Fix terminal search box losing focus in auto mode

### DIFF
--- a/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
@@ -348,7 +348,9 @@ public class GuiMEMonitorable extends AEBaseMEGui implements ISortSource, IConfi
 		Enum searchMode = AEConfig.instance.settings.getSetting( Settings.SEARCH_MODE );
 
 		if ( searchMode != SearchBoxMode.AUTOSEARCH && searchMode != SearchBoxMode.NEI_AUTOSEARCH )
+		{
 			searchField.mouseClicked( xCoord, yCoord, btn );
+		}
 
 		if ( btn == 1 && searchField.isMouseIn( xCoord, yCoord ) )
 		{


### PR DESCRIPTION
#470 Prevent the search box from losing focus in Auto Search and NEI Synchronized Auto Search modes.

Without this patch applied there is no real difference between the auto and manual search box modes (other than whether the search box initially has focus when the GUI is opened). The search box should always have focus in auto mode, and should be able to lose focus in manual mode, as has always been the case until recently. This patch fixes the problem by preventing the search box from losing focus when in Auto and NEI Synchronized Auto search modes.
