### PR TITLE
Improve performance of the UUID matcher by using a pre-compiled pattern

### DIFF
--- a/src/main/java/appeng/util/UUIDMatcher.java
+++ b/src/main/java/appeng/util/UUIDMatcher.java
@@ -19,25 +19,33 @@
 package appeng.util;
 
 
+import java.util.regex.Pattern;
+
+
 /**
- * Regex wrapper for UUIDs to not rely on try catch
+ * Regex wrapper for {@link java.util.UUID}s to not rely on try catch
  */
 public final class UUIDMatcher
 {
 	/**
-	 * String which is the regular expression for UUIDs
+	 * String which is the regular expression for {@link java.util.UUID}s
 	 */
 	private static final String UUID_REGEX = "[0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}";
 
 	/**
-	 * Checks if a potential UUID is an UUID by applying a regular expression on it.
-	 *
-	 * @param potential to be checked potential UUID
-	 *
-	 * @return true, if the potential UUID is indeed an UUID
+	 * Pattern which pre-compiles the {@link appeng.util.UUIDMatcher#UUID_REGEX}
 	 */
-	public boolean isUUID( String potential )
+	private static final Pattern PATTERN = Pattern.compile( UUID_REGEX );
+
+	/**
+	 * Checks if a potential {@link java.util.UUID} is an {@link java.util.UUID} by applying a regular expression on it.
+	 *
+	 * @param potential to be checked potential {@link java.util.UUID}
+	 *
+	 * @return true, if the potential {@link java.util.UUID} is indeed an {@link java.util.UUID}
+	 */
+	public boolean isUUID( CharSequence potential )
 	{
-		return potential.matches( UUID_REGEX );
+		return PATTERN.matcher( potential ).matches();
 	}
 }

--- a/src/test/java/appeng/util/UUIDMatcherTest.java
+++ b/src/test/java/appeng/util/UUIDMatcherTest.java
@@ -30,9 +30,9 @@ import static org.junit.Assert.assertTrue;
  */
 public class UUIDMatcherTest
 {
-	private static final String isUUID = "03ba29a1-d6bd-32ba-90b2-375e4d65abc9";
-	private static final String noUUID = "no";
-	private static final String invalidUUID = "g3ba29a1-d6bd-32ba-90b2-375e4d65abc9";
+	private static final String IS_UUID = "03ba29a1-d6bd-32ba-90b2-375e4d65abc9";
+	private static final String NO_UUID = "no";
+	private static final String INVALID_UUID = "g3ba29a1-d6bd-32ba-90b2-375e4d65abc9";
 
 	private final UUIDMatcher matcher;
 
@@ -44,18 +44,18 @@ public class UUIDMatcherTest
 	@Test
 	public void testUUID_shouldPass()
 	{
-		assertTrue( this.matcher.isUUID( isUUID ) );
+		assertTrue( this.matcher.isUUID( IS_UUID ) );
 	}
 
 	@Test
 	public void testNoUUD_shouldPass()
 	{
-		assertFalse( this.matcher.isUUID( noUUID ) );
+		assertFalse( this.matcher.isUUID( NO_UUID ) );
 	}
 
 	@Test
 	public void testInvalidUUID_shouldPass()
 	{
-		assertFalse( this.matcher.isUUID( invalidUUID ) );
+		assertFalse( this.matcher.isUUID( INVALID_UUID ) );
 	}
 }


### PR DESCRIPTION
some minor Javadoc improvements
modified the test to use constant names
