### PR TITLE
Also use the player's inventory to handle NEI fills

### DIFF
--- a/src/main/java/appeng/container/implementations/ContainerCraftingTerm.java
+++ b/src/main/java/appeng/container/implementations/ContainerCraftingTerm.java
@@ -90,6 +90,10 @@ public class ContainerCraftingTerm extends ContainerMEMonitorable implements IAE
 	@Override
 	public IInventory getInventoryByName(String name)
 	{
+		if (name.equals("player"))
+		{
+			return invPlayer;
+		}
 		return ct.getInventoryByName( name );
 	}
 

--- a/src/main/java/appeng/container/implementations/ContainerPatternTerm.java
+++ b/src/main/java/appeng/container/implementations/ContainerPatternTerm.java
@@ -447,6 +447,10 @@ public class ContainerPatternTerm extends ContainerMEMonitorable implements IAEA
 	@Override
 	public IInventory getInventoryByName(String name)
 	{
+		if (name.equals("player"))
+		{
+			return invPlayer;
+		}
 		return ct.getInventoryByName( name );
 	}
 


### PR DESCRIPTION
If the items for a recipe are not available in the ME network when you shift-left-click the NEI question mark, also try to pull from the player's inventory.

The 'ic' local variable was renamed to 'testInv', as it's used to test the IRecipe on various crafting propositions to see if the item satisfies the recipe. I can remove this if you want, but I think it increases the readability.

Adds #564, "Shift clicking "?" on NEI recipe ignores items in the player's inventory".
