### PR TITLE
Silence Recipe and Part loading in startup, condense integrations

### DIFF
--- a/src/main/java/appeng/core/AELog.java
+++ b/src/main/java/appeng/core/AELog.java
@@ -56,6 +56,11 @@ public class AELog
 		log( Level.INFO, format, data );
 	}
 
+	public static void debug(String format, Object... data)
+	{
+		log( Level.DEBUG, format, data );
+	}
+
 	public static void grinder(String o)
 	{
 		if ( AEConfig.instance.isFeatureEnabled( AEFeature.GrinderLogging ) )

--- a/src/main/java/appeng/core/api/ApiPart.java
+++ b/src/main/java/appeng/core/api/ApiPart.java
@@ -301,7 +301,7 @@ public class ApiPart implements IPartHelper
 
 			if ( !hasError )
 			{
-				AELog.info( "Layer: " + n.name + " loaded successfully - " + size + " bytes" );
+				AELog.debug( "Layer: " + n.name + " loaded successfully - " + size + " bytes" );
 			}
 
 		}

--- a/src/main/java/appeng/integration/IntegrationNode.java
+++ b/src/main/java/appeng/integration/IntegrationNode.java
@@ -117,20 +117,6 @@ public class IntegrationNode
 				state = IntegrationStage.FAILED;
 			}
 		}
-
-		if ( stage == IntegrationStage.POST_INIT )
-		{
-			if ( state == IntegrationStage.FAILED )
-			{
-				AELog.info( displayName + " - Integration Disabled" );
-				if ( !(exception instanceof ModNotInstalled) )
-					AELog.integration( exception );
-			}
-			else
-			{
-				AELog.info( displayName + " - Integration Enable" );
-			}
-		}
 	}
 
 	public boolean isActive()

--- a/src/main/java/appeng/integration/IntegrationRegistry.java
+++ b/src/main/java/appeng/integration/IntegrationRegistry.java
@@ -19,8 +19,13 @@
 package appeng.integration;
 
 
+import java.util.Iterator;
 import java.util.LinkedList;
+import java.util.List;
 
+import appeng.api.exceptions.ModNotInstalled;
+import appeng.core.AELog;
+import com.google.common.collect.Lists;
 import cpw.mods.fml.relauncher.FMLLaunchHandler;
 import cpw.mods.fml.relauncher.Side;
 
@@ -55,6 +60,81 @@ public enum IntegrationRegistry
 	{
 		for ( IntegrationNode node : modules )
 			node.Call( IntegrationStage.POST_INIT );
+
+		// Log status of all integrations
+		// (This should all be display logic - the work was in Call())
+		StringBuilder sb;
+		List<IntegrationNode> enabled = Lists.newArrayList();
+		List<IntegrationNode> disabled = Lists.newArrayList();
+		List<IntegrationNode> errored = Lists.newArrayList();
+
+		for ( IntegrationNode node : modules )
+		{
+			switch (node.state)
+			{
+			case FAILED:
+
+				Throwable exception = node.exception;
+				if ( exception instanceof ModNotInstalled )
+					disabled.add( node );
+				else
+					errored.add( node );
+				break;
+
+			case READY:
+				enabled.add( node );
+				break;
+			}
+		}
+
+		AELog.info( "=== Applied Energistics Integrations Report ===" );
+		AELog.info( "Enabled: %d  Disabled: %d  Errored: %d", enabled.size(), disabled.size(), errored.size() );
+		if ( !enabled.isEmpty() )
+		{
+			AELog.info("Enabled integrations: ");
+			for ( String line : joinIntegrationNames( enabled ) )
+				AELog.info( line );
+		}
+		if ( !disabled.isEmpty() )
+		{
+			AELog.info("Disabled integrations: ");
+			for ( String line : joinIntegrationNames( disabled ) )
+				AELog.info( line );
+		}
+		if ( !errored.isEmpty() )
+		{
+			AELog.warning( "[!] Some integrations failed." );
+			for ( IntegrationNode node : errored )
+			{
+				AELog.warning( "[!] Integration %s failed with %s", node.displayName, node.exception.getClass().getName() );
+				AELog.error( node.exception );
+			}
+		}
+		AELog.info("----------- end report");
+	}
+
+	// Small helper to not put a semicolon on the end
+	private static String[] joinIntegrationNames(List<IntegrationNode> integrations)
+	{
+		StringBuilder out = new StringBuilder("    ");
+		int lastNewline = 0;
+
+		Iterator<IntegrationNode> iter = integrations.iterator();
+		while ( iter.hasNext() )
+		{
+			if ( (out.length() - lastNewline) > 70 )
+			{
+				lastNewline = out.length();
+				out.append( "\n    " );
+			}
+
+			out.append( iter.next().displayName );
+
+			if ( iter.hasNext() )
+				out.append( "; " );
+		}
+
+		return out.toString().split("\n");
 	}
 
 	public String getStatus()

--- a/src/main/java/appeng/recipes/RecipeHandler.java
+++ b/src/main/java/appeng/recipes/RecipeHandler.java
@@ -151,7 +151,7 @@ public class RecipeHandler implements IRecipeHandler
 
 		for (Entry<Class, Integer> e : processed.entrySet())
 		{
-			AELog.info( "Recipes Loading: " + e.getKey().getSimpleName() + ": " + e.getValue() + " loaded." );
+			AELog.debug( "Recipes Loading: " + e.getKey().getSimpleName() + ": " + e.getValue() + " loaded." );
 		}
 
 		if ( AEConfig.instance.isFeatureEnabled( AEFeature.WebsiteRecipes ) )


### PR DESCRIPTION
Condensing the integration status output took several lines of code, but
I think it's worth it in quest of smaller Forge startup logs.
