### PR TITLE
Closes #593 Updating RF Integration to use version 1.7.10R1.0.2

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -36,6 +36,6 @@ api_mekansim_version=1
 api_mfr_version=1
 api_railcraft_version=1
 api_rblocks_version=1
-api_rf_version=1
+api_rf_version=2
 api_rotarycraft_version=1
 dev_buildcraft_version=1

--- a/src/main/java/appeng/core/Registration.java
+++ b/src/main/java/appeng/core/Registration.java
@@ -560,7 +560,7 @@ public class Registration
 			ph.registerNewLayer( "appeng.parts.layers.LayerIBatteryProvider", "buildcraft.api.mj.IBatteryProvider" );
 
 		if ( AppEng.instance.isIntegrationEnabled( IntegrationType.RF ) )
-			ph.registerNewLayer( "appeng.parts.layers.LayerIEnergyHandler", "cofh.api.energy.IEnergyHandler" );
+			ph.registerNewLayer( "appeng.parts.layers.LayerIEnergyHandler", "cofh.api.energy.IEnergyReceiver" );
 
 		FMLCommonHandler.instance().bus().register( TickHandler.instance );
 		MinecraftForge.EVENT_BUS.register( TickHandler.instance );

--- a/src/main/java/appeng/integration/modules/RF.java
+++ b/src/main/java/appeng/integration/modules/RF.java
@@ -31,6 +31,8 @@ public class RF extends BaseModule
 	public static RF instance;
 
 	public RF() {
+		TestClass( cofh.api.energy.IEnergyReceiver.class );
+		TestClass( cofh.api.energy.IEnergyProvider.class );
 		TestClass( cofh.api.energy.IEnergyHandler.class );
 		TestClass( cofh.api.energy.IEnergyConnection.class );
 	}

--- a/src/main/java/appeng/integration/modules/helpers/NullRFHandler.java
+++ b/src/main/java/appeng/integration/modules/helpers/NullRFHandler.java
@@ -18,40 +18,36 @@
 
 package appeng.integration.modules.helpers;
 
-import net.minecraftforge.common.util.ForgeDirection;
-import cofh.api.energy.IEnergyHandler;
 
-public class NullRFHandler implements IEnergyHandler
+import net.minecraftforge.common.util.ForgeDirection;
+
+import cofh.api.energy.IEnergyReceiver;
+
+
+public class NullRFHandler implements IEnergyReceiver
 {
 
 	@Override
-	public int receiveEnergy(ForgeDirection from, int maxReceive, boolean simulate)
+	public int receiveEnergy( ForgeDirection from, int maxReceive, boolean simulate )
 	{
 		return 0;
 	}
 
 	@Override
-	public int extractEnergy(ForgeDirection from, int maxExtract, boolean simulate)
+	public int getEnergyStored( ForgeDirection from )
 	{
 		return 0;
 	}
 
 	@Override
-	public int getEnergyStored(ForgeDirection from)
+	public int getMaxEnergyStored( ForgeDirection from )
 	{
 		return 0;
 	}
 
 	@Override
-	public int getMaxEnergyStored(ForgeDirection from)
-	{
-		return 0;
-	}
-
-	@Override
-	public boolean canConnectEnergy(ForgeDirection from)
+	public boolean canConnectEnergy( ForgeDirection from )
 	{
 		return true;
 	}
-
 }

--- a/src/main/java/appeng/parts/layers/LayerIEnergyHandler.java
+++ b/src/main/java/appeng/parts/layers/LayerIEnergyHandler.java
@@ -21,7 +21,12 @@ package appeng.parts.layers;
 import net.minecraftforge.common.util.ForgeDirection;
 import appeng.api.parts.IPart;
 import appeng.api.parts.LayerBase;
+
+import cofh.api.energy.IEnergyConnection;
 import cofh.api.energy.IEnergyHandler;
+import cofh.api.energy.IEnergyProvider;
+import cofh.api.energy.IEnergyReceiver;
+
 
 public class LayerIEnergyHandler extends LayerBase implements IEnergyHandler
 {
@@ -29,9 +34,9 @@ public class LayerIEnergyHandler extends LayerBase implements IEnergyHandler
 	@Override
 	public int receiveEnergy(ForgeDirection from, int maxReceive, boolean simulate)
 	{
-		IPart part = getPart( from );
-		if ( part instanceof IEnergyHandler )
-			return ((IEnergyHandler) part).receiveEnergy( from, maxReceive, simulate );
+		IPart part = this.getPart( from );
+		if ( part instanceof IEnergyReceiver )
+			return ((IEnergyReceiver) part).receiveEnergy( from, maxReceive, simulate );
 
 		return 0;
 	}
@@ -39,9 +44,9 @@ public class LayerIEnergyHandler extends LayerBase implements IEnergyHandler
 	@Override
 	public int extractEnergy(ForgeDirection from, int maxExtract, boolean simulate)
 	{
-		IPart part = getPart( from );
-		if ( part instanceof IEnergyHandler )
-			return ((IEnergyHandler) part).extractEnergy( from, maxExtract, simulate );
+		IPart part = this.getPart( from );
+		if ( part instanceof IEnergyProvider )
+			return ((IEnergyProvider) part).extractEnergy( from, maxExtract, simulate );
 
 		return 0;
 	}
@@ -49,9 +54,9 @@ public class LayerIEnergyHandler extends LayerBase implements IEnergyHandler
 	@Override
 	public int getEnergyStored(ForgeDirection from)
 	{
-		IPart part = getPart( from );
-		if ( part instanceof IEnergyHandler )
-			return ((IEnergyHandler) part).getEnergyStored( from );
+		IPart part = this.getPart( from );
+		if ( part instanceof IEnergyProvider )
+			return ((IEnergyProvider) part).getEnergyStored( from );
 
 		return 0;
 	}
@@ -59,9 +64,9 @@ public class LayerIEnergyHandler extends LayerBase implements IEnergyHandler
 	@Override
 	public int getMaxEnergyStored(ForgeDirection from)
 	{
-		IPart part = getPart( from );
-		if ( part instanceof IEnergyHandler )
-			return ((IEnergyHandler) part).getMaxEnergyStored( from );
+		IPart part = this.getPart( from );
+		if ( part instanceof IEnergyProvider )
+			return ((IEnergyProvider) part).getMaxEnergyStored( from );
 
 		return 0;
 	}
@@ -69,9 +74,9 @@ public class LayerIEnergyHandler extends LayerBase implements IEnergyHandler
 	@Override
 	public boolean canConnectEnergy(ForgeDirection from)
 	{
-		IPart part = getPart( from );
-		if ( part instanceof IEnergyHandler )
-			return ((IEnergyHandler) part).canConnectEnergy( from );
+		IPart part = this.getPart( from );
+		if ( part instanceof IEnergyConnection )
+			return ((IEnergyConnection) part).canConnectEnergy( from );
 
 		return false;
 	}

--- a/src/main/java/appeng/tile/powersink/RedstoneFlux.java
+++ b/src/main/java/appeng/tile/powersink/RedstoneFlux.java
@@ -18,49 +18,47 @@
 
 package appeng.tile.powersink;
 
+
 import net.minecraftforge.common.util.ForgeDirection;
+
+import cofh.api.energy.IEnergyReceiver;
+
 import appeng.api.config.PowerUnits;
 import appeng.transformer.annotations.integration.Interface;
-import cofh.api.energy.IEnergyHandler;
 
-@Interface(iname = "RF", iface = "cofh.api.energy.IEnergyHandler")
-public abstract class RedstoneFlux extends RotaryCraft implements IEnergyHandler
+
+@Interface( iname = "RF", iface = "cofh.api.energy.IEnergyReceiver" )
+public abstract class RedstoneFlux extends RotaryCraft implements IEnergyReceiver
 {
 	@Override
-	final public int receiveEnergy(ForgeDirection from, int maxReceive, boolean simulate)
+	final public int receiveEnergy( ForgeDirection from, int maxReceive, boolean simulate )
 	{
-		final int networkRFDemand = (int) Math.floor( this.getExternalPowerDemand( PowerUnits.RF, maxReceive ) );
+		final int networkRFDemand = ( int ) Math.floor( this.getExternalPowerDemand( PowerUnits.RF, maxReceive ) );
 		final int usedRF = Math.min( maxReceive, networkRFDemand );
 
 		if ( !simulate )
 		{
 			this.injectExternalPower( PowerUnits.RF, usedRF );
 		}
-		
+
 		return usedRF;
 	}
 
 	@Override
-	final public int extractEnergy(ForgeDirection from, int maxExtract, boolean simulate)
+	final public int getEnergyStored( ForgeDirection from )
 	{
-		return 0;
+		return ( int ) Math.floor( PowerUnits.AE.convertTo( PowerUnits.RF, this.getAECurrentPower() ) );
 	}
 
 	@Override
-	final public boolean canConnectEnergy(ForgeDirection from)
+	final public int getMaxEnergyStored( ForgeDirection from )
+	{
+		return ( int ) Math.floor( PowerUnits.AE.convertTo( PowerUnits.RF, this.getAEMaxPower() ) );
+	}
+
+	@Override
+	final public boolean canConnectEnergy( ForgeDirection from )
 	{
 		return this.getPowerSides().contains( from );
-	}
-
-	@Override
-	final public int getEnergyStored(ForgeDirection from)
-	{
-		return (int) Math.floor( PowerUnits.AE.convertTo( PowerUnits.RF, this.getAECurrentPower() ) );
-	}
-
-	@Override
-	final public int getMaxEnergyStored(ForgeDirection from)
-	{
-		return (int) Math.floor( PowerUnits.AE.convertTo( PowerUnits.RF, this.getAEMaxPower() ) );
 	}
 }


### PR DESCRIPTION
The new update contained a split of the IEnergyHandler into the IEnergyReceiver and IEnergyProvider.
Since all tiles in AE2 are basically IEnergyReceivers we use them and changed the detection of opposing tile entities from IEnergyHandler to IEnergyReceiver
