### PR TITLE
Fixes #604 Crash on crafting

### DIFF
--- a/src/main/java/appeng/core/Registration.java
+++ b/src/main/java/appeng/core/Registration.java
@@ -588,7 +588,9 @@ public class Registration
 
 		recipeHandler.injectRecipes();
 
-		PlayerStatsRegistration.instance.init();
+		final PlayerStatsRegistration registration = new PlayerStatsRegistration( FMLCommonHandler.instance().bus(), AEConfig.instance );
+		registration.registerAchievementHandlers();
+		registration.registerAchievements();
 
 		if ( AEConfig.instance.isFeatureEnabled( AEFeature.enableDisassemblyCrafting ) )
 			CraftingManager.getInstance().getRecipeList().add( new DisassembleRecipe() );

--- a/src/main/java/appeng/core/stats/AchievementCraftingHandler.java
+++ b/src/main/java/appeng/core/stats/AchievementCraftingHandler.java
@@ -1,0 +1,71 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.core.stats;
+
+
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.common.gameevent.PlayerEvent;
+
+import appeng.util.Platform;
+
+
+/**
+ * handles the achievement when an {@link net.minecraft.item.Item} is crafted by a player.
+ * The achievement is only added if its a real {@link net.minecraft.entity.player.EntityPlayer}.
+ *
+ * @author thatsIch
+ * @since rv2
+ */
+public class AchievementCraftingHandler
+{
+	private final PlayerDifferentiator differentiator;
+
+	public AchievementCraftingHandler( PlayerDifferentiator differentiator )
+	{
+		this.differentiator = differentiator;
+	}
+
+	@SubscribeEvent
+	public void onPlayerCraftingEvent( PlayerEvent.ItemCraftedEvent event )
+	{
+		if ( this.differentiator.isNoPlayer( event.player ) || event.crafting == null )
+			return;
+
+		for ( Achievements achievement : Achievements.values() )
+		{
+			switch ( achievement.type )
+			{
+				case Craft:
+					if ( Platform.isSameItemPrecise( achievement.stack, event.crafting ) )
+					{
+						achievement.addToPlayer( event.player );
+						return;
+					}
+					break;
+				case CraftItem:
+					if ( achievement.stack != null && achievement.stack.getItem().getClass() == event.crafting.getItem().getClass() )
+					{
+						achievement.addToPlayer( event.player );
+						return;
+					}
+				default:
+			}
+		}
+	}
+}

--- a/src/main/java/appeng/core/stats/AchievementHierarchy.java
+++ b/src/main/java/appeng/core/stats/AchievementHierarchy.java
@@ -1,0 +1,61 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.core.stats;
+
+
+/**
+ * Hierarchy of the AE2 achievements
+ *
+ * @author thatsIch
+ * @since rv2
+ */
+public class AchievementHierarchy
+{
+	/**
+	 * Setup hierarchy through assigning parents.
+	 */
+	public void registerAchievementHierarchy()
+	{
+		Achievements.Presses.setParent( Achievements.Compass );
+
+		Achievements.Fluix.setParent( Achievements.ChargedQuartz );
+
+		Achievements.Charger.setParent( Achievements.Fluix );
+
+		Achievements.CrystalGrowthAccelerator.setParent( Achievements.Charger );
+
+		Achievements.GlassCable.setParent( Achievements.Charger );
+
+		Achievements.SpatialIOExplorer.setParent( Achievements.SpatialIO );
+
+		Achievements.IOPort.setParent( Achievements.StorageCell );
+
+		Achievements.PatternTerminal.setParent( Achievements.CraftingTerminal );
+
+		Achievements.Controller.setParent( Achievements.Networking1 );
+
+		Achievements.Networking2.setParent( Achievements.Controller );
+
+		Achievements.Networking3.setParent( Achievements.Networking2 );
+
+		Achievements.P2P.setParent( Achievements.Controller );
+
+		Achievements.Recursive.setParent( Achievements.Controller );
+	}
+}

--- a/src/main/java/appeng/core/stats/AchievementPickupHandler.java
+++ b/src/main/java/appeng/core/stats/AchievementPickupHandler.java
@@ -1,0 +1,63 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.core.stats;
+
+
+import net.minecraft.item.ItemStack;
+
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.common.gameevent.PlayerEvent;
+
+import appeng.util.Platform;
+
+
+/**
+ * handles the achievement when an {@link net.minecraft.item.Item} is picked up by a player.
+ * The achievement is only added if its a real {@link net.minecraft.entity.player.EntityPlayer}.
+ *
+ * @author thatsIch
+ * @since rv2
+ */
+public class AchievementPickupHandler
+{
+	private final PlayerDifferentiator differentiator;
+
+	public AchievementPickupHandler( PlayerDifferentiator differentiator )
+	{
+		this.differentiator = differentiator;
+	}
+
+	@SubscribeEvent
+	public void onItemPickUp( PlayerEvent.ItemPickupEvent event )
+	{
+		if ( this.differentiator.isNoPlayer( event.player ) || event.pickedUp == null || event.pickedUp.getEntityItem() == null )
+			return;
+
+		ItemStack is = event.pickedUp.getEntityItem();
+
+		for ( Achievements achievement : Achievements.values() )
+		{
+			if ( achievement.type == AchievementType.Pickup && Platform.isSameItemPrecise( achievement.stack, is ) )
+			{
+				achievement.addToPlayer( event.player );
+				return;
+			}
+		}
+	}
+}

--- a/src/main/java/appeng/core/stats/PlayerDifferentiator.java
+++ b/src/main/java/appeng/core/stats/PlayerDifferentiator.java
@@ -1,0 +1,48 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.core.stats;
+
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraftforge.common.util.FakePlayer;
+
+
+/**
+ * Can differentiate if a {@link net.minecraft.entity.player.EntityPlayer} is a real player or not
+ *
+ * @author thatsIch
+ * @since rv2
+ */
+public class PlayerDifferentiator
+{
+	/**
+	 * Can determine if an {@link net.minecraft.entity.player.EntityPlayer} is not a real player.
+	 * This is based on if the {@param player} is:
+	 * - null
+	 * - dead
+	 * - fake
+	 *
+ 	 * @param player to be checked player
+	 * @return true if {@param player} is not a real player
+	 */
+	public boolean isNoPlayer( EntityPlayer player )
+	{
+		return player == null || player.isDead || player instanceof FakePlayer;
+	}
+}


### PR DESCRIPTION
The AE2 has in the contract that the item field in an IAEItemDefinition can be null due to the fact, if a special item is deactivated. This needs to be checked.

The base code was enhanced through Javadoc and split in responsibilities. The fix is contained in the AchievementCraftHandler in the null check in achievement.stack
