### PR TITLE
Issuing A Crafting Job From A Non-Native Terminal

### DIFF
--- a/src/main/java/appeng/client/gui/implementations/GuiCraftConfirm.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiCraftConfirm.java
@@ -119,8 +119,8 @@ public class GuiCraftConfirm extends AEBaseGui
 		this.selectCPU.enabled = false;
 		this.buttonList.add( this.selectCPU );
 
-		if ( this.OriginalGui != null )
-			this.cancel = new GuiButton( 0, this.guiLeft + 6, this.guiTop + this.ySize - 25, 50, 20, GuiText.Cancel.getLocal() );
+		
+		this.cancel = new GuiButton( 0, this.guiLeft + 6, this.guiTop + this.ySize - 25, 50, 20, GuiText.Cancel.getLocal() );
 
 		this.buttonList.add( this.cancel );
 	}
@@ -166,7 +166,14 @@ public class GuiCraftConfirm extends AEBaseGui
 
 		if ( btn == this.cancel )
 		{
-			NetworkHandler.instance.sendToServer( new PacketSwitchGuis( this.OriginalGui ) );
+			if ( this.OriginalGui != null )
+			{
+				NetworkHandler.instance.sendToServer( new PacketSwitchGuis( this.OriginalGui ) );
+			}
+			else
+			{
+				this.mc.thePlayer.closeScreen();
+			}
 		}
 
 		if ( btn == this.start )

--- a/src/main/java/appeng/container/implementations/ContainerCraftConfirm.java
+++ b/src/main/java/appeng/container/implementations/ContainerCraftConfirm.java
@@ -321,6 +321,10 @@ public class ContainerCraftConfirm extends AEBaseContainer
 				TileEntity te = this.openContext.getTile();
 				Platform.openGUI( this.invPlayer.player, te, this.openContext.side, OriginalGui );
 			}
+			else
+			{
+				this.invPlayer.player.closeScreen();
+			}
 		}
 	}
 


### PR DESCRIPTION
Related to issue #683

Ensures the cancel button is never null.
Adds code to close GUI if OriginalGui is null.