### PR TITLE
Refactored AEItemDefinition to use Optional instead of null

### DIFF
--- a/src/api/java/appeng/api/AEApi.java
+++ b/src/api/java/appeng/api/AEApi.java
@@ -23,6 +23,7 @@
 
 package appeng.api;
 
+
 /**
  *
  * Entry point for api.
@@ -49,7 +50,7 @@ public class AEApi
 				Class c = Class.forName( "appeng.core.Api" );
 				api = (IAppEngApi) c.getField( "INSTANCE" ).get( c );
 			}
-			catch (Throwable e)
+			catch ( Throwable e )
 			{
 				return null;
 			}
@@ -57,5 +58,4 @@ public class AEApi
 
 		return api;
 	}
-
 }

--- a/src/api/java/appeng/api/IAppEngApi.java
+++ b/src/api/java/appeng/api/IAppEngApi.java
@@ -23,7 +23,9 @@
 
 package appeng.api;
 
+
 import appeng.api.definitions.Blocks;
+import appeng.api.definitions.IDefinitions;
 import appeng.api.definitions.Items;
 import appeng.api.definitions.Materials;
 import appeng.api.definitions.Parts;
@@ -31,10 +33,10 @@ import appeng.api.exceptions.FailedConnection;
 import appeng.api.features.IRegistryContainer;
 import appeng.api.networking.IGridBlock;
 import appeng.api.networking.IGridConnection;
-import appeng.api.networking.IGridHost;
 import appeng.api.networking.IGridNode;
 import appeng.api.parts.IPartHelper;
 import appeng.api.storage.IStorageHelper;
+
 
 public interface IAppEngApi
 {
@@ -56,39 +58,52 @@ public interface IAppEngApi
 
 	/**
 	 * @return an accessible list of all of AE's Items
+	 *
+	 * @deprecated use {@link appeng.api.definitions.IDefinitions#items()}
 	 */
+	@Deprecated
 	Items items();
 
 	/**
 	 * @return an accessible list of all of AE's materials; materials are items
+	 *
+	 * @deprecated use {@link appeng.api.definitions.IDefinitions#materials()}
 	 */
+	@Deprecated
 	Materials materials();
 
 	/**
 	 * @return an accessible list of all of AE's blocks
+	 *
+	 * @deprecated use {@link appeng.api.definitions.IDefinitions#blocks()}
 	 */
+	@Deprecated
 	Blocks blocks();
 
 	/**
 	 * @return an accessible list of all of AE's parts, parts are items
+	 *
+	 * @deprecated use {@link appeng.api.definitions.IDefinitions#parts()}
 	 */
+	@Deprecated
 	Parts parts();
 
 	/**
 	 * create a grid node for your {@link IGridHost}
 	 *
 	 * @param block grid block
+	 *
 	 * @return grid node of block
 	 */
-	IGridNode createGridNode(IGridBlock block);
+	IGridNode createGridNode( IGridBlock block );
 
 	/**
-	 * create a connection between two {@link IGridNode}
+	 * create a connection between two {@link appeng.api.networking.IGridNode}
 	 *
 	 * @param a to be connected gridnode
 	 * @param b to be connected gridnode
-	 * @throws FailedConnection
+	 *
+	 * @throws appeng.api.exceptions.FailedConnection
 	 */
-	IGridConnection createGridConnection(IGridNode a, IGridNode b) throws FailedConnection;
-
+	IGridConnection createGridConnection( IGridNode a, IGridNode b ) throws FailedConnection;
 }

--- a/src/api/java/appeng/api/IAppEngApi.java
+++ b/src/api/java/appeng/api/IAppEngApi.java
@@ -89,6 +89,11 @@ public interface IAppEngApi
 	Parts parts();
 
 	/**
+	 * @return an accessible list of all AE definitions
+	 */
+	IDefinitions definitions();
+
+	/**
 	 * create a grid node for your {@link IGridHost}
 	 *
 	 * @param block grid block
@@ -106,4 +111,5 @@ public interface IAppEngApi
 	 * @throws appeng.api.exceptions.FailedConnection
 	 */
 	IGridConnection createGridConnection( IGridNode a, IGridNode b ) throws FailedConnection;
+
 }

--- a/src/api/java/appeng/api/config/AccessRestriction.java
+++ b/src/api/java/appeng/api/config/AccessRestriction.java
@@ -23,49 +23,51 @@
 
 package appeng.api.config;
 
+
 public enum AccessRestriction
 {
-	NO_ACCESS(0), READ(1), WRITE(2), READ_WRITE(3);
+	NO_ACCESS( 0 ), READ( 1 ), WRITE( 2 ), READ_WRITE( 3 );
 
 	private final int permissionBit;
 
-	private AccessRestriction(int v) {
+	private AccessRestriction( int v )
+	{
 		this.permissionBit = v;
 	}
 
-	public boolean hasPermission(AccessRestriction ar)
+	public boolean hasPermission( AccessRestriction ar )
 	{
-		return ( this.permissionBit & ar.permissionBit) == ar.permissionBit;
+		return ( this.permissionBit & ar.permissionBit ) == ar.permissionBit;
 	}
 
-	public AccessRestriction restrictPermissions(AccessRestriction ar)
+	public AccessRestriction restrictPermissions( AccessRestriction ar )
 	{
-		return this.getPermByBit( this.permissionBit & ar.permissionBit);
+		return this.getPermByBit( this.permissionBit & ar.permissionBit );
 	}
 
-	public AccessRestriction addPermissions(AccessRestriction ar)
+	public AccessRestriction addPermissions( AccessRestriction ar )
 	{
-		return this.getPermByBit( this.permissionBit | ar.permissionBit);
+		return this.getPermByBit( this.permissionBit | ar.permissionBit );
 	}
 
-	public AccessRestriction removePermissions(AccessRestriction ar)
+	public AccessRestriction removePermissions( AccessRestriction ar )
 	{
-		return this.getPermByBit( this.permissionBit & (~ar.permissionBit) );
+		return this.getPermByBit( this.permissionBit & ( ~ar.permissionBit ) );
 	}
 
-	private AccessRestriction getPermByBit(int bit)
+	private AccessRestriction getPermByBit( int bit )
 	{
-		switch (bit)
+		switch ( bit )
 		{
-		default:
-		case 0:
-			return NO_ACCESS;
-		case 1:
-			return READ;
-		case 2:
-			return WRITE;
-		case 3:
-			return READ_WRITE;
+			default:
+			case 0:
+				return NO_ACCESS;
+			case 1:
+				return READ;
+			case 2:
+				return WRITE;
+			case 3:
+				return READ_WRITE;
 		}
 	}
 }

--- a/src/api/java/appeng/api/config/ActionItems.java
+++ b/src/api/java/appeng/api/config/ActionItems.java
@@ -23,6 +23,7 @@
 
 package appeng.api.config;
 
+
 public enum ActionItems
 {
 	WRENCH, CLOSE, STASH, ENCODE, SUBSTITUTION

--- a/src/api/java/appeng/api/config/Actionable.java
+++ b/src/api/java/appeng/api/config/Actionable.java
@@ -23,6 +23,7 @@
 
 package appeng.api.config;
 
+
 public enum Actionable
 {
 	/**

--- a/src/api/java/appeng/api/config/CopyMode.java
+++ b/src/api/java/appeng/api/config/CopyMode.java
@@ -23,6 +23,7 @@
 
 package appeng.api.config;
 
+
 public enum CopyMode
 {
 	CLEAR_ON_REMOVE, KEEP_ON_REMOVE

--- a/src/api/java/appeng/api/config/FullnessMode.java
+++ b/src/api/java/appeng/api/config/FullnessMode.java
@@ -23,6 +23,7 @@
 
 package appeng.api.config;
 
+
 public enum FullnessMode
 {
 	EMPTY, HALF, FULL

--- a/src/api/java/appeng/api/config/FuzzyMode.java
+++ b/src/api/java/appeng/api/config/FuzzyMode.java
@@ -23,22 +23,24 @@
 
 package appeng.api.config;
 
+
 public enum FuzzyMode
 {
 	// Note that percentage damaged, is the inverse of percentage durability.
-	IGNORE_ALL(-1), PERCENT_99(0), PERCENT_75(25), PERCENT_50(50), PERCENT_25(75);
+	IGNORE_ALL( -1 ), PERCENT_99( 0 ), PERCENT_75( 25 ), PERCENT_50( 50 ), PERCENT_25( 75 );
 
 	final public float breakPoint;
 	final public float percentage;
 
-	private FuzzyMode(float p) {
+	private FuzzyMode( float p )
+	{
 		this.percentage = p;
 		this.breakPoint = p / 100.0f;
 	}
 
-	public int calculateBreakPoint(int maxDamage)
+	public int calculateBreakPoint( int maxDamage )
 	{
-		return (int) (( this.percentage * maxDamage) / 100.0f);
+		return (int) ( ( this.percentage * maxDamage ) / 100.0f );
 	}
 
 }

--- a/src/api/java/appeng/api/config/IncludeExclude.java
+++ b/src/api/java/appeng/api/config/IncludeExclude.java
@@ -23,6 +23,7 @@
 
 package appeng.api.config;
 
+
 public enum IncludeExclude
 {
 	WHITELIST, BLACKLIST

--- a/src/api/java/appeng/api/config/LevelEmitterMode.java
+++ b/src/api/java/appeng/api/config/LevelEmitterMode.java
@@ -23,6 +23,7 @@
 
 package appeng.api.config;
 
+
 public enum LevelEmitterMode
 {
 

--- a/src/api/java/appeng/api/config/LevelType.java
+++ b/src/api/java/appeng/api/config/LevelType.java
@@ -23,6 +23,7 @@
 
 package appeng.api.config;
 
+
 public enum LevelType
 {
 

--- a/src/api/java/appeng/api/config/ModSettings.java
+++ b/src/api/java/appeng/api/config/ModSettings.java
@@ -23,6 +23,7 @@
 
 package appeng.api.config;
 
+
 public enum ModSettings
 {
 

--- a/src/api/java/appeng/api/config/NetworkEmitterMode.java
+++ b/src/api/java/appeng/api/config/NetworkEmitterMode.java
@@ -23,6 +23,7 @@
 
 package appeng.api.config;
 
+
 public enum NetworkEmitterMode
 {
 

--- a/src/api/java/appeng/api/config/OperationMode.java
+++ b/src/api/java/appeng/api/config/OperationMode.java
@@ -23,6 +23,7 @@
 
 package appeng.api.config;
 
+
 public enum OperationMode
 {
 	FILL, EMPTY

--- a/src/api/java/appeng/api/config/OutputMode.java
+++ b/src/api/java/appeng/api/config/OutputMode.java
@@ -23,6 +23,7 @@
 
 package appeng.api.config;
 
+
 public enum OutputMode
 {
 	EXPORT_ONLY, EXPORT_OR_CRAFT, CRAFT_ONLY

--- a/src/api/java/appeng/api/config/PowerMultiplier.java
+++ b/src/api/java/appeng/api/config/PowerMultiplier.java
@@ -23,6 +23,7 @@
 
 package appeng.api.config;
 
+
 public enum PowerMultiplier
 {
 	ONE, CONFIG;
@@ -32,12 +33,12 @@ public enum PowerMultiplier
 	 */
 	public double multiplier = 1.0;
 
-	public double multiply(double in)
+	public double multiply( double in )
 	{
 		return in * this.multiplier;
 	}
 
-	public double divide(double in)
+	public double divide( double in )
 	{
 		return in / this.multiplier;
 	}

--- a/src/api/java/appeng/api/config/PowerUnits.java
+++ b/src/api/java/appeng/api/config/PowerUnits.java
@@ -23,16 +23,18 @@
 
 package appeng.api.config;
 
+
 public enum PowerUnits
 {
-	AE("gui.appliedenergistics2.units.appliedenergstics"), // Native Units - AE Energy
-	MJ("gui.appliedenergistics2.units.buildcraft"), // BuildCraft - Minecraft Joules
-	EU("gui.appliedenergistics2.units.ic2"), // IndustrialCraft 2 - Energy Units
-	WA("gui.appliedenergistics2.units.rotarycraft"), // RotaryCraft - Watts
-	RF("gui.appliedenergistics2.units.thermalexpansion"), // ThermalExpansion - Redstone Flux
-	MK("gui.appliedenergistics2.units.mekanism"); // Mekanism - Joules
+	AE( "gui.appliedenergistics2.units.appliedenergstics" ), // Native Units - AE Energy
+	MJ( "gui.appliedenergistics2.units.buildcraft" ), // BuildCraft - Minecraft Joules
+	EU( "gui.appliedenergistics2.units.ic2" ), // IndustrialCraft 2 - Energy Units
+	WA( "gui.appliedenergistics2.units.rotarycraft" ), // RotaryCraft - Watts
+	RF( "gui.appliedenergistics2.units.thermalexpansion" ), // ThermalExpansion - Redstone Flux
+	MK( "gui.appliedenergistics2.units.mekanism" ); // Mekanism - Joules
 
-	private PowerUnits(String un) {
+	private PowerUnits( String un )
+	{
 		this.unlocalizedName = un;
 	}
 
@@ -54,12 +56,13 @@ public enum PowerUnits
 	 * will normally returns 64, as it will convert the EU, to AE with AE's power settings.
 	 *
 	 * @param target target power unit
-	 * @param value value
+	 * @param value  value
+	 *
 	 * @return value converted to target units, from this units.
 	 */
-	public double convertTo(PowerUnits target, double value)
+	public double convertTo( PowerUnits target, double value )
 	{
-		return (value * this.conversionRatio ) / target.conversionRatio;
+		return ( value * this.conversionRatio ) / target.conversionRatio;
 	}
 
 }

--- a/src/api/java/appeng/api/config/RedstoneMode.java
+++ b/src/api/java/appeng/api/config/RedstoneMode.java
@@ -23,6 +23,7 @@
 
 package appeng.api.config;
 
+
 public enum RedstoneMode
 {
 	IGNORE, LOW_SIGNAL, HIGH_SIGNAL, SIGNAL_PULSE

--- a/src/api/java/appeng/api/config/RelativeDirection.java
+++ b/src/api/java/appeng/api/config/RelativeDirection.java
@@ -23,6 +23,7 @@
 
 package appeng.api.config;
 
+
 public enum RelativeDirection
 {
 	LEFT, RIGHT, UP, DOW

--- a/src/api/java/appeng/api/config/SearchBoxMode.java
+++ b/src/api/java/appeng/api/config/SearchBoxMode.java
@@ -23,6 +23,7 @@
 
 package appeng.api.config;
 
+
 public enum SearchBoxMode
 {
 	AUTOSEARCH, MANUAL_SEARCH, NEI_AUTOSEARCH, NEI_MANUAL_SEARCH

--- a/src/api/java/appeng/api/config/SecurityPermissions.java
+++ b/src/api/java/appeng/api/config/SecurityPermissions.java
@@ -23,6 +23,7 @@
 
 package appeng.api.config;
 
+
 /**
  * Represent the security systems basic permissions, these are not for anti-griefing, they are part of the mod as a
  * gameplay feature.

--- a/src/api/java/appeng/api/config/SortDir.java
+++ b/src/api/java/appeng/api/config/SortDir.java
@@ -23,6 +23,7 @@
 
 package appeng.api.config;
 
+
 public enum SortDir
 {
 	ASCENDING, DESCENDING

--- a/src/api/java/appeng/api/config/SortOrder.java
+++ b/src/api/java/appeng/api/config/SortOrder.java
@@ -23,6 +23,7 @@
 
 package appeng.api.config;
 
+
 public enum SortOrder
 {
 	NAME, AMOUNT, MOD, INVTWEAKS

--- a/src/api/java/appeng/api/config/StorageFilter.java
+++ b/src/api/java/appeng/api/config/StorageFilter.java
@@ -23,6 +23,7 @@
 
 package appeng.api.config;
 
+
 public enum StorageFilter
 {
 

--- a/src/api/java/appeng/api/config/TerminalStyle.java
+++ b/src/api/java/appeng/api/config/TerminalStyle.java
@@ -23,6 +23,7 @@
 
 package appeng.api.config;
 
+
 public enum TerminalStyle
 {
 

--- a/src/api/java/appeng/api/config/TunnelType.java
+++ b/src/api/java/appeng/api/config/TunnelType.java
@@ -23,6 +23,7 @@
 
 package appeng.api.config;
 
+
 public enum TunnelType
 {
 	ME, // Network Tunnel

--- a/src/api/java/appeng/api/config/Upgrades.java
+++ b/src/api/java/appeng/api/config/Upgrades.java
@@ -26,6 +26,8 @@ package appeng.api.config;
 
 import java.util.HashMap;
 
+import javax.annotation.Nonnull;
+
 import net.minecraft.item.ItemStack;
 
 import appeng.api.util.AEItemDefinition;
@@ -59,9 +61,7 @@ public enum Upgrades
 		return this.supportedMax;
 	}
 
-
-
-	public void registerItem( AEItemDefinition myItem, int maxSupported )
+	public void registerItem( @Nonnull AEItemDefinition myItem, int maxSupported )
 	{
 		if ( myItem != null )
 		{

--- a/src/api/java/appeng/api/config/ViewItems.java
+++ b/src/api/java/appeng/api/config/ViewItems.java
@@ -23,6 +23,7 @@
 
 package appeng.api.config;
 
+
 public enum ViewItems
 {
 	ALL, STORED, CRAFTABLE

--- a/src/api/java/appeng/api/config/YesNo.java
+++ b/src/api/java/appeng/api/config/YesNo.java
@@ -23,6 +23,7 @@
 
 package appeng.api.config;
 
+
 public enum YesNo
 {
 	YES, NO, UNDECIDED

--- a/src/api/java/appeng/api/definitions/Blocks.java
+++ b/src/api/java/appeng/api/definitions/Blocks.java
@@ -23,90 +23,155 @@
 
 package appeng.api.definitions;
 
+
+import javax.annotation.Nullable;
+
 import appeng.api.util.AEItemDefinition;
+
 
 public class Blocks
 {
-
-	/*
-	 * World Gen
-	 */
+	@Nullable
 	public AEItemDefinition blockQuartzOre;
+
+	@Nullable
 	public AEItemDefinition blockQuartzOreCharged;
+
+	@Nullable
 	public AEItemDefinition blockMatrixFrame;
 
-	/*
-	 * Decorative
-	 */
+	@Nullable
 	public AEItemDefinition blockQuartz;
+
+	@Nullable
 	public AEItemDefinition blockQuartzPillar;
+
+	@Nullable
 	public AEItemDefinition blockQuartzChiseled;
+
+	@Nullable
 	public AEItemDefinition blockQuartzGlass;
+
+	@Nullable
 	public AEItemDefinition blockQuartzVibrantGlass;
+
+	@Nullable
 	public AEItemDefinition blockQuartzTorch;
+
+	@Nullable
 	public AEItemDefinition blockFluix;
+
+	@Nullable
 	public AEItemDefinition blockSkyStone;
+
+	@Nullable
 	public AEItemDefinition blockSkyChest;
+
+	@Nullable
 	public AEItemDefinition blockSkyCompass;
 
-	/*
-	 * Misc
-	 */
+	@Nullable
 	public AEItemDefinition blockGrindStone;
+
+	@Nullable
 	public AEItemDefinition blockCrankHandle;
+
+	@Nullable
 	public AEItemDefinition blockInscriber;
+
+	@Nullable
 	public AEItemDefinition blockWireless;
+
+	@Nullable
 	public AEItemDefinition blockCharger;
+
+	@Nullable
 	public AEItemDefinition blockTinyTNT;
+
+	@Nullable
 	public AEItemDefinition blockSecurity;
 
-	/*
-	 * Quantum Network Bridge
-	 */
+	@Nullable
 	public AEItemDefinition blockQuantumRing;
+
+	@Nullable
 	public AEItemDefinition blockQuantumLink;
 
-	/*
-	 * Spatial IO
-	 */
+	@Nullable
 	public AEItemDefinition blockSpatialPylon;
+
+	@Nullable
 	public AEItemDefinition blockSpatialIOPort;
 
-	/*
-	 * Bus / Cables
-	 */
+	@Nullable
 	public AEItemDefinition blockMultiPart;
 
-	/*
-	 * Machines
-	 */
+	@Nullable
 	public AEItemDefinition blockController;
+
+	@Nullable
 	public AEItemDefinition blockDrive;
+
+	@Nullable
 	public AEItemDefinition blockChest;
+
+	@Nullable
 	public AEItemDefinition blockInterface;
+
+	@Nullable
 	public AEItemDefinition blockCellWorkbench;
+
+	@Nullable
 	public AEItemDefinition blockIOPort;
+
+	@Nullable
 	public AEItemDefinition blockCondenser;
+
+	@Nullable
 	public AEItemDefinition blockEnergyAcceptor;
+
+	@Nullable
 	public AEItemDefinition blockVibrationChamber;
+
+	@Nullable
 	public AEItemDefinition blockQuartzGrowthAccelerator;
 
+	@Nullable
 	public AEItemDefinition blockEnergyCell;
+
+	@Nullable
 	public AEItemDefinition blockEnergyCellDense;
+
+	@Nullable
 	public AEItemDefinition blockEnergyCellCreative;
 
-	// rv1
+	@Nullable
 	public AEItemDefinition blockCraftingUnit;
+
+	@Nullable
 	public AEItemDefinition blockCraftingAccelerator;
+
+	@Nullable
 	public AEItemDefinition blockCraftingStorage1k;
+
+	@Nullable
 	public AEItemDefinition blockCraftingStorage4k;
+
+	@Nullable
 	public AEItemDefinition blockCraftingStorage16k;
+
+	@Nullable
 	public AEItemDefinition blockCraftingStorage64k;
+
+	@Nullable
 	public AEItemDefinition blockCraftingMonitor;
 
+	@Nullable
 	public AEItemDefinition blockMolecularAssembler;
 
+	@Nullable
 	public AEItemDefinition blockLightDetector;
-	public AEItemDefinition blockPaint;
 
+	@Nullable
+	public AEItemDefinition blockPaint;
 }

--- a/src/api/java/appeng/api/definitions/IBlocks.java
+++ b/src/api/java/appeng/api/definitions/IBlocks.java
@@ -1,0 +1,189 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2013 AlgorithmX2
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.api.definitions;
+
+
+import com.google.common.base.Optional;
+
+import appeng.api.util.AEItemDefinition;
+
+
+/**
+ * All access is optional due to the ability to disable certain functionality via a configuration file.
+ * This needs to be caught on the used side.
+ */
+public interface IBlocks
+{
+	/*
+	 * world gen
+	 */
+	Optional<AEItemDefinition> quartzOre();
+
+	Optional<AEItemDefinition> quartzOreCharged();
+
+	Optional<AEItemDefinition> matrixFrame();
+
+	/*
+	 * decorative
+	 */
+	Optional<AEItemDefinition> quartz();
+
+	Optional<AEItemDefinition> quartzPillar();
+
+	Optional<AEItemDefinition> quartzChiseled();
+
+	Optional<AEItemDefinition> quartzGlass();
+
+	Optional<AEItemDefinition> quartzVibrantGlass();
+
+	Optional<AEItemDefinition> quartzTorch();
+
+	Optional<AEItemDefinition> fluix();
+
+	Optional<AEItemDefinition> skyStone();
+
+	Optional<AEItemDefinition> skyChest();
+
+	Optional<AEItemDefinition> skyCompass();
+
+	Optional<AEItemDefinition> skyStoneStair();
+
+	Optional<AEItemDefinition> skyStoneBlockStair();
+
+	Optional<AEItemDefinition> skyStoneBrickStair();
+
+	Optional<AEItemDefinition> skyStoneSmallBrickStair();
+
+	Optional<AEItemDefinition> fluixStair();
+
+	Optional<AEItemDefinition> quartzStair();
+
+	Optional<AEItemDefinition> chiseledQuartzStair();
+
+	Optional<AEItemDefinition> quartzPillarStair();
+
+	/*
+	 * misc
+	 */
+	Optional<AEItemDefinition> grindStone();
+
+	Optional<AEItemDefinition> crankHandle();
+
+	Optional<AEItemDefinition> inscriber();
+
+	Optional<AEItemDefinition> wireless();
+
+	Optional<AEItemDefinition> charger();
+
+	Optional<AEItemDefinition> tinyTNT();
+
+	Optional<AEItemDefinition> security();
+
+	/*
+	 * quantum Network Bridge
+	 */
+	Optional<AEItemDefinition> quantumRing();
+
+	Optional<AEItemDefinition> quantumLink();
+
+	/*
+	 * spatial iO
+	 */
+	Optional<AEItemDefinition> spatialPylon();
+
+	Optional<AEItemDefinition> spatialIOPort();
+
+	/*
+	 * Bus / cables
+	 */
+	Optional<AEItemDefinition> multiPart();
+
+	/*
+	 * machines
+	 */
+	Optional<AEItemDefinition> controller();
+
+	Optional<AEItemDefinition> drive();
+
+	Optional<AEItemDefinition> chest();
+
+	Optional<AEItemDefinition> iface();
+
+	Optional<AEItemDefinition> cellWorkbench();
+
+	Optional<AEItemDefinition> iOPort();
+
+	Optional<AEItemDefinition> condenser();
+
+	Optional<AEItemDefinition> energyAcceptor();
+
+	Optional<AEItemDefinition> vibrationChamber();
+
+	Optional<AEItemDefinition> quartzGrowthAccelerator();
+
+	Optional<AEItemDefinition> energyCell();
+
+	Optional<AEItemDefinition> energyCellDense();
+
+	Optional<AEItemDefinition> energyCellCreative();
+
+	// rv1
+	Optional<AEItemDefinition> craftingUnit();
+
+	Optional<AEItemDefinition> craftingAccelerator();
+
+	Optional<AEItemDefinition> craftingStorage1k();
+
+	Optional<AEItemDefinition> craftingStorage4k();
+
+	Optional<AEItemDefinition> craftingStorage16k();
+
+	Optional<AEItemDefinition> craftingStorage64k();
+
+	Optional<AEItemDefinition> craftingMonitor();
+
+	Optional<AEItemDefinition> molecularAssembler();
+
+	Optional<AEItemDefinition> lightDetector();
+
+	Optional<AEItemDefinition> paint();
+}

--- a/src/api/java/appeng/api/definitions/IDefinitions.java
+++ b/src/api/java/appeng/api/definitions/IDefinitions.java
@@ -1,0 +1,66 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2013 AlgorithmX2
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.api.definitions;
+
+
+public interface IDefinitions
+{
+	/**
+	 * @return an accessible list of all of AE's blocks
+	 */
+	IBlocks blocks();
+
+	/**
+	 * @return an accessible list of all of AE's Items
+	 */
+	IItems items();
+
+	/**
+	 * @return an accessible list of all of AE's materials; materials are items
+	 */
+	IMaterials materials();
+
+	/**
+	 * @return an accessible list of all of AE's parts, parts are items
+	 */
+	IParts parts();
+}

--- a/src/api/java/appeng/api/definitions/IItems.java
+++ b/src/api/java/appeng/api/definitions/IItems.java
@@ -1,0 +1,127 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2013 AlgorithmX2
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.api.definitions;
+
+
+import com.google.common.base.Optional;
+
+import appeng.api.util.AEColoredItemDefinition;
+import appeng.api.util.AEItemDefinition;
+
+
+public interface IItems
+{
+	Optional<AEItemDefinition> certusQuartzAxe();
+
+	Optional<AEItemDefinition> certusQuartzHoe();
+
+	Optional<AEItemDefinition> certusQuartzShovel();
+
+	Optional<AEItemDefinition> certusQuartzPick();
+
+	Optional<AEItemDefinition> certusQuartzSword();
+
+	Optional<AEItemDefinition> certusQuartzWrench();
+
+	Optional<AEItemDefinition> certusQuartzKnife();
+
+	Optional<AEItemDefinition> netherQuartzAxe();
+
+	Optional<AEItemDefinition> netherQuartzHoe();
+
+	Optional<AEItemDefinition> netherQuartzShovel();
+
+	Optional<AEItemDefinition> netherQuartzPick();
+
+	Optional<AEItemDefinition> netherQuartzSword();
+
+	Optional<AEItemDefinition> netherQuartzWrench();
+
+	Optional<AEItemDefinition> netherQuartzKnife();
+
+	Optional<AEItemDefinition> entropyManipulator();
+
+	Optional<AEItemDefinition> wirelessTerminal();
+
+	Optional<AEItemDefinition> biometricCard();
+
+	Optional<AEItemDefinition> chargedStaff();
+
+	Optional<AEItemDefinition> massCannon();
+
+	Optional<AEItemDefinition> memoryCard();
+
+	Optional<AEItemDefinition> networkTool();
+
+	Optional<AEItemDefinition> portableCell();
+
+	Optional<AEItemDefinition> cellCreative();
+
+	Optional<AEItemDefinition> viewCell();
+
+	Optional<AEItemDefinition> cell1k();
+
+	Optional<AEItemDefinition> cell4k();
+
+	Optional<AEItemDefinition> cell16k();
+
+	Optional<AEItemDefinition> cell64k();
+
+	Optional<AEItemDefinition> spatialCell2();
+
+	Optional<AEItemDefinition> spatialCell16();
+
+	Optional<AEItemDefinition> spatialCell128();
+
+	Optional<AEItemDefinition> facade();
+
+	Optional<AEItemDefinition> crystalSeed();
+
+	// rv1
+	Optional<AEItemDefinition> encodedPattern();
+
+	Optional<AEItemDefinition> colorApplicator();
+
+	Optional<AEColoredItemDefinition> coloredPaintBall();
+
+	Optional<AEColoredItemDefinition> coloredLumenPaintBall();
+}

--- a/src/api/java/appeng/api/definitions/IMaterials.java
+++ b/src/api/java/appeng/api/definitions/IMaterials.java
@@ -1,0 +1,159 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2013 AlgorithmX2
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.api.definitions;
+
+
+import com.google.common.base.Optional;
+
+import appeng.api.util.AEItemDefinition;
+
+
+public interface IMaterials
+{
+	Optional<AEItemDefinition> cell2SpatialPart();
+
+	Optional<AEItemDefinition> cell16SpatialPart();
+
+	Optional<AEItemDefinition> cell128SpatialPart();
+
+	Optional<AEItemDefinition> silicon();
+
+	Optional<AEItemDefinition> skyDust();
+
+	Optional<AEItemDefinition> calcProcessorPress();
+
+	Optional<AEItemDefinition> engProcessorPress();
+
+	Optional<AEItemDefinition> logicProcessorPress();
+
+	Optional<AEItemDefinition> calcProcessorPrint();
+
+	Optional<AEItemDefinition> engProcessorPrint();
+
+	Optional<AEItemDefinition> logicProcessorPrint();
+
+	Optional<AEItemDefinition> siliconPress();
+
+	Optional<AEItemDefinition> siliconPrint();
+
+	Optional<AEItemDefinition> namePress();
+
+	Optional<AEItemDefinition> logicProcessor();
+
+	Optional<AEItemDefinition> calcProcessor();
+
+	Optional<AEItemDefinition> engProcessor();
+
+	Optional<AEItemDefinition> basicCard();
+
+	Optional<AEItemDefinition> advCard();
+
+	Optional<AEItemDefinition> purifiedCertusQuartzCrystal();
+
+	Optional<AEItemDefinition> purifiedNetherQuartzCrystal();
+
+	Optional<AEItemDefinition> purifiedFluixCrystal();
+
+	Optional<AEItemDefinition> cell1kPart();
+
+	Optional<AEItemDefinition> cell4kPart();
+
+	Optional<AEItemDefinition> cell16kPart();
+
+	Optional<AEItemDefinition> cell64kPart();
+
+	Optional<AEItemDefinition> emptyStorageCell();
+
+	Optional<AEItemDefinition> cardRedstone();
+
+	Optional<AEItemDefinition> cardSpeed();
+
+	Optional<AEItemDefinition> cardCapacity();
+
+	Optional<AEItemDefinition> cardFuzzy();
+
+	Optional<AEItemDefinition> cardInverter();
+
+	Optional<AEItemDefinition> cardCrafting();
+
+	Optional<AEItemDefinition> enderDust();
+
+	Optional<AEItemDefinition> flour();
+
+	Optional<AEItemDefinition> goldDust();
+
+	Optional<AEItemDefinition> ironDust();
+
+	Optional<AEItemDefinition> fluixDust();
+
+	Optional<AEItemDefinition> certusQuartzDust();
+
+	Optional<AEItemDefinition> netherQuartzDust();
+
+	Optional<AEItemDefinition> matterBall();
+
+	Optional<AEItemDefinition> ironNugget();
+
+	Optional<AEItemDefinition> certusQuartzCrystal();
+
+	Optional<AEItemDefinition> certusQuartzCrystalCharged();
+
+	Optional<AEItemDefinition> fluixCrystal();
+
+	Optional<AEItemDefinition> fluixPearl();
+
+	Optional<AEItemDefinition> woodenGear();
+
+	Optional<AEItemDefinition> wireless();
+
+	Optional<AEItemDefinition> wirelessBooster();
+
+	Optional<AEItemDefinition> annihilationCore();
+
+	Optional<AEItemDefinition> formationCore();
+
+	Optional<AEItemDefinition> singularity();
+
+	Optional<AEItemDefinition> qESingularity();
+
+	Optional<AEItemDefinition> blankPattern();
+}

--- a/src/api/java/appeng/api/definitions/IParts.java
+++ b/src/api/java/appeng/api/definitions/IParts.java
@@ -1,0 +1,124 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2013 AlgorithmX2
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.api.definitions;
+
+
+import com.google.common.base.Optional;
+
+import appeng.api.util.AEColoredItemDefinition;
+import appeng.api.util.AEItemDefinition;
+
+
+public interface IParts
+{
+	Optional<AEColoredItemDefinition> cableSmart();
+
+	Optional<AEColoredItemDefinition> cableCovered();
+
+	Optional<AEColoredItemDefinition> cableGlass();
+
+	Optional<AEColoredItemDefinition> cableDense();
+
+	Optional<AEColoredItemDefinition> lumenCableSmart();
+
+	Optional<AEColoredItemDefinition> lumenCableCovered();
+
+	Optional<AEColoredItemDefinition> lumenCableGlass();
+
+	Optional<AEColoredItemDefinition> lumenCableDense();
+
+	Optional<AEItemDefinition> quartzFiber();
+
+	Optional<AEItemDefinition> toggleBus();
+
+	Optional<AEItemDefinition> invertedToggleBus();
+
+	Optional<AEItemDefinition> storageBus();
+
+	Optional<AEItemDefinition> importBus();
+
+	Optional<AEItemDefinition> exportBus();
+
+	Optional<AEItemDefinition> iface();
+
+	Optional<AEItemDefinition> levelEmitter();
+
+	Optional<AEItemDefinition> annihilationPlane();
+
+	Optional<AEItemDefinition> formationPlane();
+
+	Optional<AEItemDefinition> p2PTunnelME();
+
+	Optional<AEItemDefinition> p2PTunnelRedstone();
+
+	Optional<AEItemDefinition> p2PTunnelItems();
+
+	Optional<AEItemDefinition> p2PTunnelLiquids();
+
+	Optional<AEItemDefinition> p2PTunnelMJ();
+
+	Optional<AEItemDefinition> p2PTunnelEU();
+
+	Optional<AEItemDefinition> p2PTunnelRF();
+
+	Optional<AEItemDefinition> p2PTunnelLight();
+
+	Optional<AEItemDefinition> cableAnchor();
+
+	Optional<AEItemDefinition> monitor();
+
+	Optional<AEItemDefinition> semiDarkMonitor();
+
+	Optional<AEItemDefinition> darkMonitor();
+
+	Optional<AEItemDefinition> interfaceTerminal();
+
+	Optional<AEItemDefinition> patternTerminal();
+
+	Optional<AEItemDefinition> craftingTerminal();
+
+	Optional<AEItemDefinition> terminal();
+
+	Optional<AEItemDefinition> storageMonitor();
+
+	Optional<AEItemDefinition> conversionMonitor();
+}

--- a/src/api/java/appeng/api/definitions/Items.java
+++ b/src/api/java/appeng/api/definitions/Items.java
@@ -23,55 +23,123 @@
 
 package appeng.api.definitions;
 
+
+import javax.annotation.Nullable;
+
 import appeng.api.util.AEColoredItemDefinition;
 import appeng.api.util.AEItemDefinition;
 
+
 public class Items
 {
-
+	@Nullable
 	public AEItemDefinition itemCertusQuartzAxe;
+
+	@Nullable
 	public AEItemDefinition itemCertusQuartzHoe;
+
+	@Nullable
 	public AEItemDefinition itemCertusQuartzShovel;
+
+	@Nullable
 	public AEItemDefinition itemCertusQuartzPick;
+
+	@Nullable
 	public AEItemDefinition itemCertusQuartzSword;
+
+	@Nullable
 	public AEItemDefinition itemCertusQuartzWrench;
+
+	@Nullable
 	public AEItemDefinition itemCertusQuartzKnife;
 
+	@Nullable
 	public AEItemDefinition itemNetherQuartzAxe;
+
+	@Nullable
 	public AEItemDefinition itemNetherQuartzHoe;
+
+	@Nullable
 	public AEItemDefinition itemNetherQuartzShovel;
+
+	@Nullable
 	public AEItemDefinition itemNetherQuartzPick;
+
+	@Nullable
 	public AEItemDefinition itemNetherQuartzSword;
+
+	@Nullable
 	public AEItemDefinition itemNetherQuartzWrench;
+
+	@Nullable
 	public AEItemDefinition itemNetherQuartzKnife;
 
+	@Nullable
 	public AEItemDefinition itemEntropyManipulator;
+
+	@Nullable
 	public AEItemDefinition itemWirelessTerminal;
+
+	@Nullable
 	public AEItemDefinition itemBiometricCard;
+
+	@Nullable
 	public AEItemDefinition itemChargedStaff;
+
+	@Nullable
 	public AEItemDefinition itemMassCannon;
+
+	@Nullable
 	public AEItemDefinition itemMemoryCard;
+
+	@Nullable
 	public AEItemDefinition itemNetworkTool;
+
+	@Nullable
 	public AEItemDefinition itemPortableCell;
 
+	@Nullable
 	public AEItemDefinition itemCellCreative;
+
+	@Nullable
 	public AEItemDefinition itemViewCell;
 
+	@Nullable
 	public AEItemDefinition itemCell1k;
+
+	@Nullable
 	public AEItemDefinition itemCell4k;
+
+	@Nullable
 	public AEItemDefinition itemCell16k;
+
+	@Nullable
 	public AEItemDefinition itemCell64k;
 
+	@Nullable
 	public AEItemDefinition itemSpatialCell2;
+
+	@Nullable
 	public AEItemDefinition itemSpatialCell16;
+
+	@Nullable
 	public AEItemDefinition itemSpatialCell128;
 
+	@Nullable
 	public AEItemDefinition itemFacade;
+
+	@Nullable
 	public AEItemDefinition itemCrystalSeed;
 
-	// rv1
+	@Nullable
 	public AEItemDefinition itemEncodedPattern;
+
+	@Nullable
 	public AEItemDefinition itemColorApplicator;
+
+	@Nullable
 	public AEColoredItemDefinition itemPaintBall;
+
+	@Nullable
 	public AEColoredItemDefinition itemLumenPaintBall;
 }

--- a/src/api/java/appeng/api/definitions/Materials.java
+++ b/src/api/java/appeng/api/definitions/Materials.java
@@ -23,81 +23,173 @@
 
 package appeng.api.definitions;
 
+
+import javax.annotation.Nullable;
+
 import appeng.api.util.AEItemDefinition;
+
 
 public class Materials
 {
-
+	@Nullable
 	public AEItemDefinition materialCell2SpatialPart;
+
+	@Nullable
 	public AEItemDefinition materialCell16SpatialPart;
+
+	@Nullable
 	public AEItemDefinition materialCell128SpatialPart;
 
+	@Nullable
 	public AEItemDefinition materialSilicon;
+
+	@Nullable
 	public AEItemDefinition materialSkyDust;
 
+	@Nullable
 	public AEItemDefinition materialCalcProcessorPress;
+
+	@Nullable
 	public AEItemDefinition materialEngProcessorPress;
+
+	@Nullable
 	public AEItemDefinition materialLogicProcessorPress;
 
+	@Nullable
 	public AEItemDefinition materialCalcProcessorPrint;
+
+	@Nullable
 	public AEItemDefinition materialEngProcessorPrint;
+
+	@Nullable
 	public AEItemDefinition materialLogicProcessorPrint;
 
+	@Nullable
 	public AEItemDefinition materialSiliconPress;
+
+	@Nullable
 	public AEItemDefinition materialSiliconPrint;
 
+	@Nullable
 	public AEItemDefinition materialNamePress;
 
+	@Nullable
 	public AEItemDefinition materialLogicProcessor;
+
+	@Nullable
 	public AEItemDefinition materialCalcProcessor;
+
+	@Nullable
 	public AEItemDefinition materialEngProcessor;
 
+	@Nullable
 	public AEItemDefinition materialBasicCard;
+
+	@Nullable
 	public AEItemDefinition materialAdvCard;
 
+	@Nullable
 	public AEItemDefinition materialPurifiedCertusQuartzCrystal;
+
+	@Nullable
 	public AEItemDefinition materialPurifiedNetherQuartzCrystal;
+
+	@Nullable
 	public AEItemDefinition materialPurifiedFluixCrystal;
 
+	@Nullable
 	public AEItemDefinition materialCell1kPart;
+
+	@Nullable
 	public AEItemDefinition materialCell4kPart;
+
+	@Nullable
 	public AEItemDefinition materialCell16kPart;
+
+	@Nullable
 	public AEItemDefinition materialCell64kPart;
+
+	@Nullable
 	public AEItemDefinition materialEmptyStorageCell;
 
+	@Nullable
 	public AEItemDefinition materialCardRedstone;
+
+	@Nullable
 	public AEItemDefinition materialCardSpeed;
+
+	@Nullable
 	public AEItemDefinition materialCardCapacity;
+
+	@Nullable
 	public AEItemDefinition materialCardFuzzy;
+
+	@Nullable
 	public AEItemDefinition materialCardInverter;
+
+	@Nullable
 	public AEItemDefinition materialCardCrafting;
 
+	@Nullable
 	public AEItemDefinition materialEnderDust;
+
+	@Nullable
 	public AEItemDefinition materialFlour;
+
+	@Nullable
 	public AEItemDefinition materialGoldDust;
+
+	@Nullable
 	public AEItemDefinition materialIronDust;
+
+	@Nullable
 	public AEItemDefinition materialFluixDust;
+
+	@Nullable
 	public AEItemDefinition materialCertusQuartzDust;
+
+	@Nullable
 	public AEItemDefinition materialNetherQuartzDust;
 
+	@Nullable
 	public AEItemDefinition materialMatterBall;
+
+	@Nullable
 	public AEItemDefinition materialIronNugget;
 
+	@Nullable
 	public AEItemDefinition materialCertusQuartzCrystal;
+
+	@Nullable
 	public AEItemDefinition materialCertusQuartzCrystalCharged;
+
+	@Nullable
 	public AEItemDefinition materialFluixCrystal;
+
+	@Nullable
 	public AEItemDefinition materialFluixPearl;
 
+	@Nullable
 	public AEItemDefinition materialWoodenGear;
 
+	@Nullable
 	public AEItemDefinition materialWireless;
+
+	@Nullable
 	public AEItemDefinition materialWirelessBooster;
 
+	@Nullable
 	public AEItemDefinition materialAnnihilationCore;
+
+	@Nullable
 	public AEItemDefinition materialFormationCore;
 
+	@Nullable
 	public AEItemDefinition materialSingularity;
-	public AEItemDefinition materialQESingularity;
-	public AEItemDefinition materialBlankPattern;
 
+	@Nullable
+	public AEItemDefinition materialQESingularity;
+
+	@Nullable
+	public AEItemDefinition materialBlankPattern;
 }

--- a/src/api/java/appeng/api/definitions/Parts.java
+++ b/src/api/java/appeng/api/definitions/Parts.java
@@ -23,54 +23,120 @@
 
 package appeng.api.definitions;
 
+
+import javax.annotation.Nullable;
+
 import appeng.api.util.AEColoredItemDefinition;
 import appeng.api.util.AEItemDefinition;
 
+
 public class Parts
 {
-
+	@Nullable
 	public AEColoredItemDefinition partCableSmart;
+
+	@Nullable
 	public AEColoredItemDefinition partCableCovered;
+
+	@Nullable
 	public AEColoredItemDefinition partCableGlass;
+
+	@Nullable
 	public AEColoredItemDefinition partCableDense;
 
+	@Nullable
 	public AEColoredItemDefinition partLumenCableSmart;
+
+	@Nullable
 	public AEColoredItemDefinition partLumenCableCovered;
+
+	@Nullable
 	public AEColoredItemDefinition partLumenCableGlass;
+
+	@Nullable
 	public AEColoredItemDefinition partLumenCableDense;
 
+	@Nullable
 	public AEItemDefinition partQuartzFiber;
+
+	@Nullable
 	public AEItemDefinition partToggleBus;
+
+	@Nullable
 	public AEItemDefinition partInvertedToggleBus;
 
+	@Nullable
 	public AEItemDefinition partStorageBus;
+
+	@Nullable
 	public AEItemDefinition partImportBus;
+
+	@Nullable
 	public AEItemDefinition partExportBus;
+
+	@Nullable
 	public AEItemDefinition partInterface;
 
+	@Nullable
 	public AEItemDefinition partLevelEmitter;
 
+	@Nullable
 	public AEItemDefinition partAnnihilationPlane;
+
+	@Nullable
 	public AEItemDefinition partFormationPlane;
 
+	@Nullable
 	public AEItemDefinition partP2PTunnelME;
+
+	@Nullable
 	public AEItemDefinition partP2PTunnelRedstone;
+
+	@Nullable
 	public AEItemDefinition partP2PTunnelItems;
+
+	@Nullable
 	public AEItemDefinition partP2PTunnelLiquids;
+
+	@Nullable
 	public AEItemDefinition partP2PTunnelMJ;
+
+	@Nullable
 	public AEItemDefinition partP2PTunnelEU;
+
+	@Nullable
 	public AEItemDefinition partP2PTunnelRF;
+
+	@Nullable
 	public AEItemDefinition partP2PTunnelLight;
 
+	@Nullable
 	public AEItemDefinition partCableAnchor;
+
+	@Nullable
 	public AEItemDefinition partMonitor;
+
+	@Nullable
 	public AEItemDefinition partSemiDarkMonitor;
+
+	@Nullable
 	public AEItemDefinition partDarkMonitor;
 
+	@Nullable
 	public AEItemDefinition partInterfaceTerminal;
+
+	@Nullable
 	public AEItemDefinition partPatternTerminal;
+
+	@Nullable
 	public AEItemDefinition partCraftingTerminal;
+
+	@Nullable
 	public AEItemDefinition partTerminal;
+
+	@Nullable
 	public AEItemDefinition partStorageMonitor;
+
+	@Nullable
 	public AEItemDefinition partConversionMonitor;
 }

--- a/src/api/java/appeng/api/events/LocatableEventAnnounce.java
+++ b/src/api/java/appeng/api/events/LocatableEventAnnounce.java
@@ -23,8 +23,11 @@
 
 package appeng.api.events;
 
-import appeng.api.features.ILocatable;
+
 import cpw.mods.fml.common.eventhandler.Event;
+
+import appeng.api.features.ILocatable;
+
 
 /**
  * Input Event:
@@ -40,12 +43,13 @@ public class LocatableEventAnnounce extends Event
 		Unregister // Removes the locatable from the registry
 	}
 
+
 	final public ILocatable target;
 	final public LocatableEvent change;
 
-	public LocatableEventAnnounce(ILocatable o, LocatableEvent ev) {
+	public LocatableEventAnnounce( ILocatable o, LocatableEvent ev )
+	{
 		this.target = o;
 		this.change = ev;
 	}
-
 }

--- a/src/api/java/appeng/api/exceptions/AppEngException.java
+++ b/src/api/java/appeng/api/exceptions/AppEngException.java
@@ -23,12 +23,14 @@
 
 package appeng.api.exceptions;
 
+
 public class AppEngException extends Exception
 {
 
 	private static final long serialVersionUID = -9051434206368465494L;
 
-	public AppEngException(String t) {
+	public AppEngException( String t )
+	{
 		super( t );
 	}
 }

--- a/src/api/java/appeng/api/exceptions/FailedConnection.java
+++ b/src/api/java/appeng/api/exceptions/FailedConnection.java
@@ -23,11 +23,13 @@
 
 package appeng.api.exceptions;
 
+
 public class FailedConnection extends Exception
 {
 
 	private static final long serialVersionUID = -2544208090248293753L;
 
-	public FailedConnection() {
+	public FailedConnection()
+	{
 	}
 }

--- a/src/api/java/appeng/api/exceptions/MissingIngredientError.java
+++ b/src/api/java/appeng/api/exceptions/MissingIngredientError.java
@@ -23,12 +23,14 @@
 
 package appeng.api.exceptions;
 
-public class MissingIngredientError extends Exception {
+
+public class MissingIngredientError extends Exception
+{
 
 	private static final long serialVersionUID = -998858343831371697L;
 
-	public MissingIngredientError(String n) {
+	public MissingIngredientError( String n )
+	{
 		super( n );
 	}
-
 }

--- a/src/api/java/appeng/api/exceptions/ModNotInstalled.java
+++ b/src/api/java/appeng/api/exceptions/ModNotInstalled.java
@@ -23,13 +23,14 @@
 
 package appeng.api.exceptions;
 
+
 public class ModNotInstalled extends Exception
 {
 
 	private static final long serialVersionUID = -9052435206368425494L;
 
-	public ModNotInstalled(String t) {
+	public ModNotInstalled( String t )
+	{
 		super( t );
 	}
-
 }

--- a/src/api/java/appeng/api/exceptions/RecipeError.java
+++ b/src/api/java/appeng/api/exceptions/RecipeError.java
@@ -23,13 +23,14 @@
 
 package appeng.api.exceptions;
 
+
 public class RecipeError extends Exception
 {
 
 	private static final long serialVersionUID = -6602870588617670262L;
 
-	public RecipeError(String n) {
+	public RecipeError( String n )
+	{
 		super( n );
 	}
-
 }

--- a/src/api/java/appeng/api/exceptions/RegistrationError.java
+++ b/src/api/java/appeng/api/exceptions/RegistrationError.java
@@ -23,13 +23,14 @@
 
 package appeng.api.exceptions;
 
+
 public class RegistrationError extends Exception
 {
 
 	private static final long serialVersionUID = -6602870588617670263L;
 
-	public RegistrationError(String n) {
+	public RegistrationError( String n )
+	{
 		super( n );
 	}
-
 }

--- a/src/api/java/appeng/api/features/IGrinderEntry.java
+++ b/src/api/java/appeng/api/features/IGrinderEntry.java
@@ -23,7 +23,9 @@
 
 package appeng.api.features;
 
+
 import net.minecraft.item.ItemStack;
+
 
 /**
  * Registration Records for {@link IGrinderRegistry}
@@ -43,7 +45,7 @@ public interface IGrinderEntry
 	 *
 	 * @param input input item
 	 */
-	public void setInput(ItemStack input);
+	public void setInput( ItemStack input );
 
 	/**
 	 * gets the current output
@@ -71,7 +73,7 @@ public interface IGrinderEntry
 	 *
 	 * @param output output item
 	 */
-	public void setOutput(ItemStack output);
+	public void setOutput( ItemStack output );
 
 	/**
 	 * stack, and 0.0-1.0 chance that it will be generated.
@@ -79,7 +81,7 @@ public interface IGrinderEntry
 	 * @param output output item
 	 * @param chance generation chance
 	 */
-	public void setOptionalOutput(ItemStack output, float chance);
+	public void setOptionalOutput( ItemStack output, float chance );
 
 	/**
 	 * 0.0 - 1.0 the chance that the optional output will be generated.
@@ -94,7 +96,7 @@ public interface IGrinderEntry
 	 * @param output second optional output item
 	 * @param chance second optional output chance
 	 */
-	public void setSecondOptionalOutput(ItemStack output, float chance);
+	public void setSecondOptionalOutput( ItemStack output, float chance );
 
 	/**
 	 * 0.0 - 1.0 the chance that the optional output will be generated.
@@ -115,5 +117,5 @@ public interface IGrinderEntry
 	 *
 	 * @param c number of turns to produce output.
 	 */
-	public void setEnergyCost(int c);
+	public void setEnergyCost( int c );
 }

--- a/src/api/java/appeng/api/features/IGrinderRegistry.java
+++ b/src/api/java/appeng/api/features/IGrinderRegistry.java
@@ -23,9 +23,11 @@
 
 package appeng.api.features;
 
-import net.minecraft.item.ItemStack;
 
 import java.util.List;
+
+import net.minecraft.item.ItemStack;
+
 
 /**
  * Lets you manipulate Grinder Recipes, by adding or editing existing ones.
@@ -47,7 +49,7 @@ public interface IGrinderRegistry
 	 * @param out output
 	 * @param turns amount of turns to turn the input into the output
 	 */
-	public void addRecipe(ItemStack in, ItemStack out, int turns);
+	public void addRecipe( ItemStack in, ItemStack out, int turns );
 
 	/**
 	 * add a new recipe with optional outputs, duplicates will not be added.
@@ -55,10 +57,10 @@ public interface IGrinderRegistry
 	 * @param in input
 	 * @param out output
 	 * @param optional optional output
-	 * @param chance chance to get the optional output within 0.0 - 1.0
-	 * @param turns amount of turns to turn the input into the outputs
+	 * @param chance   chance to get the optional output within 0.0 - 1.0
+	 * @param turns    amount of turns to turn the input into the outputs
 	 */
-	void addRecipe(ItemStack in, ItemStack out, ItemStack optional, float chance, int turns);
+	void addRecipe( ItemStack in, ItemStack out, ItemStack optional, float chance, int turns );
 
 	/**
 	 * add a new recipe with optional outputs, duplicates will not be added.
@@ -68,17 +70,17 @@ public interface IGrinderRegistry
 	 * @param optional optional output
 	 * @param chance chance to get the optional output within 0.0 - 1.0
 	 * @param optional2 second optional output
-	 * @param chance2 chance to get the second optional output within 0.0 - 1.0
-	 * @param turns amount of turns to turn the input into the outputs
+	 * @param chance2   chance to get the second optional output within 0.0 - 1.0
+	 * @param turns     amount of turns to turn the input into the outputs
 	 */
-	void addRecipe(ItemStack in, ItemStack out, ItemStack optional, float chance, ItemStack optional2, float chance2, int turns);
+	void addRecipe( ItemStack in, ItemStack out, ItemStack optional, float chance, ItemStack optional2, float chance2, int turns );
 
 	/**
 	 * Searches for a recipe for a given input, and returns it.
 	 *
 	 * @param input input
+	 *
 	 * @return identified recipe or null
 	 */
-	public IGrinderEntry getRecipeForInput(ItemStack input);
-
+	public IGrinderEntry getRecipeForInput( ItemStack input );
 }

--- a/src/api/java/appeng/api/features/IItemComparison.java
+++ b/src/api/java/appeng/api/features/IItemComparison.java
@@ -23,11 +23,11 @@
 
 package appeng.api.features;
 
+
 public interface IItemComparison
 {
 
-	public boolean sameAsPrecise(IItemComparison comp);
+	public boolean sameAsPrecise( IItemComparison comp );
 
-	public boolean sameAsFuzzy(IItemComparison comp);
-
+	public boolean sameAsFuzzy( IItemComparison comp );
 }

--- a/src/api/java/appeng/api/features/IItemComparisonProvider.java
+++ b/src/api/java/appeng/api/features/IItemComparisonProvider.java
@@ -23,7 +23,9 @@
 
 package appeng.api.features;
 
+
 import net.minecraft.item.ItemStack;
+
 
 /**
  * Provider for special comparisons. when an item is encountered AE Will request
@@ -38,16 +40,17 @@ public interface IItemComparisonProvider
 	 * the supplied item.
 	 *
 	 * @param is item
+	 *
 	 * @return IItemComparison, or null
 	 */
-	IItemComparison getComparison(ItemStack is);
+	IItemComparison getComparison( ItemStack is );
 
 	/**
 	 * Simple test for support ( AE generally skips this and calls the above function. )
 	 *
 	 * @param stack item
+	 *
 	 * @return true, if getComparison will return a valid IItemComparison Object
 	 */
-	public boolean canHandle(ItemStack stack);
-
+	public boolean canHandle( ItemStack stack );
 }

--- a/src/api/java/appeng/api/features/ILocatable.java
+++ b/src/api/java/appeng/api/features/ILocatable.java
@@ -23,7 +23,9 @@
 
 package appeng.api.features;
 
+
 import appeng.api.events.LocatableEventAnnounce;
+
 
 /**
  * A registration record for the {@link ILocatableRegistry} use the {@link LocatableEventAnnounce} event on the Forge
@@ -36,5 +38,4 @@ public interface ILocatable
 	 * @return the serial for a locatable object
 	 */
 	long getLocatableSerial();
-
 }

--- a/src/api/java/appeng/api/features/ILocatableRegistry.java
+++ b/src/api/java/appeng/api/features/ILocatableRegistry.java
@@ -23,6 +23,7 @@
 
 package appeng.api.features;
 
+
 /**
  * A Registry for locatable items, works based on serial numbers.
  */
@@ -34,8 +35,8 @@ public interface ILocatableRegistry
 	 * returns the object.
 	 *
 	 * @param serial serial
+	 *
 	 * @return requestedObject, or null
 	 */
-	public abstract Object findLocatableBySerial(long serial);
-
+	public abstract Object findLocatableBySerial( long serial );
 }

--- a/src/api/java/appeng/api/features/IMatterCannonAmmoRegistry.java
+++ b/src/api/java/appeng/api/features/IMatterCannonAmmoRegistry.java
@@ -23,7 +23,9 @@
 
 package appeng.api.features;
 
+
 import net.minecraft.item.ItemStack;
+
 
 public interface IMatterCannonAmmoRegistry
 {
@@ -34,14 +36,14 @@ public interface IMatterCannonAmmoRegistry
 	 * @param ammo new ammo
 	 * @param weight atomic weight
 	 */
-	void registerAmmo(ItemStack ammo, double weight);
+	void registerAmmo( ItemStack ammo, double weight );
 
 	/**
 	 * get the penetration value for a particular ammo, 0 indicates a non-ammo.
 	 *
 	 * @param is ammo
+	 *
 	 * @return 0 or a valid penetration value.
 	 */
-	float getPenetration(ItemStack is);
-
+	float getPenetration( ItemStack is );
 }

--- a/src/api/java/appeng/api/features/INetworkEncodable.java
+++ b/src/api/java/appeng/api/features/INetworkEncodable.java
@@ -23,28 +23,28 @@
 
 package appeng.api.features;
 
+
 import net.minecraft.item.ItemStack;
 
-public interface INetworkEncodable {
+
+public interface INetworkEncodable
+{
 
 	/**
 	 * Used to get the current key from the item.
 	 *
 	 * @param item item
+	 *
 	 * @return string key of item
 	 */
-	String getEncryptionKey(ItemStack item);
+	String getEncryptionKey( ItemStack item );
 
 	/**
 	 * Encode the wireless frequency via the Controller.
 	 *
-	 * @param item
-	 *            the wireless terminal.
-	 * @param encKey
-	 *            the wireless encryption key.
-	 * @param name
-	 *            null for now.
+	 * @param item   the wireless terminal.
+	 * @param encKey the wireless encryption key.
+	 * @param name   null for now.
 	 */
-	void setEncryptionKey(ItemStack item, String encKey, String name);
-
+	void setEncryptionKey( ItemStack item, String encKey, String name );
 }

--- a/src/api/java/appeng/api/features/IP2PTunnelRegistry.java
+++ b/src/api/java/appeng/api/features/IP2PTunnelRegistry.java
@@ -23,8 +23,11 @@
 
 package appeng.api.features;
 
+
 import net.minecraft.item.ItemStack;
+
 import appeng.api.config.TunnelType;
+
 
 /**
  * A Registry for how p2p Tunnels are attuned
@@ -36,19 +39,17 @@ public interface IP2PTunnelRegistry
 	 * Allows third parties to register items from their mod as potential
 	 * attunements for AE's P2P Tunnels
 	 *
-	 * @param trigger
-	 *            - the item which triggers attunement
-	 * @param type
-	 *            - the type of tunnel
+	 * @param trigger - the item which triggers attunement
+	 * @param type    - the type of tunnel
 	 */
-	public abstract void addNewAttunement(ItemStack trigger, TunnelType type);
+	public abstract void addNewAttunement( ItemStack trigger, TunnelType type );
 
 	/**
 	 * returns null if no attunement can be found.
 	 *
 	 * @param trigger attunement trigger
+	 *
 	 * @return null if no attunement can be found or attunement
 	 */
-	TunnelType getTunnelTypeByItem(ItemStack trigger);
-
+	TunnelType getTunnelTypeByItem( ItemStack trigger );
 }

--- a/src/api/java/appeng/api/features/IPlayerRegistry.java
+++ b/src/api/java/appeng/api/features/IPlayerRegistry.java
@@ -23,9 +23,11 @@
 
 package appeng.api.features;
 
+
 import net.minecraft.entity.player.EntityPlayer;
 
 import com.mojang.authlib.GameProfile;
+
 
 /**
  * Maintains a save specific list of userids and username combinations this greatly simplifies storage internally and
@@ -36,20 +38,22 @@ public interface IPlayerRegistry
 
 	/**
 	 * @param gameProfile user game profile
+	 *
 	 * @return user id of a username.
 	 */
-	int getID(GameProfile gameProfile);
+	int getID( GameProfile gameProfile );
 
 	/**
 	 * @param player player
+	 *
 	 * @return user id of a player entity.
 	 */
-	int getID(EntityPlayer player);
+	int getID( EntityPlayer player );
 
 	/**
 	 * @param playerID to be found player id
+	 *
 	 * @return PlayerEntity, or null if the player could not be found.
 	 */
-	EntityPlayer findPlayer(int playerID);
-
+	EntityPlayer findPlayer( int playerID );
 }

--- a/src/api/java/appeng/api/features/IRecipeHandlerRegistry.java
+++ b/src/api/java/appeng/api/features/IRecipeHandlerRegistry.java
@@ -23,9 +23,11 @@
 
 package appeng.api.features;
 
+
 import appeng.api.recipes.ICraftHandler;
 import appeng.api.recipes.IRecipeHandler;
 import appeng.api.recipes.ISubItemResolver;
+
 
 public interface IRecipeHandlerRegistry
 {
@@ -38,7 +40,7 @@ public interface IRecipeHandlerRegistry
 	 * @param name name of crafthandler
 	 * @param handler class of crafthandler
 	 */
-	void addNewCraftHandler(String name, Class<? extends ICraftHandler> handler);
+	void addNewCraftHandler( String name, Class<? extends ICraftHandler> handler );
 
 	/**
 	 * Add a new resolver to the parser.
@@ -47,13 +49,14 @@ public interface IRecipeHandlerRegistry
 	 *
 	 * @param sir sub item resolver
 	 */
-	void addNewSubItemResolver(ISubItemResolver sir);
+	void addNewSubItemResolver( ISubItemResolver sir );
 
 	/**
 	 * @param name name of crafting handler
+	 *
 	 * @return A recipe handler by name, returns null on failure.
 	 */
-	ICraftHandler getCraftHandlerFor(String name);
+	ICraftHandler getCraftHandlerFor( String name );
 
 	/**
 	 * @return a new recipe handler, which can be used to parse, and read recipe files.
@@ -64,9 +67,9 @@ public interface IRecipeHandlerRegistry
 	 * resolve sub items by name.
 	 *
 	 * @param nameSpace namespace of item
-	 * @param itemName full name of item
+	 * @param itemName  full name of item
+	 *
 	 * @return ResolverResult or ResolverResultSet
 	 */
-	Object resolveItem(String nameSpace, String itemName);
-
+	Object resolveItem( String nameSpace, String itemName );
 }

--- a/src/api/java/appeng/api/features/IRegistryContainer.java
+++ b/src/api/java/appeng/api/features/IRegistryContainer.java
@@ -23,10 +23,12 @@
 
 package appeng.api.features;
 
+
 import appeng.api.movable.IMovableRegistry;
 import appeng.api.networking.IGridCacheRegistry;
 import appeng.api.storage.ICellRegistry;
 import appeng.api.storage.IExternalStorageRegistry;
+
 
 public interface IRegistryContainer
 {

--- a/src/api/java/appeng/api/features/ISpecialComparisonRegistry.java
+++ b/src/api/java/appeng/api/features/ISpecialComparisonRegistry.java
@@ -23,11 +23,12 @@
 
 package appeng.api.features;
 
+
 import net.minecraft.item.ItemStack;
+
 
 /**
  * A Registry of any special comparison handlers for AE To use.
- *
  */
 public interface ISpecialComparisonRegistry
 {
@@ -36,15 +37,15 @@ public interface ISpecialComparisonRegistry
 	 * return TheHandler or null.
 	 *
 	 * @param stack item
+	 *
 	 * @return a handler it found for a specific item
 	 */
-	IItemComparison getSpecialComparison(ItemStack stack);
+	IItemComparison getSpecialComparison( ItemStack stack );
 
 	/**
 	 * Register a new special comparison function with AE.
 	 *
 	 * @param prov comparison provider
 	 */
-	public void addComparisonProvider(IItemComparisonProvider prov);
-
+	public void addComparisonProvider( IItemComparisonProvider prov );
 }

--- a/src/api/java/appeng/api/features/IWirelessTermHandler.java
+++ b/src/api/java/appeng/api/features/IWirelessTermHandler.java
@@ -23,9 +23,12 @@
 
 package appeng.api.features;
 
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
+
 import appeng.api.util.IConfigManager;
+
 
 /**
  * A handler for a wireless terminal.
@@ -35,35 +38,38 @@ public interface IWirelessTermHandler extends INetworkEncodable
 
 	/**
 	 * @param is wireless terminal
+	 *
 	 * @return true, if usePower, hasPower, etc... can be called for the provided item
 	 */
-	boolean canHandle(ItemStack is);
+	boolean canHandle( ItemStack is );
 
 	/**
 	 * use an amount of power, in AE units
 	 *
-	 * @param amount
-	 *            is in AE units ( 5 per MJ ), if you return false, the item should be dead and return false for
-	 *            hasPower
+	 * @param amount is in AE units ( 5 per MJ ), if you return false, the item should be dead and return false for
+	 * hasPower
 	 * @param is wireless terminal
+	 *
 	 * @return true if wireless terminal uses power
 	 */
-	boolean usePower(EntityPlayer player, double amount, ItemStack is);
+	boolean usePower( EntityPlayer player, double amount, ItemStack is );
 
 	/**
 	 * gets the power status of the item.
 	 *
 	 * @param is wireless terminal
+	 *
 	 * @return returns true if there is any power left.
 	 */
-	boolean hasPower(EntityPlayer player, double amount, ItemStack is);
+	boolean hasPower( EntityPlayer player, double amount, ItemStack is );
 
 	/**
 	 * Return the config manager for the wireless terminal.
 	 *
 	 * @param is wireless terminal
+	 *
 	 * @return config manager of wireless terminal
 	 */
-	IConfigManager getConfigManager(ItemStack is);
+	IConfigManager getConfigManager( ItemStack is );
 
 }

--- a/src/api/java/appeng/api/features/IWirelessTermRegistry.java
+++ b/src/api/java/appeng/api/features/IWirelessTermRegistry.java
@@ -23,9 +23,11 @@
 
 package appeng.api.features;
 
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
+
 
 /**
  * Registration record for a Custom Cell handler.
@@ -38,25 +40,26 @@ public interface IWirelessTermRegistry
 	 *
 	 * @param handler wireless handler
 	 */
-	void registerWirelessHandler(IWirelessTermHandler handler);
+	void registerWirelessHandler( IWirelessTermHandler handler );
 
 	/**
 	 * @param is item which might have a handler
+	 *
 	 * @return true if there is a handler for this item
 	 */
-	boolean isWirelessTerminal(ItemStack is);
+	boolean isWirelessTerminal( ItemStack is );
 
 	/**
 	 * @param is item with handler
+	 *
 	 * @return a register handler for the item in question, or null if there
-	 *         isn't one
+	 * isn't one
 	 */
-	IWirelessTermHandler getWirelessTerminalHandler(ItemStack is);
+	IWirelessTermHandler getWirelessTerminalHandler( ItemStack is );
 
 	/**
 	 * opens the wireless terminal gui, the wireless terminal item, must be in
 	 * the active slot on the tool bar.
 	 */
-	void openWirelessTerminalGui(ItemStack item, World w, EntityPlayer player);
-
+	void openWirelessTerminalGui( ItemStack item, World w, EntityPlayer player );
 }

--- a/src/api/java/appeng/api/features/IWorldGen.java
+++ b/src/api/java/appeng/api/features/IWorldGen.java
@@ -23,8 +23,10 @@
 
 package appeng.api.features;
 
+
 import net.minecraft.world.World;
 import net.minecraft.world.WorldProvider;
+
 
 public interface IWorldGen
 {
@@ -34,12 +36,11 @@ public interface IWorldGen
 		CertusQuartz, ChargedCertusQuartz, Meteorites
 	}
 
-	public void disableWorldGenForProviderID(WorldGenType type, Class<? extends WorldProvider> provider);
+	public void disableWorldGenForProviderID( WorldGenType type, Class<? extends WorldProvider> provider );
 
-	public void enableWorldGenForDimension(WorldGenType type, int dimID);
+	public void enableWorldGenForDimension( WorldGenType type, int dimID );
 
-	public void disableWorldGenForDimension(WorldGenType type, int dimID);
+	public void disableWorldGenForDimension( WorldGenType type, int dimID );
 
-	boolean isWorldGenEnabled(WorldGenType type, World w);
-
+	boolean isWorldGenEnabled( WorldGenType type, World w );
 }

--- a/src/api/java/appeng/api/implementations/ICraftingPatternItem.java
+++ b/src/api/java/appeng/api/implementations/ICraftingPatternItem.java
@@ -23,10 +23,13 @@
 
 package appeng.api.implementations;
 
+
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
+
 import appeng.api.networking.crafting.ICraftingPatternDetails;
+
 
 /**
  * Implemented on {@link Item}
@@ -38,8 +41,9 @@ public interface ICraftingPatternItem
 	 * Access Details about a pattern
 	 *
 	 * @param is pattern
-	 * @param w crafting world
+	 * @param w  crafting world
+	 *
 	 * @return details of pattern
 	 */
-	ICraftingPatternDetails getPatternForItem(ItemStack is, World w);
+	ICraftingPatternDetails getPatternForItem( ItemStack is, World w );
 }

--- a/src/api/java/appeng/api/implementations/IPowerChannelState.java
+++ b/src/api/java/appeng/api/implementations/IPowerChannelState.java
@@ -23,6 +23,7 @@
 
 package appeng.api.implementations;
 
+
 /**
  * This is intended for use on the client side to provide details to WAILA.
  */
@@ -38,5 +39,4 @@ public interface IPowerChannelState
 	 * @return true if the part/tile isActive
 	 */
 	boolean isActive();
-
 }

--- a/src/api/java/appeng/api/implementations/IUpgradeableHost.java
+++ b/src/api/java/appeng/api/implementations/IUpgradeableHost.java
@@ -23,10 +23,13 @@
 
 package appeng.api.implementations;
 
-import appeng.api.util.IConfigurableObject;
+
 import net.minecraft.tileentity.TileEntity;
+
 import appeng.api.config.Upgrades;
 import appeng.api.implementations.tiles.ISegmentedInventory;
+import appeng.api.util.IConfigurableObject;
+
 
 public interface IUpgradeableHost extends IConfigurableObject, ISegmentedInventory
 {
@@ -34,7 +37,7 @@ public interface IUpgradeableHost extends IConfigurableObject, ISegmentedInvento
 	/**
 	 * determine how many of an upgrade are installed.
 	 */
-	int getInstalledUpgrades(Upgrades u);
+	int getInstalledUpgrades( Upgrades u );
 
 	/**
 	 * the tile...
@@ -42,5 +45,4 @@ public interface IUpgradeableHost extends IConfigurableObject, ISegmentedInvento
 	 * @return tile entity
 	 */
 	TileEntity getTile();
-
 }

--- a/src/api/java/appeng/api/implementations/TransitionResult.java
+++ b/src/api/java/appeng/api/implementations/TransitionResult.java
@@ -23,6 +23,7 @@
 
 package appeng.api.implementations;
 
+
 /**
  * Defines the result of performing a transition from the world into a storage
  * cell, if its possible, and what the energy usage is.
@@ -32,7 +33,8 @@ public class TransitionResult
 	public final boolean success;
 	public final double energyUsage;
 
-	public TransitionResult(boolean _success, double power) {
+	public TransitionResult( boolean _success, double power )
+	{
 		this.success = _success;
 		this.energyUsage = power;
 	}

--- a/src/api/java/appeng/api/implementations/guiobjects/IGuiItem.java
+++ b/src/api/java/appeng/api/implementations/guiobjects/IGuiItem.java
@@ -23,8 +23,10 @@
 
 package appeng.api.implementations.guiobjects;
 
+
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
+
 
 /**
  * Implemented on Item objects, to return objects used to manage, and interact
@@ -33,6 +35,5 @@ import net.minecraft.world.World;
 public interface IGuiItem
 {
 
-	IGuiItemObject getGuiObject(ItemStack is, World world, int x, int y, int z);
-
+	IGuiItemObject getGuiObject( ItemStack is, World world, int x, int y, int z );
 }

--- a/src/api/java/appeng/api/implementations/guiobjects/IGuiItemObject.java
+++ b/src/api/java/appeng/api/implementations/guiobjects/IGuiItemObject.java
@@ -23,7 +23,9 @@
 
 package appeng.api.implementations.guiobjects;
 
+
 import net.minecraft.item.ItemStack;
+
 
 public interface IGuiItemObject
 {

--- a/src/api/java/appeng/api/implementations/guiobjects/INetworkTool.java
+++ b/src/api/java/appeng/api/implementations/guiobjects/INetworkTool.java
@@ -23,8 +23,11 @@
 
 package appeng.api.implementations.guiobjects;
 
+
 import net.minecraft.inventory.IInventory;
+
 import appeng.api.networking.IGridHost;
+
 
 /**
  * Obtained via {@link IGuiItem} getGuiObject
@@ -33,5 +36,4 @@ public interface INetworkTool extends IInventory, IGuiItemObject
 {
 
 	IGridHost getGridHost(); // null for most purposes.
-
 }

--- a/src/api/java/appeng/api/implementations/guiobjects/IPortableCell.java
+++ b/src/api/java/appeng/api/implementations/guiobjects/IPortableCell.java
@@ -23,10 +23,12 @@
 
 package appeng.api.implementations.guiobjects;
 
+
 import appeng.api.networking.energy.IEnergySource;
 import appeng.api.storage.IMEMonitor;
 import appeng.api.storage.ITerminalHost;
 import appeng.api.storage.data.IAEItemStack;
+
 
 /**
  * Obtained via {@link IGuiItem} getGuiObject

--- a/src/api/java/appeng/api/implementations/items/IAEItemPowerStorage.java
+++ b/src/api/java/appeng/api/implementations/items/IAEItemPowerStorage.java
@@ -23,9 +23,12 @@
 
 package appeng.api.implementations.items;
 
+
 import net.minecraft.item.ItemStack;
+
 import appeng.api.config.AccessRestriction;
 import appeng.api.networking.energy.IAEPowerStorage;
+
 
 /**
  * Basically the same as {@link IAEPowerStorage}, but for items.
@@ -39,26 +42,27 @@ public interface IAEItemPowerStorage
 	 *
 	 * @return amount unable to be stored
 	 */
-	public double injectAEPower(ItemStack is, double amt);
+	public double injectAEPower( ItemStack is, double amt );
 
 	/**
 	 * Attempt to extract power from the device, it will extract what it can and
 	 * return it.
 	 *
 	 * @param amt to be extracted power from device
+	 *
 	 * @return what it could extract
 	 */
-	public double extractAEPower(ItemStack is, double amt);
+	public double extractAEPower( ItemStack is, double amt );
 
 	/**
 	 * @return the current maximum power ( this can change :P )
 	 */
-	public double getAEMaxPower(ItemStack is);
+	public double getAEMaxPower( ItemStack is );
 
 	/**
 	 * @return the current AE Power Level, this may exceed getMEMaxPower()
 	 */
-	public double getAECurrentPower(ItemStack is);
+	public double getAECurrentPower( ItemStack is );
 
 	/**
 	 * Control the power flow by telling what the network can do, either add? or
@@ -66,6 +70,5 @@ public interface IAEItemPowerStorage
 	 *
 	 * @return access restriction of network
 	 */
-	public AccessRestriction getPowerFlow(ItemStack is);
-
+	public AccessRestriction getPowerFlow( ItemStack is );
 }

--- a/src/api/java/appeng/api/implementations/items/IAEWrench.java
+++ b/src/api/java/appeng/api/implementations/items/IAEWrench.java
@@ -23,8 +23,10 @@
 
 package appeng.api.implementations.items;
 
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
+
 
 /**
  * Implemented on AE's wrench(s) as a substitute for if BC's API is not
@@ -37,12 +39,11 @@ public interface IAEWrench
 	 * Check if the wrench can be used.
 	 *
 	 * @param player wrenching player
-	 * @param x x pos of wrenched block
-	 * @param y y pos of wrenched block
-	 * @param z z pos of wrenched block
+	 * @param x      x pos of wrenched block
+	 * @param y      y pos of wrenched block
+	 * @param z      z pos of wrenched block
 	 *
 	 * @return true if wrench can be used
 	 */
-	boolean canWrench(ItemStack wrench, EntityPlayer player, int x, int y, int z);
-
+	boolean canWrench( ItemStack wrench, EntityPlayer player, int x, int y, int z );
 }

--- a/src/api/java/appeng/api/implementations/items/IBiometricCard.java
+++ b/src/api/java/appeng/api/implementations/items/IBiometricCard.java
@@ -23,13 +23,17 @@
 
 package appeng.api.implementations.items;
 
+
+import java.util.EnumSet;
+
+import net.minecraft.item.ItemStack;
+
+import com.mojang.authlib.GameProfile;
+
 import appeng.api.config.SecurityPermissions;
 import appeng.api.features.IPlayerRegistry;
 import appeng.api.networking.security.ISecurityRegistry;
-import com.mojang.authlib.GameProfile;
-import net.minecraft.item.ItemStack;
 
-import java.util.EnumSet;
 
 public interface IBiometricCard
 {
@@ -37,26 +41,28 @@ public interface IBiometricCard
 	/**
 	 * Set the  {@link GameProfile} to null, to clear it.
 	 */
-	void setProfile(ItemStack itemStack, GameProfile username);
+	void setProfile( ItemStack itemStack, GameProfile username );
 
 	/**
 	 * @return {@link GameProfile} of the player encoded on this card, or a blank string.
 	 */
-	GameProfile getProfile(ItemStack is);
+	GameProfile getProfile( ItemStack is );
 
 	/**
 	 * @param itemStack card
+	 *
 	 * @return the full list of permissions encoded on the card.
 	 */
-	EnumSet<SecurityPermissions> getPermissions(ItemStack itemStack);
+	EnumSet<SecurityPermissions> getPermissions( ItemStack itemStack );
 
 	/**
 	 * Check if a permission is encoded on the card.
 	 *
 	 * @param permission card
+	 *
 	 * @return true if this permission is set on the card.
 	 */
-	boolean hasPermission(ItemStack is, SecurityPermissions permission);
+	boolean hasPermission( ItemStack is, SecurityPermissions permission );
 
 	/**
 	 * remove a permission from the item stack.
@@ -64,7 +70,7 @@ public interface IBiometricCard
 	 * @param itemStack card
 	 * @param permission to be removed permission
 	 */
-	void removePermission(ItemStack itemStack, SecurityPermissions permission);
+	void removePermission( ItemStack itemStack, SecurityPermissions permission );
 
 	/**
 	 * add a permission to the item stack.
@@ -72,15 +78,14 @@ public interface IBiometricCard
 	 * @param itemStack card
 	 * @param permission to be added permission
 	 */
-	void addPermission(ItemStack itemStack, SecurityPermissions permission);
+	void addPermission( ItemStack itemStack, SecurityPermissions permission );
 
 	/**
 	 * lets you handle submission of security values on the card for custom behavior.
 	 *
 	 * @param registry security registry
-	 * @param pr player registry
-	 * @param is card
+	 * @param pr       player registry
+	 * @param is       card
 	 */
-	void registerPermissions(ISecurityRegistry registry, IPlayerRegistry pr, ItemStack is);
-
+	void registerPermissions( ISecurityRegistry registry, IPlayerRegistry pr, ItemStack is );
 }

--- a/src/api/java/appeng/api/implementations/items/IGrowableCrystal.java
+++ b/src/api/java/appeng/api/implementations/items/IGrowableCrystal.java
@@ -23,15 +23,16 @@
 
 package appeng.api.implementations.items;
 
+
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.item.ItemStack;
 
+
 public interface IGrowableCrystal
 {
 
-	ItemStack triggerGrowth(ItemStack is);
+	ItemStack triggerGrowth( ItemStack is );
 
-	float getMultiplier(Block blk, Material mat);
-
+	float getMultiplier( Block blk, Material mat );
 }

--- a/src/api/java/appeng/api/implementations/items/IItemGroup.java
+++ b/src/api/java/appeng/api/implementations/items/IItemGroup.java
@@ -23,9 +23,11 @@
 
 package appeng.api.implementations.items;
 
-import net.minecraft.item.ItemStack;
 
 import java.util.Set;
+
+import net.minecraft.item.ItemStack;
+
 
 /**
  * Lets you specify the name of the group of items this falls under.
@@ -37,8 +39,8 @@ public interface IItemGroup
 	 * returning null, is the same as not implementing the interface at all.
 	 *
 	 * @param is item
+	 *
 	 * @return an unlocalized string to use for the items group name.
 	 */
-	String getUnlocalizedGroupName(Set<ItemStack> otherItems, ItemStack is);
-
+	String getUnlocalizedGroupName( Set<ItemStack> otherItems, ItemStack is );
 }

--- a/src/api/java/appeng/api/implementations/items/IMemoryCard.java
+++ b/src/api/java/appeng/api/implementations/items/IMemoryCard.java
@@ -23,9 +23,11 @@
 
 package appeng.api.implementations.items;
 
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+
 
 /**
  * Memory Card API
@@ -40,14 +42,13 @@ public interface IMemoryCard
 	 * localized when displayed.
 	 *
 	 * @param is item
-	 * @param SettingsName
-	 *            unlocalized string that represents the tile entity.
+	 * @param SettingsName unlocalized string that represents the tile entity.
 	 * @param data
 	 *            may contain a String called "tooltip" which is is a
 	 *            unlocalized string displayed after the settings name, optional
 	 *            but can be used to add details to the card for later.
 	 */
-	void setMemoryCardContents(ItemStack is, String SettingsName, NBTTagCompound data);
+	void setMemoryCardContents( ItemStack is, String SettingsName, NBTTagCompound data );
 
 	/**
 	 * returns the settings name provided by a previous call to
@@ -55,25 +56,24 @@ public interface IMemoryCard
 	 * previous call to setMemoryCardContents.
 	 *
 	 * @param is item
+	 *
 	 * @return setting name
 	 */
-	String getSettingsName(ItemStack is);
+	String getSettingsName( ItemStack is );
 
 	/**
 	 * @param is item
+	 *
 	 * @return the NBT Data previously saved by setMemoryCardContents, or an
-	 *         empty NBTCompound
+	 * empty NBTCompound
 	 */
-	NBTTagCompound getData(ItemStack is);
+	NBTTagCompound getData( ItemStack is );
 
 	/**
 	 * notify the user of a outcome related to the memory card.
 	 *
-	 * @param player
-	 *            that used the card.
-	 * @param msg
-	 *            which message to send.
+	 * @param player that used the card.
+	 * @param msg which message to send.
 	 */
-	void notifyUser(EntityPlayer player, MemoryCardMessages msg);
-
+	void notifyUser( EntityPlayer player, MemoryCardMessages msg );
 }

--- a/src/api/java/appeng/api/implementations/items/ISpatialStorageCell.java
+++ b/src/api/java/appeng/api/implementations/items/ISpatialStorageCell.java
@@ -23,11 +23,14 @@
 
 package appeng.api.implementations.items;
 
+
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
+
 import appeng.api.implementations.TransitionResult;
 import appeng.api.util.WorldCoord;
+
 
 /**
  * Implemented on a {@link Item}
@@ -37,45 +40,51 @@ public interface ISpatialStorageCell
 
 	/**
 	 * @param is spatial storage cell
+	 *
 	 * @return true if this item is a spatial storage cell
 	 */
-	boolean isSpatialStorage(ItemStack is);
+	boolean isSpatialStorage( ItemStack is );
 
 	/**
 	 * @param is spatial storage cell
+	 *
 	 * @return the maximum size of the spatial storage cell along any given axis
 	 */
-	int getMaxStoredDim(ItemStack is);
+	int getMaxStoredDim( ItemStack is );
 
 	/**
 	 * @param is spatial storage cell
+	 *
 	 * @return the world for this cell
 	 */
-	World getWorld(ItemStack is);
+	World getWorld( ItemStack is );
 
 	/**
 	 * get the currently stored size.
 	 *
 	 * @param is spatial storage cell
+	 *
 	 * @return size of spatial
 	 */
-	WorldCoord getStoredSize(ItemStack is);
+	WorldCoord getStoredSize( ItemStack is );
 
 	/**
 	 * Minimum coordinates in its world for the storage cell.
 	 *
 	 * @param is spatial storage cell
+	 *
 	 * @return minimum coordinate of dimension
 	 */
-	WorldCoord getMin(ItemStack is);
+	WorldCoord getMin( ItemStack is );
 
 	/**
 	 * Maximum coordinates in its world for the storage cell.
 	 *
 	 * @param is spatial storage cell
+	 *
 	 * @return maximum coordinate of dimension
 	 */
-	WorldCoord getMax(ItemStack is);
+	WorldCoord getMax( ItemStack is );
 
 	/**
 	 * Perform a spatial swap with the contents of the cell, and the world.
@@ -85,8 +94,8 @@ public interface ISpatialStorageCell
 	 * @param min min coord
 	 * @param max max coord
 	 * @param doTransition transition
+	 *
 	 * @return result of transition
 	 */
-	TransitionResult doSpatialTransition(ItemStack is, World w, WorldCoord min, WorldCoord max, boolean doTransition);
-
+	TransitionResult doSpatialTransition( ItemStack is, World w, WorldCoord min, WorldCoord max, boolean doTransition );
 }

--- a/src/api/java/appeng/api/implementations/items/IStorageCell.java
+++ b/src/api/java/appeng/api/implementations/items/IStorageCell.java
@@ -23,9 +23,12 @@
 
 package appeng.api.implementations.items;
 
+
 import net.minecraft.item.ItemStack;
+
 import appeng.api.storage.ICellWorkbenchItem;
 import appeng.api.storage.data.IAEItemStack;
+
 
 /**
  * Any item which implements this can be treated as an IMEInventory via
@@ -46,26 +49,29 @@ public interface IStorageCell extends ICellWorkbenchItem
 	 * The limit is ({@link Integer#MAX_VALUE} + 1) / 8.
 	 *
 	 * @param cellItem item
+	 *
 	 * @return number of bytes
 	 */
-	int getBytes(ItemStack cellItem);
+	int getBytes( ItemStack cellItem );
 
 	/**
 	 * Determines the number of bytes used for any type included on the cell.
 	 *
 	 * @param cellItem item
+	 *
 	 * @return number of bytes
 	 */
-	int BytePerType(ItemStack cellItem);
+	int BytePerType( ItemStack cellItem );
 
 	/**
 	 * Must be between 1 and 63, indicates how many types you want to store on
 	 * the item.
 	 *
 	 * @param cellItem item
+	 *
 	 * @return number of types
 	 */
-	int getTotalTypes(ItemStack cellItem);
+	int getTotalTypes( ItemStack cellItem );
 
 	/**
 	 * Allows you to fine tune which items are allowed on a given cell, if you
@@ -74,9 +80,10 @@ public interface IStorageCell extends ICellWorkbenchItem
 	 *
 	 * @param cellItem item
 	 * @param requestedAddition requested addition
+	 *
 	 * @return true to preventAdditionOfItem
 	 */
-	boolean isBlackListed(ItemStack cellItem, IAEItemStack requestedAddition);
+	boolean isBlackListed( ItemStack cellItem, IAEItemStack requestedAddition );
 
 	/**
 	 * Allows you to specify if this storage cell can be stored inside other
@@ -84,8 +91,8 @@ public interface IStorageCell extends ICellWorkbenchItem
 	 * that are not general purpose storage.
 	 *
 	 * @return true if the storage cell can be stored inside other storage
-	 *         cells, this is generally false, except for certain situations
-	 *         such as the matter cannon.
+	 * cells, this is generally false, except for certain situations
+	 * such as the matter cannon.
 	 */
 	boolean storableInStorageCell();
 
@@ -94,9 +101,10 @@ public interface IStorageCell extends ICellWorkbenchItem
 	 * cell.
 	 *
 	 * @param i item
+	 *
 	 * @return if the ItemStack should behavior as a storage cell.
 	 */
-	boolean isStorageCell(ItemStack i);
+	boolean isStorageCell( ItemStack i );
 
 	/**
 	 * @return drain in ae/t this storage cell will use.

--- a/src/api/java/appeng/api/implementations/items/IStorageComponent.java
+++ b/src/api/java/appeng/api/implementations/items/IStorageComponent.java
@@ -23,8 +23,10 @@
 
 package appeng.api.implementations.items;
 
+
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+
 
 /**
  * Implemented on a {@link Item}
@@ -38,16 +40,17 @@ public interface IStorageComponent
 	 * the condenser.
 	 *
 	 * @param is item
+	 *
 	 * @return number of bytes
 	 */
-	int getBytes(ItemStack is);
+	int getBytes( ItemStack is );
 
 	/**
 	 * Just true or false for the item stack.
 	 *
 	 * @param is item
+	 *
 	 * @return true if item is a storage component
 	 */
-	boolean isStorageComponent(ItemStack is);
-
+	boolean isStorageComponent( ItemStack is );
 }

--- a/src/api/java/appeng/api/implementations/items/IUpgradeModule.java
+++ b/src/api/java/appeng/api/implementations/items/IUpgradeModule.java
@@ -23,16 +23,19 @@
 
 package appeng.api.implementations.items;
 
+
 import net.minecraft.item.ItemStack;
+
 import appeng.api.config.Upgrades;
+
 
 public interface IUpgradeModule
 {
 
 	/**
 	 * @param itemstack item with potential upgrades
+	 *
 	 * @return null, or a valid upgrade type.
 	 */
-	Upgrades getType(ItemStack itemstack);
-
+	Upgrades getType( ItemStack itemstack );
 }

--- a/src/api/java/appeng/api/implementations/items/MemoryCardMessages.java
+++ b/src/api/java/appeng/api/implementations/items/MemoryCardMessages.java
@@ -23,6 +23,7 @@
 
 package appeng.api.implementations.items;
 
+
 /**
  * Status Results for use with {@link IMemoryCard}
  */

--- a/src/api/java/appeng/api/implementations/parts/IPartCable.java
+++ b/src/api/java/appeng/api/implementations/parts/IPartCable.java
@@ -23,16 +23,19 @@
 
 package appeng.api.implementations.parts;
 
+
+import java.util.EnumSet;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraftforge.common.util.ForgeDirection;
+
 import appeng.api.networking.IGridHost;
 import appeng.api.parts.BusSupport;
 import appeng.api.parts.IPart;
 import appeng.api.parts.IPartHost;
 import appeng.api.util.AECableType;
 import appeng.api.util.AEColor;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraftforge.common.util.ForgeDirection;
 
-import java.util.EnumSet;
 
 /**
  * Implemented on the {@link IPart}s cable objects that can be placed at {@link ForgeDirection}.UNKNOWN in
@@ -60,9 +63,10 @@ public interface IPartCable extends IPart, IGridHost
 	 * Change the color of the cable, this should cost a small amount of dye, or something.
 	 *
 	 * @param newColor new color
+	 *
 	 * @return if the color change was successful.
 	 */
-	boolean changeColor(AEColor newColor, EntityPlayer who);
+	boolean changeColor( AEColor newColor, EntityPlayer who );
 
 	/**
 	 * Change sides on the cables node.
@@ -71,14 +75,14 @@ public interface IPartCable extends IPart, IGridHost
 	 *
 	 * @param sides sides of cable
 	 */
-	void setValidSides(EnumSet<ForgeDirection> sides);
+	void setValidSides( EnumSet<ForgeDirection> sides );
 
 	/**
 	 * used to tests if a cable connects to neighbors visually.
 	 *
 	 * @param side neighbor side
+	 *
 	 * @return true if this side is currently connects to an external block.
 	 */
-	boolean isConnected(ForgeDirection side);
-
+	boolean isConnected( ForgeDirection side );
 }

--- a/src/api/java/appeng/api/implementations/parts/IPartMonitor.java
+++ b/src/api/java/appeng/api/implementations/parts/IPartMonitor.java
@@ -23,8 +23,10 @@
 
 package appeng.api.implementations.parts;
 
+
 import appeng.api.networking.IGridHost;
 import appeng.api.parts.IPart;
+
 
 /**
  * Implemented by all screen like parts provided by AE.
@@ -34,8 +36,7 @@ public interface IPartMonitor extends IPart, IGridHost
 
 	/**
 	 * @return if the device is online you should check this before providing
-	 *         any other information.
+	 * any other information.
 	 */
 	boolean isPowered();
-
 }

--- a/src/api/java/appeng/api/implementations/parts/IPartStorageMonitor.java
+++ b/src/api/java/appeng/api/implementations/parts/IPartStorageMonitor.java
@@ -23,10 +23,12 @@
 
 package appeng.api.implementations.parts;
 
+
 import appeng.api.networking.IGridHost;
 import appeng.api.parts.IPart;
 import appeng.api.storage.data.IAEStack;
 import appeng.api.util.INetworkToolAgent;
+
 
 /**
  * The Storage monitor is a {@link IPart} located on the sides of a IPartHost
@@ -36,8 +38,8 @@ public interface IPartStorageMonitor extends IPartMonitor, IPart, IGridHost, INe
 
 	/**
 	 * @return the item being displayed on the storage monitor, in AEStack Form, can be either a IAEItemStack or an
-	 *         IAEFluidStack the quantity is important remember to use getStackSize() on the IAEStack, and not on the
-	 *         FluidStack/ItemStack acquired from it.
+	 * IAEFluidStack the quantity is important remember to use getStackSize() on the IAEStack, and not on the
+	 * FluidStack/ItemStack acquired from it.
 	 */
 	IAEStack<?> getDisplayed();
 
@@ -45,5 +47,4 @@ public interface IPartStorageMonitor extends IPartMonitor, IPart, IGridHost, INe
 	 * @return the current locked state of the Storage Monitor
 	 */
 	boolean isLocked();
-
 }

--- a/src/api/java/appeng/api/implementations/tiles/IChestOrDrive.java
+++ b/src/api/java/appeng/api/implementations/tiles/IChestOrDrive.java
@@ -23,9 +23,11 @@
 
 package appeng.api.implementations.tiles;
 
+
 import appeng.api.networking.IGridHost;
 import appeng.api.storage.ICellContainer;
 import appeng.api.util.IOrientable;
+
 
 public interface IChestOrDrive extends ICellContainer, IGridHost, IOrientable
 {
@@ -45,9 +47,10 @@ public interface IChestOrDrive extends ICellContainer, IGridHost, IOrientable
 	 * 3 - red
 	 *
 	 * @param slot slot index
+	 *
 	 * @return status of the slot, one of the above indices.
 	 */
-	int getCellStatus(int slot);
+	int getCellStatus( int slot );
 
 	/**
 	 * @return if the device is online you should check this before providing any other information.
@@ -56,8 +59,8 @@ public interface IChestOrDrive extends ICellContainer, IGridHost, IOrientable
 
 	/**
 	 * @param slot slot index
+	 *
 	 * @return is the cell currently blinking to show activity.
 	 */
-	boolean isCellBlinking(int slot);
-
+	boolean isCellBlinking( int slot );
 }

--- a/src/api/java/appeng/api/implementations/tiles/IColorableTile.java
+++ b/src/api/java/appeng/api/implementations/tiles/IColorableTile.java
@@ -23,15 +23,17 @@
 
 package appeng.api.implementations.tiles;
 
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraftforge.common.util.ForgeDirection;
+
 import appeng.api.util.AEColor;
+
 
 public interface IColorableTile
 {
 
 	AEColor getColor();
 
-	boolean recolourBlock(ForgeDirection side, AEColor colour, EntityPlayer who);
-
+	boolean recolourBlock( ForgeDirection side, AEColor colour, EntityPlayer who );
 }

--- a/src/api/java/appeng/api/implementations/tiles/ICraftingMachine.java
+++ b/src/api/java/appeng/api/implementations/tiles/ICraftingMachine.java
@@ -23,9 +23,12 @@
 
 package appeng.api.implementations.tiles;
 
+
 import net.minecraft.inventory.InventoryCrafting;
 import net.minecraftforge.common.util.ForgeDirection;
+
 import appeng.api.networking.crafting.ICraftingPatternDetails;
+
 
 public interface ICraftingMachine
 {
@@ -39,7 +42,7 @@ public interface ICraftingMachine
 	 *
 	 * @return if it was accepted, all or nothing.
 	 */
-	boolean pushPattern(ICraftingPatternDetails patternDetails, InventoryCrafting table, ForgeDirection ejectionDirection);
+	boolean pushPattern( ICraftingPatternDetails patternDetails, InventoryCrafting table, ForgeDirection ejectionDirection );
 
 	/**
 	 * check if the crafting machine is accepting pushes via pushPattern, if this is false, all calls to push will fail,
@@ -48,5 +51,4 @@ public interface ICraftingMachine
 	 * @return true, if pushPattern can complete, if its false push will always be false.
 	 */
 	boolean acceptsPlans();
-
 }

--- a/src/api/java/appeng/api/implementations/tiles/ICrankable.java
+++ b/src/api/java/appeng/api/implementations/tiles/ICrankable.java
@@ -23,7 +23,9 @@
 
 package appeng.api.implementations.tiles;
 
+
 import net.minecraftforge.common.util.ForgeDirection;
+
 
 /**
  * Crank/Crankable API,
@@ -53,6 +55,5 @@ public interface ICrankable
 	/**
 	 * @return true if the crank can attach on the given side.
 	 */
-	boolean canCrankAttach(ForgeDirection directionToCrank);
-
+	boolean canCrankAttach( ForgeDirection directionToCrank );
 }

--- a/src/api/java/appeng/api/implementations/tiles/ICrystalGrowthAccelerator.java
+++ b/src/api/java/appeng/api/implementations/tiles/ICrystalGrowthAccelerator.java
@@ -23,9 +23,9 @@
 
 package appeng.api.implementations.tiles;
 
+
 public interface ICrystalGrowthAccelerator
 {
 
 	boolean isPowered();
-
 }

--- a/src/api/java/appeng/api/implementations/tiles/IMEChest.java
+++ b/src/api/java/appeng/api/implementations/tiles/IMEChest.java
@@ -23,7 +23,9 @@
 
 package appeng.api.implementations.tiles;
 
+
 import appeng.api.networking.energy.IEnergySource;
+
 
 public interface IMEChest extends IChestOrDrive, ITileStorageMonitorable, IEnergySource
 {

--- a/src/api/java/appeng/api/implementations/tiles/ISegmentedInventory.java
+++ b/src/api/java/appeng/api/implementations/tiles/ISegmentedInventory.java
@@ -23,7 +23,9 @@
 
 package appeng.api.implementations.tiles;
 
+
 import net.minecraft.inventory.IInventory;
+
 
 public interface ISegmentedInventory
 {
@@ -33,8 +35,8 @@ public interface ISegmentedInventory
 	 * them a real inventories will result in duplication.
 	 *
 	 * @param name inventory name
+	 *
 	 * @return inventory with inventory name
 	 */
-	IInventory getInventoryByName(String name);
-
+	IInventory getInventoryByName( String name );
 }

--- a/src/api/java/appeng/api/implementations/tiles/ITileStorageMonitorable.java
+++ b/src/api/java/appeng/api/implementations/tiles/ITileStorageMonitorable.java
@@ -23,9 +23,12 @@
 
 package appeng.api.implementations.tiles;
 
+
 import net.minecraftforge.common.util.ForgeDirection;
+
 import appeng.api.networking.security.BaseActionSource;
 import appeng.api.storage.IStorageMonitorable;
+
 
 /**
  * Implemented on inventories that can share their inventories with other networks, best example, ME Interface.
@@ -33,6 +36,5 @@ import appeng.api.storage.IStorageMonitorable;
 public interface ITileStorageMonitorable
 {
 
-	IStorageMonitorable getMonitorable(ForgeDirection side, BaseActionSource src);
-
+	IStorageMonitorable getMonitorable( ForgeDirection side, BaseActionSource src );
 }

--- a/src/api/java/appeng/api/implementations/tiles/IViewCellStorage.java
+++ b/src/api/java/appeng/api/implementations/tiles/IViewCellStorage.java
@@ -23,7 +23,9 @@
 
 package appeng.api.implementations.tiles;
 
+
 import net.minecraft.inventory.IInventory;
+
 
 public interface IViewCellStorage
 {
@@ -34,5 +36,4 @@ public interface IViewCellStorage
 	 * @return inventory with at least 5 slot
 	 */
 	IInventory getViewCellStorage();
-
 }

--- a/src/api/java/appeng/api/implementations/tiles/IWirelessAccessPoint.java
+++ b/src/api/java/appeng/api/implementations/tiles/IWirelessAccessPoint.java
@@ -23,9 +23,11 @@
 
 package appeng.api.implementations.tiles;
 
+
 import appeng.api.networking.IGrid;
 import appeng.api.networking.security.IActionHost;
 import appeng.api.util.DimensionalCoord;
+
 
 public interface IWirelessAccessPoint extends IActionHost
 {
@@ -49,5 +51,4 @@ public interface IWirelessAccessPoint extends IActionHost
 	 * @return grid of linked WAP
 	 */
 	IGrid getGrid();
-
 }

--- a/src/api/java/appeng/api/integration/IBeeComparison.java
+++ b/src/api/java/appeng/api/integration/IBeeComparison.java
@@ -23,6 +23,7 @@
 
 package appeng.api.integration;
 
+
 /**
  * An interface to get access to the individual settings for AE's Internal Bee
  * Comparison handler.
@@ -39,5 +40,4 @@ public interface IBeeComparison
 	 * @return the Forestry IIndividual for this comparison object - cast this to a IIndividual if you want to use it.
 	 */
 	Object getIndividual();
-
 }

--- a/src/api/java/appeng/api/movable/IMovableHandler.java
+++ b/src/api/java/appeng/api/movable/IMovableHandler.java
@@ -23,8 +23,10 @@
 
 package appeng.api.movable;
 
+
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
+
 
 public interface IMovableHandler
 {
@@ -34,10 +36,11 @@ public interface IMovableHandler
 	 * that single entity, you cannot opt out of single entities.
 	 *
 	 * @param myClass tile entity class
-	 * @param tile tile entity
+	 * @param tile    tile entity
+	 *
 	 * @return true if it can handle moving
 	 */
-	boolean canHandle(Class<? extends TileEntity> myClass, TileEntity tile);
+	boolean canHandle( Class<? extends TileEntity> myClass, TileEntity tile );
 
 	/**
 	 * request that the handler move the the tile from its current location to
@@ -45,7 +48,7 @@ public interface IMovableHandler
 	 * already been fully moved.
 	 *
 	 * Potential Example:
-	 *
+	 * <p/>
 	 * <pre>
 	 * {@code
 	 * Chunk c = world.getChunkFromBlockCoords( x, z ); c.setChunkBlockTileEntity( x
@@ -58,10 +61,9 @@ public interface IMovableHandler
 	 *
 	 * @param tile to be moved tile
 	 * @param world world of tile
-	 * @param x x coord of tile
-	 * @param y y coord of tile
-	 * @param z z coord of tile
+	 * @param x     x coord of tile
+	 * @param y     y coord of tile
+	 * @param z     z coord of tile
 	 */
-	void moveTile(TileEntity tile, World world, int x, int y, int z);
-
+	void moveTile( TileEntity tile, World world, int x, int y, int z );
 }

--- a/src/api/java/appeng/api/movable/IMovableRegistry.java
+++ b/src/api/java/appeng/api/movable/IMovableRegistry.java
@@ -23,8 +23,10 @@
 
 package appeng.api.movable;
 
+
 import net.minecraft.block.Block;
 import net.minecraft.tileentity.TileEntity;
+
 
 /**
  * Used to determine if a tile is marked as movable, a block will be considered movable, if...
@@ -32,7 +34,7 @@ import net.minecraft.tileentity.TileEntity;
  * 1. The Tile or its super classes have been white listed with whiteListTileEntity.
  *
  * 2. The Tile has been register with the IMC ( which basically calls whiteListTileEntity. )
- *
+ * <p/>
  * 3. The Tile implements IMovableTile 4. A IMovableHandler is register that returns canHandle = true for the Tile
  * Entity Class
  *
@@ -64,7 +66,7 @@ public interface IMovableRegistry
 	 *
 	 * @param blk block
 	 */
-	void blacklistBlock(Block blk);
+	void blacklistBlock( Block blk );
 
 	/**
 	 * White list your tile entity with the registry.
@@ -74,27 +76,28 @@ public interface IMovableRegistry
 	 *
 	 * If you tile is handled with IMovableHandler or IMovableTile you do not need to white list it.
 	 */
-	void whiteListTileEntity(Class<? extends TileEntity> c);
+	void whiteListTileEntity( Class<? extends TileEntity> c );
 
 	/**
 	 * @param te to be moved tile entity
+	 *
 	 * @return true if the tile has accepted your request to move it
 	 */
-	boolean askToMove(TileEntity te);
+	boolean askToMove( TileEntity te );
 
 	/**
 	 * tells the tile you are done moving it.
 	 *
 	 * @param te moved tile entity
 	 */
-	void doneMoving(TileEntity te);
+	void doneMoving( TileEntity te );
 
 	/**
 	 * add a new handler movable handler.
 	 *
 	 * @param handler moving handler
 	 */
-	void addHandler(IMovableHandler handler);
+	void addHandler( IMovableHandler handler );
 
 	/**
 	 * handlers are used to perform movement, this allows you to override AE's internal version.
@@ -102,9 +105,10 @@ public interface IMovableRegistry
 	 * only valid after askToMove(...) = true
 	 *
 	 * @param te tile entity
+	 *
 	 * @return moving handler of tile entity
 	 */
-	IMovableHandler getHandler(TileEntity te);
+	IMovableHandler getHandler( TileEntity te );
 
 	/**
 	 * @return a copy of the default handler
@@ -113,8 +117,8 @@ public interface IMovableRegistry
 
 	/**
 	 * @param blk block
+	 *
 	 * @return true if this block is blacklisted
 	 */
-	boolean isBlacklisted(Block blk);
-
+	boolean isBlacklisted( Block blk );
 }

--- a/src/api/java/appeng/api/movable/IMovableTile.java
+++ b/src/api/java/appeng/api/movable/IMovableTile.java
@@ -23,6 +23,7 @@
 
 package appeng.api.movable;
 
+
 /**
  * You can implement this, or use the IMovableRegistry to white list your tile,
  * please see the registry for more information.
@@ -42,5 +43,4 @@ public interface IMovableTile
 	 * notification that your block was moved, called after validate.
 	 */
 	void doneMoving();
-
 }

--- a/src/api/java/appeng/api/networking/GridFlags.java
+++ b/src/api/java/appeng/api/networking/GridFlags.java
@@ -23,6 +23,7 @@
 
 package appeng.api.networking;
 
+
 /**
  * Various flags to determine network node behavior.
  */

--- a/src/api/java/appeng/api/networking/GridNotification.java
+++ b/src/api/java/appeng/api/networking/GridNotification.java
@@ -23,6 +23,7 @@
 
 package appeng.api.networking;
 
+
 public enum GridNotification
 {
 	/**

--- a/src/api/java/appeng/api/networking/IGrid.java
+++ b/src/api/java/appeng/api/networking/IGrid.java
@@ -23,8 +23,10 @@
 
 package appeng.api.networking;
 
+
 import appeng.api.networking.events.MENetworkEvent;
 import appeng.api.util.IReadOnlyCollection;
+
 
 /**
  * Gives you access to Grid based information.
@@ -38,18 +40,18 @@ public interface IGrid
 	 * Get Access to various grid modules
 	 *
 	 * @param iface face
+	 *
 	 * @return the IGridCache you requested.
 	 */
-	public <C extends IGridCache> C getCache(Class<? extends IGridCache> iface);
+	public <C extends IGridCache> C getCache( Class<? extends IGridCache> iface );
 
 	/**
 	 * Post an event into the network event bus.
 	 *
-	 * @param ev
-	 *            - event to post
+	 * @param ev event to post
 	 * @return returns ev back to original poster
 	 */
-	public MENetworkEvent postEvent(MENetworkEvent ev);
+	public MENetworkEvent postEvent( MENetworkEvent ev );
 
 	/**
 	 * Post an event into the network event bus, but direct it at a single node.
@@ -58,7 +60,7 @@ public interface IGrid
 	 *            event to post
 	 * @return returns ev back to original poster
 	 */
-	public MENetworkEvent postEventTo(IGridNode node, MENetworkEvent ev);
+	public MENetworkEvent postEventTo( IGridNode node, MENetworkEvent ev );
 
 	/**
 	 * get a list of the diversity of classes, you can use this to better detect which machines your interested in,
@@ -72,9 +74,10 @@ public interface IGrid
 	 * Get machines on the network.
 	 *
 	 * @param gridHostClass class of the grid host
+	 *
 	 * @return IMachineSet of all nodes belonging to hosts of specified class.
 	 */
-	public IMachineSet getMachines(Class<? extends IGridHost> gridHostClass);
+	public IMachineSet getMachines( Class<? extends IGridHost> gridHostClass );
 
 	/**
 	 * @return IReadOnlyCollection for all nodes on the network, node visitors are preferred.
@@ -90,5 +93,4 @@ public interface IGrid
 	 * @return the node considered the pivot point of the grid.
 	 */
 	public IGridNode getPivot();
-
 }

--- a/src/api/java/appeng/api/networking/IGridBlock.java
+++ b/src/api/java/appeng/api/networking/IGridBlock.java
@@ -23,13 +23,16 @@
 
 package appeng.api.networking;
 
-import appeng.api.parts.IPart;
-import appeng.api.util.AEColor;
-import appeng.api.util.DimensionalCoord;
+
+import java.util.EnumSet;
+
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import java.util.EnumSet;
+import appeng.api.parts.IPart;
+import appeng.api.util.AEColor;
+import appeng.api.util.DimensionalCoord;
+
 
 /**
  * An Implementation is required to create your node for IGridHost
@@ -77,15 +80,15 @@ public interface IGridBlock
 	/**
 	 * Notifies your IGridBlock that changes were made to your connections
 	 */
-	void onGridNotification(GridNotification notification);
+	void onGridNotification( GridNotification notification );
 
 	/**
 	 * Update Blocks network/connection/booting status. grid,
 	 *
-	 * @param grid grid
+	 * @param grid          grid
 	 * @param channelsInUse used channels
 	 */
-	public void setNetworkStatus(IGrid grid, int channelsInUse);
+	public void setNetworkStatus( IGrid grid, int channelsInUse );
 
 	/**
 	 * Determine which sides of the block can be connected too, only used when isWorldAccessible returns true, not used

--- a/src/api/java/appeng/api/networking/IGridCache.java
+++ b/src/api/java/appeng/api/networking/IGridCache.java
@@ -23,6 +23,7 @@
 
 package appeng.api.networking;
 
+
 /**
  *
  * Allows you to create a network wise service, AE2 uses these for providing
@@ -50,9 +51,9 @@ public interface IGridCache
 	 * information, do it on the next updateTick.
 	 *
 	 * @param gridNode removed from that grid
-	 * @param machine to be removed machine
+	 * @param machine  to be removed machine
 	 */
-	void removeNode(IGridNode gridNode, IGridHost machine);
+	void removeNode( IGridNode gridNode, IGridHost machine );
 
 	/**
 	 * informs you cache that a machine was added to the grid.
@@ -62,9 +63,9 @@ public interface IGridCache
 	 * information, do it on the next updateTick.
 	 *
 	 * @param gridNode added to grid node
-	 * @param machine to be added machine
+	 * @param machine  to be added machine
 	 */
-	void addNode(IGridNode gridNode, IGridHost machine);
+	void addNode( IGridNode gridNode, IGridHost machine );
 
 	/**
 	 * Called when a grid splits into two grids, AE will call a split as it
@@ -73,7 +74,7 @@ public interface IGridCache
 	 *
 	 * @param destinationStorage storage which receives half of old grid
 	 */
-	void onSplit(IGridStorage destinationStorage);
+	void onSplit( IGridStorage destinationStorage );
 
 	/**
 	 * Called when two grids merge into one, AE will call a join as it
@@ -82,13 +83,12 @@ public interface IGridCache
 	 *
 	 * @param sourceStorage old storage
 	 */
-	void onJoin(IGridStorage sourceStorage);
+	void onJoin( IGridStorage sourceStorage );
 
 	/**
 	 * Called when saving changes,
 	 *
 	 * @param destinationStorage storage
 	 */
-	void populateGridStorage(IGridStorage destinationStorage);
-
+	void populateGridStorage( IGridStorage destinationStorage );
 }

--- a/src/api/java/appeng/api/networking/IGridCacheRegistry.java
+++ b/src/api/java/appeng/api/networking/IGridCacheRegistry.java
@@ -23,7 +23,9 @@
 
 package appeng.api.networking;
 
+
 import java.util.HashMap;
+
 
 /**
  * A registry of grid caches to extend grid functionality.
@@ -36,7 +38,7 @@ public interface IGridCacheRegistry
 	 *
 	 * @param iface grid cache class
 	 */
-	void registerGridCache(Class<? extends IGridCache> iface, Class<? extends IGridCache> implementation);
+	void registerGridCache( Class<? extends IGridCache> iface, Class<? extends IGridCache> implementation );
 
 	/**
 	 * requests a new INSTANCE of a grid cache for use, used internally
@@ -45,6 +47,5 @@ public interface IGridCacheRegistry
 	 *
 	 * @return a new HashMap of IGridCaches from the registry, called from IGrid when constructing a new grid.
 	 */
-	HashMap<Class<? extends IGridCache>, IGridCache> createCacheInstance(IGrid grid);
-
+	HashMap<Class<? extends IGridCache>, IGridCache> createCacheInstance( IGrid grid );
 }

--- a/src/api/java/appeng/api/networking/IGridConnection.java
+++ b/src/api/java/appeng/api/networking/IGridConnection.java
@@ -23,7 +23,9 @@
 
 package appeng.api.networking;
 
+
 import net.minecraftforge.common.util.ForgeDirection;
+
 
 /**
  * Access to AE's internal grid connections.
@@ -40,17 +42,19 @@ public interface IGridConnection
 	 * lets you get the opposing node of the connection by passing your own node.
 	 *
 	 * @param gridNode current grid node
+	 *
 	 * @return the IGridNode which represents the opposite side of the connection.
 	 */
-	IGridNode getOtherSide(IGridNode gridNode);
+	IGridNode getOtherSide( IGridNode gridNode );
 
 	/**
 	 * determine the direction of the connection based on your node.
 	 *
 	 * @param gridNode current grid node
+	 *
 	 * @return the direction of the connection, only valid for in world connections.
 	 */
-	ForgeDirection getDirection(IGridNode gridNode);
+	ForgeDirection getDirection( IGridNode gridNode );
 
 	/**
 	 * by destroying a connection you may create new grids, and trigger un-expected behavior, you should only destroy
@@ -77,5 +81,4 @@ public interface IGridConnection
 	 * @return how many channels pass over this connections.
 	 */
 	int getUsedChannels();
-
 }

--- a/src/api/java/appeng/api/networking/IGridConnectionVisitor.java
+++ b/src/api/java/appeng/api/networking/IGridConnectionVisitor.java
@@ -23,15 +23,14 @@
 
 package appeng.api.networking;
 
+
 public interface IGridConnectionVisitor extends IGridVisitor
 {
 
 	/**
 	 * Called for each connection on the network.
 	 *
-	 * @param n
-	 *            the connection.
+	 * @param n the connection.
 	 */
-	public void visitConnection(IGridConnection n);
-
+	public void visitConnection( IGridConnection n );
 }

--- a/src/api/java/appeng/api/networking/IGridHost.java
+++ b/src/api/java/appeng/api/networking/IGridHost.java
@@ -23,10 +23,13 @@
 
 package appeng.api.networking;
 
+
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.util.ForgeDirection;
+
 import appeng.api.parts.IPart;
 import appeng.api.util.AECableType;
+
 
 /**
  *
@@ -45,10 +48,11 @@ public interface IGridHost
 	 * @param dir
 	 *            feel free to ignore this, most blocks will use the same node
 	 *            for every side.
+	 *
 	 * @return a new IGridNode, create these with
-	 *         AEApi.INSTANCE().createGridNode( MyIGridBlock )
+	 * AEApi.INSTANCE().createGridNode( MyIGridBlock )
 	 */
-	public IGridNode getGridNode(ForgeDirection dir);
+	public IGridNode getGridNode( ForgeDirection dir );
 
 	/**
 	 * Determines how cables render when they connect to this block. Priority is
@@ -56,11 +60,10 @@ public interface IGridHost
 	 *
 	 * @param dir direction
 	 */
-	public AECableType getCableConnectionType(ForgeDirection dir);
+	public AECableType getCableConnectionType( ForgeDirection dir );
 
 	/**
 	 * break this host, its violating security rules, just break your block, or part.
 	 */
 	public void securityBreak();
-
 }

--- a/src/api/java/appeng/api/networking/IGridMultiblock.java
+++ b/src/api/java/appeng/api/networking/IGridMultiblock.java
@@ -23,7 +23,9 @@
 
 package appeng.api.networking;
 
+
 import java.util.Iterator;
+
 
 /**
  * An extension of IGridBlock, only means something when your getFlags() contains REQUIRE_CHANNEL, when done properly it
@@ -39,5 +41,4 @@ public interface IGridMultiblock extends IGridBlock
 	 * @return an iterator that will iterate all the nodes for the multiblock. ( read-only iterator expected. )
 	 */
 	Iterator<IGridNode> getMultiblockNodes();
-
 }

--- a/src/api/java/appeng/api/networking/IGridNode.java
+++ b/src/api/java/appeng/api/networking/IGridNode.java
@@ -23,13 +23,16 @@
 
 package appeng.api.networking;
 
-import appeng.api.IAppEngApi;
-import appeng.api.util.IReadOnlyCollection;
+
+import java.util.EnumSet;
+
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import java.util.EnumSet;
+import appeng.api.IAppEngApi;
+import appeng.api.util.IReadOnlyCollection;
+
 
 /**
  *
@@ -49,7 +52,7 @@ public interface IGridNode
 	 *
 	 * @param visitor visitor
 	 */
-	void beginVisit(IGridVisitor visitor);
+	void beginVisit( IGridVisitor visitor );
 
 	/**
 	 * inform the node that your IGridBlock has changed its internal state, and force the node to update.
@@ -123,7 +126,7 @@ public interface IGridNode
 	 * @param name nbt name
 	 * @param nodeData to be loaded data
 	 */
-	void loadFromNBT(String name, NBTTagCompound nodeData);
+	void loadFromNBT( String name, NBTTagCompound nodeData );
 
 	/**
 	 * this should be called for each node you maintain, you can save all your nodes to the same tag with different
@@ -132,11 +135,11 @@ public interface IGridNode
 	 * @param name nbt name
 	 * @param nodeData to be saved data
 	 */
-	void saveToNBT(String name, NBTTagCompound nodeData);
+	void saveToNBT( String name, NBTTagCompound nodeData );
 
 	/**
 	 * @return if the node's channel requirements are currently met, use this for display purposes, use isActive for
-	 *         status.
+	 * status.
 	 */
 	boolean meetsChannelRequirements();
 
@@ -144,9 +147,10 @@ public interface IGridNode
 	 * see if this node has a certain flag
 	 *
 	 * @param flag flags
+	 *
 	 * @return true if has flag
 	 */
-	boolean hasFlag(GridFlags flag);
+	boolean hasFlag( GridFlags flag );
 
 	/**
 	 * tell the node who was responsible for placing it, failure to do this may result in in-compatibility with the
@@ -154,11 +158,10 @@ public interface IGridNode
 	 *
 	 * @param playerID new player id
 	 */
-	void setPlayerID(int playerID);
+	void setPlayerID( int playerID );
 
 	/**
 	 * @return the ownerID this represents the person who placed the node.
 	 */
 	int getPlayerID();
-
 }

--- a/src/api/java/appeng/api/networking/IGridStorage.java
+++ b/src/api/java/appeng/api/networking/IGridStorage.java
@@ -23,7 +23,9 @@
 
 package appeng.api.networking;
 
+
 import net.minecraft.nbt.NBTTagCompound;
+
 
 public interface IGridStorage
 {
@@ -37,5 +39,4 @@ public interface IGridStorage
 	 * @return the id for this grid storage object, used internally
 	 */
 	long getID();
-
 }

--- a/src/api/java/appeng/api/networking/IGridVisitor.java
+++ b/src/api/java/appeng/api/networking/IGridVisitor.java
@@ -23,6 +23,7 @@
 
 package appeng.api.networking;
 
+
 /**
  * Simple Visitor pattern access to network nodes.
  */
@@ -39,6 +40,5 @@ public interface IGridVisitor
 	 *
 	 * @return true to continue visiting nodes beyond this node.
 	 */
-	public boolean visitNode(IGridNode n);
-
+	public boolean visitNode( IGridNode n );
 }

--- a/src/api/java/appeng/api/networking/IMachineSet.java
+++ b/src/api/java/appeng/api/networking/IMachineSet.java
@@ -23,7 +23,9 @@
 
 package appeng.api.networking;
 
+
 import appeng.api.util.IReadOnlyCollection;
+
 
 public interface IMachineSet extends IReadOnlyCollection<IGridNode>
 {
@@ -32,5 +34,4 @@ public interface IMachineSet extends IReadOnlyCollection<IGridNode>
 	 * @return the machine class for this set.
 	 */
 	Class<? extends IGridHost> getMachineClass();
-
 }

--- a/src/api/java/appeng/api/networking/crafting/CraftingItemList.java
+++ b/src/api/java/appeng/api/networking/crafting/CraftingItemList.java
@@ -23,6 +23,7 @@
 
 package appeng.api.networking.crafting;
 
+
 public enum CraftingItemList
 {
 	ALL, STORAGE, ACTIVE, PENDING

--- a/src/api/java/appeng/api/networking/crafting/ICraftingCPU.java
+++ b/src/api/java/appeng/api/networking/crafting/ICraftingCPU.java
@@ -23,9 +23,11 @@
 
 package appeng.api.networking.crafting;
 
+
 import appeng.api.networking.security.BaseActionSource;
 import appeng.api.networking.storage.IBaseMonitor;
 import appeng.api.storage.data.IAEItemStack;
+
 
 public interface ICraftingCPU extends IBaseMonitor<IAEItemStack>
 {
@@ -54,5 +56,4 @@ public interface ICraftingCPU extends IBaseMonitor<IAEItemStack>
 	 * @return an empty string or the name of the cpu.
 	 */
 	String getName();
-
 }

--- a/src/api/java/appeng/api/networking/crafting/ICraftingCallback.java
+++ b/src/api/java/appeng/api/networking/crafting/ICraftingCallback.java
@@ -23,6 +23,7 @@
 
 package appeng.api.networking.crafting;
 
+
 public interface ICraftingCallback
 {
 
@@ -32,6 +33,5 @@ public interface ICraftingCallback
 	 * @param job
 	 *            - final job
 	 */
-	public void calculationComplete(ICraftingJob job);
-
+	public void calculationComplete( ICraftingJob job );
 }

--- a/src/api/java/appeng/api/networking/crafting/ICraftingGrid.java
+++ b/src/api/java/appeng/api/networking/crafting/ICraftingGrid.java
@@ -23,27 +23,32 @@
 
 package appeng.api.networking.crafting;
 
+
+import java.util.concurrent.Future;
+
+import net.minecraft.world.World;
+
+import com.google.common.collect.ImmutableCollection;
+import com.google.common.collect.ImmutableSet;
+
 import appeng.api.networking.IGrid;
 import appeng.api.networking.IGridCache;
 import appeng.api.networking.security.BaseActionSource;
 import appeng.api.storage.data.IAEItemStack;
-import com.google.common.collect.ImmutableCollection;
-import com.google.common.collect.ImmutableSet;
-import net.minecraft.world.World;
 
-import java.util.concurrent.Future;
 
 public interface ICraftingGrid extends IGridCache
 {
 
 	/**
 	 * @param whatToCraft requested craft
-	 * @param world crafting world
-	 * @param slot slot index
-	 * @param details pattern details
+	 * @param world       crafting world
+	 * @param slot        slot index
+	 * @param details     pattern details
+	 *
 	 * @return a collection of crafting patterns for the item in question.
 	 */
-	ImmutableCollection<ICraftingPatternDetails> getCraftingFor(IAEItemStack whatToCraft, ICraftingPatternDetails details, int slot, World world);
+	ImmutableCollection<ICraftingPatternDetails> getCraftingFor( IAEItemStack whatToCraft, ICraftingPatternDetails details, int slot, World world );
 
 	/**
 	 * Begin calculating a crafting job.
@@ -56,9 +61,9 @@ public interface ICraftingGrid extends IGridCache
 	 *            -- optional
 	 *
 	 * @return a future which will at an undetermined point in the future get you the {@link ICraftingJob} do not wait
-	 *         on this, your be waiting forever.
+	 * on this, your be waiting forever.
 	 */
-	Future<ICraftingJob> beginCraftingJob(World world, IGrid grid, BaseActionSource actionSrc, IAEItemStack craftWhat, ICraftingCallback callback);
+	Future<ICraftingJob> beginCraftingJob( World world, IGrid grid, BaseActionSource actionSrc, IAEItemStack craftWhat, ICraftingCallback callback );
 
 	/**
 	 * Submit the job to the Crafting system for processing.
@@ -79,11 +84,11 @@ public interface ICraftingGrid extends IGridCache
 	 *            usually be the same as the one provided to beginCraftingJob.
 	 *
 	 * @return null ( if failed ) or an {@link ICraftingLink} other wise, if you send requestingMachine you need to
-	 *         properly keep track of this and handle the nbt saving and loading of the object as well as the
-	 *         {@link ICraftingRequester} methods. if you send null, this object should be discarded after verifying the
-	 *         return state.
+	 * properly keep track of this and handle the nbt saving and loading of the object as well as the
+	 * {@link ICraftingRequester} methods. if you send null, this object should be discarded after verifying the
+	 * return state.
 	 */
-	ICraftingLink submitJob(ICraftingJob job, ICraftingRequester requestingMachine, ICraftingCPU target, boolean prioritizePower, BaseActionSource src);
+	ICraftingLink submitJob( ICraftingJob job, ICraftingRequester requestingMachine, ICraftingCPU target, boolean prioritizePower, BaseActionSource src );
 
 	/**
 	 * @return list of all the crafting cpus on the grid
@@ -92,16 +97,17 @@ public interface ICraftingGrid extends IGridCache
 
 	/**
 	 * @param what to be requested item
+	 *
 	 * @return true if the item can be requested via a crafting emitter.
 	 */
-	boolean canEmitFor(IAEItemStack what);
+	boolean canEmitFor( IAEItemStack what );
 
 	/**
 	 * is this item being crafted?
 	 *
 	 * @param aeStackInSlot item being crafted
+	 *
 	 * @return true if it is being crafting
 	 */
-	boolean isRequesting(IAEItemStack aeStackInSlot);
-
+	boolean isRequesting( IAEItemStack aeStackInSlot );
 }

--- a/src/api/java/appeng/api/networking/crafting/ICraftingJob.java
+++ b/src/api/java/appeng/api/networking/crafting/ICraftingJob.java
@@ -23,15 +23,17 @@
 
 package appeng.api.networking.crafting;
 
+
 import appeng.api.storage.data.IAEItemStack;
 import appeng.api.storage.data.IItemList;
+
 
 public interface ICraftingJob
 {
 
 	/**
 	 * @return if this job is a simulation, simulations cannot be submitted and only represent 1 possible future
-	 *         crafting job with fake items.
+	 * crafting job with fake items.
 	 */
 	boolean isSimulation();
 
@@ -46,11 +48,10 @@ public interface ICraftingJob
 	 *
 	 * @param plan plan
 	 */
-	void populatePlan(IItemList<IAEItemStack> plan);
+	void populatePlan( IItemList<IAEItemStack> plan );
 
 	/**
 	 * @return the final output of the job.
 	 */
 	IAEItemStack getOutput();
-
 }

--- a/src/api/java/appeng/api/networking/crafting/ICraftingLink.java
+++ b/src/api/java/appeng/api/networking/crafting/ICraftingLink.java
@@ -23,7 +23,9 @@
 
 package appeng.api.networking.crafting;
 
+
 import net.minecraft.nbt.NBTTagCompound;
+
 
 public interface ICraftingLink
 {
@@ -53,11 +55,10 @@ public interface ICraftingLink
 	 *
 	 * @param tag to be written data
 	 */
-	void writeToNBT(NBTTagCompound tag);
+	void writeToNBT( NBTTagCompound tag );
 
 	/**
 	 * @return the crafting ID for this link.
 	 */
 	String getCraftingID();
-
 }

--- a/src/api/java/appeng/api/networking/crafting/ICraftingMedium.java
+++ b/src/api/java/appeng/api/networking/crafting/ICraftingMedium.java
@@ -23,7 +23,9 @@
 
 package appeng.api.networking.crafting;
 
+
 import net.minecraft.inventory.InventoryCrafting;
+
 
 /**
  * A place to send Items for crafting purposes, this is considered part of AE's External crafting system.
@@ -36,14 +38,14 @@ public interface ICraftingMedium
 	 * possible the output should be directed.
 	 *
 	 * @param patternDetails details
-	 * @param table crafting table
+	 * @param table          crafting table
+	 *
 	 * @return if the pattern was successfully pushed.
 	 */
-	boolean pushPattern(ICraftingPatternDetails patternDetails, InventoryCrafting table);
+	boolean pushPattern( ICraftingPatternDetails patternDetails, InventoryCrafting table );
 
 	/**
 	 * @return if this is false, the crafting engine will refuse to send new jobs to this medium.
 	 */
 	boolean isBusy();
-
 }

--- a/src/api/java/appeng/api/networking/crafting/ICraftingPatternDetails.java
+++ b/src/api/java/appeng/api/networking/crafting/ICraftingPatternDetails.java
@@ -23,11 +23,14 @@
 
 package appeng.api.networking.crafting;
 
+
 import net.minecraft.inventory.InventoryCrafting;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
+
 import appeng.api.implementations.ICraftingPatternItem;
 import appeng.api.storage.data.IAEItemStack;
+
 
 /**
  * do not implement provided by {@link ICraftingPatternItem}
@@ -49,7 +52,7 @@ public interface ICraftingPatternDetails
 	 *
 	 * @return if an item can be used in the specific slot for this pattern.
 	 */
-	boolean isValidItemForSlot(int slotIndex, ItemStack itemStack, World world);
+	boolean isValidItemForSlot( int slotIndex, ItemStack itemStack, World world );
 
 	/**
 	 * @return if this pattern is a crafting pattern ( work bench )
@@ -85,17 +88,18 @@ public interface ICraftingPatternDetails
 	 * Allow using this INSTANCE of the pattern details to preform the crafting action with performance enhancements.
 	 *
 	 * @param craftingInv inventory
-	 * @param world crafting world
+	 * @param world       crafting world
+	 *
 	 * @return the crafted ( work bench ) item.
 	 */
-	ItemStack getOutput(InventoryCrafting craftingInv, World world);
+	ItemStack getOutput( InventoryCrafting craftingInv, World world );
 
 	/**
 	 * Set the priority the of this pattern.
 	 *
 	 * @param priority priority of pattern
 	 */
-	void setPriority(int priority);
+	void setPriority( int priority );
 
 	/**
 	 * Get the priority of this pattern

--- a/src/api/java/appeng/api/networking/crafting/ICraftingProvider.java
+++ b/src/api/java/appeng/api/networking/crafting/ICraftingProvider.java
@@ -23,7 +23,9 @@
 
 package appeng.api.networking.crafting;
 
+
 import appeng.api.networking.events.MENetworkCraftingPatternChange;
+
 
 /**
  * Allows a IGridHost to provide crafting patterns to the network, post a {@link MENetworkCraftingPatternChange} to tell
@@ -37,6 +39,5 @@ public interface ICraftingProvider extends ICraftingMedium
 	 *
 	 * @param craftingTracker crafting helper
 	 */
-	void provideCrafting(ICraftingProviderHelper craftingTracker);
-
+	void provideCrafting( ICraftingProviderHelper craftingTracker );
 }

--- a/src/api/java/appeng/api/networking/crafting/ICraftingProviderHelper.java
+++ b/src/api/java/appeng/api/networking/crafting/ICraftingProviderHelper.java
@@ -23,7 +23,9 @@
 
 package appeng.api.networking.crafting;
 
+
 import appeng.api.storage.data.IAEItemStack;
+
 
 /**
  * Passed to a ICraftingProvider as a interface to manipulate the available crafting jobs.
@@ -34,11 +36,10 @@ public interface ICraftingProviderHelper
 	/**
 	 * Add new Pattern to AE's crafting cache.
 	 */
-	void addCraftingOption(ICraftingMedium medium, ICraftingPatternDetails api);
+	void addCraftingOption( ICraftingMedium medium, ICraftingPatternDetails api );
 
 	/**
 	 * Set an item can Emitable
 	 */
-	void setEmitable(IAEItemStack what);
-
+	void setEmitable( IAEItemStack what );
 }

--- a/src/api/java/appeng/api/networking/crafting/ICraftingRequester.java
+++ b/src/api/java/appeng/api/networking/crafting/ICraftingRequester.java
@@ -23,11 +23,13 @@
 
 package appeng.api.networking.crafting;
 
+
+import com.google.common.collect.ImmutableSet;
+
 import appeng.api.config.Actionable;
 import appeng.api.networking.security.IActionHost;
 import appeng.api.storage.data.IAEItemStack;
 
-import com.google.common.collect.ImmutableSet;
 
 public interface ICraftingRequester extends IActionHost
 {
@@ -45,16 +47,16 @@ public interface ICraftingRequester extends IActionHost
 	 * be returned.
 	 *
 	 * @param items item
-	 * @param mode action mode
+	 * @param mode  action mode
+	 *
 	 * @return unwanted item
 	 */
-	IAEItemStack injectCraftedItems(ICraftingLink link, IAEItemStack items, Actionable mode);
+	IAEItemStack injectCraftedItems( ICraftingLink link, IAEItemStack items, Actionable mode );
 
 	/**
 	 * called when the job changes from in progress, to either complete, or canceled.
 	 *
 	 * after this call the crafting link is "dead" and should be discarded.
 	 */
-	void jobStateChange(ICraftingLink link);
-
+	void jobStateChange( ICraftingLink link );
 }

--- a/src/api/java/appeng/api/networking/crafting/ICraftingWatcher.java
+++ b/src/api/java/appeng/api/networking/crafting/ICraftingWatcher.java
@@ -23,9 +23,11 @@
 
 package appeng.api.networking.crafting;
 
+
 import java.util.Collection;
 
 import appeng.api.storage.data.IAEStack;
+
 
 public interface ICraftingWatcher extends Collection<IAEStack>
 {

--- a/src/api/java/appeng/api/networking/crafting/ICraftingWatcherHost.java
+++ b/src/api/java/appeng/api/networking/crafting/ICraftingWatcherHost.java
@@ -23,7 +23,9 @@
 
 package appeng.api.networking.crafting;
 
+
 import appeng.api.storage.data.IAEItemStack;
+
 
 public interface ICraftingWatcherHost
 {
@@ -34,14 +36,13 @@ public interface ICraftingWatcherHost
 	 *
 	 * @param newWatcher crafting watcher for this host
 	 */
-	void updateWatcher(ICraftingWatcher newWatcher);
+	void updateWatcher( ICraftingWatcher newWatcher );
 
 	/**
 	 * Called when a crafting status changes.
 	 *
 	 * @param craftingGrid current crafting grid
-	 * @param what change
+	 * @param what         change
 	 */
-	void onRequestChange(ICraftingGrid craftingGrid, IAEItemStack what);
-
+	void onRequestChange( ICraftingGrid craftingGrid, IAEItemStack what );
 }

--- a/src/api/java/appeng/api/networking/energy/IAEPowerStorage.java
+++ b/src/api/java/appeng/api/networking/energy/IAEPowerStorage.java
@@ -23,8 +23,10 @@
 
 package appeng.api.networking.energy;
 
+
 import appeng.api.config.AccessRestriction;
 import appeng.api.config.Actionable;
+
 
 /**
  * Used to access information about AE's various power accepting blocks for monitoring purposes.
@@ -40,7 +42,7 @@ public interface IAEPowerStorage extends IEnergySource
 	 *
 	 * @return amount of power which was unable to be stored
 	 */
-	public double injectAEPower(double amt, Actionable mode);
+	public double injectAEPower( double amt, Actionable mode );
 
 	/**
 	 * @return the current maximum power ( this can change :P )
@@ -66,5 +68,4 @@ public interface IAEPowerStorage extends IEnergySource
 	 * @return access restriction what the network can do
 	 */
 	public AccessRestriction getPowerFlow();
-
 }

--- a/src/api/java/appeng/api/networking/energy/IEnergyGrid.java
+++ b/src/api/java/appeng/api/networking/energy/IEnergyGrid.java
@@ -23,9 +23,11 @@
 
 package appeng.api.networking.energy;
 
+
 import appeng.api.config.Actionable;
 import appeng.api.networking.IGridCache;
 import appeng.api.networking.events.MENetworkPowerStatusChange;
+
 
 /**
  * AE's Power system.
@@ -40,7 +42,7 @@ public interface IEnergyGrid extends IGridCache, IEnergySource, IEnergyGridProvi
 
 	/**
 	 * @return the average power drain over the past 10 ticks, includes idle usage during this time, and all use of
-	 *         extractPower.
+	 * extractPower.
 	 */
 	public double getAvgPowerUsage();
 
@@ -72,13 +74,11 @@ public interface IEnergyGrid extends IGridCache, IEnergySource, IEnergyGridProvi
 	 * Another important note, is that if a network that had overflow is deleted, its power is gone, this is one of the
 	 * reasons why keeping overflow to a minimum is important.
 	 *
-	 * @param amt
-	 *            power to inject into the network
-	 * @param mode
-	 *            should the action be simulated or performed?
+	 * @param amt power to inject into the network
+	 * @param mode should the action be simulated or performed?
 	 * @return the amount of power that the network has OVER the limit.
 	 */
-	public double injectPower(double amt, Actionable mode);
+	public double injectPower( double amt, Actionable mode );
 
 	/**
 	 * this is should be considered an estimate, and not relied upon for real calculations.
@@ -100,6 +100,5 @@ public interface IEnergyGrid extends IGridCache, IEnergySource, IEnergyGridProvi
 	 *
 	 * @return Amount of power required to charge the grid, in AE.
 	 */
-	public double getEnergyDemand(double maxRequired);
-
+	public double getEnergyDemand( double maxRequired );
 }

--- a/src/api/java/appeng/api/networking/energy/IEnergyGridProvider.java
+++ b/src/api/java/appeng/api/networking/energy/IEnergyGridProvider.java
@@ -23,9 +23,11 @@
 
 package appeng.api.networking.energy;
 
+
 import java.util.Set;
 
 import appeng.api.config.Actionable;
+
 
 /**
  * internal use only.
@@ -36,16 +38,15 @@ public interface IEnergyGridProvider
 	/**
 	 * internal use only
 	 */
-	public double extractAEPower(double amt, Actionable mode, Set<IEnergyGrid> seen);
+	public double extractAEPower( double amt, Actionable mode, Set<IEnergyGrid> seen );
 
 	/**
 	 * internal use only
 	 */
-	public double injectAEPower(double amt, Actionable mode, Set<IEnergyGrid> seen);
+	public double injectAEPower( double amt, Actionable mode, Set<IEnergyGrid> seen );
 
 	/**
 	 * internal use only
 	 */
-	public double getEnergyDemand(double d, Set<IEnergyGrid> seen);
-
+	public double getEnergyDemand( double d, Set<IEnergyGrid> seen );
 }

--- a/src/api/java/appeng/api/networking/energy/IEnergySource.java
+++ b/src/api/java/appeng/api/networking/energy/IEnergySource.java
@@ -23,8 +23,10 @@
 
 package appeng.api.networking.energy;
 
+
 import appeng.api.config.Actionable;
 import appeng.api.config.PowerMultiplier;
+
 
 public interface IEnergySource
 {
@@ -34,8 +36,8 @@ public interface IEnergySource
 	 *
 	 * @param amt extracted power
 	 * @param mode should the action be simulated or performed?
+	 *
 	 * @return returns extracted power.
 	 */
-	public double extractAEPower(double amt, Actionable mode, PowerMultiplier usePowerMultiplier);
-
+	public double extractAEPower( double amt, Actionable mode, PowerMultiplier usePowerMultiplier );
 }

--- a/src/api/java/appeng/api/networking/energy/IEnergyWatcher.java
+++ b/src/api/java/appeng/api/networking/energy/IEnergyWatcher.java
@@ -23,7 +23,9 @@
 
 package appeng.api.networking.energy;
 
+
 import java.util.Collection;
+
 
 public interface IEnergyWatcher extends Collection<Double>
 {

--- a/src/api/java/appeng/api/networking/energy/IEnergyWatcherHost.java
+++ b/src/api/java/appeng/api/networking/energy/IEnergyWatcherHost.java
@@ -23,6 +23,7 @@
 
 package appeng.api.networking.energy;
 
+
 public interface IEnergyWatcherHost
 {
 
@@ -32,13 +33,12 @@ public interface IEnergyWatcherHost
 	 *
 	 * @param newWatcher new watcher
 	 */
-	void updateWatcher(IEnergyWatcher newWatcher);
+	void updateWatcher( IEnergyWatcher newWatcher );
 
 	/**
 	 * Called when a threshold is crossed.
 	 *
 	 * @param energyGrid grid
 	 */
-	void onThresholdPass(IEnergyGrid energyGrid);
-
+	void onThresholdPass( IEnergyGrid energyGrid );
 }

--- a/src/api/java/appeng/api/networking/events/MENetworkBootingStatusChange.java
+++ b/src/api/java/appeng/api/networking/events/MENetworkBootingStatusChange.java
@@ -23,7 +23,9 @@
 
 package appeng.api.networking.events;
 
+
 import appeng.api.networking.IGridNode;
+
 
 /**
  * Posted by the network when the booting status of the network goes up

--- a/src/api/java/appeng/api/networking/events/MENetworkCellArrayUpdate.java
+++ b/src/api/java/appeng/api/networking/events/MENetworkCellArrayUpdate.java
@@ -23,6 +23,7 @@
 
 package appeng.api.networking.events;
 
+
 /**
  * Posted by storage devices to inform AE to refresh its storage structure.
  *

--- a/src/api/java/appeng/api/networking/events/MENetworkChannelChanged.java
+++ b/src/api/java/appeng/api/networking/events/MENetworkChannelChanged.java
@@ -23,7 +23,9 @@
 
 package appeng.api.networking.events;
 
+
 import appeng.api.networking.IGridNode;
+
 
 /**
  * Posted by storage devices to inform AE the channel cache that the included node has changed its mind about its
@@ -34,8 +36,8 @@ public class MENetworkChannelChanged extends MENetworkEvent
 
 	public final IGridNode node;
 
-	public MENetworkChannelChanged(IGridNode n) {
+	public MENetworkChannelChanged( IGridNode n )
+	{
 		this.node = n;
 	}
-
 }

--- a/src/api/java/appeng/api/networking/events/MENetworkChannelsChanged.java
+++ b/src/api/java/appeng/api/networking/events/MENetworkChannelsChanged.java
@@ -23,7 +23,9 @@
 
 package appeng.api.networking.events;
 
+
 import appeng.api.networking.IGridHost;
+
 
 /**
  * Posted to the {@link IGridHost} when the channels on the node connections are altered.

--- a/src/api/java/appeng/api/networking/events/MENetworkControllerChange.java
+++ b/src/api/java/appeng/api/networking/events/MENetworkControllerChange.java
@@ -23,6 +23,7 @@
 
 package appeng.api.networking.events;
 
+
 /**
  * Event posted when the networks controller state changes, this can be from no
  * controller to 1 controller, or any time the network changes from conflicted

--- a/src/api/java/appeng/api/networking/events/MENetworkCraftingCpuChange.java
+++ b/src/api/java/appeng/api/networking/events/MENetworkCraftingCpuChange.java
@@ -23,15 +23,17 @@
 
 package appeng.api.networking.events;
 
+
 import appeng.api.networking.IGridNode;
+
 
 public class MENetworkCraftingCpuChange extends MENetworkEvent
 {
 
 	public final IGridNode node;
 
-	public MENetworkCraftingCpuChange(IGridNode n) {
+	public MENetworkCraftingCpuChange( IGridNode n )
+	{
 		this.node = n;
 	}
-
 }

--- a/src/api/java/appeng/api/networking/events/MENetworkCraftingPatternChange.java
+++ b/src/api/java/appeng/api/networking/events/MENetworkCraftingPatternChange.java
@@ -23,8 +23,10 @@
 
 package appeng.api.networking.events;
 
+
 import appeng.api.networking.IGridNode;
 import appeng.api.networking.crafting.ICraftingProvider;
+
 
 public class MENetworkCraftingPatternChange extends MENetworkEvent
 {
@@ -32,9 +34,9 @@ public class MENetworkCraftingPatternChange extends MENetworkEvent
 	public final ICraftingProvider provider;
 	public final IGridNode node;
 
-	public MENetworkCraftingPatternChange(ICraftingProvider p, IGridNode n) {
+	public MENetworkCraftingPatternChange( ICraftingProvider p, IGridNode n )
+	{
 		this.provider = p;
 		this.node = n;
 	}
-
 }

--- a/src/api/java/appeng/api/networking/events/MENetworkEvent.java
+++ b/src/api/java/appeng/api/networking/events/MENetworkEvent.java
@@ -23,7 +23,9 @@
 
 package appeng.api.networking.events;
 
+
 import appeng.api.networking.IGrid;
+
 
 /**
  * Part of AE's Event Bus.
@@ -69,7 +71,7 @@ public class MENetworkEvent
 	 *
 	 * @param v current number of visitors
 	 */
-	public void setVisitedObjects(int v)
+	public void setVisitedObjects( int v )
 	{
 		this.visited = v;
 	}

--- a/src/api/java/appeng/api/networking/events/MENetworkEventSubscribe.java
+++ b/src/api/java/appeng/api/networking/events/MENetworkEventSubscribe.java
@@ -23,16 +23,19 @@
 
 package appeng.api.networking.events;
 
+
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
 import appeng.api.networking.IGridCache;
 import appeng.api.networking.IGridHost;
 
+
 /**
  * Usable on any {@link IGridHost}, or {@link IGridCache}
  */
-@Retention(RetentionPolicy.RUNTIME)
-public @interface MENetworkEventSubscribe {
+@Retention( RetentionPolicy.RUNTIME )
+public @interface MENetworkEventSubscribe
+{
 
 }

--- a/src/api/java/appeng/api/networking/events/MENetworkPostCacheConstruction.java
+++ b/src/api/java/appeng/api/networking/events/MENetworkPostCacheConstruction.java
@@ -23,6 +23,7 @@
 
 package appeng.api.networking.events;
 
+
 /**
  * Posted after all the caches are available, but before the grid is fully
  * constructed, can be used to perform cross cache construction processes.

--- a/src/api/java/appeng/api/networking/events/MENetworkPowerIdleChange.java
+++ b/src/api/java/appeng/api/networking/events/MENetworkPowerIdleChange.java
@@ -23,7 +23,9 @@
 
 package appeng.api.networking.events;
 
+
 import appeng.api.networking.IGridNode;
+
 
 /**
  * Implementers of a IGridBlock must post this event when your getIdlePowerUsage
@@ -37,8 +39,8 @@ public class MENetworkPowerIdleChange extends MENetworkEvent
 
 	public final IGridNode node;
 
-	public MENetworkPowerIdleChange(IGridNode nodeThatChanged) {
+	public MENetworkPowerIdleChange( IGridNode nodeThatChanged )
+	{
 		this.node = nodeThatChanged;
 	}
-
 }

--- a/src/api/java/appeng/api/networking/events/MENetworkPowerStatusChange.java
+++ b/src/api/java/appeng/api/networking/events/MENetworkPowerStatusChange.java
@@ -23,8 +23,10 @@
 
 package appeng.api.networking.events;
 
+
 import appeng.api.networking.IGridNode;
 import appeng.api.networking.energy.IEnergyGrid;
+
 
 /**
  * Posted by the network when the power status of the network goes up or down,

--- a/src/api/java/appeng/api/networking/events/MENetworkPowerStorage.java
+++ b/src/api/java/appeng/api/networking/events/MENetworkPowerStorage.java
@@ -23,7 +23,9 @@
 
 package appeng.api.networking.events;
 
+
 import appeng.api.networking.energy.IAEPowerStorage;
+
 
 /**
  * informs the network, that a {@link IAEPowerStorage} block that had either run,
@@ -50,12 +52,13 @@ public class MENetworkPowerStorage extends MENetworkEvent
 		PROVIDE_POWER
 	}
 
+
 	public final IAEPowerStorage storage;
 	public final PowerEventType type;
 
-	public MENetworkPowerStorage(IAEPowerStorage t, PowerEventType y) {
+	public MENetworkPowerStorage( IAEPowerStorage t, PowerEventType y )
+	{
 		this.storage = t;
 		this.type = y;
 	}
-
 }

--- a/src/api/java/appeng/api/networking/events/MENetworkSecurityChange.java
+++ b/src/api/java/appeng/api/networking/events/MENetworkSecurityChange.java
@@ -23,6 +23,7 @@
 
 package appeng.api.networking.events;
 
+
 /**
  * Posted by the security framework when permissions change
  */

--- a/src/api/java/appeng/api/networking/events/MENetworkSpatialEvent.java
+++ b/src/api/java/appeng/api/networking/events/MENetworkSpatialEvent.java
@@ -23,7 +23,9 @@
 
 package appeng.api.networking.events;
 
+
 import appeng.api.networking.IGridHost;
+
 
 /**
  * An event that is posted whenever a spatial IO is active, called for IGridCache
@@ -37,7 +39,7 @@ public class MENetworkSpatialEvent extends MENetworkEvent
 	 * @param SpatialIO   ( INSTANCE of the SpatialIO block )
 	 * @param EnergyUsage ( the amount of energy that the SpatialIO uses)
 	 */
-	public MENetworkSpatialEvent(IGridHost SpatialIO, double EnergyUsage)
+	public MENetworkSpatialEvent( IGridHost SpatialIO, double EnergyUsage )
 	{
 		this.host = SpatialIO;
 		this.spatialEnergyUsage = EnergyUsage;

--- a/src/api/java/appeng/api/networking/events/MENetworkStorageEvent.java
+++ b/src/api/java/appeng/api/networking/events/MENetworkStorageEvent.java
@@ -23,8 +23,10 @@
 
 package appeng.api.networking.events;
 
+
 import appeng.api.storage.IMEMonitor;
 import appeng.api.storage.StorageChannel;
+
 
 /**
  * posted by the network when the networks Storage Changes, you can use the currentItems list to check levels, and
@@ -40,9 +42,9 @@ public class MENetworkStorageEvent extends MENetworkEvent
 	public final IMEMonitor monitor;
 	public final StorageChannel channel;
 
-	public MENetworkStorageEvent(IMEMonitor o, StorageChannel chan) {
+	public MENetworkStorageEvent( IMEMonitor o, StorageChannel chan )
+	{
 		this.monitor = o;
 		this.channel = chan;
 	}
-
 }

--- a/src/api/java/appeng/api/networking/pathing/ControllerState.java
+++ b/src/api/java/appeng/api/networking/pathing/ControllerState.java
@@ -23,6 +23,7 @@
 
 package appeng.api.networking.pathing;
 
+
 public enum ControllerState
 {
 	/**

--- a/src/api/java/appeng/api/networking/pathing/IPathingGrid.java
+++ b/src/api/java/appeng/api/networking/pathing/IPathingGrid.java
@@ -23,7 +23,9 @@
 
 package appeng.api.networking.pathing;
 
+
 import appeng.api.networking.IGridCache;
+
 
 public interface IPathingGrid extends IGridCache
 {
@@ -35,7 +37,7 @@ public interface IPathingGrid extends IGridCache
 
 	/**
 	 * @return the controller state of the network, useful if you want to
-	 *         require a controller for a feature.
+	 * require a controller for a feature.
 	 */
 	ControllerState getControllerState();
 
@@ -43,5 +45,4 @@ public interface IPathingGrid extends IGridCache
 	 * trigger a network reset, booting, path-finding and all.
 	 */
 	void repath();
-
 }

--- a/src/api/java/appeng/api/networking/security/BaseActionSource.java
+++ b/src/api/java/appeng/api/networking/security/BaseActionSource.java
@@ -23,6 +23,7 @@
 
 package appeng.api.networking.security;
 
+
 public class BaseActionSource
 {
 
@@ -35,5 +36,4 @@ public class BaseActionSource
 	{
 		return false;
 	}
-
 }

--- a/src/api/java/appeng/api/networking/security/IActionHost.java
+++ b/src/api/java/appeng/api/networking/security/IActionHost.java
@@ -23,8 +23,10 @@
 
 package appeng.api.networking.security;
 
+
 import appeng.api.networking.IGridHost;
 import appeng.api.networking.IGridNode;
+
 
 public interface IActionHost extends IGridHost
 {
@@ -35,8 +37,7 @@ public interface IActionHost extends IGridHost
 	 * machine, unless the action is preformed by a non primary node.
 	 *
 	 * @return the the gridnode that actions from this IGridHost are preformed
-	 *         by.
+	 * by.
 	 */
 	IGridNode getActionableNode();
-
 }

--- a/src/api/java/appeng/api/networking/security/ISecurityGrid.java
+++ b/src/api/java/appeng/api/networking/security/ISecurityGrid.java
@@ -23,9 +23,12 @@
 
 package appeng.api.networking.security;
 
+
 import net.minecraft.entity.player.EntityPlayer;
+
 import appeng.api.config.SecurityPermissions;
 import appeng.api.networking.IGridCache;
+
 
 public interface ISecurityGrid extends IGridCache
 {
@@ -43,7 +46,7 @@ public interface ISecurityGrid extends IGridCache
 	 *
 	 * @return true if the player has permissions.
 	 */
-	boolean hasPermission(EntityPlayer player, SecurityPermissions perm);
+	boolean hasPermission( EntityPlayer player, SecurityPermissions perm );
 
 	/**
 	 * Check if a player has permissions.
@@ -53,11 +56,10 @@ public interface ISecurityGrid extends IGridCache
 	 *
 	 * @return true if the player has permissions.
 	 */
-	boolean hasPermission(int playerID, SecurityPermissions perm);
+	boolean hasPermission( int playerID, SecurityPermissions perm );
 
 	/**
 	 * @return PlayerID of the admin, or owner, this is the person who placed the security block.
 	 */
 	int getOwner();
-
 }

--- a/src/api/java/appeng/api/networking/security/ISecurityProvider.java
+++ b/src/api/java/appeng/api/networking/security/ISecurityProvider.java
@@ -23,10 +23,12 @@
 
 package appeng.api.networking.security;
 
-import appeng.api.config.SecurityPermissions;
 
 import java.util.EnumSet;
 import java.util.HashMap;
+
+import appeng.api.config.SecurityPermissions;
+
 
 /**
  * Implemented on Security Terminal to interface with security cache.
@@ -46,7 +48,7 @@ public interface ISecurityProvider
 	 *
 	 * @param playerPerms player permissions
 	 */
-	void readPermissions(HashMap<Integer, EnumSet<SecurityPermissions>> playerPerms);
+	void readPermissions( HashMap<Integer, EnumSet<SecurityPermissions>> playerPerms );
 
 	/**
 	 * @return is security on or off?
@@ -57,5 +59,4 @@ public interface ISecurityProvider
 	 * @return player ID for who placed the security provider.
 	 */
 	int getOwner();
-
 }

--- a/src/api/java/appeng/api/networking/security/ISecurityRegistry.java
+++ b/src/api/java/appeng/api/networking/security/ISecurityRegistry.java
@@ -23,9 +23,11 @@
 
 package appeng.api.networking.security;
 
-import appeng.api.config.SecurityPermissions;
 
 import java.util.EnumSet;
+
+import appeng.api.config.SecurityPermissions;
+
 
 /**
  * Used by vanilla Security Terminal to post biometric data into the security cache.
@@ -39,6 +41,5 @@ public interface ISecurityRegistry
 	 * @param PlayerID player id
 	 * @param permissions permissions of player
 	 */
-	void addPlayer(int PlayerID, EnumSet<SecurityPermissions> permissions);
-
+	void addPlayer( int PlayerID, EnumSet<SecurityPermissions> permissions );
 }

--- a/src/api/java/appeng/api/networking/security/MachineSource.java
+++ b/src/api/java/appeng/api/networking/security/MachineSource.java
@@ -23,6 +23,7 @@
 
 package appeng.api.networking.security;
 
+
 public class MachineSource extends BaseActionSource
 {
 
@@ -34,8 +35,8 @@ public class MachineSource extends BaseActionSource
 		return true;
 	}
 
-	public MachineSource(IActionHost v) {
+	public MachineSource( IActionHost v )
+	{
 		this.via = v;
 	}
-
 }

--- a/src/api/java/appeng/api/networking/security/PlayerSource.java
+++ b/src/api/java/appeng/api/networking/security/PlayerSource.java
@@ -23,7 +23,9 @@
 
 package appeng.api.networking.security;
 
+
 import net.minecraft.entity.player.EntityPlayer;
+
 
 public class PlayerSource extends BaseActionSource
 {
@@ -37,9 +39,9 @@ public class PlayerSource extends BaseActionSource
 		return true;
 	}
 
-	public PlayerSource(EntityPlayer p, IActionHost v) {
+	public PlayerSource( EntityPlayer p, IActionHost v )
+	{
 		this.player = p;
 		this.via = v;
 	}
-
 }

--- a/src/api/java/appeng/api/networking/spatial/ISpatialCache.java
+++ b/src/api/java/appeng/api/networking/spatial/ISpatialCache.java
@@ -23,8 +23,10 @@
 
 package appeng.api.networking.spatial;
 
+
 import appeng.api.networking.IGridCache;
 import appeng.api.util.DimensionalCoord;
+
 
 public interface ISpatialCache extends IGridCache
 {
@@ -58,5 +60,4 @@ public interface ISpatialCache extends IGridCache
 	 * @return current 100% - 0% efficiency.
 	 */
 	float currentEfficiency();
-
 }

--- a/src/api/java/appeng/api/networking/storage/IBaseMonitor.java
+++ b/src/api/java/appeng/api/networking/storage/IBaseMonitor.java
@@ -23,8 +23,10 @@
 
 package appeng.api.networking.storage;
 
+
 import appeng.api.storage.IMEMonitorHandlerReceiver;
 import appeng.api.storage.data.IAEStack;
+
 
 public interface IBaseMonitor<T extends IAEStack>
 {
@@ -32,11 +34,10 @@ public interface IBaseMonitor<T extends IAEStack>
 	/**
 	 * add a new Listener to the monitor, be sure to properly remove yourself when your done.
 	 */
-	void addListener(IMEMonitorHandlerReceiver<T> l, Object verificationToken);
+	void addListener( IMEMonitorHandlerReceiver<T> l, Object verificationToken );
 
 	/**
 	 * remove a Listener to the monitor.
 	 */
-	void removeListener(IMEMonitorHandlerReceiver<T> l);
-
+	void removeListener( IMEMonitorHandlerReceiver<T> l );
 }

--- a/src/api/java/appeng/api/networking/storage/IStackWatcher.java
+++ b/src/api/java/appeng/api/networking/storage/IStackWatcher.java
@@ -23,9 +23,11 @@
 
 package appeng.api.networking.storage;
 
+
 import java.util.Collection;
 
 import appeng.api.storage.data.IAEStack;
+
 
 public interface IStackWatcher extends Collection<IAEStack>
 {

--- a/src/api/java/appeng/api/networking/storage/IStackWatcherHost.java
+++ b/src/api/java/appeng/api/networking/storage/IStackWatcherHost.java
@@ -23,10 +23,12 @@
 
 package appeng.api.networking.storage;
 
+
 import appeng.api.networking.security.BaseActionSource;
 import appeng.api.storage.StorageChannel;
 import appeng.api.storage.data.IAEStack;
 import appeng.api.storage.data.IItemList;
+
 
 public interface IStackWatcherHost
 {
@@ -37,7 +39,7 @@ public interface IStackWatcherHost
 	 *
 	 * @param newWatcher stack watcher
 	 */
-	void updateWatcher(IStackWatcher newWatcher);
+	void updateWatcher( IStackWatcher newWatcher );
 
 	/**
 	 * Called when a watched item changes amounts.
@@ -45,9 +47,8 @@ public interface IStackWatcherHost
 	 * @param o changed item list
 	 * @param fullStack old stack
 	 * @param diffStack new stack
-	 * @param src action source
-	 * @param chan storage channel
+	 * @param src       action source
+	 * @param chan      storage channel
 	 */
-	void onStackChange(IItemList o, IAEStack fullStack, IAEStack diffStack, BaseActionSource src, StorageChannel chan);
-
+	void onStackChange( IItemList o, IAEStack fullStack, IAEStack diffStack, BaseActionSource src, StorageChannel chan );
 }

--- a/src/api/java/appeng/api/networking/storage/IStorageGrid.java
+++ b/src/api/java/appeng/api/networking/storage/IStorageGrid.java
@@ -23,6 +23,7 @@
 
 package appeng.api.networking.storage;
 
+
 import appeng.api.networking.IGridCache;
 import appeng.api.networking.IGridHost;
 import appeng.api.networking.security.BaseActionSource;
@@ -31,6 +32,7 @@ import appeng.api.storage.ICellProvider;
 import appeng.api.storage.IStorageMonitorable;
 import appeng.api.storage.StorageChannel;
 import appeng.api.storage.data.IAEStack;
+
 
 /**
  * Common base class for item / fluid storage caches.
@@ -48,7 +50,7 @@ public interface IStorageGrid extends IGridCache, IStorageMonitorable
 	 *
 	 * @param input injected items
 	 */
-	void postAlterationOfStoredItems(StorageChannel chan, Iterable<? extends IAEStack> input, BaseActionSource src);
+	void postAlterationOfStoredItems( StorageChannel chan, Iterable<? extends IAEStack> input, BaseActionSource src );
 
 	/**
 	 * Used to add a cell provider to the storage system
@@ -58,11 +60,10 @@ public interface IStorageGrid extends IGridCache, IStorageMonitorable
 	 *
 	 * @param cc to be added cell provider
 	 */
-	void registerCellProvider(ICellProvider cc);
+	void registerCellProvider( ICellProvider cc );
 
 	/**
 	 * remove a provider added with addCellContainer
 	 */
-	void unregisterCellProvider(ICellProvider cc);
-
+	void unregisterCellProvider( ICellProvider cc );
 }

--- a/src/api/java/appeng/api/networking/ticking/IGridTickable.java
+++ b/src/api/java/appeng/api/networking/ticking/IGridTickable.java
@@ -23,7 +23,9 @@
 
 package appeng.api.networking.ticking;
 
+
 import appeng.api.networking.IGridNode;
+
 
 /**
  * Implement on IGridHosts which want to use AE's Network Ticking Feature.
@@ -55,7 +57,7 @@ public interface IGridTickable
 	 * @return null or a valid new TickingRequest
 	 *
 	 */
-	TickingRequest getTickingRequest(IGridNode node);
+	TickingRequest getTickingRequest( IGridNode node );
 
 	/**
 	 * AE lets you adjust your tick rate based on the results of your tick, if
@@ -74,6 +76,5 @@ public interface IGridTickable
 	 * @return tick rate adjustment.
 	 *
 	 */
-	TickRateModulation tickingRequest(IGridNode node, int TicksSinceLastCall);
-
+	TickRateModulation tickingRequest( IGridNode node, int TicksSinceLastCall );
 }

--- a/src/api/java/appeng/api/networking/ticking/ITickManager.java
+++ b/src/api/java/appeng/api/networking/ticking/ITickManager.java
@@ -23,8 +23,10 @@
 
 package appeng.api.networking.ticking;
 
+
 import appeng.api.networking.IGridCache;
 import appeng.api.networking.IGridNode;
+
 
 /**
  *
@@ -42,7 +44,7 @@ public interface ITickManager extends IGridCache
 	 *
 	 * @param node gridnode
 	 */
-	boolean alertDevice(IGridNode node);
+	boolean alertDevice( IGridNode node );
 
 	/**
 	 *
@@ -52,7 +54,7 @@ public interface ITickManager extends IGridCache
 	 *
 	 * @return if the call was successful.
 	 */
-	boolean sleepDevice(IGridNode node);
+	boolean sleepDevice( IGridNode node );
 
 	/**
 	 *
@@ -62,6 +64,5 @@ public interface ITickManager extends IGridCache
 	 *
 	 * @return if the call was successful.
 	 */
-	boolean wakeDevice(IGridNode node);
-
+	boolean wakeDevice( IGridNode node );
 }

--- a/src/api/java/appeng/api/networking/ticking/TickRateModulation.java
+++ b/src/api/java/appeng/api/networking/ticking/TickRateModulation.java
@@ -23,6 +23,7 @@
 
 package appeng.api.networking.ticking;
 
+
 public enum TickRateModulation
 {
 	/**

--- a/src/api/java/appeng/api/networking/ticking/TickingRequest.java
+++ b/src/api/java/appeng/api/networking/ticking/TickingRequest.java
@@ -23,6 +23,7 @@
 
 package appeng.api.networking.ticking;
 
+
 /**
  *
  * Describes how your tiles ticking is executed.
@@ -67,11 +68,11 @@ public class TickingRequest
 	 */
 	public final boolean canBeAlerted;
 
-	public TickingRequest(int min, int max, boolean sleep, boolean alertable) {
+	public TickingRequest( int min, int max, boolean sleep, boolean alertable )
+	{
 		this.minTickRate = min;
 		this.maxTickRate = max;
 		this.isSleeping = sleep;
 		this.canBeAlerted = alertable;
 	}
-
 }

--- a/src/api/java/appeng/api/package-info.java
+++ b/src/api/java/appeng/api/package-info.java
@@ -21,8 +21,8 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-@API(apiVersion = "rv2", owner = "appliedenergistics2", provides = "appliedenergistics2|API")
-package appeng.api;
+@API( apiVersion = "rv2", owner = "appliedenergistics2", provides = "appliedenergistics2|API" ) package appeng.api;
+
 
 import cpw.mods.fml.common.API;
 

--- a/src/api/java/appeng/api/parts/BusSupport.java
+++ b/src/api/java/appeng/api/parts/BusSupport.java
@@ -23,6 +23,7 @@
 
 package appeng.api.parts;
 
+
 public enum BusSupport
 {
 	CABLE,

--- a/src/api/java/appeng/api/parts/CableRenderMode.java
+++ b/src/api/java/appeng/api/parts/CableRenderMode.java
@@ -23,17 +23,19 @@
 
 package appeng.api.parts;
 
+
 public enum CableRenderMode
 {
 
-	Standard(false),
+	Standard( false ),
 
-	CableView(true);
+	CableView( true );
 
 	public final boolean transparentFacades;
 	public final boolean opaqueFacades;
 
-	private CableRenderMode(boolean hideFacades) {
+	private CableRenderMode( boolean hideFacades )
+	{
 		this.transparentFacades = hideFacades;
 		this.opaqueFacades = !hideFacades;
 	}

--- a/src/api/java/appeng/api/parts/IAlphaPassItem.java
+++ b/src/api/java/appeng/api/parts/IAlphaPassItem.java
@@ -23,7 +23,9 @@
 
 package appeng.api.parts;
 
+
 import net.minecraft.item.ItemStack;
+
 
 public interface IAlphaPassItem
 {
@@ -32,8 +34,8 @@ public interface IAlphaPassItem
 	 * Extend, and return true to enable a second pass for your parts in the bus rendering pipe line.
 	 *
 	 * @param is item
+	 *
 	 * @return true to enable a second pass for your parts in the bus rendering pipe line.
 	 */
-	boolean useAlphaPass(ItemStack is);
-
+	boolean useAlphaPass( ItemStack is );
 }

--- a/src/api/java/appeng/api/parts/IBoxProvider.java
+++ b/src/api/java/appeng/api/parts/IBoxProvider.java
@@ -23,6 +23,7 @@
 
 package appeng.api.parts;
 
+
 public interface IBoxProvider
 {
 
@@ -31,6 +32,5 @@ public interface IBoxProvider
 	 *
 	 * @param boxes collision boxes
 	 */
-	void getBoxes(IPartCollisionHelper boxes);
-
+	void getBoxes( IPartCollisionHelper boxes );
 }

--- a/src/api/java/appeng/api/parts/IFacadeContainer.java
+++ b/src/api/java/appeng/api/parts/IFacadeContainer.java
@@ -23,11 +23,14 @@
 
 package appeng.api.parts;
 
+
+import java.io.IOException;
+
 import io.netty.buffer.ByteBuf;
+
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import java.io.IOException;
 
 /**
  * Used Internally.
@@ -42,17 +45,17 @@ public interface IFacadeContainer
 	 *
 	 * @return true if the facade as successfully added.
 	 */
-	boolean addFacade(IFacadePart a);
+	boolean addFacade( IFacadePart a );
 
 	/**
 	 * Removed the facade on the given side, or does nothing.
 	 */
-	void removeFacade(IPartHost host, ForgeDirection side);
+	void removeFacade( IPartHost host, ForgeDirection side );
 
 	/**
 	 * @return the {@link IFacadePart} for a given side, or null.
 	 */
-	IFacadePart getFacade(ForgeDirection s);
+	IFacadePart getFacade( ForgeDirection s );
 
 	/**
 	 * rotate the facades left.
@@ -64,35 +67,37 @@ public interface IFacadeContainer
 	 *
 	 * @param data to be written data
 	 */
-	void writeToNBT(NBTTagCompound data);
+	void writeToNBT( NBTTagCompound data );
 
 	/**
 	 * read from stream
 	 *
 	 * @param data to be read data
+	 *
 	 * @return true if it was readable
+	 *
 	 * @throws IOException
 	 */
-	boolean readFromStream(ByteBuf data) throws IOException;
+	boolean readFromStream( ByteBuf data ) throws IOException;
 
 	/**
 	 * read from NBT
 	 *
 	 * @param data to be read data
 	 */
-	void readFromNBT(NBTTagCompound data);
+	void readFromNBT( NBTTagCompound data );
 
 	/**
 	 * write to stream
 	 *
 	 * @param data to be written data
+	 *
 	 * @throws IOException
 	 */
-	void writeToStream(ByteBuf data) throws IOException;
+	void writeToStream( ByteBuf data ) throws IOException;
 
 	/**
 	 * @return true if there are no facades.
 	 */
 	boolean isEmpty();
-
 }

--- a/src/api/java/appeng/api/parts/IFacadePart.java
+++ b/src/api/java/appeng/api/parts/IFacadePart.java
@@ -23,14 +23,17 @@
 
 package appeng.api.parts;
 
+
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.entity.Entity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraftforge.common.util.ForgeDirection;
+
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+
 
 /**
  * Used Internally.
@@ -49,9 +52,9 @@ public interface IFacadePart
 	 * used to collide, and pick the part
 	 *
 	 * @param ch collision helper
-	 * @param e colliding entity
+	 * @param e  colliding entity
 	 */
-	void getBoxes(IPartCollisionHelper ch, Entity e);
+	void getBoxes( IPartCollisionHelper ch, Entity e );
 
 	/**
 	 * render the part.
@@ -65,8 +68,8 @@ public interface IFacadePart
 	 * @param busBounds bounding box
 	 * @param renderStilt if to render stilt
 	 */
-	@SideOnly(Side.CLIENT)
-	void renderStatic(int x, int y, int z, IPartRenderHelper instance, RenderBlocks renderer, IFacadeContainer fc, AxisAlignedBB busBounds, boolean renderStilt);
+	@SideOnly( Side.CLIENT )
+	void renderStatic( int x, int y, int z, IPartRenderHelper instance, RenderBlocks renderer, IFacadeContainer fc, AxisAlignedBB busBounds, boolean renderStilt );
 
 	/**
 	 * render the part in inventory.
@@ -74,8 +77,8 @@ public interface IFacadePart
 	 * @param instance render helper
 	 * @param renderer renderer
 	 */
-	@SideOnly(Side.CLIENT)
-	void renderInventory(IPartRenderHelper instance, RenderBlocks renderer);
+	@SideOnly( Side.CLIENT )
+	void renderInventory( IPartRenderHelper instance, RenderBlocks renderer );
 
 	/**
 	 * @return side the facade is in
@@ -93,8 +96,7 @@ public interface IFacadePart
 
 	boolean isBC();
 
-	void setThinFacades(boolean useThinFacades);
+	void setThinFacades( boolean useThinFacades );
 
 	boolean isTransparent();
-
 }

--- a/src/api/java/appeng/api/parts/IPart.java
+++ b/src/api/java/appeng/api/parts/IPart.java
@@ -23,10 +23,13 @@
 
 package appeng.api.parts;
 
-import appeng.api.networking.IGridNode;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Random;
+
 import io.netty.buffer.ByteBuf;
+
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
@@ -39,9 +42,11 @@ import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.Random;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
+import appeng.api.networking.IGridNode;
+
 
 public interface IPart extends IBoxProvider
 {
@@ -49,7 +54,7 @@ public interface IPart extends IBoxProvider
 	/**
 	 * get an ItemStack that represents the bus, should contain the settings for whatever, can also be used in
 	 * conjunction with removePart to take a part off and drop it or something.
-	 *
+	 * <p/>
 	 * This is used to drop the bus, and to save the bus, when saving the bus, wrenched is false, and writeToNBT will be
 	 * called to save important details about the part, if the part is wrenched include in your NBT Data any settings
 	 * you might want to keep around, you can restore those settings when constructing your part.
@@ -58,52 +63,52 @@ public interface IPart extends IBoxProvider
 	 *
 	 * @return item of part
 	 */
-	ItemStack getItemStack(PartItemStack type);
+	ItemStack getItemStack( PartItemStack type );
 
 	/**
 	 * render item form for inventory, or entity.
-	 *
+	 * <p/>
 	 * GL Available
 	 *
 	 * @param rh       helper
 	 * @param renderer renderer
 	 */
-	@SideOnly(Side.CLIENT)
-	void renderInventory(IPartRenderHelper rh, RenderBlocks renderer);
+	@SideOnly( Side.CLIENT )
+	void renderInventory( IPartRenderHelper rh, RenderBlocks renderer );
 
 	/**
 	 * render world renderer ( preferred )
-	 *
+	 * <p/>
 	 * GL is NOT Available
 	 *
-	 * @param x x coord
-	 * @param y y coord
-	 * @param z z coord
-	 * @param rh helper
+	 * @param x        x coord
+	 * @param y        y coord
+	 * @param z        z coord
+	 * @param rh       helper
 	 * @param renderer renderer
 	 */
-	@SideOnly(Side.CLIENT)
-	void renderStatic(int x, int y, int z, IPartRenderHelper rh, RenderBlocks renderer);
+	@SideOnly( Side.CLIENT )
+	void renderStatic( int x, int y, int z, IPartRenderHelper rh, RenderBlocks renderer );
 
 	/**
 	 * render TESR.
-	 *
+	 * <p/>
 	 * GL Available
 	 *
-	 * @param x x coord
-	 * @param y y coord
-	 * @param z z coord
-	 * @param rh helper
+	 * @param x        x coord
+	 * @param y        y coord
+	 * @param z        z coord
+	 * @param rh       helper
 	 * @param renderer renderer
 	 */
-	@SideOnly(Side.CLIENT)
-	void renderDynamic(double x, double y, double z, IPartRenderHelper rh, RenderBlocks renderer);
+	@SideOnly( Side.CLIENT )
+	void renderDynamic( double x, double y, double z, IPartRenderHelper rh, RenderBlocks renderer );
 
 	/**
 	 * @return the Block sheet icon used when rendering the breaking particles, return null to use the ItemStack
 	 * texture.
 	 */
-	@SideOnly(Side.CLIENT)
+	@SideOnly( Side.CLIENT )
 	IIcon getBreakingTexture();
 
 	/**
@@ -129,14 +134,14 @@ public interface IPart extends IBoxProvider
 	 *
 	 * @param data to be written nbt data
 	 */
-	void writeToNBT(NBTTagCompound data);
+	void writeToNBT( NBTTagCompound data );
 
 	/**
 	 * Read the previously written NBT Data. this is the mirror for writeToNBT
 	 *
 	 * @param data to be read nbt data
 	 */
-	void readFromNBT(NBTTagCompound data);
+	void readFromNBT( NBTTagCompound data );
 
 	/**
 	 * @return get the amount of light produced by the bus
@@ -150,7 +155,7 @@ public interface IPart extends IBoxProvider
 	 *
 	 * @return true if entity can climb
 	 */
-	boolean isLadder(EntityLivingBase entity);
+	boolean isLadder( EntityLivingBase entity );
 
 	/**
 	 * a block around the bus's host has been changed.
@@ -174,7 +179,7 @@ public interface IPart extends IBoxProvider
 	 *
 	 * @throws IOException
 	 */
-	void writeToStream(ByteBuf data) throws IOException;
+	void writeToStream( ByteBuf data ) throws IOException;
 
 	/**
 	 * read data from bus packet.
@@ -185,12 +190,12 @@ public interface IPart extends IBoxProvider
 	 *
 	 * @throws IOException
 	 */
-	boolean readFromStream(ByteBuf data) throws IOException;
+	boolean readFromStream( ByteBuf data ) throws IOException;
 
 	/**
 	 * get the Grid Node for the Bus, be sure your IGridBlock is NOT isWorldAccessible, if it is your going to cause
 	 * crashes.
-	 *
+	 * <p/>
 	 * or null if you don't have a grid node.
 	 *
 	 * @return grid node
@@ -202,7 +207,7 @@ public interface IPart extends IBoxProvider
 	 *
 	 * @param entity colliding entity
 	 */
-	void onEntityCollision(Entity entity);
+	void onEntityCollision( Entity entity );
 
 	/**
 	 * called when your part is being removed from the world.
@@ -228,36 +233,36 @@ public interface IPart extends IBoxProvider
 	 * @param host part side
 	 * @param tile tile entity of part
 	 */
-	void setPartHostInfo(ForgeDirection side, IPartHost host, TileEntity tile);
+	void setPartHostInfo( ForgeDirection side, IPartHost host, TileEntity tile );
 
 	/**
 	 * Called when you right click the part, very similar to Block.onActivateBlock
 	 *
 	 * @param player right clicking player
-	 * @param pos position of block
+	 * @param pos    position of block
 	 *
 	 * @return if your activate method performed something.
 	 */
-	boolean onActivate(EntityPlayer player, Vec3 pos);
+	boolean onActivate( EntityPlayer player, Vec3 pos );
 
 	/**
 	 * Called when you right click the part, very similar to Block.onActivateBlock
 	 *
 	 * @param player shift right clicking player
-	 * @param pos position of block
+	 * @param pos    position of block
 	 *
 	 * @return if your activate method performed something, you should use false unless you really need it.
 	 */
-	boolean onShiftActivate(EntityPlayer player, Vec3 pos);
+	boolean onShiftActivate( EntityPlayer player, Vec3 pos );
 
 	/**
 	 * Add drops to the items being dropped into the world, if your item stores its contents when wrenched use the
 	 * wrenched boolean to control what data is saved vs dropped when it is broken.
 	 *
-	 * @param drops item drops if wrenched
+	 * @param drops    item drops if wrenched
 	 * @param wrenched control flag for wrenched vs broken
 	 */
-	void getDrops(List<ItemStack> drops, boolean wrenched);
+	void getDrops( List<ItemStack> drops, boolean wrenched );
 
 	/**
 	 * @return 0 - 8, reasonable default 3-4, this controls the cable connection to the node.
@@ -268,21 +273,21 @@ public interface IPart extends IBoxProvider
 	 * same as Block.randomDisplayTick, for but parts.
 	 *
 	 * @param world world of block
-	 * @param x x coord of block
-	 * @param y y coord of block
-	 * @param z z coord of block
-	 * @param r random
+	 * @param x     x coord of block
+	 * @param y     y coord of block
+	 * @param z     z coord of block
+	 * @param r     random
 	 */
-	void randomDisplayTick(World world, int x, int y, int z, Random r);
+	void randomDisplayTick( World world, int x, int y, int z, Random r );
 
 	/**
 	 * Called when placed in the world by a player, this happens before addWorld.
 	 *
 	 * @param player placing player
-	 * @param held held item
-	 * @param side placing side
+	 * @param held   held item
+	 * @param side   placing side
 	 */
-	void onPlacement(EntityPlayer player, ItemStack held, ForgeDirection side);
+	void onPlacement( EntityPlayer player, ItemStack held, ForgeDirection side );
 
 	/**
 	 * Used to determine which parts can be placed on what cables.
@@ -291,6 +296,5 @@ public interface IPart extends IBoxProvider
 	 *
 	 * @return true if the part can be placed on this support.
 	 */
-	boolean canBePlacedOn(BusSupport what);
-
+	boolean canBePlacedOn( BusSupport what );
 }

--- a/src/api/java/appeng/api/parts/IPartCollisionHelper.java
+++ b/src/api/java/appeng/api/parts/IPartCollisionHelper.java
@@ -23,7 +23,9 @@
 
 package appeng.api.parts;
 
+
 import net.minecraftforge.common.util.ForgeDirection;
+
 
 public interface IPartCollisionHelper
 {
@@ -40,7 +42,7 @@ public interface IPartCollisionHelper
 	 * @param maxY maximal y collision
 	 * @param maxZ maximal z collision
 	 */
-	void addBox(double minX, double minY, double minZ, double maxX, double maxY, double maxZ);
+	void addBox( double minX, double minY, double minZ, double maxX, double maxY, double maxZ );
 
 	/**
 	 * @return east in world space.
@@ -61,5 +63,4 @@ public interface IPartCollisionHelper
 	 * @return true if this test is to get the BB Collision information.
 	 */
 	boolean isBBCollision();
-
 }

--- a/src/api/java/appeng/api/parts/IPartHelper.java
+++ b/src/api/java/appeng/api/parts/IPartHelper.java
@@ -23,9 +23,11 @@
 
 package appeng.api.parts;
 
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
+
 
 public interface IPartHelper
 {
@@ -54,14 +56,14 @@ public interface IPartHelper
 	 * implement that interface on a part get implement it.
 	 *
 	 * @return true on success, false on failure, usually a error will be logged
-	 *         as well.
+	 * as well.
 	 */
-	boolean registerNewLayer(String string, String layerInterface);
+	boolean registerNewLayer( String string, String layerInterface );
 
 	/**
 	 * Register IBusItem with renderer
 	 */
-	void setItemBusRenderer(IPartItem i);
+	void setItemBusRenderer( IPartItem i );
 
 	/**
 	 * use in use item, to try and place a IBusItem
@@ -72,10 +74,11 @@ public interface IPartHelper
 	 * @param z z pos of part
 	 * @param side side which the part should be on
 	 * @param player player placing part
-	 * @param world part in world
+	 * @param world  part in world
+	 *
 	 * @return true if placing was successful
 	 */
-	boolean placeBus(ItemStack is, int x, int y, int z, int side, EntityPlayer player, World world);
+	boolean placeBus( ItemStack is, int x, int y, int z, int side, EntityPlayer player, World world );
 
 	/**
 	 * @return the render mode

--- a/src/api/java/appeng/api/parts/IPartHost.java
+++ b/src/api/java/appeng/api/parts/IPartHost.java
@@ -23,15 +23,18 @@
 
 package appeng.api.parts;
 
-import appeng.api.util.AEColor;
-import appeng.api.util.DimensionalCoord;
+
+import java.util.Set;
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Vec3;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import java.util.Set;
+import appeng.api.util.AEColor;
+import appeng.api.util.DimensionalCoord;
+
 
 /**
  * Implemented on AE's TileEntity or AE's FMP Part.
@@ -52,9 +55,10 @@ public interface IPartHost
 	 *
 	 * @param part to be added part
 	 * @param side part placed onto side
+	 *
 	 * @return returns false if the part cannot be added.
 	 */
-	boolean canAddPart(ItemStack part, ForgeDirection side);
+	boolean canAddPart( ItemStack part, ForgeDirection side );
 
 	/**
 	 * try to add a new part to the specified side, returns false if it failed to be added.
@@ -62,18 +66,20 @@ public interface IPartHost
 	 * @param is new part
 	 * @param side onto side
 	 * @param owner with owning player
+	 *
 	 * @return null if the item failed to add, the side it was placed on other wise ( may different for cables,
-	 *         {@link ForgeDirection}.UNKNOWN )
+	 * {@link ForgeDirection}.UNKNOWN )
 	 */
-	ForgeDirection addPart(ItemStack is, ForgeDirection side, EntityPlayer owner);
+	ForgeDirection addPart( ItemStack is, ForgeDirection side, EntityPlayer owner );
 
 	/**
 	 * Get part by side ( center is {@link ForgeDirection}.UNKNOWN )
 	 *
 	 * @param side side of part
+	 *
 	 * @return the part located on the specified side, or null if there is no part.
 	 */
-	IPart getPart(ForgeDirection side);
+	IPart getPart( ForgeDirection side );
 
 	/**
 	 * removes the part on the side, this doesn't drop it or anything, if you don't do something with it, its just
@@ -85,7 +91,7 @@ public interface IPartHost
 	 * @param suppressUpdate
 	 *            - used if you need to replace a part's INSTANCE, without really removing it first.
 	 */
-	void removePart(ForgeDirection side, boolean suppressUpdate);
+	void removePart( ForgeDirection side, boolean suppressUpdate );
 
 	/**
 	 * something changed, might want to send a packet to clients to update state.
@@ -104,7 +110,7 @@ public interface IPartHost
 
 	/**
 	 * @return the color of the host type ( this is determined by the middle cable. ) if no cable is present, it returns
-	 *         {@link AEColor} .Transparent other wise it returns the color of the cable in the center.
+	 * {@link AEColor} .Transparent other wise it returns the color of the cable in the center.
 	 */
 	AEColor getColor();
 
@@ -118,15 +124,16 @@ public interface IPartHost
 	 *
 	 * @return returns if microblocks are blocking this cable path.
 	 */
-	boolean isBlocked(ForgeDirection side);
+	boolean isBlocked( ForgeDirection side );
 
 	/**
 	 * finds the part located at the position ( pos must be relative, not global )
 	 *
 	 * @param pos part position
+	 *
 	 * @return a new SelectedPart, this is never null.
 	 */
-	SelectedPart selectPart(Vec3 pos);
+	SelectedPart selectPart( Vec3 pos );
 
 	/**
 	 * can be used by parts to trigger the tile or part to save.
@@ -142,9 +149,10 @@ public interface IPartHost
 	 * get the redstone state of host on this side, this value is cached internally.
 	 *
 	 * @param side side of part
+	 *
 	 * @return true of the part host is receiving redstone from an external source.
 	 */
-	boolean hasRedstone(ForgeDirection side);
+	boolean hasRedstone( ForgeDirection side );
 
 	/**
 	 * returns false if this block contains any parts or facades, true other wise.

--- a/src/api/java/appeng/api/parts/IPartItem.java
+++ b/src/api/java/appeng/api/parts/IPartItem.java
@@ -23,7 +23,9 @@
 
 package appeng.api.parts;
 
+
 import net.minecraft.item.ItemStack;
+
 
 //@formatter:off
 /**
@@ -58,8 +60,8 @@ public interface IPartItem
 	 * create a new part INSTANCE, from the item stack.
 	 *
 	 * @param is item
+	 *
 	 * @return part from item
 	 */
-	IPart createPartFromItemStack(ItemStack is);
-
+	IPart createPartFromItemStack( ItemStack is );
 }

--- a/src/api/java/appeng/api/parts/IPartRenderHelper.java
+++ b/src/api/java/appeng/api/parts/IPartRenderHelper.java
@@ -23,14 +23,17 @@
 
 package appeng.api.parts;
 
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
+
+import java.util.EnumSet;
+
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.util.IIcon;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import java.util.EnumSet;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
 
 public interface IPartRenderHelper
 {
@@ -47,7 +50,7 @@ public interface IPartRenderHelper
 	 * @param maxY maximal y bound
 	 * @param maxZ maximal z bound
 	 */
-	void setBounds(float minX, float minY, float minZ, float maxX, float maxY, float maxZ);
+	void setBounds( float minX, float minY, float minZ, float maxX, float maxY, float maxZ );
 
 	/**
 	 * static renderer
@@ -61,8 +64,8 @@ public interface IPartRenderHelper
 	 * @param face direction its facing
 	 * @param renderer renderer of part
 	 */
-	@SideOnly(Side.CLIENT)
-	void renderFace(int x, int y, int z, IIcon ico, ForgeDirection face, RenderBlocks renderer);
+	@SideOnly( Side.CLIENT )
+	void renderFace( int x, int y, int z, IIcon ico, ForgeDirection face, RenderBlocks renderer );
 
 	/**
 	 * static renderer
@@ -75,10 +78,10 @@ public interface IPartRenderHelper
 	 * @param ico icon of part
 	 * @param face face of part
 	 * @param edgeThickness thickness of the edge
-	 * @param renderer renderer
+	 * @param renderer      renderer
 	 */
-	@SideOnly(Side.CLIENT)
-	void renderFaceCutout(int x, int y, int z, IIcon ico, ForgeDirection face, float edgeThickness, RenderBlocks renderer);
+	@SideOnly( Side.CLIENT )
+	void renderFaceCutout( int x, int y, int z, IIcon ico, ForgeDirection face, float edgeThickness, RenderBlocks renderer );
 
 	/**
 	 * static renderer
@@ -90,26 +93,26 @@ public interface IPartRenderHelper
 	 * @param z z pos of block
 	 * @param renderer renderer
 	 */
-	@SideOnly(Side.CLIENT)
-	void renderBlock(int x, int y, int z, RenderBlocks renderer);
+	@SideOnly( Side.CLIENT )
+	void renderBlock( int x, int y, int z, RenderBlocks renderer );
 
 	/**
 	 * render a single face in inventory renderer.
 	 *
 	 * @param IIcon icon of part
 	 * @param direction face of part
-	 * @param renderer renderer
+	 * @param renderer  renderer
 	 */
-	@SideOnly(Side.CLIENT)
-	void renderInventoryFace(IIcon IIcon, ForgeDirection direction, RenderBlocks renderer);
+	@SideOnly( Side.CLIENT )
+	void renderInventoryFace( IIcon IIcon, ForgeDirection direction, RenderBlocks renderer );
 
 	/**
 	 * render a box in inventory renderer.
 	 *
 	 * @param renderer renderer
 	 */
-	@SideOnly(Side.CLIENT)
-	void renderInventoryBox(RenderBlocks renderer);
+	@SideOnly( Side.CLIENT )
+	void renderInventoryBox( RenderBlocks renderer );
 
 	/**
 	 * inventory, and static renderer.
@@ -120,10 +123,10 @@ public interface IPartRenderHelper
 	 * @param up up face
 	 * @param north north face
 	 * @param south south face
-	 * @param west west face
-	 * @param east east face
+	 * @param west  west face
+	 * @param east  east face
 	 */
-	void setTexture(IIcon down, IIcon up, IIcon north, IIcon south, IIcon west, IIcon east);
+	void setTexture( IIcon down, IIcon up, IIcon north, IIcon south, IIcon west, IIcon east );
 
 	/**
 	 * inventory, and static renderer.
@@ -132,14 +135,14 @@ public interface IPartRenderHelper
 	 *
 	 * @param ico to be set icon
 	 */
-	void setTexture(IIcon ico);
+	void setTexture( IIcon ico );
 
 	/**
 	 * configure the color multiplier for the inventory renderer.
 	 *
 	 * @param whiteVariant color multiplier
 	 */
-	void setInvColor(int whiteVariant);
+	void setInvColor( int whiteVariant );
 
 	/**
 	 * @return the block used for rendering, might need it for some reason...
@@ -167,7 +170,7 @@ public interface IPartRenderHelper
 	 *
 	 * Only worth it if you render more then 1 block.
 	 */
-	ISimplifiedBundle useSimplifiedRendering(int x, int y, int z, IBoxProvider p, ISimplifiedBundle sim);
+	ISimplifiedBundle useSimplifiedRendering( int x, int y, int z, IBoxProvider p, ISimplifiedBundle sim );
 
 	/**
 	 * disables, useSimplifiedRendering.
@@ -182,20 +185,19 @@ public interface IPartRenderHelper
 	 * @param z z pos of part
 	 * @param renderer renderer of part
 	 */
-	void renderBlockCurrentBounds(int x, int y, int z, RenderBlocks renderer);
+	void renderBlockCurrentBounds( int x, int y, int z, RenderBlocks renderer );
 
 	/**
 	 * allow you to enable your part to render during the alpha pass or the standard pass.
 	 *
 	 * @param pass render pass
 	 */
-	void renderForPass(int pass);
+	void renderForPass( int pass );
 
 	/**
 	 * Set which faces to render, remember to set back to ALL when you are done.
 	 *
 	 * @param complementOf sides to render
 	 */
-	void setFacesToRender(EnumSet<ForgeDirection> complementOf);
-
+	void setFacesToRender( EnumSet<ForgeDirection> complementOf );
 }

--- a/src/api/java/appeng/api/parts/LayerBase.java
+++ b/src/api/java/appeng/api/parts/LayerBase.java
@@ -23,10 +23,12 @@
 
 package appeng.api.parts;
 
+
+import java.util.Set;
+
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import java.util.Set;
 
 /**
  * All Layers must extends this, this get part implementation is provided to interface with the parts, however a real
@@ -41,9 +43,10 @@ public abstract class LayerBase extends TileEntity // implements IPartHost
 	 * This Method looks silly, that is because its not used at runtime, a real implementation will be used instead.
 	 *
 	 * @param side side of part
+	 *
 	 * @return the part for the requested side.
 	 */
-	public IPart getPart(ForgeDirection side)
+	public IPart getPart( ForgeDirection side )
 	{
 		return null; // place holder.
 	}
@@ -74,5 +77,4 @@ public abstract class LayerBase extends TileEntity // implements IPartHost
 	{
 		// something!
 	}
-
 }

--- a/src/api/java/appeng/api/parts/LayerFlags.java
+++ b/src/api/java/appeng/api/parts/LayerFlags.java
@@ -23,6 +23,7 @@
 
 package appeng.api.parts;
 
+
 public enum LayerFlags
 {
 

--- a/src/api/java/appeng/api/parts/PartItemStack.java
+++ b/src/api/java/appeng/api/parts/PartItemStack.java
@@ -23,6 +23,7 @@
 
 package appeng.api.parts;
 
+
 public enum PartItemStack
 {
 	Pick,

--- a/src/api/java/appeng/api/parts/SelectedPart.java
+++ b/src/api/java/appeng/api/parts/SelectedPart.java
@@ -23,7 +23,9 @@
 
 package appeng.api.parts;
 
+
 import net.minecraftforge.common.util.ForgeDirection;
+
 
 /**
  * Reports a selected part from th IPartHost
@@ -46,22 +48,24 @@ public class SelectedPart
 	 */
 	public final ForgeDirection side;
 
-	public SelectedPart() {
+	public SelectedPart()
+	{
 		this.part = null;
 		this.facade = null;
 		this.side = ForgeDirection.UNKNOWN;
 	}
 
-	public SelectedPart(IPart part, ForgeDirection side) {
+	public SelectedPart( IPart part, ForgeDirection side )
+	{
 		this.part = part;
 		this.facade = null;
 		this.side = side;
 	}
 
-	public SelectedPart(IFacadePart facade, ForgeDirection side) {
+	public SelectedPart( IFacadePart facade, ForgeDirection side )
+	{
 		this.part = null;
 		this.facade = facade;
 		this.side = side;
 	}
-
 }

--- a/src/api/java/appeng/api/recipes/ICraftHandler.java
+++ b/src/api/java/appeng/api/recipes/ICraftHandler.java
@@ -23,11 +23,13 @@
 
 package appeng.api.recipes;
 
+
+import java.util.List;
+
 import appeng.api.exceptions.MissingIngredientError;
 import appeng.api.exceptions.RecipeError;
 import appeng.api.exceptions.RegistrationError;
 
-import java.util.List;
 
 public interface ICraftHandler
 {
@@ -37,9 +39,10 @@ public interface ICraftHandler
 	 *
 	 * @param input parsed inputs
 	 * @param output parsed outputs
+	 *
 	 * @throws RecipeError
 	 */
-	public void setup(List<List<IIngredient>> input, List<List<IIngredient>> output) throws RecipeError;
+	public void setup( List<List<IIngredient>> input, List<List<IIngredient>> output ) throws RecipeError;
 
 	/**
 	 * called when all recipes are parsed, and your required to register your recipe.
@@ -48,5 +51,4 @@ public interface ICraftHandler
 	 * @throws MissingIngredientError
 	 */
 	public void register() throws RegistrationError, MissingIngredientError;
-
 }

--- a/src/api/java/appeng/api/recipes/IIngredient.java
+++ b/src/api/java/appeng/api/recipes/IIngredient.java
@@ -23,11 +23,15 @@
 
 package appeng.api.recipes;
 
+
 import net.minecraft.item.ItemStack;
+
 import appeng.api.exceptions.MissingIngredientError;
 import appeng.api.exceptions.RegistrationError;
 
-public interface IIngredient {
+
+public interface IIngredient
+{
 
 	/**
 	 * Acquire a single input stack for the current recipe, if more then one ItemStack is possible a
@@ -45,6 +49,7 @@ public interface IIngredient {
 	 * multiple inputs per slot.
 	 *
 	 * @return an array of ItemStacks for the recipe handler.
+	 *
 	 * @throws RegistrationError
 	 * @throws MissingIngredientError
 	 */
@@ -79,9 +84,9 @@ public interface IIngredient {
 
 	/**
 	 * Bakes the lists in for faster runtime look-ups.
+	 *
 	 * @throws MissingIngredientError
 	 * @throws RegistrationError
 	 */
 	void bake() throws RegistrationError, MissingIngredientError;
-
 }

--- a/src/api/java/appeng/api/recipes/IRecipeHandler.java
+++ b/src/api/java/appeng/api/recipes/IRecipeHandler.java
@@ -23,6 +23,7 @@
 
 package appeng.api.recipes;
 
+
 /**
  * Represents the AE2 Recipe Loading/Reading Class
  */
@@ -33,13 +34,12 @@ public interface IRecipeHandler
 	 * Call when you want to read recipes in from a file based on a loader
 	 *
 	 * @param loader recipe loader
-	 * @param path path of file
+	 * @param path   path of file
 	 */
-	void parseRecipes(IRecipeLoader loader, String path);
+	void parseRecipes( IRecipeLoader loader, String path );
 
 	/**
 	 * this loads the read recipes into minecraft, should be called in Init.
 	 */
 	void injectRecipes();
-
 }

--- a/src/api/java/appeng/api/recipes/IRecipeLoader.java
+++ b/src/api/java/appeng/api/recipes/IRecipeLoader.java
@@ -23,11 +23,12 @@
 
 package appeng.api.recipes;
 
+
 import java.io.BufferedReader;
+
 
 public interface IRecipeLoader
 {
 
-	BufferedReader getFile(String s) throws Exception;
-
+	BufferedReader getFile( String s ) throws Exception;
 }

--- a/src/api/java/appeng/api/recipes/ISubItemResolver.java
+++ b/src/api/java/appeng/api/recipes/ISubItemResolver.java
@@ -23,14 +23,15 @@
 
 package appeng.api.recipes;
 
+
 public interface ISubItemResolver
 {
 
 	/**
 	 * @param namespace namespace of sub item
-	 * @param fullName name of sub item
+	 * @param fullName  name of sub item
+	 *
 	 * @return either a ResolveResult, or a ResolverResultSet
 	 */
-	public Object resolveItemByName(String namespace, String fullName);
-
+	public Object resolveItemByName( String namespace, String fullName );
 }

--- a/src/api/java/appeng/api/recipes/ResolverResult.java
+++ b/src/api/java/appeng/api/recipes/ResolverResult.java
@@ -23,7 +23,9 @@
 
 package appeng.api.recipes;
 
+
 import net.minecraft.nbt.NBTTagCompound;
+
 
 public class ResolverResult
 {
@@ -32,16 +34,17 @@ public class ResolverResult
 	final public int damageValue;
 	final public NBTTagCompound compound;
 
-	public ResolverResult(String name, int damage) {
+	public ResolverResult( String name, int damage )
+	{
 		this.itemName = name;
 		this.damageValue = damage;
 		this.compound = null;
 	}
 
-	public ResolverResult(String name, int damage, NBTTagCompound data) {
+	public ResolverResult( String name, int damage, NBTTagCompound data )
+	{
 		this.itemName = name;
 		this.damageValue = damage;
 		this.compound = data;
 	}
-
 }

--- a/src/api/java/appeng/api/recipes/ResolverResultSet.java
+++ b/src/api/java/appeng/api/recipes/ResolverResultSet.java
@@ -23,10 +23,12 @@
 
 package appeng.api.recipes;
 
+
 import java.util.Arrays;
 import java.util.List;
 
 import net.minecraft.item.ItemStack;
+
 
 public class ResolverResultSet
 {
@@ -34,9 +36,9 @@ public class ResolverResultSet
 	public final String name;
 	public final List<ItemStack> results;
 
-	public ResolverResultSet(String myName, ItemStack... set) {
+	public ResolverResultSet( String myName, ItemStack... set )
+	{
 		this.results = Arrays.asList( set );
 		this.name = myName;
 	}
-
 }

--- a/src/api/java/appeng/api/storage/ICellContainer.java
+++ b/src/api/java/appeng/api/storage/ICellContainer.java
@@ -23,7 +23,9 @@
 
 package appeng.api.storage;
 
+
 import appeng.api.networking.security.IActionHost;
+
 
 /**
  * Represents an {@link appeng.api.networking.IGridHost} that contributes to storage, such as a ME Chest, or ME Drive.
@@ -36,6 +38,5 @@ public interface ICellContainer extends IActionHost, ICellProvider, ISaveProvide
 	 *
 	 * @param slot slot index
 	 */
-	void blinkCell(int slot);
-
+	void blinkCell( int slot );
 }

--- a/src/api/java/appeng/api/storage/ICellHandler.java
+++ b/src/api/java/appeng/api/storage/ICellHandler.java
@@ -23,12 +23,16 @@
 
 package appeng.api.storage;
 
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
-import appeng.api.implementations.tiles.IChestOrDrive;
+
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+
+import appeng.api.implementations.tiles.IChestOrDrive;
+
 
 /**
  * Registration record for {@link ICellRegistry}
@@ -41,47 +45,44 @@ public interface ICellHandler
 	 * request a handler )
 	 *
 	 * @param is to be checked item
+	 *
 	 * @return return true, if getCellHandler will not return null.
 	 */
-	boolean isCell(ItemStack is);
+	boolean isCell( ItemStack is );
 
 	/**
 	 * If you cannot handle the provided item, return null
 	 *
-	 * @param is
-	 *            a storage cell item.
-	 * @param host
-	 *            anytime the contents of your storage cell changes it should use this to request a save, please
-	 *            note, this value can be null.
-	 * @param channel
-	 *            the storage channel requested.
+	 * @param is a storage cell item.
+	 * @param host anytime the contents of your storage cell changes it should use this to request a save, please note, this value can be null.
+	 * @param channel the storage channel requested.
 	 *
 	 * @return a new IMEHandler for the provided item
 	 */
-	IMEInventoryHandler getCellInventory(ItemStack is, ISaveProvider host, StorageChannel channel);
+	IMEInventoryHandler getCellInventory( ItemStack is, ISaveProvider host, StorageChannel channel );
 
 	/**
 	 * @return the ME Chest texture for light pixels this storage cell type, should be 10x10 with 3px of transparent
-	 *         padding on a 16x16 texture, null is valid if your cell cannot be used in the ME Chest. refer to the
-	 *         assets for examples.
+	 * padding on a 16x16 texture, null is valid if your cell cannot be used in the ME Chest. refer to the
+	 * assets for examples.
 	 */
-	@SideOnly(Side.CLIENT)
+	@SideOnly( Side.CLIENT )
 	IIcon getTopTexture_Light();
 
 	/**
 	 * @return the ME Chest texture for medium pixels this storage cell type, should be 10x10 with 3px of transparent
-	 *         padding on a 16x16 texture, null is valid if your cell cannot be used in the ME Chest. refer to the
-	 *         assets for examples.
+	 * padding on a 16x16 texture, null is valid if your cell cannot be used in the ME Chest. refer to the
+	 * assets for examples.
 	 */
-	@SideOnly(Side.CLIENT)
+	@SideOnly( Side.CLIENT )
 	IIcon getTopTexture_Medium();
 
 	/**
 	 * @return the ME Chest texture for dark pixels this storage cell type, should be 10x10 with 3px of transparent
-	 *         padding on a 16x16 texture, null is valid if your cell cannot be used in the ME Chest. refer to the
-	 *         assets for examples.
+	 * padding on a 16x16 texture, null is valid if your cell cannot be used in the ME Chest. refer to the
+	 * assets for examples.
 	 */
-	@SideOnly(Side.CLIENT)
+	@SideOnly( Side.CLIENT )
 	IIcon getTopTexture_Dark();
 
 	/**
@@ -93,11 +94,11 @@ public interface ICellHandler
 	 * @param player player opening chest gui
 	 * @param chest to be opened chest
 	 * @param cellHandler cell handler
-	 * @param inv inventory handler
-	 * @param is item
-	 * @param chan storage channel
+	 * @param inv         inventory handler
+	 * @param is          item
+	 * @param chan        storage channel
 	 */
-	void openChestGui(EntityPlayer player, IChestOrDrive chest, ICellHandler cellHandler, IMEInventoryHandler inv, ItemStack is, StorageChannel chan);
+	void openChestGui( EntityPlayer player, IChestOrDrive chest, ICellHandler cellHandler, IMEInventoryHandler inv, ItemStack is, StorageChannel chan );
 
 	/**
 	 * 0 - cell is missing.
@@ -113,11 +114,10 @@ public interface ICellHandler
 	 *
 	 * @return get the status of the cell based on its contents.
 	 */
-	int getStatusForCell(ItemStack is, IMEInventory handler);
+	int getStatusForCell( ItemStack is, IMEInventory handler );
 
 	/**
 	 * @return the ae/t to drain for this storage cell inside a chest/drive.
 	 */
-	double cellIdleDrain(ItemStack is, IMEInventory handler);
-
+	double cellIdleDrain( ItemStack is, IMEInventory handler );
 }

--- a/src/api/java/appeng/api/storage/ICellInventory.java
+++ b/src/api/java/appeng/api/storage/ICellInventory.java
@@ -23,10 +23,13 @@
 
 package appeng.api.storage;
 
+
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
+
 import appeng.api.config.FuzzyMode;
 import appeng.api.storage.data.IAEItemStack;
+
 
 public interface ICellInventory extends IMEInventory<IAEItemStack>
 {
@@ -115,5 +118,4 @@ public interface ICellInventory extends IMEInventory<IAEItemStack>
 	 * @return the status number for this drive.
 	 */
 	int getStatusForCell();
-
 }

--- a/src/api/java/appeng/api/storage/ICellInventoryHandler.java
+++ b/src/api/java/appeng/api/storage/ICellInventoryHandler.java
@@ -23,8 +23,10 @@
 
 package appeng.api.storage;
 
+
 import appeng.api.config.IncludeExclude;
 import appeng.api.storage.data.IAEItemStack;
+
 
 public interface ICellInventoryHandler extends IMEInventoryHandler<IAEItemStack>
 {
@@ -39,5 +41,4 @@ public interface ICellInventoryHandler extends IMEInventoryHandler<IAEItemStack>
 	boolean isFuzzy();
 
 	IncludeExclude getIncludeExcludeMode();
-
 }

--- a/src/api/java/appeng/api/storage/ICellProvider.java
+++ b/src/api/java/appeng/api/storage/ICellProvider.java
@@ -23,7 +23,9 @@
 
 package appeng.api.storage;
 
+
 import java.util.List;
+
 
 /**
  * Allows you to provide cells via non IGridHosts directly to the storage system, drives, and similar features should go
@@ -40,7 +42,7 @@ public interface ICellProvider
 	 *
 	 * @return a valid list of handlers, NEVER NULL
 	 */
-	List<IMEInventoryHandler> getCellArray(StorageChannel channel);
+	List<IMEInventoryHandler> getCellArray( StorageChannel channel );
 
 	/**
 	 * the storage's priority.
@@ -48,5 +50,4 @@ public interface ICellProvider
 	 * Positive and negative are supported
 	 */
 	int getPriority();
-
 }

--- a/src/api/java/appeng/api/storage/ICellRegistry.java
+++ b/src/api/java/appeng/api/storage/ICellRegistry.java
@@ -23,8 +23,11 @@
 
 package appeng.api.storage;
 
+
 import net.minecraft.item.ItemStack;
+
 import appeng.api.IAppEngApi;
+
 
 /**
  * Storage Cell Registry, used for specially implemented cells, if you just want to make a item act like a cell, or new
@@ -40,24 +43,26 @@ public interface ICellRegistry
 	 *
 	 * @param handler cell handler
 	 */
-	void addCellHandler(ICellHandler handler);
+	void addCellHandler( ICellHandler handler );
 
 	/**
 	 * return true, if you can get a InventoryHandler for the item passed.
 	 *
 	 * @param is to be checked item
+	 *
 	 * @return true if the provided item, can be handled by a handler in AE, ( AE May choose to skip this and just get
-	 *         the handler instead. )
+	 * the handler instead. )
 	 */
-	boolean isCellHandled(ItemStack is);
+	boolean isCellHandled( ItemStack is );
 
 	/**
 	 * get the handler, for the requested type.
 	 *
 	 * @param is to be checked item
+	 *
 	 * @return the handler registered for this item type.
 	 */
-	ICellHandler getHandler(ItemStack is);
+	ICellHandler getHandler( ItemStack is );
 
 	/**
 	 * returns an IMEInventoryHandler for the provided item.
@@ -68,6 +73,5 @@ public interface ICellRegistry
 	 *
 	 * @return new IMEInventoryHandler, or null if there isn't one.
 	 */
-	IMEInventoryHandler getCellInventory(ItemStack is, ISaveProvider host, StorageChannel chan);
-
+	IMEInventoryHandler getCellInventory( ItemStack is, ISaveProvider host, StorageChannel chan );
 }

--- a/src/api/java/appeng/api/storage/ICellWorkbenchItem.java
+++ b/src/api/java/appeng/api/storage/ICellWorkbenchItem.java
@@ -23,9 +23,12 @@
 
 package appeng.api.storage;
 
+
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
+
 import appeng.api.config.FuzzyMode;
+
 
 public interface ICellWorkbenchItem
 {
@@ -34,9 +37,10 @@ public interface ICellWorkbenchItem
 	 * if this return false, the item will not be treated as a cell, and cannot be inserted into the work bench.
 	 *
 	 * @param is item
+	 *
 	 * @return true if the item should be editable in the cell workbench.
 	 */
-	boolean isEditable(ItemStack is);
+	boolean isEditable( ItemStack is );
 
 	/**
 	 * used to edit the upgrade slots on your cell, should have a capacity of 0-24, you are also responsible for
@@ -44,7 +48,7 @@ public interface ICellWorkbenchItem
 	 *
 	 * onInventoryChange will be called when saving is needed.
 	 */
-	IInventory getUpgradesInventory(ItemStack is);
+	IInventory getUpgradesInventory( ItemStack is );
 
 	/**
 	 * Used to extract, or mirror the contents of the work bench onto the cell.
@@ -53,16 +57,15 @@ public interface ICellWorkbenchItem
 	 *
 	 * onInventoryChange will be called when saving is needed.
 	 */
-	IInventory getConfigInventory(ItemStack is);
+	IInventory getConfigInventory( ItemStack is );
 
 	/**
 	 * @return the current fuzzy status.
 	 */
-	FuzzyMode getFuzzyMode(ItemStack is);
+	FuzzyMode getFuzzyMode( ItemStack is );
 
 	/**
 	 * sets the setting on the cell.
 	 */
-	void setFuzzyMode(ItemStack is, FuzzyMode fzMode);
-
+	void setFuzzyMode( ItemStack is, FuzzyMode fzMode );
 }

--- a/src/api/java/appeng/api/storage/IExternalStorageHandler.java
+++ b/src/api/java/appeng/api/storage/IExternalStorageHandler.java
@@ -23,9 +23,12 @@
 
 package appeng.api.storage;
 
+
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.util.ForgeDirection;
+
 import appeng.api.networking.security.BaseActionSource;
+
 
 /**
  * A Registration Record for {@link IExternalStorageRegistry}
@@ -39,9 +42,10 @@ public interface IExternalStorageHandler
 	 *
 	 * @param te to be handled tile entity
 	 * @param mySrc source
+	 *
 	 * @return true, if it can get a handler via getInventory
 	 */
-	boolean canHandle(TileEntity te, ForgeDirection d, StorageChannel channel, BaseActionSource mySrc);
+	boolean canHandle( TileEntity te, ForgeDirection d, StorageChannel channel, BaseActionSource mySrc );
 
 	/**
 	 * if this can handle the given inventory, return the a IMEInventory implementing class for it, if not return null
@@ -52,9 +56,9 @@ public interface IExternalStorageHandler
 	 * @param te to be handled tile entity
 	 * @param d direction
 	 * @param channel channel
-	 * @param src source
+	 * @param src     source
+	 *
 	 * @return The Handler for the inventory
 	 */
-	IMEInventory getInventory(TileEntity te, ForgeDirection d, StorageChannel channel, BaseActionSource src);
-
+	IMEInventory getInventory( TileEntity te, ForgeDirection d, StorageChannel channel, BaseActionSource src );
 }

--- a/src/api/java/appeng/api/storage/IExternalStorageRegistry.java
+++ b/src/api/java/appeng/api/storage/IExternalStorageRegistry.java
@@ -23,10 +23,13 @@
 
 package appeng.api.storage;
 
+
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.util.ForgeDirection;
+
 import appeng.api.IAppEngApi;
 import appeng.api.networking.security.BaseActionSource;
+
 
 /**
  * A Registry of External Storage handlers.
@@ -41,15 +44,15 @@ public interface IExternalStorageRegistry
 	 *
 	 * @param esh storage handler
 	 */
-	void addExternalStorageInterface(IExternalStorageHandler esh);
+	void addExternalStorageInterface( IExternalStorageHandler esh );
 
 	/**
-	 * @param te tile entity
+	 * @param te       tile entity
 	 * @param opposite direction
-	 * @param channel channel
-	 * @param mySrc source
+	 * @param channel  channel
+	 * @param mySrc    source
+	 *
 	 * @return the handler for a given tile / forge direction
 	 */
-	IExternalStorageHandler getHandler(TileEntity te, ForgeDirection opposite, StorageChannel channel, BaseActionSource mySrc);
-
+	IExternalStorageHandler getHandler( TileEntity te, ForgeDirection opposite, StorageChannel channel, BaseActionSource mySrc );
 }

--- a/src/api/java/appeng/api/storage/IMEInventory.java
+++ b/src/api/java/appeng/api/storage/IMEInventory.java
@@ -23,6 +23,7 @@
 
 package appeng.api.storage;
 
+
 import appeng.api.config.Actionable;
 import appeng.api.networking.security.BaseActionSource;
 import appeng.api.storage.data.IAEStack;
@@ -45,35 +46,32 @@ public interface IMEInventory<StackType extends IAEStack>
 	 * Store new items, or simulate the addition of new items into the ME Inventory.
 	 *
 	 * @param input item to add.
-	 * @param type action type
-	 * @param src action source
+	 * @param type  action type
+	 * @param src   action source
+	 *
 	 * @return returns the number of items not added.
 	 */
-	public StackType injectItems(StackType input, Actionable type, BaseActionSource src);
+	public StackType injectItems( StackType input, Actionable type, BaseActionSource src );
 
 	/**
 	 * Extract the specified item from the ME Inventory
 	 *
-	 * @param request
-	 *            item to request ( with stack size. )
-	 * @param mode
-	 *            simulate, or perform action?
+	 * @param request item to request ( with stack size. )
+	 * @param mode simulate, or perform action?
 	 * @return returns the number of items extracted, null
 	 */
-	public StackType extractItems(StackType request, Actionable mode, BaseActionSource src);
+	public StackType extractItems( StackType request, Actionable mode, BaseActionSource src );
 
 	/**
 	 * request a full report of all available items, storage.
 	 *
-	 * @param out
-	 *            the IItemList the results will be written too
+	 * @param out the IItemList the results will be written too
 	 * @return returns same list that was passed in, is passed out
 	 */
-	public IItemList<StackType> getAvailableItems(IItemList<StackType> out);
+	public IItemList<StackType> getAvailableItems( IItemList<StackType> out );
 
 	/**
 	 * @return the type of channel your handler should be part of
 	 */
 	public StorageChannel getChannel();
-
 }

--- a/src/api/java/appeng/api/storage/IMEInventoryHandler.java
+++ b/src/api/java/appeng/api/storage/IMEInventoryHandler.java
@@ -23,8 +23,10 @@
 
 package appeng.api.storage;
 
+
 import appeng.api.config.AccessRestriction;
 import appeng.api.storage.data.IAEStack;
+
 
 /**
  * Thin logic layer that can be swapped with different IMEInventory implementations, used to handle features related to
@@ -46,20 +48,18 @@ public interface IMEInventoryHandler<StackType extends IAEStack> extends IMEInve
 	 * determine if a particular item is prioritized for this inventory handler, if it is, then it will be added to this
 	 * inventory prior to any non-prioritized inventories.
 	 *
-	 * @param input
-	 *            - item that might be added
+	 * @param input item that might be added
 	 * @return if its prioritized
 	 */
-	public boolean isPrioritized(StackType input);
+	public boolean isPrioritized( StackType input );
 
 	/**
 	 * determine if an item can be accepted and stored.
 	 *
-	 * @param input
-	 *            - item that might be added
+	 * @param input item that might be added
 	 * @return if the item can be added
 	 */
-	public boolean canAccept(StackType input);
+	public boolean canAccept( StackType input );
 
 	/**
 	 * determine what the priority of the inventory is.
@@ -72,8 +72,8 @@ public interface IMEInventoryHandler<StackType extends IAEStack> extends IMEInve
 	 * pass back value for blinkCell.
 	 *
 	 * @return the slot index for the cell that this represents in the storage unit, the method on the
-	 *         {@link ICellContainer} will be called with this value, only trust the return value of this method if you
-	 *         are the implementer of the {@link IMEInventoryHandler}.
+	 * {@link ICellContainer} will be called with this value, only trust the return value of this method if you
+	 * are the implementer of the {@link IMEInventoryHandler}.
 	 */
 	public int getSlot();
 
@@ -82,9 +82,8 @@ public interface IMEInventoryHandler<StackType extends IAEStack> extends IMEInve
 	 * belongs, however in some cases you can save processor time, or require that the second, or first pass is simply
 	 * ignored, this allows you to do that.
 	 *
-	 * @param i
-	 *            - pass number ( 1 or 2 )
+	 * @param i pass number ( 1 or 2 )
 	 * @return true, if this inventory is valid for this pass.
 	 */
-	public boolean validForPass(int i);
+	public boolean validForPass( int i );
 }

--- a/src/api/java/appeng/api/storage/IMEMonitor.java
+++ b/src/api/java/appeng/api/storage/IMEMonitor.java
@@ -23,9 +23,11 @@
 
 package appeng.api.storage;
 
+
 import appeng.api.networking.storage.IBaseMonitor;
 import appeng.api.storage.data.IAEStack;
 import appeng.api.storage.data.IItemList;
+
 
 public interface IMEMonitor<T extends IAEStack> extends IMEInventoryHandler<T>, IBaseMonitor<T>
 {
@@ -34,8 +36,7 @@ public interface IMEMonitor<T extends IAEStack> extends IMEInventoryHandler<T>, 
 	@Deprecated
 	/**
 	 * This method is discouraged when accessing data via a IMEMonitor
-	 */
-	public IItemList<T> getAvailableItems(IItemList out);
+	 */ public IItemList<T> getAvailableItems( IItemList out );
 
 	/**
 	 * Get access to the full item list of the network, preferred over {@link IMEInventory} .getAvailableItems(...)
@@ -43,5 +44,4 @@ public interface IMEMonitor<T extends IAEStack> extends IMEInventoryHandler<T>, 
 	 * @return full storage list.
 	 */
 	IItemList<T> getStorageList();
-
 }

--- a/src/api/java/appeng/api/storage/IMEMonitorHandlerReceiver.java
+++ b/src/api/java/appeng/api/storage/IMEMonitorHandlerReceiver.java
@@ -23,9 +23,11 @@
 
 package appeng.api.storage;
 
+
 import appeng.api.networking.security.BaseActionSource;
 import appeng.api.networking.storage.IBaseMonitor;
 import appeng.api.storage.data.IAEStack;
+
 
 public interface IMEMonitorHandlerReceiver<StackType extends IAEStack>
 {
@@ -34,20 +36,20 @@ public interface IMEMonitorHandlerReceiver<StackType extends IAEStack>
 	 * return true if this object should remain as a listener.
 	 *
 	 * @param verificationToken to be checked object
+	 *
 	 * @return true if object should remain as a listener
 	 */
-	boolean isValid(Object verificationToken);
+	boolean isValid( Object verificationToken );
 
 	/**
 	 * called when changes are made to the Monitor, but only if listener is still valid.
 	 *
 	 * @param change done change
 	 */
-	void postChange(IBaseMonitor<StackType> monitor, Iterable<StackType> change, BaseActionSource actionSource);
+	void postChange( IBaseMonitor<StackType> monitor, Iterable<StackType> change, BaseActionSource actionSource );
 
 	/**
 	 * called when the list updates its contents, this is mostly for handling power events.
 	 */
 	void onListUpdate();
-
 }

--- a/src/api/java/appeng/api/storage/ISaveProvider.java
+++ b/src/api/java/appeng/api/storage/ISaveProvider.java
@@ -27,6 +27,5 @@ package appeng.api.storage;
 public interface ISaveProvider
 {
 
-	void saveChanges(IMEInventory cellInventory);
-
+	void saveChanges( IMEInventory cellInventory );
 }

--- a/src/api/java/appeng/api/storage/IStorageHelper.java
+++ b/src/api/java/appeng/api/storage/IStorageHelper.java
@@ -23,6 +23,15 @@
 
 package appeng.api.storage;
 
+
+import java.io.IOException;
+
+import io.netty.buffer.ByteBuf;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.fluids.FluidStack;
+
 import appeng.api.networking.crafting.ICraftingLink;
 import appeng.api.networking.crafting.ICraftingRequester;
 import appeng.api.networking.energy.IEnergySource;
@@ -30,12 +39,7 @@ import appeng.api.networking.security.BaseActionSource;
 import appeng.api.storage.data.IAEFluidStack;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.api.storage.data.IItemList;
-import io.netty.buffer.ByteBuf;
-import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraftforge.fluids.FluidStack;
 
-import java.io.IOException;
 
 public interface IStorageHelper
 {
@@ -44,25 +48,24 @@ public interface IStorageHelper
 	 * load a crafting link from nbt data.
 	 *
 	 * @param data to be loaded data
+	 *
 	 * @return crafting link
 	 */
-	ICraftingLink loadCraftingLink(NBTTagCompound data, ICraftingRequester req);
+	ICraftingLink loadCraftingLink( NBTTagCompound data, ICraftingRequester req );
 
 	/**
-	 * @param is
-	 *            An ItemStack
+	 * @param is an ItemStack
 	 *
 	 * @return a new INSTANCE of {@link IAEItemStack} from a MC {@link ItemStack}
 	 */
-	IAEItemStack createItemStack(ItemStack is);
+	IAEItemStack createItemStack( ItemStack is );
 
 	/**
-	 * @param is
-	 *            A FluidStack
+	 * @param is a FluidStack
 	 *
 	 * @return a new INSTANCE of {@link IAEFluidStack} from a Forge {@link FluidStack}
 	 */
-	IAEFluidStack createFluidStack(FluidStack is);
+	IAEFluidStack createFluidStack( FluidStack is );
 
 	/**
 	 * @return a new INSTANCE of {@link IItemList} for items
@@ -78,19 +81,23 @@ public interface IStorageHelper
 	 * Read a AE Item Stack from a byte stream, returns a AE item stack or null.
 	 *
 	 * @param input to be loaded data
+	 *
 	 * @return item based of data
+	 *
 	 * @throws IOException if file could not be read
 	 */
-	IAEItemStack readItemFromPacket(ByteBuf input) throws IOException;
+	IAEItemStack readItemFromPacket( ByteBuf input ) throws IOException;
 
 	/**
 	 * Read a AE Fluid Stack from a byte stream, returns a AE fluid stack or null.
 	 *
 	 * @param input to be loaded data
+	 *
 	 * @return fluid based on data
+	 *
 	 * @throws IOException if file could not be written
 	 */
-	IAEFluidStack readFluidFromPacket(ByteBuf input) throws IOException;
+	IAEFluidStack readFluidFromPacket( ByteBuf input ) throws IOException;
 
 	/**
 	 * use energy from energy, to remove request items from cell, at the request of src.
@@ -98,20 +105,21 @@ public interface IStorageHelper
 	 * @param energy to be drained energy source
 	 * @param cell cell of requested items
 	 * @param request requested items
-	 * @param src action source
+	 * @param src     action source
+	 *
 	 * @return items that successfully extracted.
 	 */
-	IAEItemStack poweredExtraction(IEnergySource energy, IMEInventory<IAEItemStack> cell, IAEItemStack request, BaseActionSource src);
+	IAEItemStack poweredExtraction( IEnergySource energy, IMEInventory<IAEItemStack> cell, IAEItemStack request, BaseActionSource src );
 
 	/**
 	 * use energy from energy, to inject input items into cell, at the request of src
 	 *
 	 * @param energy to be added energy source
-	 * @param cell injected cell
-	 * @param input to be injected items
-	 * @param src action source
+	 * @param cell   injected cell
+	 * @param input  to be injected items
+	 * @param src    action source
+	 *
 	 * @return items that failed to insert.
 	 */
-	IAEItemStack poweredInsert(IEnergySource energy, IMEInventory<IAEItemStack> cell, IAEItemStack input, BaseActionSource src);
-
+	IAEItemStack poweredInsert( IEnergySource energy, IMEInventory<IAEItemStack> cell, IAEItemStack input, BaseActionSource src );
 }

--- a/src/api/java/appeng/api/storage/IStorageMonitorable.java
+++ b/src/api/java/appeng/api/storage/IStorageMonitorable.java
@@ -23,9 +23,11 @@
 
 package appeng.api.storage;
 
+
 import appeng.api.implementations.tiles.ITileStorageMonitorable;
 import appeng.api.storage.data.IAEFluidStack;
 import appeng.api.storage.data.IAEItemStack;
+
 
 /**
  * represents the internal behavior of a {@link ITileStorageMonitorable} use it to get this value for a tile, or part.
@@ -44,5 +46,4 @@ public interface IStorageMonitorable
 	 * Access the fluid inventory for the monitorable storage.
 	 */
 	IMEMonitor<IAEFluidStack> getFluidInventory();
-
 }

--- a/src/api/java/appeng/api/storage/ITerminalHost.java
+++ b/src/api/java/appeng/api/storage/ITerminalHost.java
@@ -23,7 +23,9 @@
 
 package appeng.api.storage;
 
+
 import appeng.api.util.IConfigurableObject;
+
 
 public interface ITerminalHost extends IStorageMonitorable, IConfigurableObject
 {

--- a/src/api/java/appeng/api/storage/MEMonitorHandler.java
+++ b/src/api/java/appeng/api/storage/MEMonitorHandler.java
@@ -23,16 +23,19 @@
 
 package appeng.api.storage;
 
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map.Entry;
+
+import com.google.common.collect.ImmutableList;
+
 import appeng.api.config.AccessRestriction;
 import appeng.api.config.Actionable;
 import appeng.api.networking.security.BaseActionSource;
 import appeng.api.storage.data.IAEStack;
 import appeng.api.storage.data.IItemList;
-import com.google.common.collect.ImmutableList;
 
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map.Entry;
 
 /**
  * Common implementation of a simple class that monitors injection/extraction of a inventory to send events to a list of
@@ -59,16 +62,16 @@ public class MEMonitorHandler<StackType extends IAEStack> implements IMEMonitor<
 		return this.listeners.entrySet().iterator();
 	}
 
-	protected void postChangesToListeners( Iterable<StackType> changes, BaseActionSource src)
+	protected void postChangesToListeners( Iterable<StackType> changes, BaseActionSource src )
 	{
 		this.notifyListenersOfChange( changes, src );
 	}
 
-	protected void notifyListenersOfChange(Iterable<StackType> diff, BaseActionSource src)
+	protected void notifyListenersOfChange( Iterable<StackType> diff, BaseActionSource src )
 	{
 		this.hasChanged = true;// need to update the cache.
 		Iterator<Entry<IMEMonitorHandlerReceiver<StackType>, Object>> i = this.getListeners();
-		while (i.hasNext())
+		while ( i.hasNext() )
 		{
 			Entry<IMEMonitorHandlerReceiver<StackType>, Object> o = i.next();
 			IMEMonitorHandlerReceiver<StackType> receiver = o.getKey();
@@ -79,7 +82,7 @@ public class MEMonitorHandler<StackType extends IAEStack> implements IMEMonitor<
 		}
 	}
 
-	private StackType monitorDifference(IAEStack original, StackType leftOvers, boolean extraction, BaseActionSource src)
+	private StackType monitorDifference( IAEStack original, StackType leftOvers, boolean extraction, BaseActionSource src )
 	{
 		StackType diff = (StackType) original.copy();
 
@@ -94,42 +97,44 @@ public class MEMonitorHandler<StackType extends IAEStack> implements IMEMonitor<
 		return leftOvers;
 	}
 
-	public MEMonitorHandler(IMEInventoryHandler<StackType> t) {
+	public MEMonitorHandler( IMEInventoryHandler<StackType> t )
+	{
 		this.internalHandler = t;
 		this.cachedList = (IItemList<StackType>) t.getChannel().createList();
 	}
 
-	public MEMonitorHandler(IMEInventoryHandler<StackType> t, StorageChannel chan) {
+	public MEMonitorHandler( IMEInventoryHandler<StackType> t, StorageChannel chan )
+	{
 		this.internalHandler = t;
 		this.cachedList = (IItemList<StackType>) chan.createList();
 	}
 
 	@Override
-	public void addListener(IMEMonitorHandlerReceiver<StackType> l, Object verificationToken)
+	public void addListener( IMEMonitorHandlerReceiver<StackType> l, Object verificationToken )
 	{
 		this.listeners.put( l, verificationToken );
 	}
 
 	@Override
-	public void removeListener(IMEMonitorHandlerReceiver<StackType> l)
+	public void removeListener( IMEMonitorHandlerReceiver<StackType> l )
 	{
 		this.listeners.remove( l );
 	}
 
 	@Override
-	public StackType injectItems(StackType input, Actionable mode, BaseActionSource src)
+	public StackType injectItems( StackType input, Actionable mode, BaseActionSource src )
 	{
 		if ( mode == Actionable.SIMULATE )
 			return this.getHandler().injectItems( input, mode, src );
-		return this.monitorDifference(input.copy(), this.getHandler().injectItems(input, mode, src), false, src);
+		return this.monitorDifference( input.copy(), this.getHandler().injectItems( input, mode, src ), false, src );
 	}
 
 	@Override
-	public StackType extractItems(StackType request, Actionable mode, BaseActionSource src)
+	public StackType extractItems( StackType request, Actionable mode, BaseActionSource src )
 	{
 		if ( mode == Actionable.SIMULATE )
 			return this.getHandler().extractItems( request, mode, src );
-		return this.monitorDifference(request.copy(), this.getHandler().extractItems(request, mode, src), true, src);
+		return this.monitorDifference( request.copy(), this.getHandler().extractItems( request, mode, src ), true, src );
 	}
 
 	@Override
@@ -146,7 +151,7 @@ public class MEMonitorHandler<StackType extends IAEStack> implements IMEMonitor<
 	}
 
 	@Override
-	public IItemList<StackType> getAvailableItems(IItemList out)
+	public IItemList<StackType> getAvailableItems( IItemList out )
 	{
 		return this.getHandler().getAvailableItems( out );
 	}
@@ -164,13 +169,13 @@ public class MEMonitorHandler<StackType extends IAEStack> implements IMEMonitor<
 	}
 
 	@Override
-	public boolean isPrioritized(StackType input)
+	public boolean isPrioritized( StackType input )
 	{
 		return this.getHandler().isPrioritized( input );
 	}
 
 	@Override
-	public boolean canAccept(StackType input)
+	public boolean canAccept( StackType input )
 	{
 		return this.getHandler().canAccept( input );
 	}
@@ -188,9 +193,8 @@ public class MEMonitorHandler<StackType extends IAEStack> implements IMEMonitor<
 	}
 
 	@Override
-	public boolean validForPass(int i)
+	public boolean validForPass( int i )
 	{
 		return this.getHandler().validForPass( i );
 	}
-
 }

--- a/src/api/java/appeng/api/storage/StorageChannel.java
+++ b/src/api/java/appeng/api/storage/StorageChannel.java
@@ -23,11 +23,13 @@
 
 package appeng.api.storage;
 
+
 import appeng.api.AEApi;
 import appeng.api.storage.data.IAEFluidStack;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.api.storage.data.IAEStack;
 import appeng.api.storage.data.IItemList;
+
 
 public enum StorageChannel
 {
@@ -43,11 +45,13 @@ public enum StorageChannel
 
 	public final Class<? extends IAEStack> type;
 
-	private StorageChannel( Class<? extends IAEStack> t ) {
+	private StorageChannel( Class<? extends IAEStack> t )
+	{
 		this.type = t;
 	}
 
-	public IItemList createList() {
+	public IItemList createList()
+	{
 		if ( this == ITEMS )
 			return AEApi.instance().storage().createItemList();
 		else

--- a/src/api/java/appeng/api/storage/data/IAEFluidStack.java
+++ b/src/api/java/appeng/api/storage/data/IAEFluidStack.java
@@ -23,8 +23,10 @@
 
 package appeng.api.storage.data;
 
+
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
+
 
 /**
  * An alternate version of FluidStack for AE to keep tabs on things easier, and
@@ -32,7 +34,7 @@ import net.minecraftforge.fluids.FluidStack;
  *
  * You may hold on to these if you want, just make sure you let go of them when
  * your not using them.
- *
+ * <p/>
  * Don't Implement.
  *
  * Construct with Util.createFluidStack( FluidStack )
@@ -59,11 +61,10 @@ public interface IAEFluidStack extends IAEStack<IAEFluidStack>
 	/**
 	 * Combines two IAEItemStacks via addition.
 	 *
-	 * @param option
-	 *            , to add to the current one.
+	 * @param option to add to the current one.
 	 */
 	@Override
-	void add(IAEFluidStack option);
+	void add( IAEFluidStack option );
 
 	/**
 	 * quick way to get access to the Forge Fluid Definition.
@@ -71,5 +72,4 @@ public interface IAEFluidStack extends IAEStack<IAEFluidStack>
 	 * @return fluid definition
 	 */
 	Fluid getFluid();
-
 }

--- a/src/api/java/appeng/api/storage/data/IAEItemStack.java
+++ b/src/api/java/appeng/api/storage/data/IAEItemStack.java
@@ -23,8 +23,10 @@
 
 package appeng.api.storage.data;
 
+
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+
 
 /**
  * An alternate version of ItemStack for AE to keep tabs on things easier, and to support larger storage. stackSizes of
@@ -64,11 +66,10 @@ public interface IAEItemStack extends IAEStack<IAEItemStack>
 	/**
 	 * Combines two IAEItemStacks via addition.
 	 *
-	 * @param option
-	 *            to add to the current one.
+	 * @param option to add to the current one.
 	 */
 	@Override
-	void add(IAEItemStack option);
+	void add( IAEItemStack option );
 
 	/**
 	 * quick way to get access to the MC Item Definition.
@@ -85,21 +86,23 @@ public interface IAEItemStack extends IAEStack<IAEItemStack>
 	/**
 	 * Compare the Ore Dictionary ID for this to another item.
 	 */
-	boolean sameOre(IAEItemStack is);
+	boolean sameOre( IAEItemStack is );
 
 	/**
 	 * compare the item/damage/nbt of the stack.
 	 *
 	 * @param otherStack to be compared item
+	 *
 	 * @return true if it is the same type (same item, damage, nbt)
 	 */
-	boolean isSameType(IAEItemStack otherStack);
+	boolean isSameType( IAEItemStack otherStack );
 
 	/**
 	 * compare the item/damage/nbt of the stack.
 	 *
 	 * @param stored to be compared item
+	 *
 	 * @return true if it is the same type (same item, damage, nbt)
 	 */
-	boolean isSameType(ItemStack stored);
+	boolean isSameType( ItemStack stored );
 }

--- a/src/api/java/appeng/api/storage/data/IAEStack.java
+++ b/src/api/java/appeng/api/storage/data/IAEStack.java
@@ -23,12 +23,16 @@
 
 package appeng.api.storage.data;
 
-import appeng.api.config.FuzzyMode;
-import appeng.api.storage.StorageChannel;
-import io.netty.buffer.ByteBuf;
-import net.minecraft.nbt.NBTTagCompound;
 
 import java.io.IOException;
+
+import io.netty.buffer.ByteBuf;
+
+import net.minecraft.nbt.NBTTagCompound;
+
+import appeng.api.config.FuzzyMode;
+import appeng.api.storage.StorageChannel;
+
 
 public interface IAEStack<StackType extends IAEStack>
 {
@@ -38,7 +42,7 @@ public interface IAEStack<StackType extends IAEStack>
 	 *
 	 * @param is added item
 	 */
-	void add(StackType is);
+	void add( StackType is );
 
 	/**
 	 * number of items in the stack.
@@ -50,10 +54,9 @@ public interface IAEStack<StackType extends IAEStack>
 	/**
 	 * changes the number of items in the stack.
 	 *
-	 * @param stackSize
-	 *            , ItemStack.stackSize = N
+	 * @param stackSize  ItemStack.stackSize = N
 	 */
-	StackType setStackSize(long stackSize);
+	StackType setStackSize( long stackSize );
 
 	/**
 	 * Same as getStackSize, but for requestable items. ( LP )
@@ -67,7 +70,7 @@ public interface IAEStack<StackType extends IAEStack>
 	 *
 	 * @return basically itemStack.stackSize = N but for setStackSize items.
 	 */
-	StackType setCountRequestable(long countRequestable);
+	StackType setCountRequestable( long countRequestable );
 
 	/**
 	 * true, if the item can be crafted.
@@ -81,7 +84,7 @@ public interface IAEStack<StackType extends IAEStack>
 	 *
 	 * @param isCraftable can item be crafted
 	 */
-	StackType setCraftable(boolean isCraftable);
+	StackType setCraftable( boolean isCraftable );
 
 	/**
 	 * clears, requestable, craftable, and stack sizes.
@@ -100,33 +103,33 @@ public interface IAEStack<StackType extends IAEStack>
 	 *
 	 * @param i additional stack size
 	 */
-	void incStackSize(long i);
+	void incStackSize( long i );
 
 	/**
 	 * removes some from the stack size.
 	 */
-	void decStackSize(long i);
+	void decStackSize( long i );
 
 	/**
 	 * adds items to the requestable
 	 *
 	 * @param i increased amount of requested items
 	 */
-	void incCountRequestable(long i);
+	void incCountRequestable( long i );
 
 	/**
 	 * removes items from the requestable
 	 *
 	 * @param i decreased amount of requested items
 	 */
-	void decCountRequestable(long i);
+	void decCountRequestable( long i );
 
 	/**
 	 * write to a NBTTagCompound.
 	 *
 	 * @param i to be written data
 	 */
-	void writeToNBT(NBTTagCompound i);
+	void writeToNBT( NBTTagCompound i );
 
 	/**
 	 * Compare stacks using precise logic.
@@ -138,10 +141,11 @@ public interface IAEStack<StackType extends IAEStack>
 	 * IAEFluidStack, FluidStack
 	 *
 	 * @param obj compared object
+	 *
 	 * @return true if they are the same.
 	 */
 	@Override
-	boolean equals(Object obj);
+	boolean equals( Object obj );
 
 	/**
 	 * compare stacks using fuzzy logic
@@ -150,17 +154,19 @@ public interface IAEStack<StackType extends IAEStack>
 	 *
 	 * @param st stacks
 	 * @param mode used fuzzy mode
+	 *
 	 * @return true if two stacks are equal based on AE Fuzzy Comparison.
 	 */
-	boolean fuzzyComparison(Object st, FuzzyMode mode);
+	boolean fuzzyComparison( Object st, FuzzyMode mode );
 
 	/**
 	 * Slower for disk saving, but smaller/more efficient for packets.
 	 *
 	 * @param data to be written data
+	 *
 	 * @throws IOException
 	 */
-	void writeToPacket(ByteBuf data) throws IOException;
+	void writeToPacket( ByteBuf data ) throws IOException;
 
 	/**
 	 * Clone the Item / Fluid Stack
@@ -197,5 +203,4 @@ public interface IAEStack<StackType extends IAEStack>
 	 * @return ITEM or FLUID
 	 */
 	StorageChannel getChannel();
-
 }

--- a/src/api/java/appeng/api/storage/data/IAETagCompound.java
+++ b/src/api/java/appeng/api/storage/data/IAETagCompound.java
@@ -23,8 +23,11 @@
 
 package appeng.api.storage.data;
 
+
 import net.minecraft.nbt.NBTTagCompound;
+
 import appeng.api.features.IItemComparison;
+
 
 /**
  * Don't cast this... either compare with it, or copy it.
@@ -43,14 +46,14 @@ public interface IAETagCompound
 	 * compare to other NBTTagCompounds or IAETagCompounds
 	 *
 	 * @param a compared object
+	 *
 	 * @return true, if they are the same.
 	 */
 	@Override
-	boolean equals(Object a);
+	boolean equals( Object a );
 
 	/**
 	 * @return the special comparison for this tag
 	 */
 	IItemComparison getSpecialComparison();
-
 }

--- a/src/api/java/appeng/api/storage/data/IItemContainer.java
+++ b/src/api/java/appeng/api/storage/data/IItemContainer.java
@@ -23,9 +23,11 @@
 
 package appeng.api.storage.data;
 
-import appeng.api.config.FuzzyMode;
 
 import java.util.Collection;
+
+import appeng.api.config.FuzzyMode;
+
 
 /**
  * Represents a list of items in AE.
@@ -42,24 +44,25 @@ public interface IItemContainer<StackType extends IAEStack>
 	 *
 	 * @param option added stack
 	 */
-	public void add(StackType option); // adds stack as is
+	public void add( StackType option ); // adds stack as is
 
 	/**
 	 * @param i compared item
+	 *
 	 * @return a stack equivalent to the stack passed in, but with the correct stack size information, or null if its
-	 *         not present
+	 * not present
 	 */
-	StackType findPrecise(StackType i);
+	StackType findPrecise( StackType i );
 
 	/**
 	 * @param input compared item
+	 *
 	 * @return a list of relevant fuzzy matched stacks
 	 */
-	public Collection<StackType> findFuzzy(StackType input, FuzzyMode fuzzy);
+	public Collection<StackType> findFuzzy( StackType input, FuzzyMode fuzzy );
 
 	/**
 	 * @return true if there are no items in the list
 	 */
 	public boolean isEmpty();
-
 }

--- a/src/api/java/appeng/api/storage/data/IItemList.java
+++ b/src/api/java/appeng/api/storage/data/IItemList.java
@@ -23,7 +23,9 @@
 
 package appeng.api.storage.data;
 
+
 import java.util.Iterator;
+
 
 /**
  * Represents a list of items in AE.
@@ -41,14 +43,14 @@ public interface IItemList<StackType extends IAEStack> extends IItemContainer<St
 	 *
 	 * @param option stacktype option
 	 */
-	public void addStorage(StackType option); // adds a stack as stored
+	public void addStorage( StackType option ); // adds a stack as stored
 
 	/**
 	 * add a stack to the list as craftable, this will merge the stack with an item already in the list if found.
 	 *
 	 * @param option stacktype option
 	 */
-	public void addCrafting(StackType option);
+	public void addCrafting( StackType option );
 
 	/**
 	 * add a stack to the list, stack size is used to add to requestable, this will merge the stack with an item already
@@ -56,7 +58,7 @@ public interface IItemList<StackType extends IAEStack> extends IItemContainer<St
 	 *
 	 * @param option stacktype option
 	 */
-	public void addRequestable(StackType option); // adds a stack as requestable
+	public void addRequestable( StackType option ); // adds a stack as requestable
 
 	/**
 	 * @return the first item in the list
@@ -78,5 +80,4 @@ public interface IItemList<StackType extends IAEStack> extends IItemContainer<St
 	 * resets stack sizes to 0.
 	 */
 	void resetStatus();
-
 }

--- a/src/api/java/appeng/api/util/AECableType.java
+++ b/src/api/java/appeng/api/util/AECableType.java
@@ -23,6 +23,7 @@
 
 package appeng.api.util;
 
+
 public enum AECableType
 {
 	/**

--- a/src/api/java/appeng/api/util/AEColor.java
+++ b/src/api/java/appeng/api/util/AEColor.java
@@ -23,7 +23,12 @@
 
 package appeng.api.util;
 
+
+import java.util.Arrays;
+import java.util.List;
+
 import net.minecraft.util.StatCollector;
+
 
 /**
  * List of all colors supported by AE, their names, and various colors for display.
@@ -33,39 +38,41 @@ import net.minecraft.util.StatCollector;
 public enum AEColor
 {
 
-	White("gui.appliedenergistics2.White", 0xBEBEBE, 0xDBDBDB, 0xFAFAFA),
+	White( "gui.appliedenergistics2.White", 0xBEBEBE, 0xDBDBDB, 0xFAFAFA ),
 
-	Orange("gui.appliedenergistics2.Orange", 0xF99739, 0xFAAE44, 0xF4DEC3),
+	Orange( "gui.appliedenergistics2.Orange", 0xF99739, 0xFAAE44, 0xF4DEC3 ),
 
-	Magenta("gui.appliedenergistics2.Magenta", 0x821E82, 0xB82AB8, 0xC598C8),
+	Magenta( "gui.appliedenergistics2.Magenta", 0x821E82, 0xB82AB8, 0xC598C8 ),
 
-	LightBlue("gui.appliedenergistics2.LightBlue", 0x628DCB, 0x82ACE7, 0xD8F6FF),
+	LightBlue( "gui.appliedenergistics2.LightBlue", 0x628DCB, 0x82ACE7, 0xD8F6FF ),
 
-	Yellow("gui.appliedenergistics2.Yellow", 0xFFF7AA, 0xF8FF4A, 0xFFFFE8),
+	Yellow( "gui.appliedenergistics2.Yellow", 0xFFF7AA, 0xF8FF4A, 0xFFFFE8 ),
 
-	Lime("gui.appliedenergistics2.Lime", 0x7CFF4A, 0xBBFF51, 0xE7F7D7),
+	Lime( "gui.appliedenergistics2.Lime", 0x7CFF4A, 0xBBFF51, 0xE7F7D7 ),
 
-	Pink("gui.appliedenergistics2.Pink", 0xDC8DB5, 0xF8B5D7, 0xF7DEEB),
+	Pink( "gui.appliedenergistics2.Pink", 0xDC8DB5, 0xF8B5D7, 0xF7DEEB ),
 
-	Gray("gui.appliedenergistics2.Gray", 0x7C7C7C, 0xA0A0A0, 0xC9C9C9),
+	Gray( "gui.appliedenergistics2.Gray", 0x7C7C7C, 0xA0A0A0, 0xC9C9C9 ),
 
-	LightGray("gui.appliedenergistics2.LightGray", 0x9D9D9D, 0xCDCDCD, 0xEFEFEF),
+	LightGray( "gui.appliedenergistics2.LightGray", 0x9D9D9D, 0xCDCDCD, 0xEFEFEF ),
 
-	Cyan("gui.appliedenergistics2.Cyan", 0x2F9BA5, 0x51AAC6, 0xAEDDF4),
+	Cyan( "gui.appliedenergistics2.Cyan", 0x2F9BA5, 0x51AAC6, 0xAEDDF4 ),
 
-	Purple("gui.appliedenergistics2.Purple", 0x8230B2, 0xA453CE, 0xC7A3CC),
+	Purple( "gui.appliedenergistics2.Purple", 0x8230B2, 0xA453CE, 0xC7A3CC ),
 
-	Blue("gui.appliedenergistics2.Blue", 0x2D29A0, 0x514AFF, 0xDDE6FF),
+	Blue( "gui.appliedenergistics2.Blue", 0x2D29A0, 0x514AFF, 0xDDE6FF ),
 
-	Brown("gui.appliedenergistics2.Brown", 0x724E35, 0xB7967F, 0xE0D2C8),
+	Brown( "gui.appliedenergistics2.Brown", 0x724E35, 0xB7967F, 0xE0D2C8 ),
 
-	Green("gui.appliedenergistics2.Green", 0x45A021, 0x60E32E, 0xE3F2E3),
+	Green( "gui.appliedenergistics2.Green", 0x45A021, 0x60E32E, 0xE3F2E3 ),
 
-	Red("gui.appliedenergistics2.Red", 0xA50029, 0xFF003C, 0xFFE6ED),
+	Red( "gui.appliedenergistics2.Red", 0xA50029, 0xFF003C, 0xFFE6ED ),
 
-	Black("gui.appliedenergistics2.Black", 0x2B2B2B, 0x565656, 0x848484),
+	Black( "gui.appliedenergistics2.Black", 0x2B2B2B, 0x565656, 0x848484 ),
 
-	Transparent("gui.appliedenergistics2.Fluix", 0x1B2344, 0x895CA8, 0xD7BBEC);
+	Transparent( "gui.appliedenergistics2.Fluix", 0x1B2344, 0x895CA8, 0xD7BBEC );
+
+	public static final List<AEColor> VALID_COLORS = Arrays.asList( White, Orange, Magenta, LightBlue, Yellow, Lime, Pink, Gray, LightGray, Cyan, Purple, Blue, Brown, Green, Red, Black );
 
 	/**
 	 * Unlocalized name for color.
@@ -87,7 +94,8 @@ public enum AEColor
 	 */
 	final public int whiteVariant;
 
-	AEColor(String unlocalizedName, int blackHex, int medHex, int whiteHex) {
+	AEColor( String unlocalizedName, int blackHex, int medHex, int whiteHex )
+	{
 		this.unlocalizedName = unlocalizedName;
 		this.blackVariant = blackHex;
 		this.mediumVariant = medHex;
@@ -97,7 +105,7 @@ public enum AEColor
 	/**
 	 * Logic to see which colors match each other.. special handle for Transparent
 	 */
-	public boolean matches(AEColor color)
+	public boolean matches( AEColor color )
 	{
 		return this == Transparent || color == Transparent || this == color;
 	}

--- a/src/api/java/appeng/api/util/AEColoredItemDefinition.java
+++ b/src/api/java/appeng/api/util/AEColoredItemDefinition.java
@@ -23,10 +23,12 @@
 
 package appeng.api.util;
 
+
 import net.minecraft.block.Block;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
+
 
 public interface AEColoredItemDefinition
 {
@@ -34,37 +36,37 @@ public interface AEColoredItemDefinition
 	/**
 	 * @return the {@link Block} Implementation if applicable
 	 */
-	Block block(AEColor color);
+	Block block( AEColor color );
 
 	/**
 	 * @return the {@link Item} Implementation if applicable
 	 */
-	Item item(AEColor color);
+	Item item( AEColor color );
 
 	/**
 	 * @return the {@link TileEntity} Class if applicable.
 	 */
-	Class<? extends TileEntity> entity(AEColor color);
+	Class<? extends TileEntity> entity( AEColor color );
 
 	/**
 	 * @return an {@link ItemStack} with specified quantity of this item.
 	 */
-	ItemStack stack(AEColor color, int stackSize);
+	ItemStack stack( AEColor color, int stackSize );
 
 	/**
-	 * @param stackSize
-	 *            - stack size of the result.
+	 * @param stackSize - stack size of the result.
+	 *
 	 * @return an array of all colors.
 	 */
-	ItemStack[] allStacks(int stackSize);
+	ItemStack[] allStacks( int stackSize );
 
 	/**
 	 * Compare {@link ItemStack} with this {@link AEItemDefinition}
 	 *
-	 * @param color compared color of item
+	 * @param color          compared color of item
 	 * @param comparableItem compared item
+	 *
 	 * @return true if the item stack is a matching item.
 	 */
-	boolean sameAs(AEColor color, ItemStack comparableItem);
-
+	boolean sameAs( AEColor color, ItemStack comparableItem );
 }

--- a/src/api/java/appeng/api/util/AEItemDefinition.java
+++ b/src/api/java/appeng/api/util/AEItemDefinition.java
@@ -23,11 +23,13 @@
 
 package appeng.api.util;
 
+
 import net.minecraft.block.Block;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.IBlockAccess;
+
 
 /**
  * Gives easy access to different part of the various, items/blocks/materials in AE.
@@ -53,15 +55,16 @@ public interface AEItemDefinition
 	/**
 	 * @return an {@link ItemStack} with specified quantity of this item.
 	 */
-	ItemStack stack(int stackSize);
+	ItemStack stack( int stackSize );
 
 	/**
 	 * Compare {@link ItemStack} with this {@link AEItemDefinition}
 	 *
 	 * @param comparableItem compared item
+	 *
 	 * @return true if the item stack is a matching item.
 	 */
-	boolean sameAsStack(ItemStack comparableItem);
+	boolean sameAsStack( ItemStack comparableItem );
 
 	/**
 	 * Compare Block with world.
@@ -73,5 +76,5 @@ public interface AEItemDefinition
 	 *
 	 * @return if the block is placed in the world at the specific location.
 	 */
-	boolean sameAsBlock(IBlockAccess world, int x, int y, int z);
+	boolean sameAsBlock( IBlockAccess world, int x, int y, int z );
 }

--- a/src/api/java/appeng/api/util/DimensionalCoord.java
+++ b/src/api/java/appeng/api/util/DimensionalCoord.java
@@ -23,8 +23,10 @@
 
 package appeng.api.util;
 
+
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
+
 
 /**
  * Represents a location in the Minecraft Universe
@@ -35,19 +37,22 @@ public class DimensionalCoord extends WorldCoord
 	private final World w;
 	private final int dimId;
 
-	public DimensionalCoord(DimensionalCoord s) {
+	public DimensionalCoord( DimensionalCoord s )
+	{
 		super( s.x, s.y, s.z );
 		this.w = s.w;
 		this.dimId = s.dimId;
 	}
 
-	public DimensionalCoord(TileEntity s) {
+	public DimensionalCoord( TileEntity s )
+	{
 		super( s );
 		this.w = s.getWorldObj();
 		this.dimId = this.w.provider.dimensionId;
 	}
 
-	public DimensionalCoord(World _w, int _x, int _y, int _z) {
+	public DimensionalCoord( World _w, int _x, int _y, int _z )
+	{
 		super( _x, _y, _z );
 		this.w = _w;
 		this.dimId = _w.provider.dimensionId;
@@ -59,15 +64,15 @@ public class DimensionalCoord extends WorldCoord
 		return new DimensionalCoord( this );
 	}
 
-	public boolean isEqual(DimensionalCoord c)
+	public boolean isEqual( DimensionalCoord c )
 	{
 		return this.x == c.x && this.y == c.y && this.z == c.z && c.w == this.w;
 	}
 
 	@Override
-	public boolean equals(Object obj)
+	public boolean equals( Object obj )
 	{
-		return obj instanceof DimensionalCoord && this.isEqual((DimensionalCoord) obj);
+		return obj instanceof DimensionalCoord && this.isEqual( (DimensionalCoord) obj );
 	}
 
 	@Override
@@ -76,7 +81,7 @@ public class DimensionalCoord extends WorldCoord
 		return super.hashCode() ^ this.dimId;
 	}
 
-	public boolean isInWorld(World world)
+	public boolean isInWorld( World world )
 	{
 		return this.w == world;
 	}

--- a/src/api/java/appeng/api/util/ICommonTile.java
+++ b/src/api/java/appeng/api/util/ICommonTile.java
@@ -23,10 +23,12 @@
 
 package appeng.api.util;
 
+
+import java.util.ArrayList;
+
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 
-import java.util.ArrayList;
 
 public interface ICommonTile
 {
@@ -36,11 +38,10 @@ public interface ICommonTile
 	 * the block itself.
 	 *
 	 * @param world world of tile entity
-	 * @param x x pos of tile entity
-	 * @param y y pos of tile entity
-	 * @param z z pos of tile entity
+	 * @param x     x pos of tile entity
+	 * @param y     y pos of tile entity
+	 * @param z     z pos of tile entity
 	 * @param drops drops of tile entity
 	 */
-	void getDrops(World world, int x, int y, int z, ArrayList<ItemStack> drops);
-
+	void getDrops( World world, int x, int y, int z, ArrayList<ItemStack> drops );
 }

--- a/src/api/java/appeng/api/util/IConfigManager.java
+++ b/src/api/java/appeng/api/util/IConfigManager.java
@@ -23,9 +23,11 @@
 
 package appeng.api.util;
 
-import net.minecraft.nbt.NBTTagCompound;
 
 import java.util.Set;
+
+import net.minecraft.nbt.NBTTagCompound;
+
 
 /**
  * Used to adjust settings on an object,
@@ -48,37 +50,38 @@ public interface IConfigManager
 	 * @param settingName name of setting
 	 * @param defaultValue default value of setting
 	 */
-	void registerSetting(Enum settingName, Enum defaultValue);
+	void registerSetting( Enum settingName, Enum defaultValue );
 
 	/**
 	 * Get Value of a particular setting
 	 *
 	 * @param settingName name of setting
+	 *
 	 * @return value of setting
 	 */
-	Enum getSetting(Enum settingName);
+	Enum getSetting( Enum settingName );
 
 	/**
 	 * Change setting
 	 *
 	 * @param settingName to be changed setting
-	 * @param newValue  new value for setting
+	 * @param newValue    new value for setting
+	 *
 	 * @return changed setting
 	 */
-	Enum putSetting(Enum settingName, Enum newValue);
+	Enum putSetting( Enum settingName, Enum newValue );
 
 	/**
 	 * write all settings to the NBT Tag so they can be read later.
 	 *
 	 * @param dest to be written nbt tag
 	 */
-	void writeToNBT(NBTTagCompound dest);
+	void writeToNBT( NBTTagCompound dest );
 
 	/**
 	 * Only works after settings have been registered
 	 *
 	 * @param src to be read nbt tag
 	 */
-	void readFromNBT(NBTTagCompound src);
-
+	void readFromNBT( NBTTagCompound src );
 }

--- a/src/api/java/appeng/api/util/IConfigurableObject.java
+++ b/src/api/java/appeng/api/util/IConfigurableObject.java
@@ -23,6 +23,7 @@
 
 package appeng.api.util;
 
+
 /**
  * Implemented by various Tiles or Parts in AE
  */
@@ -33,5 +34,4 @@ public interface IConfigurableObject
 	 * get the config manager for the object.
 	 */
 	IConfigManager getConfigManager();
-
 }

--- a/src/api/java/appeng/api/util/INetworkToolAgent.java
+++ b/src/api/java/appeng/api/util/INetworkToolAgent.java
@@ -23,7 +23,9 @@
 
 package appeng.api.util;
 
+
 import net.minecraft.util.MovingObjectPosition;
+
 
 /**
  * Implement on Tile or part to customize if the info gui opens, or an action is preformed.
@@ -31,6 +33,5 @@ import net.minecraft.util.MovingObjectPosition;
 public interface INetworkToolAgent
 {
 
-	boolean showNetworkInfo(MovingObjectPosition where);
-
+	boolean showNetworkInfo( MovingObjectPosition where );
 }

--- a/src/api/java/appeng/api/util/IOrientable.java
+++ b/src/api/java/appeng/api/util/IOrientable.java
@@ -23,7 +23,9 @@
 
 package appeng.api.util;
 
+
 import net.minecraftforge.common.util.ForgeDirection;
+
 
 /**
  * Nearly all of AE's Tile Entities implement IOrientable.
@@ -52,9 +54,9 @@ public interface IOrientable
 
 	/**
 	 * Update the orientation
+	 *
 	 * @param Forward new forward direction
-	 * @param Up new upwards direction
+	 * @param Up      new upwards direction
 	 */
-	void setOrientation(ForgeDirection Forward, ForgeDirection Up);
-
+	void setOrientation( ForgeDirection Forward, ForgeDirection Up );
 }

--- a/src/api/java/appeng/api/util/IOrientableBlock.java
+++ b/src/api/java/appeng/api/util/IOrientableBlock.java
@@ -23,7 +23,9 @@
 
 package appeng.api.util;
 
+
 import net.minecraft.world.IBlockAccess;
+
 
 /**
  * Implemented on many of AE's non Tile Entity Blocks as a way to get a IOrientable.
@@ -38,11 +40,11 @@ public interface IOrientableBlock
 
 	/**
 	 * @param world world of block
-	 * @param x x pos of block
-	 * @param y y pos of block
-	 * @param z z pos of block
+	 * @param x     x pos of block
+	 * @param y     y pos of block
+	 * @param z     z pos of block
+	 *
 	 * @return a IOrientable if applicable
 	 */
-	IOrientable getOrientable(IBlockAccess world, int x, int y, int z);
-
+	IOrientable getOrientable( IBlockAccess world, int x, int y, int z );
 }

--- a/src/api/java/appeng/api/util/IReadOnlyCollection.java
+++ b/src/api/java/appeng/api/util/IReadOnlyCollection.java
@@ -23,6 +23,7 @@
 
 package appeng.api.util;
 
+
 public interface IReadOnlyCollection<T> extends Iterable<T>
 {
 
@@ -39,6 +40,5 @@ public interface IReadOnlyCollection<T> extends Iterable<T>
 	/**
 	 * @return return true if the object is part of the set.
 	 */
-	boolean contains(Object node);
-
+	boolean contains( Object node );
 }

--- a/src/api/java/appeng/api/util/WorldCoord.java
+++ b/src/api/java/appeng/api/util/WorldCoord.java
@@ -23,8 +23,10 @@
 
 package appeng.api.util;
 
+
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.util.ForgeDirection;
+
 
 /**
  * Represents a relative coordinate, either relative to another object, or
@@ -37,7 +39,7 @@ public class WorldCoord
 	public int y;
 	public int z;
 
-	public WorldCoord add(ForgeDirection direction, int length)
+	public WorldCoord add( ForgeDirection direction, int length )
 	{
 		this.x += direction.offsetX * length;
 		this.y += direction.offsetY * length;
@@ -45,7 +47,7 @@ public class WorldCoord
 		return this;
 	}
 
-	public WorldCoord subtract(ForgeDirection direction, int length)
+	public WorldCoord subtract( ForgeDirection direction, int length )
 	{
 		this.x -= direction.offsetX * length;
 		this.y -= direction.offsetY * length;
@@ -53,7 +55,7 @@ public class WorldCoord
 		return this;
 	}
 
-	public WorldCoord add(int _x, int _y, int _z)
+	public WorldCoord add( int _x, int _y, int _z )
 	{
 		this.x += _x;
 		this.y += _y;
@@ -61,7 +63,7 @@ public class WorldCoord
 		return this;
 	}
 
-	public WorldCoord subtract(int _x, int _y, int _z)
+	public WorldCoord subtract( int _x, int _y, int _z )
 	{
 		this.x -= _x;
 		this.y -= _y;
@@ -69,7 +71,7 @@ public class WorldCoord
 		return this;
 	}
 
-	public WorldCoord multiple(int _x, int _y, int _z)
+	public WorldCoord multiple( int _x, int _y, int _z )
 	{
 		this.x *= _x;
 		this.y *= _y;
@@ -77,7 +79,7 @@ public class WorldCoord
 		return this;
 	}
 
-	public WorldCoord divide(int _x, int _y, int _z)
+	public WorldCoord divide( int _x, int _y, int _z )
 	{
 		this.x /= _x;
 		this.y /= _y;
@@ -85,20 +87,22 @@ public class WorldCoord
 		return this;
 	}
 
-	public WorldCoord(int _x, int _y, int _z) {
+	public WorldCoord( int _x, int _y, int _z )
+	{
 		this.x = _x;
 		this.y = _y;
 		this.z = _z;
 	}
 
-	public WorldCoord(TileEntity s) {
+	public WorldCoord( TileEntity s )
+	{
 		this( s.xCoord, s.yCoord, s.zCoord );
 	}
 
 	/**
 	 * Will Return NULL if it's at some diagonal!
 	 */
-	public ForgeDirection directionTo(WorldCoord loc)
+	public ForgeDirection directionTo( WorldCoord loc )
 	{
 		int ox = this.x - loc.x;
 		int oy = this.y - loc.y;
@@ -129,7 +133,7 @@ public class WorldCoord
 		return null;
 	}
 
-	public boolean isEqual(WorldCoord c)
+	public boolean isEqual( WorldCoord c )
 	{
 		return this.x == c.x && this.y == c.y && this.z == c.z;
 	}
@@ -140,9 +144,9 @@ public class WorldCoord
 	}
 
 	@Override
-	public boolean equals(Object obj)
+	public boolean equals( Object obj )
 	{
-		return obj instanceof WorldCoord && this.isEqual((WorldCoord) obj);
+		return obj instanceof WorldCoord && this.isEqual( (WorldCoord) obj );
 	}
 
 	@Override
@@ -154,6 +158,6 @@ public class WorldCoord
 	@Override
 	public int hashCode()
 	{
-		return ( this.y << 24) ^ this.x ^ this.z;
+		return ( this.y << 24 ) ^ this.x ^ this.z;
 	}
 }

--- a/src/main/java/appeng/block/AEBaseItemBlockChargeable.java
+++ b/src/main/java/appeng/block/AEBaseItemBlockChargeable.java
@@ -30,10 +30,13 @@ import net.minecraft.nbt.NBTTagCompound;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
-import appeng.api.AEApi;
+import com.google.common.base.Optional;
+
 import appeng.api.config.AccessRestriction;
 import appeng.api.config.PowerUnits;
 import appeng.api.implementations.items.IAEItemPowerStorage;
+import appeng.api.util.AEItemDefinition;
+import appeng.core.Api;
 import appeng.core.localization.GuiText;
 import appeng.util.Platform;
 
@@ -66,11 +69,21 @@ public class AEBaseItemBlockChargeable extends AEBaseItemBlock implements IAEIte
 
 	private double getMaxEnergyCapacity()
 	{
-		Block blk = Block.getBlockFromItem( this );
-		if ( blk == AEApi.instance().blocks().blockEnergyCell.block() )
-			return 200000;
-		else
-			return 8 * 200000;
+		Block blockID = Block.getBlockFromItem( this );
+		final Optional<AEItemDefinition> maybeEnergyCell = Api.INSTANCE.definitions().blocks().energyCell();
+		if ( maybeEnergyCell.isPresent() )
+		{
+			if ( blockID == maybeEnergyCell.get().block() )
+			{
+				return 200000;
+			}
+			else
+			{
+				return 8 * 200000;
+			}
+		}
+
+		return 0;
 	}
 
 	private double getInternal(ItemStack is)

--- a/src/main/java/appeng/block/crafting/BlockCraftingMonitor.java
+++ b/src/main/java/appeng/block/crafting/BlockCraftingMonitor.java
@@ -18,6 +18,7 @@
 
 package appeng.block.crafting;
 
+
 import java.util.List;
 
 import net.minecraft.creativetab.CreativeTabs;
@@ -29,19 +30,46 @@ import net.minecraftforge.common.util.ForgeDirection;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
-import appeng.api.AEApi;
+import com.google.common.base.Optional;
+
+import appeng.api.util.AEItemDefinition;
 import appeng.client.render.BaseBlockRender;
 import appeng.client.render.blocks.RenderBlockCraftingCPUMonitor;
 import appeng.client.texture.ExtraBlockTextures;
+import appeng.core.Api;
 import appeng.tile.crafting.TileCraftingMonitorTile;
+
 
 public class BlockCraftingMonitor extends BlockCraftingUnit
 {
 
-	public BlockCraftingMonitor() {
+	public BlockCraftingMonitor()
+	{
 		super( BlockCraftingMonitor.class );
 
 		this.setTileEntity( TileCraftingMonitorTile.class );
+	}
+
+	@Override
+	public IIcon getIcon( int direction, int metadata )
+	{
+		final Optional<AEItemDefinition> maybeCraftingUnit = Api.INSTANCE.definitions().blocks().craftingUnit();
+		if ( maybeCraftingUnit.isPresent() )
+		{
+			if ( direction != ForgeDirection.SOUTH.ordinal() )
+			{
+				return maybeCraftingUnit.get().block().getIcon( direction, metadata );
+			}
+		}
+
+		switch ( metadata )
+		{
+			default:
+			case 0:
+				return super.getIcon( 0, 0 );
+			case FLAG_FORMED:
+				return ExtraBlockTextures.BlockCraftingMonitorFit_Light.getIcon();
+		}
 	}
 
 	@Override
@@ -51,24 +79,8 @@ public class BlockCraftingMonitor extends BlockCraftingUnit
 	}
 
 	@Override
-	public IIcon getIcon(int direction, int metadata)
-	{
-		if ( direction != ForgeDirection.SOUTH.ordinal() )
-			return AEApi.instance().blocks().blockCraftingUnit.block().getIcon( direction, metadata );
-
-		switch (metadata)
-		{
-		default:
-		case 0:
-			return super.getIcon( 0, 0 );
-		case FLAG_FORMED:
-			return ExtraBlockTextures.BlockCraftingMonitorFit_Light.getIcon();
-		}
-	}
-
-	@Override
-	@SideOnly(Side.CLIENT)
-	public void getCheckedSubBlocks(Item item, CreativeTabs tabs, List<ItemStack> itemStacks)
+	@SideOnly( Side.CLIENT )
+	public void getCheckedSubBlocks( Item item, CreativeTabs tabs, List<ItemStack> itemStacks )
 	{
 		itemStacks.add( new ItemStack( this, 1, 0 ) );
 	}

--- a/src/main/java/appeng/block/crafting/ItemCraftingStorage.java
+++ b/src/main/java/appeng/block/crafting/ItemCraftingStorage.java
@@ -42,7 +42,7 @@ public class ItemCraftingStorage extends AEBaseItemBlock
 	@Override
 	public ItemStack getContainerItem(ItemStack itemStack)
 	{
-		return AEApi.instance().blocks().blockCraftingUnit.stack( 1 );
+		return AEApi.instance().definitions().blocks().craftingUnit().get().stack( 1 );
 	}
 
 }

--- a/src/main/java/appeng/block/misc/BlockCharger.java
+++ b/src/main/java/appeng/block/misc/BlockCharger.java
@@ -97,7 +97,7 @@ public class BlockCharger extends AEBaseBlock implements ICustomCollision
 		if ( tile instanceof TileCharger )
 		{
 			TileCharger tc = (TileCharger) tile;
-			if ( AEApi.instance().materials().materialCertusQuartzCrystalCharged.sameAsStack( tc.getStackInSlot( 0 ) ) )
+			if ( AEApi.instance().definitions().materials().certusQuartzCrystalCharged().get().sameAsStack( tc.getStackInSlot( 0 ) ) )
 			{
 
 				double xOff = 0.0;

--- a/src/main/java/appeng/block/networking/BlockCableBus.java
+++ b/src/main/java/appeng/block/networking/BlockCableBus.java
@@ -424,10 +424,10 @@ public class BlockCableBus extends AEBaseBlock implements IRedNetConnection
 
 	public void setupTile()
 	{
-		this.setTileEntity( noTesrTile = Api.INSTANCE.partHelper.getCombinedInstance( TileCableBus.class.getName() ) );
+		this.setTileEntity( noTesrTile = Api.INSTANCE.getPartHelper().getCombinedInstance( TileCableBus.class.getName() ) );
 		if ( Platform.isClient() )
 		{
-			tesrTile = Api.INSTANCE.partHelper.getCombinedInstance( TileCableBusTESR.class.getName() );
+			tesrTile = Api.INSTANCE.getPartHelper().getCombinedInstance( TileCableBusTESR.class.getName() );
 			GameRegistry.registerTileEntity( tesrTile, "ClientOnly_TESR_CableBus" );
 			CommonHelper.proxy.bindTileEntitySpecialRenderer( tesrTile, this );
 		}

--- a/src/main/java/appeng/block/solids/OreQuartz.java
+++ b/src/main/java/appeng/block/solids/OreQuartz.java
@@ -93,7 +93,7 @@ public class OreQuartz extends AEBaseBlock
 
 	ItemStack getItemDropped()
 	{
-		return AEApi.instance().materials().materialCertusQuartzCrystal.stack( 1 );
+		return AEApi.instance().definitions().materials().certusQuartzCrystal().get().stack( 1 );
 	}
 
 	@Override

--- a/src/main/java/appeng/block/solids/OreQuartz.java
+++ b/src/main/java/appeng/block/solids/OreQuartz.java
@@ -37,12 +37,11 @@ import appeng.core.features.AEFeature;
 
 public class OreQuartz extends AEBaseBlock
 {
+	private int boostBrightnessLow;
+	private int boostBrightnessHigh;
+	private boolean enhanceBrightness;
 
-	public int boostBrightnessLow;
-	public int boostBrightnessHigh;
-	public boolean enhanceBrightness;
-
-	public OreQuartz(Class self) {
+	public OreQuartz(Class<? extends OreQuartz> self) {
 		super( self, Material.rock );
 		this.setFeature( EnumSet.of( AEFeature.Core ) );
 		this.setHardness( 3.0F );
@@ -73,9 +72,13 @@ public class OreQuartz extends AEBaseBlock
 			j1 = Math.max( j1 >> 20, j1 >> 4 );
 
 			if ( j1 > 4 )
+			{
 				j1 += this.boostBrightnessHigh;
+			}
 			else
+			{
 				j1 += this.boostBrightnessLow;
+			}
 
 			if ( j1 > 15 )
 				j1 = 15;
@@ -144,4 +147,18 @@ public class OreQuartz extends AEBaseBlock
 		}
 	}
 
+	public void setBoostBrightnessLow( int boostBrightnessLow )
+	{
+		this.boostBrightnessLow = boostBrightnessLow;
+	}
+
+	public void setBoostBrightnessHigh( int boostBrightnessHigh )
+	{
+		this.boostBrightnessHigh = boostBrightnessHigh;
+	}
+
+	public void setEnhanceBrightness( boolean enhanceBrightness )
+	{
+		this.enhanceBrightness = enhanceBrightness;
+	}
 }

--- a/src/main/java/appeng/block/solids/OreQuartzCharged.java
+++ b/src/main/java/appeng/block/solids/OreQuartzCharged.java
@@ -37,8 +37,8 @@ public class OreQuartzCharged extends OreQuartz
 
 	public OreQuartzCharged() {
 		super( OreQuartzCharged.class );
-		this.boostBrightnessLow = 2;
-		this.boostBrightnessHigh = 5;
+		this.setBoostBrightnessLow( 2 );
+		this.setBoostBrightnessHigh( 5 );
 	}
 
 	@Override

--- a/src/main/java/appeng/block/solids/OreQuartzCharged.java
+++ b/src/main/java/appeng/block/solids/OreQuartzCharged.java
@@ -44,7 +44,7 @@ public class OreQuartzCharged extends OreQuartz
 	@Override
 	ItemStack getItemDropped()
 	{
-		return AEApi.instance().materials().materialCertusQuartzCrystalCharged.stack( 1 );
+		return AEApi.instance().definitions().materials().certusQuartzCrystalCharged().get().stack( 1 );
 	}
 
 	@Override

--- a/src/main/java/appeng/block/stair/ChiseledQuartzStairBlock.java
+++ b/src/main/java/appeng/block/stair/ChiseledQuartzStairBlock.java
@@ -21,14 +21,15 @@ package appeng.block.stair;
 
 import java.util.EnumSet;
 
+import net.minecraft.block.Block;
+
 import appeng.block.AEBaseStairBlock;
-import appeng.block.solids.BlockQuartzChiseled;
 import appeng.core.features.AEFeature;
 
 
 public class ChiseledQuartzStairBlock extends AEBaseStairBlock
 {
-	public ChiseledQuartzStairBlock( BlockQuartzChiseled block )
+	public ChiseledQuartzStairBlock( Block block )
 	{
 		super( block, 0, EnumSet.of( AEFeature.Core ) );
 	}

--- a/src/main/java/appeng/block/stair/QuartzPillarStairBlock.java
+++ b/src/main/java/appeng/block/stair/QuartzPillarStairBlock.java
@@ -21,14 +21,15 @@ package appeng.block.stair;
 
 import java.util.EnumSet;
 
+import net.minecraft.block.Block;
+
 import appeng.block.AEBaseStairBlock;
-import appeng.block.solids.BlockQuartzPillar;
 import appeng.core.features.AEFeature;
 
 
 public class QuartzPillarStairBlock extends AEBaseStairBlock
 {
-	public QuartzPillarStairBlock( BlockQuartzPillar block )
+	public QuartzPillarStairBlock( Block block )
 	{
 		super( block, 0, EnumSet.of( AEFeature.Core ) );
 	}

--- a/src/main/java/appeng/block/stair/QuartzStairBlock.java
+++ b/src/main/java/appeng/block/stair/QuartzStairBlock.java
@@ -21,14 +21,15 @@ package appeng.block.stair;
 
 import java.util.EnumSet;
 
+import net.minecraft.block.Block;
+
 import appeng.block.AEBaseStairBlock;
-import appeng.block.solids.BlockQuartz;
 import appeng.core.features.AEFeature;
 
 
 public class QuartzStairBlock extends AEBaseStairBlock
 {
-	public QuartzStairBlock( BlockQuartz block )
+	public QuartzStairBlock( Block block )
 	{
 		super( block, 0, EnumSet.of( AEFeature.Core ) );
 	}

--- a/src/main/java/appeng/block/storage/BlockSkyChest.java
+++ b/src/main/java/appeng/block/storage/BlockSkyChest.java
@@ -82,8 +82,8 @@ public class BlockSkyChest extends AEBaseBlock implements ICustomCollision
 	public IIcon getIcon(int direction, int metadata)
 	{
 		if ( metadata == 1 )
-			return AEApi.instance().blocks().blockSkyStone.block().getIcon( direction, 1 );
-		return AEApi.instance().blocks().blockSkyStone.block().getIcon( direction, metadata );
+			return AEApi.instance().definitions().blocks().skyStone().get().block().getIcon( direction, 1 );
+		return AEApi.instance().definitions().blocks().skyStone().get().block().getIcon( direction, metadata );
 	}
 
 	@Override

--- a/src/main/java/appeng/client/gui/implementations/GuiCraftAmount.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiCraftAmount.java
@@ -84,25 +84,25 @@ public class GuiCraftAmount extends AEBaseGui
 
 		if ( target instanceof WirelessTerminalGuiObject )
 		{
-			myIcon = AEApi.instance().items().itemWirelessTerminal.stack( 1 );
+			myIcon = AEApi.instance().definitions().items().wirelessTerminal().get().stack( 1 );
 			this.OriginalGui = GuiBridge.GUI_WIRELESS_TERM;
 		}
 
 		if ( target instanceof PartTerminal )
 		{
-			myIcon = AEApi.instance().parts().partTerminal.stack( 1 );
+			myIcon = AEApi.instance().definitions().parts().terminal().get().stack( 1 );
 			this.OriginalGui = GuiBridge.GUI_ME;
 		}
 
 		if ( target instanceof PartCraftingTerminal )
 		{
-			myIcon = AEApi.instance().parts().partCraftingTerminal.stack( 1 );
+			myIcon = AEApi.instance().definitions().parts().craftingTerminal().get().stack( 1 );
 			this.OriginalGui = GuiBridge.GUI_CRAFTING_TERMINAL;
 		}
 
 		if ( target instanceof PartPatternTerminal )
 		{
-			myIcon = AEApi.instance().parts().partPatternTerminal.stack( 1 );
+			myIcon = AEApi.instance().definitions().parts().patternTerminal().get().stack( 1 );
 			this.OriginalGui = GuiBridge.GUI_PATTERN_TERMINAL;
 		}
 

--- a/src/main/java/appeng/client/gui/implementations/GuiCraftingStatus.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiCraftingStatus.java
@@ -62,25 +62,25 @@ public class GuiCraftingStatus extends GuiCraftingCPU
 
 		if ( target instanceof WirelessTerminalGuiObject )
 		{
-			this.myIcon = AEApi.instance().items().itemWirelessTerminal.stack( 1 );
+			this.myIcon = AEApi.instance().definitions().items().wirelessTerminal().get().stack( 1 );
 			this.OriginalGui = GuiBridge.GUI_WIRELESS_TERM;
 		}
 
 		if ( target instanceof PartTerminal )
 		{
-			this.myIcon = AEApi.instance().parts().partTerminal.stack( 1 );
+			this.myIcon = AEApi.instance().definitions().parts().terminal().get().stack( 1 );
 			this.OriginalGui = GuiBridge.GUI_ME;
 		}
 
 		if ( target instanceof PartCraftingTerminal )
 		{
-			this.myIcon = AEApi.instance().parts().partCraftingTerminal.stack( 1 );
+			this.myIcon = AEApi.instance().definitions().parts().craftingTerminal().get().stack( 1 );
 			this.OriginalGui = GuiBridge.GUI_CRAFTING_TERMINAL;
 		}
 
 		if ( target instanceof PartPatternTerminal )
 		{
-			this.myIcon = AEApi.instance().parts().partPatternTerminal.stack( 1 );
+			this.myIcon = AEApi.instance().definitions().parts().patternTerminal().get().stack( 1 );
 			this.OriginalGui = GuiBridge.GUI_PATTERN_TERMINAL;
 		}
 	}

--- a/src/main/java/appeng/client/gui/implementations/GuiIOPort.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiIOPort.java
@@ -50,8 +50,8 @@ public class GuiIOPort extends GuiUpgradeable
 	public void drawBG(int offsetX, int offsetY, int mouseX, int mouseY)
 	{
 		super.drawBG( offsetX, offsetY, mouseX, mouseY );
-		this.drawItem( offsetX + 66 - 8, offsetY + 17, AEApi.instance().items().itemCell1k.stack( 1 ) );
-		this.drawItem( offsetX + 94 + 8, offsetY + 17, AEApi.instance().blocks().blockDrive.stack( 1 ) );
+		this.drawItem( offsetX + 66 - 8, offsetY + 17, AEApi.instance().definitions().items().cell1k().get().stack( 1 ) );
+		this.drawItem( offsetX + 94 + 8, offsetY + 17, AEApi.instance().definitions().blocks().drive().get().stack( 1 ) );
 	}
 
 	@Override

--- a/src/main/java/appeng/client/gui/implementations/GuiPriority.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiPriority.java
@@ -85,37 +85,37 @@ public class GuiPriority extends AEBaseGui
 
 		if ( target instanceof PartStorageBus )
 		{
-			myIcon = AEApi.instance().parts().partStorageBus.stack( 1 );
+			myIcon = AEApi.instance().definitions().parts().storageBus().get().stack( 1 );
 			this.OriginalGui = GuiBridge.GUI_STORAGEBUS;
 		}
 
 		if ( target instanceof PartFormationPlane )
 		{
-			myIcon = AEApi.instance().parts().partFormationPlane.stack( 1 );
+			myIcon = AEApi.instance().definitions().parts().formationPlane().get().stack( 1 );
 			this.OriginalGui = GuiBridge.GUI_FORMATION_PLANE;
 		}
 
 		if ( target instanceof TileDrive )
 		{
-			myIcon = AEApi.instance().blocks().blockDrive.stack( 1 );
+			myIcon = AEApi.instance().definitions().blocks().drive().get().stack( 1 );
 			this.OriginalGui = GuiBridge.GUI_DRIVE;
 		}
 
 		if ( target instanceof TileChest )
 		{
-			myIcon = AEApi.instance().blocks().blockChest.stack( 1 );
+			myIcon = AEApi.instance().definitions().blocks().chest().get().stack( 1 );
 			this.OriginalGui = GuiBridge.GUI_CHEST;
 		}
 
 		if ( target instanceof TileInterface )
 		{
-			myIcon = AEApi.instance().blocks().blockInterface.stack( 1 );
+			myIcon = AEApi.instance().definitions().blocks().iface().get().stack( 1 );
 			this.OriginalGui = GuiBridge.GUI_INTERFACE;
 		}
 
 		if ( target instanceof PartInterface )
 		{
-			myIcon = AEApi.instance().parts().partInterface.stack( 1 );
+			myIcon = AEApi.instance().definitions().parts().iface().get().stack( 1 );
 			this.OriginalGui = GuiBridge.GUI_INTERFACE;
 		}
 

--- a/src/main/java/appeng/client/render/BusRenderHelper.java
+++ b/src/main/java/appeng/client/render/BusRenderHelper.java
@@ -52,7 +52,7 @@ public class BusRenderHelper implements IPartRenderHelper
 	double maxY = 16;
 	double maxZ = 16;
 
-	final AEBaseBlock blk = (AEBaseBlock) AEApi.instance().blocks().blockMultiPart.block();
+	final AEBaseBlock blk = (AEBaseBlock) AEApi.instance().definitions().blocks().multiPart().get().block();
 	final BaseBlockRender bbr = new BaseBlockRender();
 
 	private ForgeDirection ax = ForgeDirection.EAST;
@@ -348,7 +348,7 @@ public class BusRenderHelper implements IPartRenderHelper
 		if ( !this.renderThis() )
 			return;
 
-		AEBaseBlock blk = (AEBaseBlock) AEApi.instance().blocks().blockMultiPart.block();
+		AEBaseBlock blk = (AEBaseBlock) AEApi.instance().definitions().blocks().multiPart().get().block();
 		BlockRenderInfo info = blk.getRendererInstance();
 		ForgeDirection forward = BusRenderHelper.INSTANCE.az;
 		ForgeDirection up = BusRenderHelper.INSTANCE.ay;
@@ -370,12 +370,12 @@ public class BusRenderHelper implements IPartRenderHelper
 	@Override
 	public Block getBlock()
 	{
-		return AEApi.instance().blocks().blockMultiPart.block();
+		return AEApi.instance().definitions().blocks().multiPart().get().block();
 	}
 
 	public void setRenderColor(int color)
 	{
-		BlockCableBus blk = (BlockCableBus) AEApi.instance().blocks().blockMultiPart.block();
+		BlockCableBus blk = (BlockCableBus) AEApi.instance().definitions().blocks().multiPart().get().block();
 		blk.setRenderColor( color );
 	}
 

--- a/src/main/java/appeng/client/render/blocks/RenderBlockCraftingCPU.java
+++ b/src/main/java/appeng/client/render/blocks/RenderBlockCraftingCPU.java
@@ -70,7 +70,7 @@ public class RenderBlockCraftingCPU extends BaseBlockRender
 
 		IIcon nonForward = theIcon;
 		if ( isMonitor )
-			nonForward = AEApi.instance().blocks().blockCraftingUnit.block().getIcon( 0, meta | (formed ? 8 : 0) );
+			nonForward = AEApi.instance().definitions().blocks().craftingUnit().get().block().getIcon( 0, meta | (formed ? 8 : 0) );
 
 		if ( formed && renderer.overrideBlockTexture == null )
 		{

--- a/src/main/java/appeng/client/render/blocks/RenderQNB.java
+++ b/src/main/java/appeng/client/render/blocks/RenderQNB.java
@@ -109,14 +109,14 @@ public class RenderQNB extends BaseBlockRender
 
 		renderer.renderAllFaces = true;
 
-		if ( tqb.getBlockType() == AEApi.instance().blocks().blockQuantumLink.block() )
+		if ( tqb.getBlockType() == AEApi.instance().definitions().blocks().quantumLink().get().block() )
 		{
 			if ( tqb.isFormed() )
 			{
-				AEColoredItemDefinition glassCableDefinition = AEApi.instance().parts().partCableGlass;
+				AEColoredItemDefinition glassCableDefinition = AEApi.instance().definitions().parts().cableGlass().get();
 				Item transparentGlassCable = glassCableDefinition.item( AEColor.Transparent );
 
-				AEColoredItemDefinition coveredCableDefinition = AEApi.instance().parts().partCableCovered;
+				AEColoredItemDefinition coveredCableDefinition = AEApi.instance().definitions().parts().cableCovered().get();
 				Item transparentCoveredCable = coveredCableDefinition.item( AEColor.Transparent );
 
 				EnumSet<ForgeDirection> sides = tqb.getConnections();
@@ -144,7 +144,7 @@ public class RenderQNB extends BaseBlockRender
 				// renderCableAt(0.11D, world, x, y, z, block, modelId,
 				// renderer,
 				// AppEngTextureRegistry.Blocks.MECable.get(), true, 0.0D);
-				AEColoredItemDefinition coveredCableDefinition = AEApi.instance().parts().partCableCovered;
+				AEColoredItemDefinition coveredCableDefinition = AEApi.instance().definitions().parts().cableCovered().get();
 				Item transparentCoveredCable = coveredCableDefinition.item( AEColor.Transparent );
 
 				this.renderCableAt( 0.188D, world, x, y, z, block, renderer, transparentCoveredCable.getIconIndex( coveredCableDefinition.stack( AEColor.Transparent, 1 ) ), 0.05D,

--- a/src/main/java/appeng/client/render/blocks/RenderQuartzGlass.java
+++ b/src/main/java/appeng/client/render/blocks/RenderQuartzGlass.java
@@ -56,8 +56,8 @@ public class RenderQuartzGlass extends BaseBlockRender
 
 	boolean isGlass(AEBaseBlock imb, IBlockAccess world, int x, int y, int z)
 	{
-		return world.getBlock( x, y, z ) == AEApi.instance().blocks().blockQuartzGlass.block()
-				|| world.getBlock( x, y, z ) == AEApi.instance().blocks().blockQuartzVibrantGlass.block();
+		return world.getBlock( x, y, z ) == AEApi.instance().definitions().blocks().quartzGlass().get().block()
+				|| world.getBlock( x, y, z ) == AEApi.instance().definitions().blocks().quartzVibrantGlass().get().block();
 	}
 
 	void renderEdge(AEBaseBlock imb, IBlockAccess world, int x, int y, int z, RenderBlocks renderer, ForgeDirection side, ForgeDirection direction)

--- a/src/main/java/appeng/client/render/blocks/RenderQuartzOre.java
+++ b/src/main/java/appeng/client/render/blocks/RenderQuartzOre.java
@@ -48,9 +48,9 @@ public class RenderQuartzOre extends BaseBlockRender
 	public boolean renderInWorld(AEBaseBlock block, IBlockAccess world, int x, int y, int z, RenderBlocks renderer)
 	{
 		OreQuartz blk = (OreQuartz) block;
-		blk.enhanceBrightness = true;
+		blk.setEnhanceBrightness( true );
 		super.renderInWorld( block, world, x, y, z, renderer );
-		blk.enhanceBrightness = false;
+		blk.setEnhanceBrightness( false );
 
 		blk.getRendererInstance().setTemporaryRenderIcon( ExtraBlockTextures.OreQuartzStone.getIcon() );
 		boolean out = super.renderInWorld( block, world, x, y, z, renderer );

--- a/src/main/java/appeng/container/implementations/ContainerInscriber.java
+++ b/src/main/java/appeng/container/implementations/ContainerInscriber.java
@@ -140,8 +140,8 @@ public class ContainerInscriber extends ContainerUpgradeable implements IProgres
 				otherSlot = this.top.getStack();
 
 			// name presses
-			if ( AEApi.instance().materials().materialNamePress.sameAsStack( otherSlot ) )
-				return AEApi.instance().materials().materialNamePress.sameAsStack( is );
+			if ( AEApi.instance().definitions().materials().namePress().get().sameAsStack( otherSlot ) )
+				return AEApi.instance().definitions().materials().namePress().get().sameAsStack( is );
 
 			// everything else
 			for (InscriberRecipe i : Inscribe.RECIPES )

--- a/src/main/java/appeng/container/implementations/ContainerPatternTerm.java
+++ b/src/main/java/appeng/container/implementations/ContainerPatternTerm.java
@@ -218,7 +218,7 @@ public class ContainerPatternTerm extends ContainerMEMonitorable implements IAEA
 				this.patternSlotIN.putStack( null );
 
 			// add a new encoded pattern.
-			this.patternSlotOUT.putStack( output = AEApi.instance().items().itemEncodedPattern.stack( 1 ) );
+			this.patternSlotOUT.putStack( output = AEApi.instance().definitions().items().encodedPattern().get().stack( 1 ) );
 		}
 
 		// encode the slot.
@@ -303,7 +303,7 @@ public class ContainerPatternTerm extends ContainerMEMonitorable implements IAEA
 		if ( output == null )
 			return false;
 
-		return AEApi.instance().items().itemEncodedPattern.sameAsStack( output ) || AEApi.instance().materials().materialBlankPattern.sameAsStack( output );
+		return AEApi.instance().definitions().items().encodedPattern().get().sameAsStack( output ) || AEApi.instance().definitions().materials().blankPattern().get().sameAsStack( output );
 	}
 
 	@Override

--- a/src/main/java/appeng/container/implementations/ContainerQuartzKnife.java
+++ b/src/main/java/appeng/container/implementations/ContainerQuartzKnife.java
@@ -120,7 +120,7 @@ public class ContainerQuartzKnife extends AEBaseContainer implements IAEAppEngIn
 		{
 			if ( this.myName.length() > 0 )
 			{
-				ItemStack name = AEApi.instance().materials().materialNamePress.stack( 1 );
+				ItemStack name = AEApi.instance().definitions().materials().namePress().get().stack( 1 );
 				NBTTagCompound c = Platform.openNbtData( name );
 				c.setString( "InscribeName", this.myName );
 				return name;

--- a/src/main/java/appeng/container/slot/SlotRestrictedInput.java
+++ b/src/main/java/appeng/container/slot/SlotRestrictedInput.java
@@ -168,17 +168,17 @@ public class SlotRestrictedInput extends AppEngSlot
 			return false;// pattern != null;
 		}
 		case BLANK_PATTERN:
-			return AEApi.instance().materials().materialBlankPattern.sameAsStack( i );
+			return AEApi.instance().definitions().materials().blankPattern().get().sameAsStack( i );
 		case PATTERN:
 
 			if ( i.getItem() instanceof ICraftingPatternItem )
 				return true;
 
-			return AEApi.instance().materials().materialBlankPattern.sameAsStack( i );
+			return AEApi.instance().definitions().materials().blankPattern().get().sameAsStack( i );
 
 		case INSCRIBER_PLATE:
 
-			if ( AEApi.instance().materials().materialNamePress.sameAsStack( i ) )
+			if ( AEApi.instance().definitions().materials().namePress().get().sameAsStack( i ) )
 				return true;
 
 			for (ItemStack is : Inscribe.PLATES )
@@ -199,7 +199,7 @@ public class SlotRestrictedInput extends AppEngSlot
 			return isMetalIngot( i );
 
 		case VIEW_CELL:
-			return AEApi.instance().items().itemViewCell.sameAsStack( i );
+			return AEApi.instance().definitions().items().viewCell().get().sameAsStack( i );
 		case ORE:
 			return appeng.api.AEApi.instance().registries().grinder().getRecipeForInput( i ) != null;
 		case FUEL:
@@ -207,9 +207,9 @@ public class SlotRestrictedInput extends AppEngSlot
 		case POWERED_TOOL:
 			return Platform.isChargeable( i );
 		case QE_SINGULARITY:
-			return api.materials().materialQESingularity.sameAsStack( i );
+			return api.definitions().materials().qESingularity().get().sameAsStack( i );
 		case RANGE_BOOSTER:
-			return api.materials().materialWirelessBooster.sameAsStack( i );
+			return api.definitions().materials().wirelessBooster().get().sameAsStack( i );
 		case SPATIAL_STORAGE_CELLS:
 			return i.getItem() instanceof ISpatialStorageCell && ((ISpatialStorageCell) i.getItem()).isSpatialStorage( i );
 		case STORAGE_CELLS:

--- a/src/main/java/appeng/core/AELog.java
+++ b/src/main/java/appeng/core/AELog.java
@@ -26,10 +26,10 @@ import appeng.core.features.AEFeature;
 import appeng.tile.AEBaseTile;
 import appeng.util.Platform;
 
-public class AELog
+public final class AELog
 {
 
-	public static final FMLRelaunchLog instance = FMLRelaunchLog.log;
+	public static final FMLRelaunchLog INSTANCE = FMLRelaunchLog.log;
 
 	private AELog() {
 	}

--- a/src/main/java/appeng/core/Api.java
+++ b/src/main/java/appeng/core/Api.java
@@ -18,6 +18,7 @@
 
 package appeng.core;
 
+
 import net.minecraftforge.common.util.ForgeDirection;
 
 import appeng.api.IAppEngApi;
@@ -39,13 +40,32 @@ import appeng.me.GridConnection;
 import appeng.me.GridNode;
 import appeng.util.Platform;
 
-public class Api implements IAppEngApi
-{
 
+public final class Api implements IAppEngApi
+{
 	public static final Api INSTANCE = new Api();
 
-	private Api() {
+	private final ApiPart partHelper;
 
+	// private MovableTileRegistry MovableRegistry = new MovableTileRegistry();
+	private final IRegistryContainer registryContainer;
+	private final IStorageHelper storageHelper;
+	private final Materials materials;
+	private final Items items;
+	private final Blocks blocks;
+	private final Parts parts;
+	private final ApiDefinitions definitions;
+
+	private Api()
+	{
+		this.parts = new Parts();
+		this.blocks = new Blocks();
+		this.items = new Items();
+		this.materials = new Materials();
+		this.storageHelper = new ApiStorage();
+		this.registryContainer = new RegistryContainer();
+		this.partHelper = new ApiPart();
+		this.definitions = new ApiDefinitions( this.partHelper );
 	}
 
 	// private MovableTileRegistry MovableRegistry = new MovableTileRegistry();
@@ -54,15 +74,16 @@ public class Api implements IAppEngApi
 
 	public final ApiPart partHelper = new ApiPart();
 
-	private final Materials materials = new Materials();
-	private final Items items = new Items();
-	private final Blocks blocks = new Blocks();
-	private final Parts parts = new Parts();
+	@Override
+	public IStorageHelper storage()
+	{
+		return this.storageHelper;
+	}
 
 	@Override
-	public IRegistryContainer registries()
+	public IPartHelper partHelper()
 	{
-		return this.rc;
+		return this.partHelper;
 	}
 
 	@Override
@@ -90,19 +111,13 @@ public class Api implements IAppEngApi
 	}
 
 	@Override
-	public IStorageHelper storage()
+	public ApiDefinitions definitions()
 	{
-		return this.storageHelper;
+		return this.definitions;
 	}
 
 	@Override
-	public IPartHelper partHelper()
-	{
-		return this.partHelper;
-	}
-
-	@Override
-	public IGridNode createGridNode(IGridBlock blk)
+	public IGridNode createGridNode( IGridBlock blk )
 	{
 		if ( Platform.isClient() )
 			throw new RuntimeException( "Grid Features are Server Side Only." );
@@ -110,9 +125,13 @@ public class Api implements IAppEngApi
 	}
 
 	@Override
-	public IGridConnection createGridConnection(IGridNode a, IGridNode b) throws FailedConnection
+	public IGridConnection createGridConnection( IGridNode a, IGridNode b ) throws FailedConnection
 	{
 		return new GridConnection( a, b, ForgeDirection.UNKNOWN );
 	}
 
+	public ApiPart getPartHelper()
+	{
+		return this.partHelper;
+	}
 }

--- a/src/main/java/appeng/core/Api.java
+++ b/src/main/java/appeng/core/Api.java
@@ -54,7 +54,14 @@ public final class Api implements IAppEngApi
 	private final Items items;
 	private final Blocks blocks;
 	private final Parts parts;
-	private final ApiDefinitions definitions;
+
+	/**
+	 * Contains all definitions.
+	 *
+	 * This cannot be final as it can currently only be successfully, if the API is fully constructed and every helper
+	 * is available through the public API.
+	 */
+	private ApiDefinitions definitions;
 
 	private Api()
 	{
@@ -65,14 +72,21 @@ public final class Api implements IAppEngApi
 		this.storageHelper = new ApiStorage();
 		this.registryContainer = new RegistryContainer();
 		this.partHelper = new ApiPart();
+	}
+
+	/**
+	 * Package private to prevent calling it from anywhere else.
+	 */
+	void initDefinitions()
+	{
 		this.definitions = new ApiDefinitions( this.partHelper );
 	}
 
-	// private MovableTileRegistry MovableRegistry = new MovableTileRegistry();
-	private final RegistryContainer rc = new RegistryContainer();
-	private final ApiStorage storageHelper = new ApiStorage();
-
-	public final ApiPart partHelper = new ApiPart();
+	@Override
+	public IRegistryContainer registries()
+	{
+		return this.registryContainer;
+	}
 
 	@Override
 	public IStorageHelper storage()

--- a/src/main/java/appeng/core/ApiDefinitions.java
+++ b/src/main/java/appeng/core/ApiDefinitions.java
@@ -1,0 +1,90 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.core;
+
+
+import appeng.api.definitions.IBlocks;
+import appeng.api.definitions.IDefinitions;
+import appeng.api.definitions.IItems;
+import appeng.api.definitions.IMaterials;
+import appeng.api.definitions.IParts;
+import appeng.api.parts.IPartHelper;
+import appeng.core.api.definitions.ApiBlocks;
+import appeng.core.api.definitions.ApiItems;
+import appeng.core.api.definitions.ApiMaterials;
+import appeng.core.api.definitions.ApiParts;
+
+
+/**
+ * Internal implementation of the definitions for the API
+ */
+public final class ApiDefinitions implements IDefinitions
+{
+	private final IBlocks blocks;
+	private final IItems items;
+	private final IMaterials materials;
+	private final IParts parts;
+	private final FeatureHandlerRegistry handlers;
+	private final FeatureRegistry features;
+
+	public ApiDefinitions( IPartHelper partHelper )
+	{
+		this.features = new FeatureRegistry();
+		this.handlers = new FeatureHandlerRegistry();
+
+		this.blocks = new ApiBlocks( this.features, this.handlers );
+		this.items = new ApiItems( this.features, this.handlers );
+		this.materials = new ApiMaterials( this.features, this.handlers );
+		this.parts = new ApiParts( this.features, this.handlers, partHelper );
+	}
+
+	public FeatureHandlerRegistry getFeatureHandlerRegistry()
+	{
+		return this.handlers;
+	}
+
+	public FeatureRegistry getFeatureRegistry()
+	{
+		return this.features;
+	}
+
+	@Override
+	public IBlocks blocks()
+	{
+		return this.blocks;
+	}
+
+	@Override
+	public IItems items()
+	{
+		return this.items;
+	}
+
+	@Override
+	public IMaterials materials()
+	{
+		return this.materials;
+	}
+
+	@Override
+	public IParts parts()
+	{
+		return this.parts;
+	}
+}

--- a/src/main/java/appeng/core/AppEng.java
+++ b/src/main/java/appeng/core/AppEng.java
@@ -22,8 +22,6 @@ package appeng.core;
 import java.io.File;
 import java.util.concurrent.TimeUnit;
 
-import com.google.common.base.Stopwatch;
-
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.Mod;
@@ -36,6 +34,8 @@ import cpw.mods.fml.common.event.FMLServerAboutToStartEvent;
 import cpw.mods.fml.common.event.FMLServerStartingEvent;
 import cpw.mods.fml.common.event.FMLServerStoppingEvent;
 import cpw.mods.fml.common.network.NetworkRegistry;
+
+import com.google.common.base.Stopwatch;
 
 import appeng.core.crash.CrashEnhancement;
 import appeng.core.crash.CrashInfo;
@@ -182,7 +182,7 @@ public class AppEng
 	}
 
 	@EventHandler
-	public void serverStarting( FMLServerAboutToStartEvent evt )
+	public void serverAboutToStart( FMLServerAboutToStartEvent evt )
 	{
 		WorldSettings.getInstance().init();
 	}

--- a/src/main/java/appeng/core/CreativeTab.java
+++ b/src/main/java/appeng/core/CreativeTab.java
@@ -19,6 +19,11 @@
 package appeng.core;
 
 
+import java.util.List;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
@@ -26,8 +31,9 @@ import net.minecraft.item.ItemStack;
 
 import appeng.api.AEApi;
 import appeng.api.IAppEngApi;
-import appeng.api.definitions.Items;
-import appeng.api.definitions.Materials;
+import appeng.api.definitions.IBlocks;
+import appeng.api.definitions.IItems;
+import appeng.api.definitions.IMaterials;
 import appeng.api.util.AEItemDefinition;
 
 
@@ -56,20 +62,31 @@ public final class CreativeTab extends CreativeTabs
 	public ItemStack getIconItemStack()
 	{
 		final IAppEngApi api = AEApi.instance();
-		final appeng.api.definitions.Blocks blocks = api.blocks();
-		final Items items = api.items();
-		final Materials materials = api.materials();
+		final IBlocks blocks = api.definitions().blocks();
+		final IItems items = api.definitions().items();
+		final IMaterials materials = api.definitions().materials();
 
-		return this.findFirst( blocks.blockController, blocks.blockChest, blocks.blockCellWorkbench, blocks.blockFluix, items.itemCell1k, items.itemNetworkTool, materials.materialFluixCrystal, materials.materialCertusQuartzCrystal );
+		// ArrayLists do not like generics, so we use a linked list instead.
+		final List<Optional<AEItemDefinition>> choices = Lists.newLinkedList();
+		choices.add( blocks.controller() );
+		choices.add( blocks.chest() );
+		choices.add( blocks.cellWorkbench() );
+		choices.add( blocks.fluix() );
+		choices.add( items.cell1k() );
+		choices.add( items.networkTool() );
+		choices.add( materials.fluixCrystal() );
+		choices.add( materials.certusQuartzCrystal() );
+
+		return this.findFirst( choices );
 	}
 
-	private ItemStack findFirst( AEItemDefinition... choices )
+	private ItemStack findFirst( List<Optional<AEItemDefinition>> choices )
 	{
-		for ( AEItemDefinition a : choices )
+		for ( Optional<AEItemDefinition> choice : choices )
 		{
-			if ( a != null )
+			if ( choice.isPresent() )
 			{
-				ItemStack is = a.stack( 1 );
+				ItemStack is = choice.get().stack( 1 );
 				if ( is != null )
 				{
 					return is;

--- a/src/main/java/appeng/core/CreativeTabFacade.java
+++ b/src/main/java/appeng/core/CreativeTabFacade.java
@@ -43,7 +43,7 @@ public final class CreativeTabFacade extends CreativeTabs
 	@Override
 	public ItemStack getIconItemStack()
 	{
-		return ((ItemFacade) AEApi.instance().items().itemFacade.item()).getCreativeTabIcon();
+		return ((ItemFacade) AEApi.instance().definitions().items().facade().get().item()).getCreativeTabIcon();
 	}
 
 	public static void init()

--- a/src/main/java/appeng/core/FeatureHandlerRegistry.java
+++ b/src/main/java/appeng/core/FeatureHandlerRegistry.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.core;
+
+
+import java.util.HashSet;
+import java.util.Set;
+
+import appeng.core.features.IFeatureHandler;
+
+
+public class FeatureHandlerRegistry
+{
+	private final Set<IFeatureHandler> registry = new HashSet<IFeatureHandler>();
+
+	public void addFeatureHandler( IFeatureHandler feature )
+	{
+		this.registry.add( feature );
+	}
+
+	public Set<IFeatureHandler> getRegisteredFeatureHandlers()
+	{
+		return this.registry;
+	}
+}

--- a/src/main/java/appeng/core/FeatureRegistry.java
+++ b/src/main/java/appeng/core/FeatureRegistry.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.core;
+
+
+import java.util.HashSet;
+import java.util.Set;
+
+import appeng.core.features.IAEFeature;
+
+
+public class FeatureRegistry
+{
+	private final Set<IAEFeature> registry = new HashSet<IAEFeature>();
+
+	public void addFeature( IAEFeature feature )
+	{
+		this.registry.add( feature );
+	}
+
+	public Set<IAEFeature> getRegisteredFeatures()
+	{
+		return this.registry;
+	}
+}

--- a/src/main/java/appeng/core/Registration.java
+++ b/src/main/java/appeng/core/Registration.java
@@ -19,12 +19,6 @@
 package appeng.core;
 
 
-import java.lang.reflect.Field;
-
-import com.google.common.base.Optional;
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimap;
-
 import net.minecraft.item.crafting.CraftingManager;
 import net.minecraft.util.WeightedRandomChestContent;
 import net.minecraft.world.biome.BiomeGenBase;
@@ -45,6 +39,10 @@ import appeng.api.AEApi;
 import appeng.api.IAppEngApi;
 import appeng.api.config.Upgrades;
 import appeng.api.definitions.Blocks;
+import appeng.api.definitions.IBlocks;
+import appeng.api.definitions.IItems;
+import appeng.api.definitions.IMaterials;
+import appeng.api.definitions.IParts;
 import appeng.api.definitions.Items;
 import appeng.api.definitions.Materials;
 import appeng.api.definitions.Parts;
@@ -62,116 +60,22 @@ import appeng.api.networking.spatial.ISpatialCache;
 import appeng.api.networking.storage.IStorageGrid;
 import appeng.api.networking.ticking.ITickManager;
 import appeng.api.parts.IPartHelper;
-import appeng.api.util.AEColor;
-import appeng.api.util.AEItemDefinition;
-import appeng.block.crafting.BlockCraftingMonitor;
-import appeng.block.crafting.BlockCraftingStorage;
-import appeng.block.crafting.BlockCraftingUnit;
-import appeng.block.crafting.BlockMolecularAssembler;
-import appeng.block.grindstone.BlockCrank;
-import appeng.block.grindstone.BlockGrinder;
-import appeng.block.misc.BlockCellWorkbench;
-import appeng.block.misc.BlockCharger;
-import appeng.block.misc.BlockCondenser;
-import appeng.block.misc.BlockInscriber;
-import appeng.block.misc.BlockInterface;
-import appeng.block.misc.BlockLightDetector;
-import appeng.block.misc.BlockPaint;
-import appeng.block.misc.BlockQuartzGrowthAccelerator;
-import appeng.block.misc.BlockQuartzTorch;
-import appeng.block.misc.BlockSecurity;
-import appeng.block.misc.BlockSkyCompass;
-import appeng.block.misc.BlockTinyTNT;
-import appeng.block.misc.BlockVibrationChamber;
 import appeng.block.networking.BlockCableBus;
-import appeng.block.networking.BlockController;
-import appeng.block.networking.BlockCreativeEnergyCell;
-import appeng.block.networking.BlockDenseEnergyCell;
-import appeng.block.networking.BlockEnergyAcceptor;
-import appeng.block.networking.BlockEnergyCell;
-import appeng.block.networking.BlockWireless;
-import appeng.block.qnb.BlockQuantumLinkChamber;
-import appeng.block.qnb.BlockQuantumRing;
-import appeng.block.solids.BlockFluix;
-import appeng.block.solids.BlockQuartz;
-import appeng.block.solids.BlockQuartzChiseled;
-import appeng.block.solids.BlockQuartzGlass;
-import appeng.block.solids.BlockQuartzLamp;
-import appeng.block.solids.BlockQuartzPillar;
-import appeng.block.solids.BlockSkyStone;
-import appeng.block.solids.OreQuartz;
-import appeng.block.solids.OreQuartzCharged;
-import appeng.block.spatial.BlockMatrixFrame;
-import appeng.block.spatial.BlockSpatialIOPort;
-import appeng.block.spatial.BlockSpatialPylon;
-import appeng.block.stair.ChiseledQuartzStairBlock;
-import appeng.block.stair.FluixStairBlock;
-import appeng.block.stair.QuartzPillarStairBlock;
-import appeng.block.stair.QuartzStairBlock;
-import appeng.block.stair.SkyStoneBlockStairBlock;
-import appeng.block.stair.SkyStoneBrickStairBlock;
-import appeng.block.stair.SkyStoneSmallBrickStairBlock;
-import appeng.block.stair.SkyStoneStairBlock;
-import appeng.block.storage.BlockChest;
-import appeng.block.storage.BlockDrive;
-import appeng.block.storage.BlockIOPort;
-import appeng.block.storage.BlockSkyChest;
 import appeng.core.features.AEFeature;
-import appeng.core.features.ColoredItemDefinition;
-import appeng.core.features.DamagedItemDefinition;
 import appeng.core.features.IAEFeature;
 import appeng.core.features.IFeatureHandler;
-import appeng.core.features.IStackSrc;
-import appeng.core.features.ItemStackSrc;
-import appeng.core.features.NullItemDefinition;
-import appeng.core.features.WrappedDamageItemDefinition;
 import appeng.core.features.registries.P2PTunnelRegistry;
 import appeng.core.features.registries.entries.BasicCellHandler;
 import appeng.core.features.registries.entries.CreativeCellHandler;
 import appeng.core.localization.GuiText;
 import appeng.core.localization.PlayerMessages;
 import appeng.core.stats.PlayerStatsRegistration;
-import appeng.debug.BlockChunkloader;
-import appeng.debug.BlockCubeGenerator;
-import appeng.debug.BlockItemGen;
-import appeng.debug.BlockPhantomNode;
-import appeng.debug.ToolDebugCard;
-import appeng.debug.ToolEraser;
-import appeng.debug.ToolMeteoritePlacer;
-import appeng.debug.ToolReplicatorCard;
 import appeng.hooks.AETrading;
 import appeng.hooks.MeteoriteWorldGen;
 import appeng.hooks.QuartzWorldGen;
 import appeng.hooks.TickHandler;
 import appeng.integration.IntegrationType;
 import appeng.items.materials.ItemMultiMaterial;
-import appeng.items.materials.MaterialType;
-import appeng.items.misc.ItemCrystalSeed;
-import appeng.items.misc.ItemEncodedPattern;
-import appeng.items.misc.ItemPaintBall;
-import appeng.items.parts.ItemFacade;
-import appeng.items.parts.ItemMultiPart;
-import appeng.items.parts.PartType;
-import appeng.items.storage.ItemBasicStorageCell;
-import appeng.items.storage.ItemCreativeStorageCell;
-import appeng.items.storage.ItemSpatialStorageCell;
-import appeng.items.storage.ItemViewCell;
-import appeng.items.tools.ToolBiometricCard;
-import appeng.items.tools.ToolMemoryCard;
-import appeng.items.tools.ToolNetworkTool;
-import appeng.items.tools.powered.ToolChargedStaff;
-import appeng.items.tools.powered.ToolColorApplicator;
-import appeng.items.tools.powered.ToolEntropyManipulator;
-import appeng.items.tools.powered.ToolMassCannon;
-import appeng.items.tools.powered.ToolPortableCell;
-import appeng.items.tools.powered.ToolWirelessTerminal;
-import appeng.items.tools.quartz.ToolQuartzAxe;
-import appeng.items.tools.quartz.ToolQuartzCuttingKnife;
-import appeng.items.tools.quartz.ToolQuartzHoe;
-import appeng.items.tools.quartz.ToolQuartzPickaxe;
-import appeng.items.tools.quartz.ToolQuartzSpade;
-import appeng.items.tools.quartz.ToolQuartzSword;
-import appeng.items.tools.quartz.ToolQuartzWrench;
 import appeng.me.cache.CraftingGridCache;
 import appeng.me.cache.EnergyGridCache;
 import appeng.me.cache.GridStorageCache;
@@ -207,7 +111,6 @@ import appeng.recipes.ores.OreDictionaryHandler;
 import appeng.spatial.BiomeGenStorage;
 import appeng.spatial.StorageWorldProvider;
 import appeng.tile.AEBaseTile;
-import appeng.util.ClassInstantiation;
 import appeng.util.Platform;
 
 
@@ -216,37 +119,20 @@ public final class Registration
 	final public static Registration INSTANCE = new Registration();
 
 	private final RecipeHandler recipeHandler;
-	private final Multimap<AEFeature, Class<? extends IAEFeature>> featuresToEntities;
 	public BiomeGenBase storageBiome;
 
 	private Registration()
 	{
 		this.recipeHandler = new RecipeHandler();
-		this.featuresToEntities = ArrayListMultimap.create();
 	}
 
 	public void preInitialize( FMLPreInitializationEvent event )
 	{
 		this.registerSpatial( false );
 
-		IRecipeHandlerRegistry recipeRegistry = AEApi.instance().registries().recipes();
-		recipeRegistry.addNewSubItemResolver( new AEItemResolver() );
-
-		recipeRegistry.addNewCraftHandler( "hccrusher", HCCrusher.class );
-		recipeRegistry.addNewCraftHandler( "mekcrusher", MekCrusher.class );
-		recipeRegistry.addNewCraftHandler( "mekechamber", MekEnrichment.class );
-		recipeRegistry.addNewCraftHandler( "grind", Grind.class );
-		recipeRegistry.addNewCraftHandler( "crusher", Crusher.class );
-		recipeRegistry.addNewCraftHandler( "grindfz", GrindFZ.class );
-		recipeRegistry.addNewCraftHandler( "pulverizer", Pulverizer.class );
-		recipeRegistry.addNewCraftHandler( "macerator", Macerator.class );
-
-		recipeRegistry.addNewCraftHandler( "smelt", Smelt.class );
-		recipeRegistry.addNewCraftHandler( "inscribe", Inscribe.class );
-		recipeRegistry.addNewCraftHandler( "press", Press.class );
-
-		recipeRegistry.addNewCraftHandler( "shaped", Shaped.class );
-		recipeRegistry.addNewCraftHandler( "shapeless", Shapeless.class );
+		final Api api = Api.INSTANCE;
+		IRecipeHandlerRegistry recipeRegistry = api.registries().recipes();
+		this.registerCraftHandlers( recipeRegistry );
 
 		RecipeSorter.register( "AE2-Facade", FacadeRecipe.class, Category.SHAPED, "" );
 		RecipeSorter.register( "AE2-Shaped", ShapedRecipe.class, Category.SHAPED, "" );
@@ -254,219 +140,33 @@ public final class Registration
 
 		MinecraftForge.EVENT_BUS.register( OreDictionaryHandler.INSTANCE );
 
-		Items items = Api.INSTANCE.items();
-		Materials materials = Api.INSTANCE.materials();
-		Parts parts = Api.INSTANCE.parts();
-		Blocks blocks = Api.INSTANCE.blocks();
+		final ApiDefinitions definitions = api.definitions();
 
-		AEItemDefinition materialItem = this.addFeature( ItemMultiMaterial.class );
+		final IBlocks apiBlocks = definitions.blocks();
+		final IItems apiItems = definitions.items();
+		final IMaterials apiMaterials = definitions.materials();
+		final IParts apiParts = definitions.parts();
 
-		Class<?> materialClass = materials.getClass();
-		for ( MaterialType mat : MaterialType.values() )
+		final Items items = api.items();
+		final Materials materials = api.materials();
+		final Parts parts = api.parts();
+		final Blocks blocks = api.blocks();
+
+		this.assignMaterials( materials, apiMaterials );
+		this.assignParts( parts, apiParts );
+		this.assignBlocks( blocks, apiBlocks );
+		this.assignItems( items, apiItems );
+
+		// Register all detected handlers and features (items, blocks) in pre-init
+		for ( IFeatureHandler handler : definitions.getFeatureHandlerRegistry().getRegisteredFeatureHandlers() )
 		{
-			try
-			{
-				if ( mat == MaterialType.InvalidType )
-					( ( ItemMultiMaterial ) materialItem.item() ).createMaterial( mat );
-				else
-				{
-					Field f = materialClass.getField( "material" + mat.name() );
-					IStackSrc is = ( ( ItemMultiMaterial ) materialItem.item() ).createMaterial( mat );
-					if ( is != null )
-						f.set( materials, new DamagedItemDefinition( is ) );
-					else
-						f.set( materials, new NullItemDefinition() );
-				}
-			}
-			catch ( Throwable err )
-			{
-				AELog.severe( "Error creating material: " + mat.name() );
-				throw new RuntimeException( err );
-			}
+			handler.register();
 		}
 
-		AEItemDefinition partItem = this.addFeature( ItemMultiPart.class );
-
-		Class<?> partClass = parts.getClass();
-		for ( PartType type : PartType.values() )
+		for ( IAEFeature feature : definitions.getFeatureRegistry().getRegisteredFeatures() )
 		{
-			try
-			{
-				if ( type == PartType.InvalidType )
-					( ( ItemMultiPart ) partItem.item() ).createPart( type, null );
-				else
-				{
-					Field f = partClass.getField( "part" + type.name() );
-					Enum<AEColor>[] variants = type.getVariants();
-					if ( variants == null )
-					{
-						ItemStackSrc is = ( ( ItemMultiPart ) partItem.item() ).createPart( type, null );
-						if ( is != null )
-							f.set( parts, new DamagedItemDefinition( is ) );
-						else
-							f.set( parts, new NullItemDefinition() );
-					}
-					else
-					{
-						if ( variants[0] instanceof AEColor )
-						{
-							ColoredItemDefinition def = new ColoredItemDefinition();
-
-							for ( Enum<AEColor> v : variants )
-							{
-								ItemStackSrc is = ( ( ItemMultiPart ) partItem.item() ).createPart( type, v );
-								if ( is != null )
-									def.add( ( AEColor ) v, is );
-							}
-
-							f.set( parts, def );
-						}
-					}
-				}
-			}
-			catch ( Throwable err )
-			{
-				AELog.severe( "Error creating part: " + type.name() );
-				throw new RuntimeException( err );
-			}
+			feature.postInit();
 		}
-
-		// very important block!
-		blocks.blockMultiPart = this.addFeature( BlockCableBus.class );
-
-		blocks.blockCraftingUnit = this.addFeature( BlockCraftingUnit.class );
-		blocks.blockCraftingAccelerator = new WrappedDamageItemDefinition( blocks.blockCraftingUnit, 1 );
-		blocks.blockCraftingMonitor = this.addFeature( BlockCraftingMonitor.class );
-		blocks.blockCraftingStorage1k = this.addFeature( BlockCraftingStorage.class );
-		blocks.blockCraftingStorage4k = new WrappedDamageItemDefinition( blocks.blockCraftingStorage1k, 1 );
-		blocks.blockCraftingStorage16k = new WrappedDamageItemDefinition( blocks.blockCraftingStorage1k, 2 );
-		blocks.blockCraftingStorage64k = new WrappedDamageItemDefinition( blocks.blockCraftingStorage1k, 3 );
-		blocks.blockMolecularAssembler = this.addFeature( BlockMolecularAssembler.class );
-
-		blocks.blockQuartzOre = this.addFeature( OreQuartz.class );
-		blocks.blockQuartzOreCharged = this.addFeature( OreQuartzCharged.class );
-		blocks.blockMatrixFrame = this.addFeature( BlockMatrixFrame.class );
-		blocks.blockQuartz = this.addFeature( BlockQuartz.class );
-		blocks.blockFluix = this.addFeature( BlockFluix.class );
-		blocks.blockSkyStone = this.addFeature( BlockSkyStone.class );
-		blocks.blockSkyChest = this.addFeature( BlockSkyChest.class );
-		blocks.blockSkyCompass = this.addFeature( BlockSkyCompass.class );
-
-		blocks.blockQuartzGlass = this.addFeature( BlockQuartzGlass.class );
-		blocks.blockQuartzVibrantGlass = this.addFeature( BlockQuartzLamp.class );
-		blocks.blockQuartzPillar = this.addFeature( BlockQuartzPillar.class );
-		blocks.blockQuartzChiseled = this.addFeature( BlockQuartzChiseled.class );
-		blocks.blockQuartzTorch = this.addFeature( BlockQuartzTorch.class );
-		blocks.blockLightDetector = this.addFeature( BlockLightDetector.class );
-		blocks.blockCharger = this.addFeature( BlockCharger.class );
-		blocks.blockQuartzGrowthAccelerator = this.addFeature( BlockQuartzGrowthAccelerator.class );
-
-		blocks.blockGrindStone = this.addFeature( BlockGrinder.class );
-		blocks.blockCrankHandle = this.addFeature( BlockCrank.class );
-		blocks.blockInscriber = this.addFeature( BlockInscriber.class );
-		blocks.blockWireless = this.addFeature( BlockWireless.class );
-		blocks.blockTinyTNT = this.addFeature( BlockTinyTNT.class );
-
-		blocks.blockQuantumRing = this.addFeature( BlockQuantumRing.class );
-		blocks.blockQuantumLink = this.addFeature( BlockQuantumLinkChamber.class );
-
-		blocks.blockSpatialPylon = this.addFeature( BlockSpatialPylon.class );
-		blocks.blockSpatialIOPort = this.addFeature( BlockSpatialIOPort.class );
-
-		blocks.blockController = this.addFeature( BlockController.class );
-		blocks.blockDrive = this.addFeature( BlockDrive.class );
-		blocks.blockChest = this.addFeature( BlockChest.class );
-		blocks.blockInterface = this.addFeature( BlockInterface.class );
-		blocks.blockCellWorkbench = this.addFeature( BlockCellWorkbench.class );
-		blocks.blockIOPort = this.addFeature( BlockIOPort.class );
-		blocks.blockCondenser = this.addFeature( BlockCondenser.class );
-		blocks.blockEnergyAcceptor = this.addFeature( BlockEnergyAcceptor.class );
-		blocks.blockVibrationChamber = this.addFeature( BlockVibrationChamber.class );
-
-		blocks.blockEnergyCell = this.addFeature( BlockEnergyCell.class );
-		blocks.blockEnergyCellDense = this.addFeature( BlockDenseEnergyCell.class );
-		blocks.blockEnergyCellCreative = this.addFeature( BlockCreativeEnergyCell.class );
-
-		blocks.blockSecurity = this.addFeature( BlockSecurity.class );
-		blocks.blockPaint = this.addFeature( BlockPaint.class );
-
-		items.itemCellCreative = this.addFeature( ItemCreativeStorageCell.class );
-		items.itemViewCell = this.addFeature( ItemViewCell.class );
-		items.itemEncodedPattern = this.addFeature( ItemEncodedPattern.class );
-
-		items.itemCell1k = this.addFeature( ItemBasicStorageCell.class, MaterialType.Cell1kPart, 1 );
-		items.itemCell4k = this.addFeature( ItemBasicStorageCell.class, MaterialType.Cell4kPart, 4 );
-		items.itemCell16k = this.addFeature( ItemBasicStorageCell.class, MaterialType.Cell16kPart, 16 );
-		items.itemCell64k = this.addFeature( ItemBasicStorageCell.class, MaterialType.Cell64kPart, 64 );
-
-		items.itemSpatialCell2 = this.addFeature( ItemSpatialStorageCell.class, MaterialType.Cell2SpatialPart, 2 );
-		items.itemSpatialCell16 = this.addFeature( ItemSpatialStorageCell.class, MaterialType.Cell16SpatialPart, 16 );
-		items.itemSpatialCell128 = this.addFeature( ItemSpatialStorageCell.class, MaterialType.Cell128SpatialPart, 128 );
-
-		items.itemCertusQuartzKnife = this.addFeature( ToolQuartzCuttingKnife.class, AEFeature.CertusQuartzTools );
-		items.itemCertusQuartzWrench = this.addFeature( ToolQuartzWrench.class, AEFeature.CertusQuartzTools );
-		items.itemCertusQuartzAxe = this.addFeature( ToolQuartzAxe.class, AEFeature.CertusQuartzTools );
-		items.itemCertusQuartzHoe = this.addFeature( ToolQuartzHoe.class, AEFeature.CertusQuartzTools );
-		items.itemCertusQuartzPick = this.addFeature( ToolQuartzPickaxe.class, AEFeature.CertusQuartzTools );
-		items.itemCertusQuartzShovel = this.addFeature( ToolQuartzSpade.class, AEFeature.CertusQuartzTools );
-		items.itemCertusQuartzSword = this.addFeature( ToolQuartzSword.class, AEFeature.CertusQuartzTools );
-
-		items.itemNetherQuartzKnife = this.addFeature( ToolQuartzCuttingKnife.class, AEFeature.NetherQuartzTools );
-		items.itemNetherQuartzWrench = this.addFeature( ToolQuartzWrench.class, AEFeature.NetherQuartzTools );
-		items.itemNetherQuartzAxe = this.addFeature( ToolQuartzAxe.class, AEFeature.NetherQuartzTools );
-		items.itemNetherQuartzHoe = this.addFeature( ToolQuartzHoe.class, AEFeature.NetherQuartzTools );
-		items.itemNetherQuartzPick = this.addFeature( ToolQuartzPickaxe.class, AEFeature.NetherQuartzTools );
-		items.itemNetherQuartzShovel = this.addFeature( ToolQuartzSpade.class, AEFeature.NetherQuartzTools );
-		items.itemNetherQuartzSword = this.addFeature( ToolQuartzSword.class, AEFeature.NetherQuartzTools );
-
-		items.itemMassCannon = this.addFeature( ToolMassCannon.class );
-		items.itemMemoryCard = this.addFeature( ToolMemoryCard.class );
-		items.itemChargedStaff = this.addFeature( ToolChargedStaff.class );
-		items.itemEntropyManipulator = this.addFeature( ToolEntropyManipulator.class );
-		items.itemColorApplicator = this.addFeature( ToolColorApplicator.class );
-
-		items.itemWirelessTerminal = this.addFeature( ToolWirelessTerminal.class );
-		items.itemNetworkTool = this.addFeature( ToolNetworkTool.class );
-		items.itemPortableCell = this.addFeature( ToolPortableCell.class );
-		items.itemBiometricCard = this.addFeature( ToolBiometricCard.class );
-
-		items.itemFacade = this.addFeature( ItemFacade.class );
-		items.itemCrystalSeed = this.addFeature( ItemCrystalSeed.class );
-
-		ColoredItemDefinition paintBall;
-		ColoredItemDefinition lumenPaintBall;
-		items.itemPaintBall = paintBall = new ColoredItemDefinition();
-		items.itemLumenPaintBall = lumenPaintBall = new ColoredItemDefinition();
-		AEItemDefinition pb = this.addFeature( ItemPaintBall.class );
-
-		for ( AEColor c : AEColor.values() )
-		{
-			if ( c != AEColor.Transparent )
-			{
-				paintBall.add( c, new ItemStackSrc( pb.item(), c.ordinal() ) );
-				lumenPaintBall.add( c, new ItemStackSrc( pb.item(), 20 + c.ordinal() ) );
-			}
-		}
-
-		// stairs
-		this.addFeature( SkyStoneStairBlock.class, blocks.blockSkyStone.block(), 0 );
-		this.addFeature( SkyStoneBlockStairBlock.class, blocks.blockSkyStone.block(), 1 );
-		this.addFeature( SkyStoneBrickStairBlock.class, blocks.blockSkyStone.block(), 2 );
-		this.addFeature( SkyStoneSmallBrickStairBlock.class, blocks.blockSkyStone.block(), 3 );
-		this.addFeature( FluixStairBlock.class, blocks.blockFluix.block() );
-		this.addFeature( QuartzStairBlock.class, blocks.blockQuartz.block() );
-		this.addFeature( ChiseledQuartzStairBlock.class, blocks.blockQuartzChiseled.block() );
-		this.addFeature( QuartzPillarStairBlock.class, blocks.blockQuartzPillar.block() );
-
-		// unsupported developer tools
-		this.addFeature( ToolEraser.class );
-		this.addFeature( ToolMeteoritePlacer.class );
-		this.addFeature( ToolDebugCard.class );
-		this.addFeature( ToolReplicatorCard.class );
-		this.addFeature( BlockItemGen.class );
-		this.addFeature( BlockChunkloader.class );
-		this.addFeature( BlockPhantomNode.class );
-		this.addFeature( BlockCubeGenerator.class );
 	}
 
 	private void registerSpatial( boolean force )
@@ -508,36 +208,278 @@ public final class Registration
 		}
 	}
 
-	private AEItemDefinition addFeature( Class<? extends IAEFeature> featureClass, Object... args )
+	private void registerCraftHandlers( IRecipeHandlerRegistry registry )
 	{
-		final ClassInstantiation<IAEFeature> instantiation = new ClassInstantiation<IAEFeature>( featureClass, args );
-		final Optional<IAEFeature> instance = instantiation.get();
+		registry.addNewSubItemResolver( new AEItemResolver() );
 
-		if ( instance.isPresent() )
-		{
-			final IAEFeature feature = instance.get();
-			final IFeatureHandler handler = feature.handler();
-			if ( handler.isFeatureAvailable() )
-			{
-				for ( AEFeature f : handler.getFeatures() )
-				{
-					this.featuresToEntities.put( f, featureClass );
-				}
+		registry.addNewCraftHandler( "hccrusher", HCCrusher.class );
+		registry.addNewCraftHandler( "mekcrusher", MekCrusher.class );
+		registry.addNewCraftHandler( "mekechamber", MekEnrichment.class );
+		registry.addNewCraftHandler( "grind", Grind.class );
+		registry.addNewCraftHandler( "crusher", Crusher.class );
+		registry.addNewCraftHandler( "grindfz", GrindFZ.class );
+		registry.addNewCraftHandler( "pulverizer", Pulverizer.class );
+		registry.addNewCraftHandler( "macerator", Macerator.class );
 
-				handler.register();
-				feature.postInit();
+		registry.addNewCraftHandler( "smelt", Smelt.class );
+		registry.addNewCraftHandler( "inscribe", Inscribe.class );
+		registry.addNewCraftHandler( "press", Press.class );
 
-				return handler.getDefinition();
-			}
-			else
-			{
-				return null;
-			}
-		}
-		else
-		{
-			throw new RuntimeException( "Error upon Class Instantiation with Feature: " + featureClass.getName() );
-		}
+		registry.addNewCraftHandler( "shaped", Shaped.class );
+		registry.addNewCraftHandler( "shapeless", Shapeless.class );
+	}
+
+	/**
+	 * Assigns materials from the new API to the old API
+	 *
+	 * @param target old API
+	 * @param source new API
+	 *
+	 * @deprecated to be removed when the public definition API is removed
+	 */
+	@Deprecated
+	private void assignMaterials( Materials target, IMaterials source )
+	{
+		target.materialCell2SpatialPart = source.cell2SpatialPart().orNull();
+		target.materialCell16SpatialPart = source.cell16SpatialPart().orNull();
+		target.materialCell128SpatialPart = source.cell128SpatialPart().orNull();
+
+		target.materialSilicon = source.silicon().orNull();
+		target.materialSkyDust = source.skyDust().orNull();
+
+		target.materialCalcProcessorPress = source.calcProcessorPress().orNull();
+		target.materialEngProcessorPress = source.engProcessorPress().orNull();
+		target.materialLogicProcessorPress = source.logicProcessorPress().orNull();
+
+		target.materialCalcProcessorPrint = source.calcProcessorPrint().orNull();
+		target.materialEngProcessorPrint = source.engProcessorPrint().orNull();
+		target.materialLogicProcessorPrint = source.logicProcessorPrint().orNull();
+
+		target.materialSiliconPress = source.siliconPress().orNull();
+		target.materialSiliconPrint = source.siliconPrint().orNull();
+
+		target.materialNamePress = source.namePress().orNull();
+
+		target.materialLogicProcessor = source.logicProcessor().orNull();
+		target.materialCalcProcessor = source.calcProcessor().orNull();
+		target.materialEngProcessor = source.engProcessor().orNull();
+
+		target.materialBasicCard = source.basicCard().orNull();
+		target.materialAdvCard = source.advCard().orNull();
+
+		target.materialPurifiedCertusQuartzCrystal = source.purifiedCertusQuartzCrystal().orNull();
+		target.materialPurifiedNetherQuartzCrystal = source.purifiedNetherQuartzCrystal().orNull();
+		target.materialPurifiedFluixCrystal = source.purifiedFluixCrystal().orNull();
+
+		target.materialCell1kPart = source.cell1kPart().orNull();
+		target.materialCell4kPart = source.cell4kPart().orNull();
+		target.materialCell16kPart = source.cell16kPart().orNull();
+		target.materialCell64kPart = source.cell64kPart().orNull();
+		target.materialEmptyStorageCell = source.emptyStorageCell().orNull();
+
+		target.materialCardRedstone = source.cardRedstone().orNull();
+		target.materialCardSpeed = source.cardSpeed().orNull();
+		target.materialCardCapacity = source.cardCapacity().orNull();
+		target.materialCardFuzzy = source.cardFuzzy().orNull();
+		target.materialCardInverter = source.cardInverter().orNull();
+		target.materialCardCrafting = source.cardCrafting().orNull();
+
+		target.materialEnderDust = source.enderDust().orNull();
+		target.materialFlour = source.flour().orNull();
+		target.materialGoldDust = source.goldDust().orNull();
+		target.materialIronDust = source.ironDust().orNull();
+		target.materialFluixDust = source.fluixDust().orNull();
+		target.materialCertusQuartzDust = source.certusQuartzDust().orNull();
+		target.materialNetherQuartzDust = source.netherQuartzDust().orNull();
+
+		target.materialMatterBall = source.matterBall().orNull();
+		target.materialIronNugget = source.ironNugget().orNull();
+
+		target.materialCertusQuartzCrystal = source.certusQuartzCrystal().orNull();
+		target.materialCertusQuartzCrystalCharged = source.certusQuartzCrystalCharged().orNull();
+		target.materialFluixCrystal = source.fluixCrystal().orNull();
+		target.materialFluixPearl = source.fluixPearl().orNull();
+
+		target.materialWoodenGear = source.woodenGear().orNull();
+
+		target.materialWireless = source.wireless().orNull();
+		target.materialWirelessBooster = source.wirelessBooster().orNull();
+
+		target.materialAnnihilationCore = source.annihilationCore().orNull();
+		target.materialFormationCore = source.formationCore().orNull();
+
+		target.materialSingularity = source.singularity().orNull();
+		target.materialQESingularity = source.qESingularity().orNull();
+		target.materialBlankPattern = source.blankPattern().orNull();
+	}
+
+	/**
+	 * Assigns parts from the new API to the old API
+	 *
+	 * @param target old API
+	 * @param source new API
+	 *
+	 * @deprecated to be removed when the public definition API is removed
+	 */
+	@Deprecated
+	private void assignParts( Parts target, IParts source )
+	{
+		target.partCableSmart = source.cableSmart().orNull();
+		target.partCableCovered = source.cableCovered().orNull();
+		target.partCableGlass = source.cableGlass().orNull();
+		target.partCableDense = source.cableDense().orNull();
+		target.partLumenCableSmart = source.lumenCableSmart().orNull();
+		target.partLumenCableCovered = source.lumenCableCovered().orNull();
+		target.partLumenCableGlass = source.lumenCableGlass().orNull();
+		target.partLumenCableDense = source.lumenCableDense().orNull();
+		target.partQuartzFiber = source.quartzFiber().orNull();
+		target.partToggleBus = source.toggleBus().orNull();
+		target.partInvertedToggleBus = source.invertedToggleBus().orNull();
+		target.partStorageBus = source.storageBus().orNull();
+		target.partImportBus = source.importBus().orNull();
+		target.partExportBus = source.exportBus().orNull();
+		target.partInterface = source.iface().orNull();
+		target.partLevelEmitter = source.levelEmitter().orNull();
+		target.partAnnihilationPlane = source.annihilationPlane().orNull();
+		target.partFormationPlane = source.formationPlane().orNull();
+		target.partP2PTunnelME = target.partP2PTunnelRedstone = target.partP2PTunnelItems = target.partP2PTunnelLiquids = target.partP2PTunnelMJ = target.partP2PTunnelEU = target.partP2PTunnelRF = target.partP2PTunnelLight = target.partCableAnchor = source.cableAnchor().orNull();
+		target.partMonitor = source.monitor().orNull();
+		target.partSemiDarkMonitor = source.semiDarkMonitor().orNull();
+		target.partDarkMonitor = source.darkMonitor().orNull();
+		target.partInterfaceTerminal = source.interfaceTerminal().orNull();
+		target.partPatternTerminal = source.patternTerminal().orNull();
+		target.partCraftingTerminal = source.craftingTerminal().orNull();
+		target.partTerminal = source.terminal().orNull();
+		target.partStorageMonitor = source.storageMonitor().orNull();
+		target.partConversionMonitor = source.conversionMonitor().orNull();
+	}
+
+	/**
+	 * Assigns blocks from the new API to the old API
+	 *
+	 * @param target old API
+	 * @param source new API
+	 *
+	 * @deprecated to be removed when the public definition API is removed
+	 */
+	@Deprecated
+	private void assignBlocks( Blocks target, IBlocks source )
+	{
+		target.blockMultiPart = source.multiPart().orNull();
+
+		target.blockCraftingUnit = source.craftingUnit().orNull();
+		target.blockCraftingAccelerator = source.craftingAccelerator().orNull();
+		target.blockCraftingMonitor = source.craftingMonitor().orNull();
+		target.blockCraftingStorage1k = source.craftingStorage1k().orNull();
+		target.blockCraftingStorage4k = source.craftingStorage4k().orNull();
+		target.blockCraftingStorage16k = source.craftingStorage16k().orNull();
+		target.blockCraftingStorage64k = source.craftingStorage64k().orNull();
+		target.blockMolecularAssembler = source.molecularAssembler().orNull();
+
+		target.blockQuartzOre = source.quartzOre().orNull();
+		target.blockQuartzOreCharged = source.quartzOreCharged().orNull();
+		target.blockMatrixFrame = source.matrixFrame().orNull();
+		target.blockQuartz = source.quartz().orNull();
+		target.blockFluix = source.fluix().orNull();
+		target.blockSkyStone = source.skyStone().orNull();
+		target.blockSkyChest = source.skyChest().orNull();
+		target.blockSkyCompass = source.skyCompass().orNull();
+
+		target.blockQuartzGlass = source.quartzGlass().orNull();
+		target.blockQuartzVibrantGlass = source.quartzVibrantGlass().orNull();
+		target.blockQuartzPillar = source.quartzPillar().orNull();
+		target.blockQuartzChiseled = source.quartzChiseled().orNull();
+		target.blockQuartzTorch = source.quartzTorch().orNull();
+		target.blockLightDetector = source.lightDetector().orNull();
+		target.blockCharger = source.charger().orNull();
+		target.blockQuartzGrowthAccelerator = source.quartzGrowthAccelerator().orNull();
+
+		target.blockGrindStone = source.grindStone().orNull();
+		target.blockCrankHandle = source.crankHandle().orNull();
+		target.blockInscriber = source.inscriber().orNull();
+		target.blockWireless = source.wireless().orNull();
+		target.blockTinyTNT = source.tinyTNT().orNull();
+
+		target.blockQuantumRing = source.quantumRing().orNull();
+		target.blockQuantumLink = source.quantumLink().orNull();
+
+		target.blockSpatialPylon = source.spatialPylon().orNull();
+		target.blockSpatialIOPort = source.spatialIOPort().orNull();
+
+		target.blockController = source.controller().orNull();
+		target.blockDrive = source.drive().orNull();
+		target.blockChest = source.chest().orNull();
+		target.blockInterface = source.iface().orNull();
+		target.blockCellWorkbench = source.cellWorkbench().orNull();
+		target.blockIOPort = source.iOPort().orNull();
+		target.blockCondenser = source.condenser().orNull();
+		target.blockEnergyAcceptor = source.energyAcceptor().orNull();
+		target.blockVibrationChamber = source.vibrationChamber().orNull();
+
+		target.blockEnergyCell = source.energyCell().orNull();
+		target.blockEnergyCellDense = source.energyCellDense().orNull();
+		target.blockEnergyCellCreative = source.energyCellCreative().orNull();
+
+		target.blockSecurity = source.security().orNull();
+		target.blockPaint = source.paint().orNull();
+	}
+
+	/**
+	 * Assigns materials from the new API to the old API
+	 *
+	 * @param target old API
+	 * @param source new API
+	 *
+	 * @deprecated to be removed when the public definition API is removed
+	 */
+	@Deprecated
+	private void assignItems( Items target, IItems source )
+	{
+		target.itemCellCreative = source.cellCreative().orNull();
+		target.itemViewCell = source.viewCell().orNull();
+		target.itemEncodedPattern = source.encodedPattern().orNull();
+
+		target.itemCell1k = source.cell1k().orNull();
+		target.itemCell4k = source.cell4k().orNull();
+		target.itemCell16k = source.cell16k().orNull();
+		target.itemCell64k = source.cell64k().orNull();
+
+		target.itemSpatialCell2 = source.spatialCell2().orNull();
+		target.itemSpatialCell16 = source.spatialCell16().orNull();
+		target.itemSpatialCell128 = source.spatialCell128().orNull();
+
+		target.itemCertusQuartzKnife = source.certusQuartzKnife().orNull();
+		target.itemCertusQuartzWrench = source.certusQuartzWrench().orNull();
+		target.itemCertusQuartzAxe = source.certusQuartzAxe().orNull();
+		target.itemCertusQuartzHoe = source.certusQuartzHoe().orNull();
+		target.itemCertusQuartzPick = source.certusQuartzPick().orNull();
+		target.itemCertusQuartzShovel = source.certusQuartzShovel().orNull();
+		target.itemCertusQuartzSword = source.certusQuartzSword().orNull();
+
+		target.itemNetherQuartzKnife = source.netherQuartzKnife().orNull();
+		target.itemNetherQuartzWrench = source.netherQuartzWrench().orNull();
+		target.itemNetherQuartzAxe = source.netherQuartzAxe().orNull();
+		target.itemNetherQuartzHoe = source.netherQuartzHoe().orNull();
+		target.itemNetherQuartzPick = source.netherQuartzPick().orNull();
+		target.itemNetherQuartzShovel = source.netherQuartzShovel().orNull();
+		target.itemNetherQuartzSword = source.netherQuartzSword().orNull();
+
+		target.itemMassCannon = source.massCannon().orNull();
+		target.itemMemoryCard = source.memoryCard().orNull();
+		target.itemChargedStaff = source.chargedStaff().orNull();
+		target.itemEntropyManipulator = source.entropyManipulator().orNull();
+		target.itemColorApplicator = source.colorApplicator().orNull();
+
+		target.itemWirelessTerminal = source.wirelessTerminal().orNull();
+		target.itemNetworkTool = source.networkTool().orNull();
+		target.itemPortableCell = source.portableCell().orNull();
+		target.itemBiometricCard = source.biometricCard().orNull();
+
+		target.itemFacade = source.facade().orNull();
+		target.itemCrystalSeed = source.crystalSeed().orNull();
+
+		target.itemPaintBall = source.coloredPaintBall().orNull();
+		target.itemLumenPaintBall = source.coloredLumenPaintBall().orNull();
 	}
 
 	public void initialize( FMLInitializationEvent event )
@@ -621,14 +563,14 @@ public final class Registration
 		final Items items = api.items();
 
 		// default settings..
-		( ( P2PTunnelRegistry ) registries.p2pTunnel() ).configure();
+		( (P2PTunnelRegistry) registries.p2pTunnel() ).configure();
 
 		// add to localization..
 		PlayerMessages.values();
 		GuiText.values();
 
-		Api.INSTANCE.partHelper.initFMPSupport();
-		( ( BlockCableBus ) blocks.blockMultiPart.block() ).setupTile();
+		Api.INSTANCE.getPartHelper().initFMPSupport();
+		( (BlockCableBus) blocks.blockMultiPart.block() ).setupTile();
 
 		// Interface
 		Upgrades.CRAFTING.registerItem( parts.partInterface, 1 );
@@ -697,7 +639,7 @@ public final class Registration
 
 		if ( items.itemWirelessTerminal != null )
 		{
-			registries.wireless().registerWirelessHandler( ( IWirelessTermHandler ) items.itemWirelessTerminal.item() );
+			registries.wireless().registerWirelessHandler( (IWirelessTermHandler) items.itemWirelessTerminal.item() );
 		}
 
 		if ( AEConfig.instance.isFeatureEnabled( AEFeature.ChestLoot ) )

--- a/src/main/java/appeng/core/WorldSettings.java
+++ b/src/main/java/appeng/core/WorldSettings.java
@@ -92,7 +92,7 @@ public class WorldSettings extends Configuration
 		}
 
 		final ConfigCategory playerList = this.getCategory( "players" );
-		this.mappings = new PlayerMappings( playerList, AELog.instance );
+		this.mappings = new PlayerMappings( playerList, AELog.INSTANCE );
 	}
 
 	public static WorldSettings getInstance()

--- a/src/main/java/appeng/core/api/definitions/ApiBlocks.java
+++ b/src/main/java/appeng/core/api/definitions/ApiBlocks.java
@@ -1,0 +1,679 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.core.api.definitions;
+
+
+import javax.annotation.Nullable;
+
+import net.minecraft.block.Block;
+
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+
+import appeng.api.definitions.IBlocks;
+import appeng.api.util.AEItemDefinition;
+import appeng.block.crafting.BlockCraftingMonitor;
+import appeng.block.crafting.BlockCraftingStorage;
+import appeng.block.crafting.BlockCraftingUnit;
+import appeng.block.crafting.BlockMolecularAssembler;
+import appeng.block.grindstone.BlockCrank;
+import appeng.block.grindstone.BlockGrinder;
+import appeng.block.misc.BlockCellWorkbench;
+import appeng.block.misc.BlockCharger;
+import appeng.block.misc.BlockCondenser;
+import appeng.block.misc.BlockInscriber;
+import appeng.block.misc.BlockInterface;
+import appeng.block.misc.BlockLightDetector;
+import appeng.block.misc.BlockPaint;
+import appeng.block.misc.BlockQuartzGrowthAccelerator;
+import appeng.block.misc.BlockQuartzTorch;
+import appeng.block.misc.BlockSecurity;
+import appeng.block.misc.BlockSkyCompass;
+import appeng.block.misc.BlockTinyTNT;
+import appeng.block.misc.BlockVibrationChamber;
+import appeng.block.networking.BlockCableBus;
+import appeng.block.networking.BlockController;
+import appeng.block.networking.BlockCreativeEnergyCell;
+import appeng.block.networking.BlockDenseEnergyCell;
+import appeng.block.networking.BlockEnergyAcceptor;
+import appeng.block.networking.BlockEnergyCell;
+import appeng.block.networking.BlockWireless;
+import appeng.block.qnb.BlockQuantumLinkChamber;
+import appeng.block.qnb.BlockQuantumRing;
+import appeng.block.solids.BlockFluix;
+import appeng.block.solids.BlockQuartz;
+import appeng.block.solids.BlockQuartzChiseled;
+import appeng.block.solids.BlockQuartzGlass;
+import appeng.block.solids.BlockQuartzLamp;
+import appeng.block.solids.BlockQuartzPillar;
+import appeng.block.solids.BlockSkyStone;
+import appeng.block.solids.OreQuartz;
+import appeng.block.solids.OreQuartzCharged;
+import appeng.block.spatial.BlockMatrixFrame;
+import appeng.block.spatial.BlockSpatialIOPort;
+import appeng.block.spatial.BlockSpatialPylon;
+import appeng.block.stair.ChiseledQuartzStairBlock;
+import appeng.block.stair.FluixStairBlock;
+import appeng.block.stair.QuartzPillarStairBlock;
+import appeng.block.stair.QuartzStairBlock;
+import appeng.block.stair.SkyStoneBlockStairBlock;
+import appeng.block.stair.SkyStoneBrickStairBlock;
+import appeng.block.stair.SkyStoneSmallBrickStairBlock;
+import appeng.block.stair.SkyStoneStairBlock;
+import appeng.block.storage.BlockChest;
+import appeng.block.storage.BlockDrive;
+import appeng.block.storage.BlockIOPort;
+import appeng.block.storage.BlockSkyChest;
+import appeng.core.FeatureHandlerRegistry;
+import appeng.core.FeatureRegistry;
+import appeng.core.features.IAEFeature;
+import appeng.core.features.IFeatureHandler;
+import appeng.core.features.WrappedDamageItemDefinition;
+import appeng.debug.BlockChunkloader;
+import appeng.debug.BlockCubeGenerator;
+import appeng.debug.BlockItemGen;
+import appeng.debug.BlockPhantomNode;
+
+
+/**
+ * Internal implementation for the API blocks
+ */
+public final class ApiBlocks implements IBlocks
+{
+	private final FeatureRegistry features;
+	private final FeatureHandlerRegistry handlers;
+
+	private final Optional<AEItemDefinition> quartzOre;
+	private final Optional<AEItemDefinition> quartzOreCharged;
+	private final Optional<AEItemDefinition> matrixFrame;
+	private final Optional<AEItemDefinition> quartz;
+	private final Optional<AEItemDefinition> quartzPillar;
+	private final Optional<AEItemDefinition> quartzChiseled;
+	private final Optional<AEItemDefinition> quartzGlass;
+	private final Optional<AEItemDefinition> quartzVibrantGlass;
+	private final Optional<AEItemDefinition> quartzTorch;
+	private final Optional<AEItemDefinition> fluix;
+	private final Optional<AEItemDefinition> skyStone;
+	private final Optional<AEItemDefinition> skyChest;
+	private final Optional<AEItemDefinition> skyCompass;
+	private final Optional<AEItemDefinition> grindStone;
+	private final Optional<AEItemDefinition> crankHandle;
+	private final Optional<AEItemDefinition> inscriber;
+	private final Optional<AEItemDefinition> wireless;
+	private final Optional<AEItemDefinition> charger;
+	private final Optional<AEItemDefinition> tinyTNT;
+	private final Optional<AEItemDefinition> security;
+	private final Optional<AEItemDefinition> quantumRing;
+	private final Optional<AEItemDefinition> quantumLink;
+	private final Optional<AEItemDefinition> spatialPylon;
+	private final Optional<AEItemDefinition> spatialIOPort;
+	private final Optional<AEItemDefinition> multiPart;
+	private final Optional<AEItemDefinition> controller;
+	private final Optional<AEItemDefinition> drive;
+	private final Optional<AEItemDefinition> chest;
+	private final Optional<AEItemDefinition> iface;
+	private final Optional<AEItemDefinition> cellWorkbench;
+	private final Optional<AEItemDefinition> iOPort;
+	private final Optional<AEItemDefinition> condenser;
+	private final Optional<AEItemDefinition> energyAcceptor;
+	private final Optional<AEItemDefinition> vibrationChamber;
+	private final Optional<AEItemDefinition> quartzGrowthAccelerator;
+	private final Optional<AEItemDefinition> energyCell;
+	private final Optional<AEItemDefinition> energyCellDense;
+	private final Optional<AEItemDefinition> energyCellCreative;
+	private final Optional<AEItemDefinition> craftingUnit;
+	private final Optional<AEItemDefinition> craftingAccelerator;
+	private final Optional<AEItemDefinition> craftingStorage1k;
+	private final Optional<AEItemDefinition> craftingStorage4k;
+	private final Optional<AEItemDefinition> craftingStorage16k;
+	private final Optional<AEItemDefinition> craftingStorage64k;
+	private final Optional<AEItemDefinition> craftingMonitor;
+	private final Optional<AEItemDefinition> molecularAssembler;
+	private final Optional<AEItemDefinition> lightDetector;
+	private final Optional<AEItemDefinition> paint;
+	private final Optional<AEItemDefinition> skyStoneStair;
+	private final Optional<AEItemDefinition> skyStoneBlockStair;
+	private final Optional<AEItemDefinition> skyStoneBrickStair;
+	private final Optional<AEItemDefinition> skyStoneSmallBrickStair;
+	private final Optional<AEItemDefinition> fluixStair;
+	private final Optional<AEItemDefinition> quartzStair;
+	private final Optional<AEItemDefinition> chiseledQuartzStair;
+	private final Optional<AEItemDefinition> quartzPillarStair;
+
+	private final Optional<AEItemDefinition> itemGen;
+	private final Optional<AEItemDefinition> chunkLoader;
+	private final Optional<AEItemDefinition> phantomNode;
+	private final Optional<AEItemDefinition> cubeGenerator;
+
+	public ApiBlocks( FeatureRegistry features, FeatureHandlerRegistry handlers )
+	{
+		this.features = features;
+		this.handlers = handlers;
+
+		this.quartzOre = this.getMaybeDefinition( new OreQuartz() );
+		this.quartzOreCharged = this.getMaybeDefinition( new OreQuartzCharged() );
+		this.matrixFrame = this.getMaybeDefinition( new BlockMatrixFrame() );
+		this.quartz = this.getMaybeDefinition( new BlockQuartz() );
+		this.quartzPillar = this.getMaybeDefinition( new BlockQuartzPillar() );
+		this.quartzChiseled = this.getMaybeDefinition( new BlockQuartzChiseled() );
+		this.quartzGlass = this.getMaybeDefinition( new BlockQuartzGlass() );
+		this.quartzVibrantGlass = this.getMaybeDefinition( new BlockQuartzLamp() );
+		this.quartzTorch = this.getMaybeDefinition( new BlockQuartzTorch() );
+		this.fluix = this.getMaybeDefinition( new BlockFluix() );
+		this.skyStone = this.getMaybeDefinition( new BlockSkyStone() );
+		this.skyChest = this.getMaybeDefinition( new BlockSkyChest() );
+		this.skyCompass = this.getMaybeDefinition( new BlockSkyCompass() );
+		this.grindStone = this.getMaybeDefinition( new BlockGrinder() );
+		this.crankHandle = this.getMaybeDefinition( new BlockCrank() );
+		this.inscriber = this.getMaybeDefinition( new BlockInscriber() );
+		this.wireless = this.getMaybeDefinition( new BlockWireless() );
+		this.charger = this.getMaybeDefinition( new BlockCharger() );
+		this.tinyTNT = this.getMaybeDefinition( new BlockTinyTNT() );
+		this.security = this.getMaybeDefinition( new BlockSecurity() );
+		this.quantumRing = this.getMaybeDefinition( new BlockQuantumRing() );
+		this.quantumLink = this.getMaybeDefinition( new BlockQuantumLinkChamber() );
+		this.spatialPylon = this.getMaybeDefinition( new BlockSpatialPylon() );
+		this.spatialIOPort = this.getMaybeDefinition( new BlockSpatialIOPort() );
+		this.multiPart = this.getMaybeDefinition( new BlockCableBus() );
+		this.controller = this.getMaybeDefinition( new BlockController() );
+		this.drive = this.getMaybeDefinition( new BlockDrive() );
+		this.chest = this.getMaybeDefinition( new BlockChest() );
+		this.iface = this.getMaybeDefinition( new BlockInterface() );
+		this.cellWorkbench = this.getMaybeDefinition( new BlockCellWorkbench() );
+		this.iOPort = this.getMaybeDefinition( new BlockIOPort() );
+		this.condenser = this.getMaybeDefinition( new BlockCondenser() );
+		this.energyAcceptor = this.getMaybeDefinition( new BlockEnergyAcceptor() );
+		this.vibrationChamber = this.getMaybeDefinition( new BlockVibrationChamber() );
+		this.quartzGrowthAccelerator = this.getMaybeDefinition( new BlockQuartzGrowthAccelerator() );
+		this.energyCell = this.getMaybeDefinition( new BlockEnergyCell() );
+		this.energyCellDense = this.getMaybeDefinition( new BlockDenseEnergyCell() );
+		this.energyCellCreative = this.getMaybeDefinition( new BlockCreativeEnergyCell() );
+		this.craftingUnit = this.getMaybeDefinition( new BlockCraftingUnit() );
+		this.craftingAccelerator = this.craftingUnit.transform( new WrappedItemDamageDefinitionTransformation( 1 ) );
+		this.craftingStorage1k = this.getMaybeDefinition( new BlockCraftingStorage() );
+		this.craftingStorage4k = this.craftingStorage1k.transform( new WrappedItemDamageDefinitionTransformation( 1 ) );
+		this.craftingStorage16k = this.craftingStorage1k.transform( new WrappedItemDamageDefinitionTransformation( 2 ) );
+		this.craftingStorage64k = this.craftingStorage1k.transform( new WrappedItemDamageDefinitionTransformation( 3 ) );
+		this.craftingMonitor = this.getMaybeDefinition( new BlockCraftingMonitor() );
+		this.molecularAssembler = this.getMaybeDefinition( new BlockMolecularAssembler() );
+		this.lightDetector = this.getMaybeDefinition( new BlockLightDetector() );
+		this.paint = this.getMaybeDefinition( new BlockPaint() );
+
+		if ( this.skyStone.isPresent() )
+		{
+			final AEItemDefinition definition = this.skyStone.get();
+			final Block blockID = definition.block();
+
+			this.skyStoneStair = this.getMaybeDefinition( new SkyStoneStairBlock( blockID, 0 ) );
+			this.skyStoneBlockStair = this.getMaybeDefinition( new SkyStoneBlockStairBlock( blockID, 1 ) );
+			this.skyStoneBrickStair = this.getMaybeDefinition( new SkyStoneBrickStairBlock( blockID, 2 ) );
+			this.skyStoneSmallBrickStair = this.getMaybeDefinition( new SkyStoneSmallBrickStairBlock( blockID, 3 ) );
+		}
+		else
+		{
+			this.skyStoneStair = Optional.absent();
+			this.skyStoneBlockStair = Optional.absent();
+			this.skyStoneBrickStair = Optional.absent();
+			this.skyStoneSmallBrickStair = Optional.absent();
+		}
+
+		if ( this.fluix.isPresent() )
+		{
+			final AEItemDefinition definition = this.fluix.get();
+			final Block blockID = definition.block();
+
+			this.fluixStair = this.getMaybeDefinition( new FluixStairBlock( blockID ) );
+		}
+		else
+		{
+			this.fluixStair = Optional.absent();
+		}
+
+		if ( this.quartz.isPresent() )
+		{
+			final AEItemDefinition definition = this.quartz.get();
+			final Block blockID = definition.block();
+
+			this.quartzStair = this.getMaybeDefinition( new QuartzStairBlock( blockID ) );
+		}
+		else
+		{
+			this.quartzStair = Optional.absent();
+		}
+
+		if ( this.quartzChiseled.isPresent() )
+		{
+			final AEItemDefinition definition = this.quartzChiseled.get();
+			final Block blockID = definition.block();
+
+			this.chiseledQuartzStair = this.getMaybeDefinition( new ChiseledQuartzStairBlock( blockID ) );
+		}
+		else
+		{
+			this.chiseledQuartzStair = Optional.absent();
+		}
+
+		if ( this.quartzPillar.isPresent() )
+		{
+			final AEItemDefinition definition = this.quartzPillar.get();
+			final Block blockID = definition.block();
+
+			this.quartzPillarStair = this.getMaybeDefinition( new QuartzPillarStairBlock( blockID ) );
+		}
+		else
+		{
+			this.quartzPillarStair = Optional.absent();
+		}
+
+		this.itemGen = this.getMaybeDefinition( new BlockItemGen() );
+		this.chunkLoader = this.getMaybeDefinition( new BlockChunkloader() );
+		this.phantomNode = this.getMaybeDefinition( new BlockPhantomNode() );
+		this.cubeGenerator = this.getMaybeDefinition( new BlockCubeGenerator() );
+	}
+
+	private Optional<AEItemDefinition> getMaybeDefinition( IAEFeature feature )
+	{
+		final IFeatureHandler handler = feature.handler();
+
+		if ( handler.isFeatureAvailable() )
+		{
+			this.handlers.addFeatureHandler( handler );
+			this.features.addFeature( feature );
+
+			return Optional.of( handler.getDefinition() );
+		}
+		else
+		{
+			return Optional.absent();
+		}
+	}
+
+	@Override
+	public Optional<AEItemDefinition> quartzOre()
+	{
+		return this.quartzOre;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> quartzOreCharged()
+	{
+		return this.quartzOreCharged;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> matrixFrame()
+	{
+		return this.matrixFrame;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> quartz()
+	{
+		return this.quartz;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> quartzPillar()
+	{
+		return this.quartzPillar;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> quartzChiseled()
+	{
+		return this.quartzChiseled;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> quartzGlass()
+	{
+		return this.quartzGlass;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> quartzVibrantGlass()
+	{
+		return this.quartzVibrantGlass;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> quartzTorch()
+	{
+		return this.quartzTorch;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> fluix()
+	{
+		return this.fluix;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> skyStone()
+	{
+		return this.skyStone;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> skyChest()
+	{
+		return this.skyChest;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> skyCompass()
+	{
+		return this.skyCompass;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> skyStoneStair()
+	{
+		return this.skyStoneStair;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> skyStoneBlockStair()
+	{
+		return this.skyStoneBlockStair;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> skyStoneBrickStair()
+	{
+		return this.skyStoneBrickStair;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> skyStoneSmallBrickStair()
+	{
+		return this.skyStoneSmallBrickStair;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> fluixStair()
+	{
+		return this.fluixStair;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> quartzStair()
+	{
+		return this.quartzStair;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> chiseledQuartzStair()
+	{
+		return this.chiseledQuartzStair;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> quartzPillarStair()
+	{
+		return this.quartzPillarStair;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> grindStone()
+	{
+		return this.grindStone;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> crankHandle()
+	{
+		return this.crankHandle;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> inscriber()
+	{
+		return this.inscriber;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> wireless()
+	{
+		return this.wireless;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> charger()
+	{
+		return this.charger;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> tinyTNT()
+	{
+		return this.tinyTNT;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> security()
+	{
+		return this.security;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> quantumRing()
+	{
+		return this.quantumRing;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> quantumLink()
+	{
+		return this.quantumLink;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> spatialPylon()
+	{
+		return this.spatialPylon;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> spatialIOPort()
+	{
+		return this.spatialIOPort;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> multiPart()
+	{
+		return this.multiPart;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> controller()
+	{
+		return this.controller;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> drive()
+	{
+		return this.drive;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> chest()
+	{
+		return this.chest;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> iface()
+	{
+		return this.iface;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> cellWorkbench()
+	{
+		return this.cellWorkbench;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> iOPort()
+	{
+		return this.iOPort;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> condenser()
+	{
+		return this.condenser;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> energyAcceptor()
+	{
+		return this.energyAcceptor;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> vibrationChamber()
+	{
+		return this.vibrationChamber;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> quartzGrowthAccelerator()
+	{
+		return this.quartzGrowthAccelerator;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> energyCell()
+	{
+		return this.energyCell;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> energyCellDense()
+	{
+		return this.energyCellDense;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> energyCellCreative()
+	{
+		return this.energyCellCreative;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> craftingUnit()
+	{
+		return this.craftingUnit;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> craftingAccelerator()
+	{
+		return this.craftingAccelerator;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> craftingStorage1k()
+	{
+		return this.craftingStorage1k;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> craftingStorage4k()
+	{
+		return this.craftingStorage4k;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> craftingStorage16k()
+	{
+		return this.craftingStorage16k;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> craftingStorage64k()
+	{
+		return this.craftingStorage64k;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> craftingMonitor()
+	{
+		return this.craftingMonitor;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> molecularAssembler()
+	{
+		return this.molecularAssembler;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> lightDetector()
+	{
+		return this.lightDetector;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> paint()
+	{
+		return this.paint;
+	}
+
+	public Optional<AEItemDefinition> chunkLoader()
+	{
+		return this.chunkLoader;
+	}
+
+	public Optional<AEItemDefinition> itemGen()
+	{
+		return this.itemGen;
+	}
+
+	public Optional<AEItemDefinition> phantomNode()
+	{
+		return this.phantomNode;
+	}
+
+	public Optional<AEItemDefinition> cubeGenerator()
+	{
+		return this.cubeGenerator;
+	}
+
+	private static class WrappedItemDamageDefinitionTransformation implements Function<AEItemDefinition, AEItemDefinition>
+	{
+		private final int itemDamage;
+
+		public WrappedItemDamageDefinitionTransformation( int itemDamage )
+		{
+			this.itemDamage = itemDamage;
+		}
+
+		@Nullable
+		@Override
+		public AEItemDefinition apply( AEItemDefinition input )
+		{
+			return new WrappedDamageItemDefinition( input, this.itemDamage );
+		}
+	}
+}

--- a/src/main/java/appeng/core/api/definitions/ApiItems.java
+++ b/src/main/java/appeng/core/api/definitions/ApiItems.java
@@ -1,0 +1,481 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.core.api.definitions;
+
+
+import javax.annotation.Nullable;
+
+import net.minecraft.item.Item;
+
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+
+import appeng.api.definitions.IItems;
+import appeng.api.util.AEColor;
+import appeng.api.util.AEColoredItemDefinition;
+import appeng.api.util.AEItemDefinition;
+import appeng.core.FeatureHandlerRegistry;
+import appeng.core.FeatureRegistry;
+import appeng.core.features.AEFeature;
+import appeng.core.features.ColoredItemDefinition;
+import appeng.core.features.IAEFeature;
+import appeng.core.features.IFeatureHandler;
+import appeng.core.features.ItemStackSrc;
+import appeng.debug.ToolDebugCard;
+import appeng.debug.ToolEraser;
+import appeng.debug.ToolMeteoritePlacer;
+import appeng.debug.ToolReplicatorCard;
+import appeng.items.materials.MaterialType;
+import appeng.items.misc.ItemCrystalSeed;
+import appeng.items.misc.ItemEncodedPattern;
+import appeng.items.misc.ItemPaintBall;
+import appeng.items.parts.ItemFacade;
+import appeng.items.storage.ItemBasicStorageCell;
+import appeng.items.storage.ItemCreativeStorageCell;
+import appeng.items.storage.ItemSpatialStorageCell;
+import appeng.items.storage.ItemViewCell;
+import appeng.items.tools.ToolBiometricCard;
+import appeng.items.tools.ToolMemoryCard;
+import appeng.items.tools.ToolNetworkTool;
+import appeng.items.tools.powered.ToolChargedStaff;
+import appeng.items.tools.powered.ToolColorApplicator;
+import appeng.items.tools.powered.ToolEntropyManipulator;
+import appeng.items.tools.powered.ToolMassCannon;
+import appeng.items.tools.powered.ToolPortableCell;
+import appeng.items.tools.powered.ToolWirelessTerminal;
+import appeng.items.tools.quartz.ToolQuartzAxe;
+import appeng.items.tools.quartz.ToolQuartzCuttingKnife;
+import appeng.items.tools.quartz.ToolQuartzHoe;
+import appeng.items.tools.quartz.ToolQuartzPickaxe;
+import appeng.items.tools.quartz.ToolQuartzSpade;
+import appeng.items.tools.quartz.ToolQuartzSword;
+import appeng.items.tools.quartz.ToolQuartzWrench;
+
+
+/**
+ * Internal implementation for the API items
+ */
+public final class ApiItems implements IItems
+{
+	private final FeatureRegistry features;
+	private final FeatureHandlerRegistry handlers;
+
+	private final Optional<AEItemDefinition> certusQuartzAxe;
+	private final Optional<AEItemDefinition> certusQuartzHoe;
+	private final Optional<AEItemDefinition> certusQuartzShovel;
+	private final Optional<AEItemDefinition> certusQuartzPick;
+	private final Optional<AEItemDefinition> certusQuartzSword;
+	private final Optional<AEItemDefinition> certusQuartzWrench;
+	private final Optional<AEItemDefinition> certusQuartzKnife;
+
+	private final Optional<AEItemDefinition> netherQuartzAxe;
+	private final Optional<AEItemDefinition> netherQuartzHoe;
+	private final Optional<AEItemDefinition> netherQuartzShovel;
+	private final Optional<AEItemDefinition> netherQuartzPick;
+	private final Optional<AEItemDefinition> netherQuartzSword;
+	private final Optional<AEItemDefinition> netherQuartzWrench;
+	private final Optional<AEItemDefinition> netherQuartzKnife;
+
+	private final Optional<AEItemDefinition> entropyManipulator;
+	private final Optional<AEItemDefinition> wirelessTerminal;
+	private final Optional<AEItemDefinition> biometricCard;
+	private final Optional<AEItemDefinition> chargedStaff;
+	private final Optional<AEItemDefinition> massCannon;
+	private final Optional<AEItemDefinition> memoryCard;
+	private final Optional<AEItemDefinition> networkTool;
+	private final Optional<AEItemDefinition> portableCell;
+
+	private final Optional<AEItemDefinition> cellCreative;
+	private final Optional<AEItemDefinition> viewCell;
+
+	private final Optional<AEItemDefinition> cell1k;
+	private final Optional<AEItemDefinition> cell4k;
+	private final Optional<AEItemDefinition> cell16k;
+	private final Optional<AEItemDefinition> cell64k;
+
+	private final Optional<AEItemDefinition> spatialCell2;
+	private final Optional<AEItemDefinition> spatialCell16;
+	private final Optional<AEItemDefinition> spatialCell128;
+
+	private final Optional<AEItemDefinition> facade;
+	private final Optional<AEItemDefinition> crystalSeed;
+
+	// rv1
+	private final Optional<AEItemDefinition> encodedPattern;
+	private final Optional<AEItemDefinition> colorApplicator;
+
+	private final Optional<AEItemDefinition> paintBall;
+	private final Optional<AEColoredItemDefinition> coloredPaintBall;
+	private final Optional<AEColoredItemDefinition> coloredLumenPaintBall;
+
+	// unsupported dev tools
+	private final Optional<AEItemDefinition> toolEraser;
+	private final Optional<AEItemDefinition> toolMeteoritePlacer;
+	private final Optional<AEItemDefinition> toolDebugCard;
+	private final Optional<AEItemDefinition> toolReplicatorCard;
+
+	public ApiItems( FeatureRegistry features, FeatureHandlerRegistry handlers )
+	{
+		this.features = features;
+		this.handlers = handlers;
+
+		this.certusQuartzAxe = this.getMaybeDefinition( new ToolQuartzAxe( AEFeature.CertusQuartzTools ) );
+		this.certusQuartzHoe = this.getMaybeDefinition( new ToolQuartzHoe( AEFeature.CertusQuartzTools ) );
+		this.certusQuartzShovel = this.getMaybeDefinition( new ToolQuartzSpade( AEFeature.CertusQuartzTools ) );
+		this.certusQuartzPick = this.getMaybeDefinition( new ToolQuartzPickaxe( AEFeature.CertusQuartzTools ) );
+		this.certusQuartzSword = this.getMaybeDefinition( new ToolQuartzSword( AEFeature.CertusQuartzTools ) );
+		this.certusQuartzWrench = this.getMaybeDefinition( new ToolQuartzWrench( AEFeature.CertusQuartzTools ) );
+		this.certusQuartzKnife = this.getMaybeDefinition( new ToolQuartzCuttingKnife( AEFeature.CertusQuartzTools ) );
+
+		this.netherQuartzAxe = this.getMaybeDefinition( new ToolQuartzAxe( AEFeature.NetherQuartzTools ) );
+		this.netherQuartzHoe = this.getMaybeDefinition( new ToolQuartzHoe( AEFeature.NetherQuartzTools ) );
+		this.netherQuartzShovel = this.getMaybeDefinition( new ToolQuartzSpade( AEFeature.NetherQuartzTools ) );
+		this.netherQuartzPick = this.getMaybeDefinition( new ToolQuartzPickaxe( AEFeature.NetherQuartzTools ) );
+		this.netherQuartzSword = this.getMaybeDefinition( new ToolQuartzSword( AEFeature.NetherQuartzTools ) );
+		this.netherQuartzWrench = this.getMaybeDefinition( new ToolQuartzWrench( AEFeature.NetherQuartzTools ) );
+		this.netherQuartzKnife = this.getMaybeDefinition( new ToolQuartzCuttingKnife( AEFeature.NetherQuartzTools ) );
+
+		this.entropyManipulator = this.getMaybeDefinition( new ToolEntropyManipulator() );
+		this.wirelessTerminal = this.getMaybeDefinition( new ToolWirelessTerminal() );
+		this.biometricCard = this.getMaybeDefinition( new ToolBiometricCard() );
+		this.chargedStaff = this.getMaybeDefinition( new ToolChargedStaff() );
+		this.massCannon = this.getMaybeDefinition( new ToolMassCannon() );
+		this.memoryCard = this.getMaybeDefinition( new ToolMemoryCard() );
+		this.networkTool = this.getMaybeDefinition( new ToolNetworkTool() );
+		this.portableCell = this.getMaybeDefinition( new ToolPortableCell() );
+
+		this.cellCreative = this.getMaybeDefinition( new ItemCreativeStorageCell() );
+		this.viewCell = this.getMaybeDefinition( new ItemViewCell() );
+
+		this.cell1k = this.getMaybeDefinition( new ItemBasicStorageCell( MaterialType.Cell1kPart, 1 ) );
+		this.cell4k = this.getMaybeDefinition( new ItemBasicStorageCell( MaterialType.Cell4kPart, 4 ) );
+		this.cell16k = this.getMaybeDefinition( new ItemBasicStorageCell( MaterialType.Cell16kPart, 16 ) );
+		this.cell64k = this.getMaybeDefinition( new ItemBasicStorageCell( MaterialType.Cell64kPart, 64 ) );
+
+		this.spatialCell2 = this.getMaybeDefinition( new ItemSpatialStorageCell( MaterialType.Cell2SpatialPart, 2 ) );
+		this.spatialCell16 = this.getMaybeDefinition( new ItemSpatialStorageCell( MaterialType.Cell2SpatialPart, 16 ) );
+		this.spatialCell128 = this.getMaybeDefinition( new ItemSpatialStorageCell( MaterialType.Cell2SpatialPart, 128 ) );
+
+		this.facade = this.getMaybeDefinition( new ItemFacade() );
+		this.crystalSeed = this.getMaybeDefinition( new ItemCrystalSeed() );
+
+		// rv1
+		this.encodedPattern = this.getMaybeDefinition( new ItemEncodedPattern() );
+		this.colorApplicator = this.getMaybeDefinition( new ToolColorApplicator() );
+
+		this.paintBall = this.getMaybeDefinition( new ItemPaintBall() );
+		this.coloredPaintBall = this.paintBall.transform( new ColoredTransformationFunction( new ColoredItemDefinition(), 0 ) );
+		this.coloredLumenPaintBall = this.paintBall.transform( new ColoredTransformationFunction( new ColoredItemDefinition(), 20 ) );
+
+		this.toolEraser = this.getMaybeDefinition( new ToolEraser() );
+		this.toolMeteoritePlacer = this.getMaybeDefinition( new ToolMeteoritePlacer() );
+		this.toolDebugCard = this.getMaybeDefinition( new ToolDebugCard() );
+		this.toolReplicatorCard = this.getMaybeDefinition( new ToolReplicatorCard() );
+	}
+
+	private Optional<AEItemDefinition> getMaybeDefinition( IAEFeature feature )
+	{
+		final IFeatureHandler handler = feature.handler();
+
+		if ( handler.isFeatureAvailable() )
+		{
+			this.handlers.addFeatureHandler( handler );
+			this.features.addFeature( feature );
+
+			return Optional.of( handler.getDefinition() );
+		}
+		else
+		{
+			return Optional.absent();
+		}
+	}
+
+	@Override
+	public Optional<AEItemDefinition> certusQuartzAxe()
+	{
+		return this.certusQuartzAxe;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> certusQuartzHoe()
+	{
+		return this.certusQuartzHoe;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> certusQuartzShovel()
+	{
+		return this.certusQuartzShovel;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> certusQuartzPick()
+	{
+		return this.certusQuartzPick;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> certusQuartzSword()
+	{
+		return this.certusQuartzSword;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> certusQuartzWrench()
+	{
+		return this.certusQuartzWrench;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> certusQuartzKnife()
+	{
+		return this.certusQuartzKnife;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> netherQuartzAxe()
+	{
+		return this.netherQuartzAxe;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> netherQuartzHoe()
+	{
+		return this.netherQuartzHoe;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> netherQuartzShovel()
+	{
+		return this.netherQuartzShovel;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> netherQuartzPick()
+	{
+		return this.netherQuartzPick;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> netherQuartzSword()
+	{
+		return this.netherQuartzSword;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> netherQuartzWrench()
+	{
+		return this.netherQuartzWrench;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> netherQuartzKnife()
+	{
+		return this.netherQuartzKnife;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> entropyManipulator()
+	{
+		return this.entropyManipulator;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> wirelessTerminal()
+	{
+		return this.wirelessTerminal;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> biometricCard()
+	{
+		return this.biometricCard;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> chargedStaff()
+	{
+		return this.chargedStaff;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> massCannon()
+	{
+		return this.massCannon;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> memoryCard()
+	{
+		return this.memoryCard;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> networkTool()
+	{
+		return this.networkTool;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> portableCell()
+	{
+		return this.portableCell;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> cellCreative()
+	{
+		return this.cellCreative;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> viewCell()
+	{
+		return this.viewCell;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> cell1k()
+	{
+		return this.cell1k;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> cell4k()
+	{
+		return this.cell4k;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> cell16k()
+	{
+		return this.cell16k;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> cell64k()
+	{
+		return this.cell64k;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> spatialCell2()
+	{
+		return this.spatialCell2;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> spatialCell16()
+	{
+		return this.spatialCell16;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> spatialCell128()
+	{
+		return this.spatialCell128;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> facade()
+	{
+		return this.facade;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> crystalSeed()
+	{
+		return this.crystalSeed;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> encodedPattern()
+	{
+		return this.encodedPattern;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> colorApplicator()
+	{
+		return this.colorApplicator;
+	}
+
+	@Override
+	public Optional<AEColoredItemDefinition> coloredPaintBall()
+	{
+		return this.coloredPaintBall;
+	}
+
+	@Override
+	public Optional<AEColoredItemDefinition> coloredLumenPaintBall()
+	{
+		return this.coloredLumenPaintBall;
+	}
+
+	public Optional<AEItemDefinition> paintBall()
+	{
+		return this.paintBall;
+	}
+
+	public Optional<AEItemDefinition> toolEraser()
+	{
+		return this.toolEraser;
+	}
+
+	public Optional<AEItemDefinition> toolMeteoritePlacer()
+	{
+		return this.toolMeteoritePlacer;
+	}
+
+	public Optional<AEItemDefinition> toolDebugCard()
+	{
+		return this.toolDebugCard;
+	}
+
+	public Optional<AEItemDefinition> toolReplicatorCard()
+	{
+		return this.toolReplicatorCard;
+	}
+
+	private static final class ColoredTransformationFunction implements Function<AEItemDefinition, AEColoredItemDefinition>
+	{
+		private final ColoredItemDefinition colorDefinition;
+		private final int offset;
+
+		public ColoredTransformationFunction( ColoredItemDefinition colorDefinition, int offset )
+		{
+			this.colorDefinition = colorDefinition;
+			this.offset = offset;
+		}
+
+		@Nullable
+		@Override
+		public AEColoredItemDefinition apply( AEItemDefinition input )
+		{
+			final Item item = input.item();
+
+			for ( AEColor color : AEColor.VALID_COLORS )
+			{
+				this.colorDefinition.add( color, new ItemStackSrc( item, this.offset + color.ordinal() ) );
+			}
+
+			return this.colorDefinition;
+		}
+	}
+}

--- a/src/main/java/appeng/core/api/definitions/ApiMaterials.java
+++ b/src/main/java/appeng/core/api/definitions/ApiMaterials.java
@@ -1,0 +1,570 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.core.api.definitions;
+
+
+import javax.annotation.Nullable;
+
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+
+import appeng.api.definitions.IMaterials;
+import appeng.api.util.AEItemDefinition;
+import appeng.core.FeatureHandlerRegistry;
+import appeng.core.FeatureRegistry;
+import appeng.core.features.DamagedItemDefinition;
+import appeng.core.features.IAEFeature;
+import appeng.core.features.IFeatureHandler;
+import appeng.core.features.IStackSrc;
+import appeng.core.features.NullItemDefinition;
+import appeng.items.materials.ItemMultiMaterial;
+import appeng.items.materials.MaterialType;
+
+
+/**
+ * Internal implementation for the API materials
+ */
+public final class ApiMaterials implements IMaterials
+{
+	private final FeatureRegistry features;
+	private final FeatureHandlerRegistry handlers;
+
+	private final Optional<AEItemDefinition> cell2SpatialPart;
+	private final Optional<AEItemDefinition> cell16SpatialPart;
+	private final Optional<AEItemDefinition> cell128SpatialPart;
+
+	private final Optional<AEItemDefinition> silicon;
+	private final Optional<AEItemDefinition> skyDust;
+
+	private final Optional<AEItemDefinition> calcProcessorPress;
+	private final Optional<AEItemDefinition> engProcessorPress;
+	private final Optional<AEItemDefinition> logicProcessorPress;
+
+	private final Optional<AEItemDefinition> calcProcessorPrint;
+	private final Optional<AEItemDefinition> engProcessorPrint;
+	private final Optional<AEItemDefinition> logicProcessorPrint;
+
+	private final Optional<AEItemDefinition> siliconPress;
+	private final Optional<AEItemDefinition> siliconPrint;
+
+	private final Optional<AEItemDefinition> namePress;
+
+	private final Optional<AEItemDefinition> logicProcessor;
+	private final Optional<AEItemDefinition> calcProcessor;
+	private final Optional<AEItemDefinition> engProcessor;
+
+	private final Optional<AEItemDefinition> basicCard;
+	private final Optional<AEItemDefinition> advCard;
+
+	private final Optional<AEItemDefinition> purifiedCertusQuartzCrystal;
+	private final Optional<AEItemDefinition> purifiedNetherQuartzCrystal;
+	private final Optional<AEItemDefinition> purifiedFluixCrystal;
+
+	private final Optional<AEItemDefinition> cell1kPart;
+	private final Optional<AEItemDefinition> cell4kPart;
+	private final Optional<AEItemDefinition> cell16kPart;
+	private final Optional<AEItemDefinition> cell64kPart;
+	private final Optional<AEItemDefinition> emptyStorageCell;
+
+	private final Optional<AEItemDefinition> cardRedstone;
+	private final Optional<AEItemDefinition> cardSpeed;
+	private final Optional<AEItemDefinition> cardCapacity;
+	private final Optional<AEItemDefinition> cardFuzzy;
+	private final Optional<AEItemDefinition> cardInverter;
+	private final Optional<AEItemDefinition> cardCrafting;
+
+	private final Optional<AEItemDefinition> enderDust;
+	private final Optional<AEItemDefinition> flour;
+	private final Optional<AEItemDefinition> goldDust;
+	private final Optional<AEItemDefinition> ironDust;
+	private final Optional<AEItemDefinition> fluixDust;
+	private final Optional<AEItemDefinition> certusQuartzDust;
+	private final Optional<AEItemDefinition> netherQuartzDust;
+
+	private final Optional<AEItemDefinition> matterBall;
+	private final Optional<AEItemDefinition> ironNugget;
+
+	private final Optional<AEItemDefinition> certusQuartzCrystal;
+	private final Optional<AEItemDefinition> certusQuartzCrystalCharged;
+	private final Optional<AEItemDefinition> fluixCrystal;
+	private final Optional<AEItemDefinition> fluixPearl;
+
+	private final Optional<AEItemDefinition> woodenGear;
+
+	private final Optional<AEItemDefinition> wireless;
+	private final Optional<AEItemDefinition> wirelessBooster;
+
+	private final Optional<AEItemDefinition> annihilationCore;
+	private final Optional<AEItemDefinition> formationCore;
+
+	private final Optional<AEItemDefinition> singularity;
+	private final Optional<AEItemDefinition> qESingularity;
+	private final Optional<AEItemDefinition> blankPattern;
+
+	public ApiMaterials( FeatureRegistry features, FeatureHandlerRegistry handlers )
+	{
+		this.features = features;
+		this.handlers = handlers;
+
+		final ItemMultiMaterial itemMultiMaterial = new ItemMultiMaterial();
+		final Optional<AEItemDefinition> multiMaterial = this.getMaybeDefinition( itemMultiMaterial );
+
+		this.cell2SpatialPart = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.Cell2SpatialPart ) );
+		this.cell16SpatialPart = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.Cell16SpatialPart ) );
+		this.cell128SpatialPart = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.Cell128SpatialPart ) );
+
+		this.silicon = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.Silicon ) );
+		this.skyDust = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.SkyDust ) );
+
+		this.calcProcessorPress = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.CalcProcessorPress ) );
+		this.engProcessorPress = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.EngProcessorPress ) );
+		this.logicProcessorPress = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.LogicProcessorPress ) );
+
+		this.calcProcessorPrint = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.CalcProcessorPrint ) );
+		this.engProcessorPrint = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.EngProcessorPrint ) );
+		this.logicProcessorPrint = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.LogicProcessorPrint ) );
+
+		this.siliconPress = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.SiliconPress ) );
+		this.siliconPrint = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.SiliconPrint ) );
+
+		this.namePress = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.NamePress ) );
+
+		this.logicProcessor = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.LogicProcessor ) );
+		this.calcProcessor = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.CalcProcessor ) );
+		this.engProcessor = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.EngProcessor ) );
+
+		this.basicCard = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.BasicCard ) );
+		this.advCard = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.AdvCard ) );
+
+		this.purifiedCertusQuartzCrystal = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.PurifiedCertusQuartzCrystal ) );
+		this.purifiedNetherQuartzCrystal = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.PurifiedNetherQuartzCrystal ) );
+		this.purifiedFluixCrystal = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.PurifiedFluixCrystal ) );
+
+		this.cell1kPart = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.Cell1kPart ) );
+		this.cell4kPart = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.Cell4kPart ) );
+		this.cell16kPart = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.Cell16kPart ) );
+		this.cell64kPart = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.Cell64kPart ) );
+		this.emptyStorageCell = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.EmptyStorageCell ) );
+
+		this.cardRedstone = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.CardRedstone ) );
+		this.cardSpeed = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.CardSpeed ) );
+		this.cardCapacity = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.CardCapacity ) );
+		this.cardFuzzy = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.CardFuzzy ) );
+		this.cardInverter = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.CardInverter ) );
+		this.cardCrafting = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.CardCrafting ) );
+
+		this.enderDust = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.EnderDust ) );
+		this.flour = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.Flour ) );
+		this.goldDust = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.GoldDust ) );
+		this.ironDust = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.IronDust ) );
+		this.fluixDust = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.FluixDust ) );
+		this.certusQuartzDust = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.CertusQuartzDust ) );
+		this.netherQuartzDust = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.NetherQuartzDust ) );
+
+		this.matterBall = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.MatterBall ) );
+		this.ironNugget = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.IronNugget ) );
+
+		this.certusQuartzCrystal = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.CertusQuartzCrystal ) );
+		this.certusQuartzCrystalCharged = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.CertusQuartzCrystalCharged ) );
+		this.fluixCrystal = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.FluixCrystal ) );
+		this.fluixPearl = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.FluixPearl ) );
+
+		this.woodenGear = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.WoodenGear ) );
+
+		this.wireless = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.Wireless ) );
+		this.wirelessBooster = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.WirelessBooster ) );
+
+		this.annihilationCore = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.AnnihilationCore ) );
+		this.formationCore = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.FormationCore ) );
+
+		this.singularity = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.Singularity ) );
+		this.qESingularity = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.QESingularity ) );
+		this.blankPattern = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.BlankPattern ) );
+	}
+
+	private Optional<AEItemDefinition> getMaybeDefinition( IAEFeature feature )
+	{
+		final IFeatureHandler handler = feature.handler();
+
+		if ( handler.isFeatureAvailable() )
+		{
+			this.handlers.addFeatureHandler( handler );
+			this.features.addFeature( feature );
+
+			return Optional.of( handler.getDefinition() );
+		}
+		else
+		{
+			return Optional.absent();
+		}
+	}
+
+	@Override
+	public Optional<AEItemDefinition> cell2SpatialPart()
+	{
+		return this.cell2SpatialPart;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> cell16SpatialPart()
+	{
+		return this.cell16SpatialPart;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> cell128SpatialPart()
+	{
+		return this.cell128SpatialPart;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> silicon()
+	{
+		return this.silicon;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> skyDust()
+	{
+		return this.skyDust;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> calcProcessorPress()
+	{
+		return this.calcProcessorPress;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> engProcessorPress()
+	{
+		return this.engProcessorPress;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> logicProcessorPress()
+	{
+		return this.logicProcessorPress;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> calcProcessorPrint()
+	{
+		return this.calcProcessorPrint;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> engProcessorPrint()
+	{
+		return this.engProcessorPrint;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> logicProcessorPrint()
+	{
+		return this.logicProcessorPrint;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> siliconPress()
+	{
+		return this.siliconPress;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> siliconPrint()
+	{
+		return this.siliconPrint;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> namePress()
+	{
+		return this.namePress;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> logicProcessor()
+	{
+		return this.logicProcessor;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> calcProcessor()
+	{
+		return this.calcProcessor;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> engProcessor()
+	{
+		return this.engProcessor;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> basicCard()
+	{
+		return this.basicCard;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> advCard()
+	{
+		return this.advCard;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> purifiedCertusQuartzCrystal()
+	{
+		return this.purifiedCertusQuartzCrystal;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> purifiedNetherQuartzCrystal()
+	{
+		return this.purifiedNetherQuartzCrystal;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> purifiedFluixCrystal()
+	{
+		return this.purifiedFluixCrystal;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> cell1kPart()
+	{
+		return this.cell1kPart;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> cell4kPart()
+	{
+		return this.cell4kPart;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> cell16kPart()
+	{
+		return this.cell16kPart;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> cell64kPart()
+	{
+		return this.cell64kPart;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> emptyStorageCell()
+	{
+		return this.emptyStorageCell;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> cardRedstone()
+	{
+		return this.cardRedstone;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> cardSpeed()
+	{
+		return this.cardSpeed;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> cardCapacity()
+	{
+		return this.cardCapacity;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> cardFuzzy()
+	{
+		return this.cardFuzzy;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> cardInverter()
+	{
+		return this.cardInverter;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> cardCrafting()
+	{
+		return this.cardCrafting;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> enderDust()
+	{
+		return this.enderDust;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> flour()
+	{
+		return this.flour;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> goldDust()
+	{
+		return this.goldDust;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> ironDust()
+	{
+		return this.ironDust;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> fluixDust()
+	{
+		return this.fluixDust;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> certusQuartzDust()
+	{
+		return this.certusQuartzDust;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> netherQuartzDust()
+	{
+		return this.netherQuartzDust;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> matterBall()
+	{
+		return this.matterBall;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> ironNugget()
+	{
+		return this.ironNugget;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> certusQuartzCrystal()
+	{
+		return this.certusQuartzCrystal;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> certusQuartzCrystalCharged()
+	{
+		return this.certusQuartzCrystalCharged;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> fluixCrystal()
+	{
+		return this.fluixCrystal;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> fluixPearl()
+	{
+		return this.fluixPearl;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> woodenGear()
+	{
+		return this.woodenGear;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> wireless()
+	{
+		return this.wireless;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> wirelessBooster()
+	{
+		return this.wirelessBooster;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> annihilationCore()
+	{
+		return this.annihilationCore;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> formationCore()
+	{
+		return this.formationCore;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> singularity()
+	{
+		return this.singularity;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> qESingularity()
+	{
+		return this.qESingularity;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> blankPattern()
+	{
+		return this.blankPattern;
+	}
+
+	private static final class MaterialTransformationFunction implements Function<AEItemDefinition, AEItemDefinition>
+	{
+		private final ItemMultiMaterial itemMultiMaterial;
+		private final MaterialType type;
+
+		public MaterialTransformationFunction( ItemMultiMaterial itemMultiMaterial, MaterialType type )
+		{
+			this.itemMultiMaterial = itemMultiMaterial;
+			this.type = type;
+		}
+
+		@Nullable
+		@Override
+		public AEItemDefinition apply( AEItemDefinition input )
+		{
+			final IStackSrc stackSource = this.itemMultiMaterial.createMaterial( this.type );
+			final Optional<IStackSrc> maybeSource = Optional.fromNullable( stackSource );
+
+			if ( maybeSource.isPresent() )
+			{
+				return new DamagedItemDefinition( stackSource );
+			}
+			else
+			{
+				return new NullItemDefinition();
+			}
+		}
+	}
+}

--- a/src/main/java/appeng/core/api/definitions/ApiParts.java
+++ b/src/main/java/appeng/core/api/definitions/ApiParts.java
@@ -1,0 +1,429 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.core.api.definitions;
+
+
+import javax.annotation.Nullable;
+
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+
+import appeng.api.definitions.IParts;
+import appeng.api.parts.IPartHelper;
+import appeng.api.util.AEColor;
+import appeng.api.util.AEColoredItemDefinition;
+import appeng.api.util.AEItemDefinition;
+import appeng.core.FeatureHandlerRegistry;
+import appeng.core.FeatureRegistry;
+import appeng.core.features.ColoredItemDefinition;
+import appeng.core.features.DamagedItemDefinition;
+import appeng.core.features.IAEFeature;
+import appeng.core.features.IFeatureHandler;
+import appeng.core.features.IStackSrc;
+import appeng.core.features.ItemStackSrc;
+import appeng.core.features.NullItemDefinition;
+import appeng.items.parts.ItemMultiPart;
+import appeng.items.parts.PartType;
+
+
+/**
+ * Internal implementation for the API parts
+ */
+public final class ApiParts implements IParts
+{
+	private final FeatureRegistry features;
+	private final FeatureHandlerRegistry handlers;
+
+	private final Optional<AEColoredItemDefinition> cableSmart;
+	private final Optional<AEColoredItemDefinition> cableCovered;
+	private final Optional<AEColoredItemDefinition> cableGlass;
+	private final Optional<AEColoredItemDefinition> cableDense;
+	private final Optional<AEColoredItemDefinition> lumenCableSmart;
+	private final Optional<AEColoredItemDefinition> lumenCableCovered;
+	private final Optional<AEColoredItemDefinition> lumenCableGlass;
+	private final Optional<AEColoredItemDefinition> lumenCableDense;
+	private final Optional<AEItemDefinition> quartzFiber;
+	private final Optional<AEItemDefinition> toggleBus;
+	private final Optional<AEItemDefinition> invertedToggleBus;
+	private final Optional<AEItemDefinition> storageBus;
+	private final Optional<AEItemDefinition> importBus;
+	private final Optional<AEItemDefinition> exportBus;
+	private final Optional<AEItemDefinition> iface;
+	private final Optional<AEItemDefinition> levelEmitter;
+	private final Optional<AEItemDefinition> annihilationPlane;
+	private final Optional<AEItemDefinition> formationPlane;
+	private final Optional<AEItemDefinition> p2PTunnelME;
+	private final Optional<AEItemDefinition> p2PTunnelRedstone;
+	private final Optional<AEItemDefinition> p2PTunnelItems;
+	private final Optional<AEItemDefinition> p2PTunnelLiquids;
+	private final Optional<AEItemDefinition> p2PTunnelMJ;
+	private final Optional<AEItemDefinition> p2PTunnelEU;
+	private final Optional<AEItemDefinition> p2PTunnelRF;
+	private final Optional<AEItemDefinition> p2PTunnelLight;
+	private final Optional<AEItemDefinition> cableAnchor;
+	private final Optional<AEItemDefinition> monitor;
+	private final Optional<AEItemDefinition> semiDarkMonitor;
+	private final Optional<AEItemDefinition> darkMonitor;
+	private final Optional<AEItemDefinition> interfaceTerminal;
+	private final Optional<AEItemDefinition> patternTerminal;
+	private final Optional<AEItemDefinition> craftingTerminal;
+	private final Optional<AEItemDefinition> terminal;
+	private final Optional<AEItemDefinition> storageMonitor;
+	private final Optional<AEItemDefinition> conversionMonitor;
+
+	public ApiParts( FeatureRegistry features, FeatureHandlerRegistry handlers, IPartHelper partHelper )
+	{
+		this.features = features;
+		this.handlers = handlers;
+
+		final ItemMultiPart itemMultiPart = new ItemMultiPart( partHelper );
+		final Optional<AEItemDefinition> multiPart = this.getMaybeDefinition( itemMultiPart );
+
+		this.cableSmart = multiPart.transform( new ColoredPartTransformationFunction( itemMultiPart, PartType.CableSmart ) );
+		this.cableCovered = multiPart.transform( new ColoredPartTransformationFunction( itemMultiPart, PartType.CableCovered ) );
+		this.cableGlass = multiPart.transform( new ColoredPartTransformationFunction( itemMultiPart, PartType.CableGlass ) );
+		this.cableDense = multiPart.transform( new ColoredPartTransformationFunction( itemMultiPart, PartType.CableDense ) );
+		this.lumenCableSmart = Optional.absent(); // has yet to be implemented, no PartType defined for it yet
+		this.lumenCableCovered = Optional.absent(); // has yet to be implemented, no PartType defined for it yet
+		this.lumenCableGlass = Optional.absent(); // has yet to be implemented, no PartType defined for it yet
+		this.lumenCableDense = Optional.absent(); // has yet to be implemented, no PartType defined for it yet
+		this.quartzFiber = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.QuartzFiber ) );
+		this.toggleBus = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.ToggleBus ) );
+		this.invertedToggleBus = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.InvertedToggleBus ) );
+		this.storageBus = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.StorageBus ) );
+		this.importBus = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.ImportBus ) );
+		this.exportBus = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.ExportBus ) );
+		this.iface = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.Interface ) );
+		this.levelEmitter = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.LevelEmitter ) );
+		this.annihilationPlane = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.AnnihilationPlane ) );
+		this.formationPlane = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.FormationPlane ) );
+		this.p2PTunnelME = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.P2PTunnelME ) );
+		this.p2PTunnelRedstone = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.P2PTunnelRedstone ) );
+		this.p2PTunnelItems = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.P2PTunnelItems ) );
+		this.p2PTunnelLiquids = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.P2PTunnelLiquids ) );
+		this.p2PTunnelMJ = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.P2PTunnelMJ ) );
+		this.p2PTunnelEU = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.P2PTunnelEU ) );
+		this.p2PTunnelRF = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.P2PTunnelRF ) );
+		this.p2PTunnelLight = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.P2PTunnelLight ) );
+		this.cableAnchor = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.CableAnchor ) );
+		this.monitor = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.Monitor ) );
+		this.semiDarkMonitor = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.SemiDarkMonitor ) );
+		this.darkMonitor = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.DarkMonitor ) );
+		this.interfaceTerminal = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.InterfaceTerminal ) );
+		this.patternTerminal = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.PatternTerminal ) );
+		this.craftingTerminal = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.CraftingTerminal ) );
+		this.terminal = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.Terminal ) );
+		this.storageMonitor = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.StorageMonitor ) );
+		this.conversionMonitor = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.ConversionMonitor ) );
+	}
+
+	private Optional<AEItemDefinition> getMaybeDefinition( IAEFeature feature )
+	{
+		final IFeatureHandler handler = feature.handler();
+
+		if ( handler.isFeatureAvailable() )
+		{
+			this.handlers.addFeatureHandler( handler );
+			this.features.addFeature( feature );
+
+			return Optional.of( handler.getDefinition() );
+		}
+		else
+		{
+			return Optional.absent();
+		}
+	}
+
+	@Override
+	public Optional<AEColoredItemDefinition> cableSmart()
+	{
+		return this.cableSmart;
+	}
+
+	@Override
+	public Optional<AEColoredItemDefinition> cableCovered()
+	{
+		return this.cableCovered;
+	}
+
+	@Override
+	public Optional<AEColoredItemDefinition> cableGlass()
+	{
+		return this.cableGlass;
+	}
+
+	@Override
+	public Optional<AEColoredItemDefinition> cableDense()
+	{
+		return this.cableDense;
+	}
+
+	@Override
+	public Optional<AEColoredItemDefinition> lumenCableSmart()
+	{
+		return this.lumenCableSmart;
+	}
+
+	@Override
+	public Optional<AEColoredItemDefinition> lumenCableCovered()
+	{
+		return this.lumenCableCovered;
+	}
+
+	@Override
+	public Optional<AEColoredItemDefinition> lumenCableGlass()
+	{
+		return this.lumenCableGlass;
+	}
+
+	@Override
+	public Optional<AEColoredItemDefinition> lumenCableDense()
+	{
+		return this.lumenCableDense;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> quartzFiber()
+	{
+		return this.quartzFiber;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> toggleBus()
+	{
+		return this.toggleBus;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> invertedToggleBus()
+	{
+		return this.invertedToggleBus;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> storageBus()
+	{
+		return this.storageBus;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> importBus()
+	{
+		return this.importBus;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> exportBus()
+	{
+		return this.exportBus;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> iface()
+	{
+		return this.iface;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> levelEmitter()
+	{
+		return this.levelEmitter;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> annihilationPlane()
+	{
+		return this.annihilationPlane;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> formationPlane()
+	{
+		return this.formationPlane;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> p2PTunnelME()
+	{
+		return this.p2PTunnelME;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> p2PTunnelRedstone()
+	{
+		return this.p2PTunnelRedstone;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> p2PTunnelItems()
+	{
+		return this.p2PTunnelItems;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> p2PTunnelLiquids()
+	{
+		return this.p2PTunnelLiquids;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> p2PTunnelMJ()
+	{
+		return this.p2PTunnelMJ;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> p2PTunnelEU()
+	{
+		return this.p2PTunnelEU;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> p2PTunnelRF()
+	{
+		return this.p2PTunnelRF;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> p2PTunnelLight()
+	{
+		return this.p2PTunnelLight;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> cableAnchor()
+	{
+		return this.cableAnchor;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> monitor()
+	{
+		return this.monitor;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> semiDarkMonitor()
+	{
+		return this.semiDarkMonitor;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> darkMonitor()
+	{
+		return this.darkMonitor;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> interfaceTerminal()
+	{
+		return this.interfaceTerminal;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> patternTerminal()
+	{
+		return this.patternTerminal;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> craftingTerminal()
+	{
+		return this.craftingTerminal;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> terminal()
+	{
+		return this.terminal;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> storageMonitor()
+	{
+		return this.storageMonitor;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> conversionMonitor()
+	{
+		return this.conversionMonitor;
+	}
+
+	private static final class ColoredPartTransformationFunction implements Function<AEItemDefinition, AEColoredItemDefinition>
+	{
+		private final ItemMultiPart multiPart;
+		private final PartType type;
+
+		public ColoredPartTransformationFunction( ItemMultiPart multiPart, PartType type )
+		{
+			this.multiPart = multiPart;
+			this.type = type;
+		}
+
+		@Nullable
+		@Override
+		public AEColoredItemDefinition apply( @Nullable AEItemDefinition input )
+		{
+			final ColoredItemDefinition coloredDefinition = new ColoredItemDefinition();
+			for ( AEColor color : this.type.getVariants() )
+			{
+				ItemStackSrc multiPartSource = this.multiPart.createPart( this.type, color );
+				final Optional<ItemStackSrc> maybeSource = Optional.fromNullable( multiPartSource );
+
+				if ( maybeSource.isPresent() )
+				{
+					coloredDefinition.add( color, multiPartSource );
+				}
+			}
+
+			return coloredDefinition;
+		}
+	}
+
+
+	private static final class PartTransformationFunction implements Function<AEItemDefinition, AEItemDefinition>
+	{
+		private final ItemMultiPart multiPart;
+		private final PartType type;
+
+		public PartTransformationFunction( ItemMultiPart multiPart, PartType type )
+		{
+			this.multiPart = multiPart;
+			this.type = type;
+		}
+
+		@Nullable
+		@Override
+		public AEItemDefinition apply( AEItemDefinition input )
+		{
+			final IStackSrc stackSource = this.multiPart.createPart( this.type, null );
+			final Optional<IStackSrc> maybeSource = Optional.fromNullable( stackSource );
+
+			if ( maybeSource.isPresent() )
+			{
+				return new DamagedItemDefinition( stackSource );
+			}
+			else
+			{
+				return new NullItemDefinition();
+			}
+		}
+	}
+}

--- a/src/main/java/appeng/core/features/AEBlockFeatureHandler.java
+++ b/src/main/java/appeng/core/features/AEBlockFeatureHandler.java
@@ -46,7 +46,7 @@ public class AEBlockFeatureHandler implements IFeatureHandler
 		this.features = features;
 		this.featured = featured;
 		this.extractor = new FeatureNameExtractor( featured.getClass(), subName );
-		this.enabled = new FeaturedActiveChecker( features ).get();
+		this.enabled = new FeaturedActiveChecker( features ).isFeatureActive();
 		this.definition = new AEBlockDefinition( featured, this.enabled );
 	}
 

--- a/src/main/java/appeng/core/features/FeaturedActiveChecker.java
+++ b/src/main/java/appeng/core/features/FeaturedActiveChecker.java
@@ -33,7 +33,7 @@ public class FeaturedActiveChecker
 		this.features = features;
 	}
 
-	public boolean get()
+	public boolean isFeatureActive()
 	{
 		for ( AEFeature f : this.features )
 		{

--- a/src/main/java/appeng/core/features/ItemFeatureHandler.java
+++ b/src/main/java/appeng/core/features/ItemFeatureHandler.java
@@ -46,7 +46,7 @@ public class ItemFeatureHandler implements IFeatureHandler
 		this.features = features;
 		this.item = item;
 		this.extractor = new FeatureNameExtractor( featured.getClass(), subName );
-		this.enabled = new FeaturedActiveChecker( features ).get();
+		this.enabled = new FeaturedActiveChecker( features ).isFeatureActive();
 		this.definition = new ItemDefinition( item, this.enabled );
 	}
 

--- a/src/main/java/appeng/core/features/StairBlockFeatureHandler.java
+++ b/src/main/java/appeng/core/features/StairBlockFeatureHandler.java
@@ -44,7 +44,7 @@ public class StairBlockFeatureHandler implements IFeatureHandler
 		this.features = features;
 		this.stairs = stairs;
 		this.extractor = new FeatureNameExtractor( stairs.getClass(), subName );
-		this.enabled = new FeaturedActiveChecker( features ).get();
+		this.enabled = new FeaturedActiveChecker( features ).isFeatureActive();
 		this.definition = new BlockDefinition( stairs, this.enabled );
 	}
 

--- a/src/main/java/appeng/core/features/registries/P2PTunnelRegistry.java
+++ b/src/main/java/appeng/core/features/registries/P2PTunnelRegistry.java
@@ -30,7 +30,8 @@ import cpw.mods.fml.common.registry.GameRegistry;
 
 import appeng.api.AEApi;
 import appeng.api.config.TunnelType;
-import appeng.api.definitions.Parts;
+import appeng.api.definitions.IBlocks;
+import appeng.api.definitions.IParts;
 import appeng.api.features.IP2PTunnelRegistry;
 import appeng.api.util.AEColor;
 import appeng.util.Platform;
@@ -78,14 +79,14 @@ public class P2PTunnelRegistry implements IP2PTunnelRegistry
 		/**
 		 * attune based on lots of random item related stuff
 		 */
-		appeng.api.definitions.Blocks AEBlocks = AEApi.instance().blocks();
-		Parts Parts = AEApi.instance().parts();
+		IBlocks AEBlocks = AEApi.instance().definitions().blocks();
+		IParts Parts = AEApi.instance().definitions().parts();
 
-		this.addNewAttunement( AEBlocks.blockInterface.stack( 1 ), TunnelType.ITEM );
-		this.addNewAttunement( Parts.partInterface.stack( 1 ), TunnelType.ITEM );
-		this.addNewAttunement( Parts.partStorageBus.stack( 1 ), TunnelType.ITEM );
-		this.addNewAttunement( Parts.partImportBus.stack( 1 ), TunnelType.ITEM );
-		this.addNewAttunement( Parts.partExportBus.stack( 1 ), TunnelType.ITEM );
+		this.addNewAttunement( AEBlocks.iface().get().stack( 1 ), TunnelType.ITEM );
+		this.addNewAttunement( Parts.iface().get().stack( 1 ), TunnelType.ITEM );
+		this.addNewAttunement( Parts.storageBus().get().stack( 1 ), TunnelType.ITEM );
+		this.addNewAttunement( Parts.importBus().get().stack( 1 ), TunnelType.ITEM );
+		this.addNewAttunement( Parts.exportBus().get().stack( 1 ), TunnelType.ITEM );
 		this.addNewAttunement( new ItemStack( Blocks.hopper ), TunnelType.ITEM );
 		this.addNewAttunement( new ItemStack( Blocks.chest ), TunnelType.ITEM );
 		this.addNewAttunement( new ItemStack( Blocks.trapped_chest ), TunnelType.ITEM );
@@ -108,10 +109,10 @@ public class P2PTunnelRegistry implements IP2PTunnelRegistry
 
 		for (AEColor c : AEColor.values())
 		{
-			this.addNewAttunement( Parts.partCableGlass.stack( c, 1 ), TunnelType.ME );
-			this.addNewAttunement( Parts.partCableCovered.stack( c, 1 ), TunnelType.ME );
-			this.addNewAttunement( Parts.partCableSmart.stack( c, 1 ), TunnelType.ME );
-			this.addNewAttunement( Parts.partCableDense.stack( c, 1 ), TunnelType.ME );
+			this.addNewAttunement( Parts.cableGlass().get().stack( c, 1 ), TunnelType.ME );
+			this.addNewAttunement( Parts.cableCovered().get().stack( c, 1 ), TunnelType.ME );
+			this.addNewAttunement( Parts.cableSmart().get().stack( c, 1 ), TunnelType.ME );
+			this.addNewAttunement( Parts.cableDense().get().stack( c, 1 ), TunnelType.ME );
 		}
 	}
 

--- a/src/main/java/appeng/core/stats/Achievements.java
+++ b/src/main/java/appeng/core/stats/Achievements.java
@@ -33,79 +33,79 @@ public enum Achievements
 {
 
 	// done
-	Compass( -2, -4, AEApi.instance().blocks().blockSkyCompass, AchievementType.Craft ),
+	Compass( -2, -4, AEApi.instance().definitions().blocks().skyCompass().get(), AchievementType.Craft ),
 
 	// done
-	Presses( -2, -2, AEApi.instance().materials().materialLogicProcessorPress, AchievementType.Custom ),
+	Presses( -2, -2, AEApi.instance().definitions().materials().logicProcessorPress().get(), AchievementType.Custom ),
 
 	// done
-	SpatialIO( -4, -4, AEApi.instance().blocks().blockSpatialIOPort, AchievementType.Craft ),
+	SpatialIO( -4, -4, AEApi.instance().definitions().blocks().spatialIOPort().get(), AchievementType.Craft ),
 
 	// done
-	SpatialIOExplorer( -4, -2, AEApi.instance().items().itemSpatialCell128, AchievementType.Custom ),
+	SpatialIOExplorer( -4, -2, AEApi.instance().definitions().items().spatialCell128().get(), AchievementType.Custom ),
 
 	// done
-	StorageCell( -6, -4, AEApi.instance().items().itemCell64k, AchievementType.CraftItem ),
+	StorageCell( -6, -4, AEApi.instance().definitions().items().cell64k().get(), AchievementType.CraftItem ),
 
 	// done
-	IOPort( -6, -2, AEApi.instance().blocks().blockIOPort, AchievementType.Craft ),
+	IOPort( -6, -2, AEApi.instance().definitions().blocks().iOPort().get(), AchievementType.Craft ),
 
 	// done
-	CraftingTerminal( -8, -4, AEApi.instance().parts().partCraftingTerminal, AchievementType.Craft ),
+	CraftingTerminal( -8, -4, AEApi.instance().definitions().parts().craftingTerminal().get(), AchievementType.Craft ),
 
 	// done
-	PatternTerminal( -8, -2, AEApi.instance().parts().partPatternTerminal, AchievementType.Craft ),
+	PatternTerminal( -8, -2, AEApi.instance().definitions().parts().patternTerminal().get(), AchievementType.Craft ),
 
 	// done
-	ChargedQuartz( 0, -4, AEApi.instance().materials().materialCertusQuartzCrystalCharged, AchievementType.Pickup ),
+	ChargedQuartz( 0, -4, AEApi.instance().definitions().materials().certusQuartzCrystalCharged().get(), AchievementType.Pickup ),
 
 	// done
-	Fluix( 0, -2, AEApi.instance().materials().materialFluixCrystal, AchievementType.Pickup ),
+	Fluix( 0, -2, AEApi.instance().definitions().materials().fluixCrystal().get(), AchievementType.Pickup ),
 
 	// done
-	Charger( 0, 0, AEApi.instance().blocks().blockCharger, AchievementType.Craft ),
+	Charger( 0, 0, AEApi.instance().definitions().blocks().charger().get(), AchievementType.Craft ),
 
 	// done
-	CrystalGrowthAccelerator( -2, 0, AEApi.instance().blocks().blockQuartzGrowthAccelerator, AchievementType.Craft ),
+	CrystalGrowthAccelerator( -2, 0, AEApi.instance().definitions().blocks().quartzGrowthAccelerator().get(), AchievementType.Craft ),
 
 	// done
-	GlassCable( 2, 0, AEApi.instance().parts().partCableGlass, AchievementType.Craft ),
+	GlassCable( 2, 0, AEApi.instance().definitions().parts().cableGlass().get(), AchievementType.Craft ),
 
 	// done
-	Networking1( 4, -6, AEApi.instance().parts().partCableCovered, AchievementType.Custom ),
+	Networking1( 4, -6, AEApi.instance().definitions().parts().cableCovered().get(), AchievementType.Custom ),
 
 	// done
-	Controller( 4, -4, AEApi.instance().blocks().blockController, AchievementType.Craft ),
+	Controller( 4, -4, AEApi.instance().definitions().blocks().controller().get(), AchievementType.Craft ),
 
 	// done
-	Networking2( 4, 0, AEApi.instance().parts().partCableSmart, AchievementType.Custom ),
+	Networking2( 4, 0, AEApi.instance().definitions().parts().cableSmart().get(), AchievementType.Custom ),
 
 	// done
-	Networking3( 4, 2, AEApi.instance().parts().partCableDense, AchievementType.Custom ),
+	Networking3( 4, 2, AEApi.instance().definitions().parts().cableDense().get(), AchievementType.Custom ),
 
 	// done
-	P2P( 2, -2, AEApi.instance().parts().partP2PTunnelME, AchievementType.Craft ),
+	P2P( 2, -2, AEApi.instance().definitions().parts().p2PTunnelME().get(), AchievementType.Craft ),
 
 	// done
-	Recursive( 6, -2, AEApi.instance().blocks().blockInterface, AchievementType.Craft ),
+	Recursive( 6, -2, AEApi.instance().definitions().blocks().iface().get(), AchievementType.Craft ),
 
 	// done
-	CraftingCPU( 6, 0, AEApi.instance().blocks().blockCraftingStorage64k, AchievementType.CraftItem ),
+	CraftingCPU( 6, 0, AEApi.instance().definitions().blocks().craftingStorage64k().get(), AchievementType.CraftItem ),
 
 	// done
-	Facade( 6, 2, AEApi.instance().items().itemFacade, AchievementType.CraftItem ),
+	Facade( 6, 2, AEApi.instance().definitions().items().facade().get(), AchievementType.CraftItem ),
 
 	// done
-	NetworkTool( 8, 0, AEApi.instance().items().itemNetworkTool, AchievementType.Craft ),
+	NetworkTool( 8, 0, AEApi.instance().definitions().items().networkTool().get(), AchievementType.Craft ),
 
 	// done
-	PortableCell( 8, 2, AEApi.instance().items().itemPortableCell, AchievementType.Craft ),
+	PortableCell( 8, 2, AEApi.instance().definitions().items().portableCell().get(), AchievementType.Craft ),
 
 	// done
-	StorageBus( 10, 0, AEApi.instance().parts().partStorageBus, AchievementType.Craft ),
+	StorageBus( 10, 0, AEApi.instance().definitions().parts().storageBus().get(), AchievementType.Craft ),
 
 	// done
-	QNB( 10, 2, AEApi.instance().blocks().blockQuantumLink, AchievementType.Craft );
+	QNB( 10, 2, AEApi.instance().definitions().blocks().quantumLink().get(), AchievementType.Craft );
 
 	public final ItemStack stack;
 	public final AchievementType type;
@@ -132,7 +132,7 @@ public enum Achievements
 
 	private Achievements( int x, int y, AEColoredItemDefinition which, AchievementType type )
 	{
-		this.stack = (which != null) ? which.stack( AEColor.Transparent, 1 ) : null;
+		this.stack = ( which != null ) ? which.stack( AEColor.Transparent, 1 ) : null;
 		this.type = type;
 		this.x = x;
 		this.y = y;
@@ -140,7 +140,7 @@ public enum Achievements
 
 	private Achievements( int x, int y, AEItemDefinition which, AchievementType type )
 	{
-		this.stack = (which != null) ? which.stack( 1 ) : null;
+		this.stack = ( which != null ) ? which.stack( 1 ) : null;
 		this.type = type;
 		this.x = x;
 		this.y = y;

--- a/src/main/java/appeng/core/sync/GuiBridge.java
+++ b/src/main/java/appeng/core/sync/GuiBridge.java
@@ -37,7 +37,7 @@ import cpw.mods.fml.relauncher.ReflectionHelper;
 
 import appeng.api.AEApi;
 import appeng.api.config.SecurityPermissions;
-import appeng.api.definitions.Materials;
+import appeng.api.definitions.IMaterials;
 import appeng.api.exceptions.AppEngException;
 import appeng.api.features.IWirelessTermHandler;
 import appeng.api.implementations.IUpgradeableHost;
@@ -271,9 +271,9 @@ public enum GuiBridge implements IGuiHandler
 					{
 						ItemStack is = ((Slot) so).getStack();
 
-						Materials m = AEApi.instance().materials();
-						if ( m.materialLogicProcessorPress.sameAsStack( is ) || m.materialEngProcessorPress.sameAsStack( is )
-								|| m.materialCalcProcessorPress.sameAsStack( is ) || m.materialSiliconPress.sameAsStack( is ) )
+						IMaterials m = AEApi.instance().definitions().materials();
+						if ( m.logicProcessorPress().get().sameAsStack( is ) || m.engProcessorPress().get().sameAsStack( is )
+								|| m.calcProcessorPress().get().sameAsStack( is ) || m.siliconPress().get().sameAsStack( is ) )
 						{
 							Achievements.Presses.addToPlayer( inventory.player );
 						}

--- a/src/main/java/appeng/core/sync/packets/PacketClick.java
+++ b/src/main/java/appeng/core/sync/packets/PacketClick.java
@@ -63,13 +63,13 @@ public class PacketClick extends AppEngPacket
 			ToolNetworkTool tnt = (ToolNetworkTool) is.getItem();
 			tnt.serverSideToolLogic( is, player, player.worldObj, this.x, this.y, this.z, this.side, this.hitX, this.hitY, this.hitZ );
 		}
-		else if ( is != null && AEApi.instance().items().itemMemoryCard.sameAsStack( is ) )
+		else if ( is != null && AEApi.instance().definitions().items().memoryCard().get().sameAsStack( is ) )
 		{
 			IMemoryCard mem = (IMemoryCard) is.getItem();
 			mem.notifyUser( player, MemoryCardMessages.SETTINGS_CLEARED );
 			is.setTagCompound( null );
 		}
-		else if ( is != null && AEApi.instance().items().itemColorApplicator.sameAsStack( is ) )
+		else if ( is != null && AEApi.instance().definitions().items().colorApplicator().get().sameAsStack( is ) )
 		{
 			ToolColorApplicator mem = (ToolColorApplicator) is.getItem();
 			mem.cycleColors( is, mem.getColor( is ), 1 );

--- a/src/main/java/appeng/entity/EntityChargedQuartz.java
+++ b/src/main/java/appeng/entity/EntityChargedQuartz.java
@@ -87,7 +87,7 @@ final public class EntityChargedQuartz extends AEBaseEntityItem
 	public boolean transform()
 	{
 		ItemStack item = this.getEntityItem();
-		if ( AEApi.instance().materials().materialCertusQuartzCrystalCharged.sameAsStack( item ) )
+		if ( AEApi.instance().definitions().materials().certusQuartzCrystalCharged().get().sameAsStack( item ) )
 		{
 			AxisAlignedBB region = AxisAlignedBB.getBoundingBox( this.posX - 1, this.posY - 1, this.posZ - 1, this.posX + 1, this.posY + 1, this.posZ + 1 );
 			List<Entity> l = this.getCheckedEntitiesWithinAABBExcludingEntity( region );
@@ -126,7 +126,7 @@ final public class EntityChargedQuartz extends AEBaseEntityItem
 				if ( netherQuartz.getEntityItem().stackSize <= 0 )
 					netherQuartz.setDead();
 
-				ItemStack Output = AEApi.instance().materials().materialFluixCrystal.stack( 2 );
+				ItemStack Output = AEApi.instance().definitions().materials().fluixCrystal().get().stack( 2 );
 				this.worldObj.spawnEntityInWorld( new EntityItem( this.worldObj, this.posX, this.posY, this.posZ, Output ) );
 
 				return true;

--- a/src/main/java/appeng/entity/EntitySingularity.java
+++ b/src/main/java/appeng/entity/EntitySingularity.java
@@ -73,7 +73,7 @@ final public class EntitySingularity extends AEBaseEntityItem
 			return;
 
 		ItemStack item = this.getEntityItem();
-		if ( AEApi.instance().materials().materialSingularity.sameAsStack( item ) )
+		if ( AEApi.instance().definitions().materials().singularity().get().sameAsStack( item ) )
 		{
 			AxisAlignedBB region = AxisAlignedBB.getBoundingBox( this.posX - 4, this.posY - 4, this.posZ - 4, this.posX + 4, this.posY + 4, this.posZ + 4 );
 			List<Entity> l = this.getCheckedEntitiesWithinAABBExcludingEntity( region );
@@ -116,7 +116,7 @@ final public class EntitySingularity extends AEBaseEntityItem
 								if ( other.stackSize == 0 )
 									e.setDead();
 
-								ItemStack Output = AEApi.instance().materials().materialQESingularity.stack( 2 );
+								ItemStack Output = AEApi.instance().definitions().materials().qESingularity().get().stack( 2 );
 								NBTTagCompound cmp = Platform.openNbtData( Output );
 								cmp.setLong( "freq", ( new Date() ).getTime() * 100 + ( randTickSeed++ ) % 100 );
 								item.stackSize--;

--- a/src/main/java/appeng/entity/EntityTinyTNTPrimed.java
+++ b/src/main/java/appeng/entity/EntityTinyTNTPrimed.java
@@ -80,7 +80,7 @@ final public class EntityTinyTNTPrimed extends EntityTNTPrimed implements IEntit
 
 		if ( this.isInWater() && Platform.isServer() ) // put out the fuse.
 		{
-			EntityItem item = new EntityItem( this.worldObj, this.posX, this.posY, this.posZ, AEApi.instance().blocks().blockTinyTNT.stack( 1 ) );
+			EntityItem item = new EntityItem( this.worldObj, this.posX, this.posY, this.posZ, AEApi.instance().definitions().blocks().tinyTNT().get().stack( 1 ) );
 			item.motionX = this.motionX;
 			item.motionY = this.motionY;
 			item.motionZ = this.motionZ;

--- a/src/main/java/appeng/facade/FacadeContainer.java
+++ b/src/main/java/appeng/facade/FacadeContainer.java
@@ -99,7 +99,7 @@ public class FacadeContainer implements IFacadeContainer
 				}
 				else if ( !isBC )
 				{
-					ItemFacade ifa = (ItemFacade) AEApi.instance().items().itemFacade.item();
+					ItemFacade ifa = (ItemFacade) AEApi.instance().definitions().items().facade().get().item();
 					ItemStack facade = ifa.createFromIDs( ids );
 					if ( facade != null )
 					{

--- a/src/main/java/appeng/fmp/PartRegistry.java
+++ b/src/main/java/appeng/fmp/PartRegistry.java
@@ -51,7 +51,7 @@ public enum PartRegistry
 		try
 		{
 			if ( this == CableBusPart )
-				return (TMultiPart) Api.INSTANCE.partHelper.getCombinedInstance( this.part.getName() ).newInstance();
+				return (TMultiPart) Api.INSTANCE.getPartHelper().getCombinedInstance( this.part.getName() ).newInstance();
 			else
 				return this.part.getConstructor( int.class ).newInstance( meta );
 		}

--- a/src/main/java/appeng/fmp/QuartzTorchPart.java
+++ b/src/main/java/appeng/fmp/QuartzTorchPart.java
@@ -52,7 +52,7 @@ public class QuartzTorchPart extends McSidedMetaPart implements IRandomDisplayTi
 	@Override
 	public Block getBlock()
 	{
-		return AEApi.instance().blocks().blockQuartzTorch.block();
+		return AEApi.instance().definitions().blocks().quartzTorch().get().block();
 	}
 
 	@Override

--- a/src/main/java/appeng/helpers/MeteoritePlacer.java
+++ b/src/main/java/appeng/helpers/MeteoritePlacer.java
@@ -402,7 +402,7 @@ public class MeteoritePlacer
 
 	Fallout type = new Fallout();
 
-	final Block skystone = AEApi.instance().blocks().blockSkyStone.block();
+	final Block skystone = AEApi.instance().definitions().blocks().skyStone().get().block();
 	final Block skychest;
 
 	double real_sizeOfMeteorite = (Math.random() * 6.0) + 2;
@@ -413,10 +413,10 @@ public class MeteoritePlacer
 
 	public MeteoritePlacer() {
 
-		if ( AEApi.instance().blocks().blockSkyChest.block() == null )
+		if ( !AEApi.instance().definitions().blocks().skyChest().isPresent())
 			this.skychest = Blocks.chest;
 		else
-			this.skychest = AEApi.instance().blocks().blockSkyChest.block();
+			this.skychest = AEApi.instance().definitions().blocks().skyChest().get().block();
 
 		this.validSpawn.add( Blocks.stone );
 		this.validSpawn.add( Blocks.cobblestone );
@@ -685,16 +685,16 @@ public class MeteoritePlacer
 						switch (r % 4)
 						{
 						case 0:
-							toAdd = AEApi.instance().materials().materialCalcProcessorPress.stack( 1 );
+							toAdd = AEApi.instance().definitions().materials().calcProcessorPress().get().stack( 1 );
 							break;
 						case 1:
-							toAdd = AEApi.instance().materials().materialEngProcessorPress.stack( 1 );
+							toAdd = AEApi.instance().definitions().materials().engProcessorPress().get().stack( 1 );
 							break;
 						case 2:
-							toAdd = AEApi.instance().materials().materialLogicProcessorPress.stack( 1 );
+							toAdd = AEApi.instance().definitions().materials().logicProcessorPress().get().stack( 1 );
 							break;
 						case 3:
-							toAdd = AEApi.instance().materials().materialSiliconPress.stack( 1 );
+							toAdd = AEApi.instance().definitions().materials().siliconPress().get().stack( 1 );
 							break;
 						default:
 						}
@@ -716,7 +716,7 @@ public class MeteoritePlacer
 					switch ((int) (Math.random() * 1000) % 3)
 					{
 					case 0:
-						ap.addItems( AEApi.instance().blocks().blockSkyStone.stack( (int) (Math.random() * 12) + 1 ) );
+						ap.addItems( AEApi.instance().definitions().blocks().skyStone().get().stack( (int) (Math.random() * 12) + 1 ) );
 						break;
 					case 1:
 						List<ItemStack> possibles = new LinkedList<ItemStack>();

--- a/src/main/java/appeng/hooks/AETrading.java
+++ b/src/main/java/appeng/hooks/AETrading.java
@@ -96,12 +96,12 @@ public class AETrading implements IVillageTradeHandler
 	@Override
 	public void manipulateTradesForVillager(EntityVillager villager, MerchantRecipeList recipeList, Random random)
 	{
-		this.addMerchant( recipeList, AEApi.instance().materials().materialSilicon.stack( 1 ), 1, random, 2 );
-		this.addMerchant( recipeList, AEApi.instance().materials().materialCertusQuartzCrystal.stack( 1 ), 2, random, 4 );
-		this.addMerchant( recipeList, AEApi.instance().materials().materialCertusQuartzDust.stack( 1 ), 1, random, 3 );
+		this.addMerchant( recipeList, AEApi.instance().definitions().materials().silicon().get().stack( 1 ), 1, random, 2 );
+		this.addMerchant( recipeList, AEApi.instance().definitions().materials().certusQuartzCrystal().get().stack( 1 ), 2, random, 4 );
+		this.addMerchant( recipeList, AEApi.instance().definitions().materials().certusQuartzDust().get().stack( 1 ), 1, random, 3 );
 
-		this.addTrade( recipeList, AEApi.instance().materials().materialCertusQuartzDust.stack( 1 ),
-				AEApi.instance().materials().materialCertusQuartzCrystal.stack( 1 ), random, 2 );
+		this.addTrade( recipeList, AEApi.instance().definitions().materials().certusQuartzDust().get().stack( 1 ),
+				AEApi.instance().definitions().materials().certusQuartzCrystal().get().stack( 1 ), random, 2 );
 	}
 
 }

--- a/src/main/java/appeng/hooks/QuartzWorldGen.java
+++ b/src/main/java/appeng/hooks/QuartzWorldGen.java
@@ -40,8 +40,8 @@ final public class QuartzWorldGen implements IWorldGenerator
 	final WorldGenMinable oreCharged;
 
 	public QuartzWorldGen() {
-		Block normal = AEApi.instance().blocks().blockQuartzOre.block();
-		Block charged = AEApi.instance().blocks().blockQuartzOreCharged.block();
+		Block normal = AEApi.instance().definitions().blocks().quartzOre().get().block();
+		Block charged = AEApi.instance().definitions().blocks().quartzOreCharged().get().block();
 
 		if ( normal != null && charged != null )
 		{

--- a/src/main/java/appeng/integration/modules/BC.java
+++ b/src/main/java/appeng/integration/modules/BC.java
@@ -44,7 +44,7 @@ import buildcraft.transport.TileGenericPipe;
 
 import appeng.api.AEApi;
 import appeng.api.config.TunnelType;
-import appeng.api.definitions.Blocks;
+import appeng.api.definitions.IBlocks;
 import appeng.api.features.IP2PTunnelRegistry;
 import appeng.api.parts.IFacadePart;
 import appeng.api.util.AEItemDefinition;
@@ -230,11 +230,11 @@ public class BC extends BaseModule implements IBC
 		AEApi.instance().partHelper().registerNewLayer( "appeng.parts.layers.LayerIPipeConnection", "buildcraft.api.transport.IPipeConnection" );
 		AEApi.instance().registries().externalStorage().addExternalStorageInterface( new BCPipeHandler() );
 
-		Blocks b = AEApi.instance().blocks();
-		this.addFacade( b.blockFluix.stack( 1 ) );
-		this.addFacade( b.blockQuartz.stack( 1 ) );
-		this.addFacade( b.blockQuartzChiseled.stack( 1 ) );
-		this.addFacade( b.blockQuartzPillar.stack( 1 ) );
+		IBlocks b = AEApi.instance().definitions().blocks();
+		this.addFacade( b.fluix().get().stack( 1 ) );
+		this.addFacade( b.quartz().get().stack( 1 ) );
+		this.addFacade( b.quartzChiseled().get().stack( 1 ) );
+		this.addFacade( b.quartzPillar().get().stack( 1 ) );
 
 		try
 		{
@@ -245,7 +245,7 @@ public class BC extends BaseModule implements IBC
 			// not supported?
 		}
 
-		Block skyStone = b.blockSkyStone.block();
+		Block skyStone = b.skyStone().get().block();
 		if ( skyStone != null )
 		{
 			this.addFacade( new ItemStack( skyStone, 1, 0 ) );
@@ -259,8 +259,8 @@ public class BC extends BaseModule implements IBC
 	{
 		SchematicRegistry.declareBlueprintSupport( AppEng.MOD_ID );
 
-		Blocks blocks = AEApi.instance().blocks();
-		Block cable = blocks.blockMultiPart.block();
+		IBlocks blocks = AEApi.instance().definitions().blocks();
+		Block cable = blocks.multiPart().get().block();
 		for (Field f : blocks.getClass().getFields())
 		{
 			AEItemDefinition def;

--- a/src/main/java/appeng/integration/modules/FMP.java
+++ b/src/main/java/appeng/integration/modules/FMP.java
@@ -38,7 +38,7 @@ import codechicken.multipart.TMultiPart;
 import codechicken.multipart.TileMultipart;
 
 import appeng.api.AEApi;
-import appeng.api.definitions.Blocks;
+import appeng.api.definitions.IBlocks;
 import appeng.api.parts.IPartHost;
 import appeng.core.AELog;
 import appeng.fmp.CableBusPart;
@@ -86,13 +86,15 @@ public class FMP implements IIntegrationModule, IPartFactory, IPartConverter, IF
 	@Override
 	public void init() throws Throwable
 	{
-		this.createAndRegister( AEApi.instance().blocks().blockQuartz.block(), 0 );
-		this.createAndRegister( AEApi.instance().blocks().blockQuartzPillar.block(), 0 );
-		this.createAndRegister( AEApi.instance().blocks().blockQuartzChiseled.block(), 0 );
-		this.createAndRegister( AEApi.instance().blocks().blockSkyStone.block(), 0 );
-		this.createAndRegister( AEApi.instance().blocks().blockSkyStone.block(), 1 );
-		this.createAndRegister( AEApi.instance().blocks().blockSkyStone.block(), 2 );
-		this.createAndRegister( AEApi.instance().blocks().blockSkyStone.block(), 3 );
+		final IBlocks blocks = AEApi.instance().definitions().blocks();
+
+		this.createAndRegister( blocks.quartz().get().block(), 0 );
+		this.createAndRegister( blocks.quartzPillar().get().block(), 0 );
+		this.createAndRegister( blocks.quartzChiseled().get().block(), 0 );
+		this.createAndRegister( blocks.skyStone().get().block(), 0 );
+		this.createAndRegister( blocks.skyStone().get().block(), 1 );
+		this.createAndRegister( blocks.skyStone().get().block(), 2 );
+		this.createAndRegister( blocks.skyStone().get().block(), 3 );
 
 		PartRegistry[] reg = PartRegistry.values();
 
@@ -186,8 +188,8 @@ public class FMP implements IIntegrationModule, IPartFactory, IPartConverter, IF
 	@Override
 	public Iterable<Block> blockTypes()
 	{
-		Blocks def = AEApi.instance().blocks();
-		return Arrays.asList( def.blockMultiPart.block(), def.blockQuartzTorch.block() );
+		IBlocks def = AEApi.instance().definitions().blocks();
+		return Arrays.asList( def.multiPart().get().block(), def.quartzTorch().get().block() );
 	}
 
 }

--- a/src/main/java/appeng/integration/modules/ImmibisMicroblocks.java
+++ b/src/main/java/appeng/integration/modules/ImmibisMicroblocks.java
@@ -102,8 +102,8 @@ public class ImmibisMicroblocks extends BaseModule implements IImmibisMicroblock
 
 		if ( te instanceof IMultipartTile && this.canConvertTiles && isPartItem )
 		{
-			final Block blk = AEApi.instance().blocks().blockMultiPart.block();
-			final ItemStack what = AEApi.instance().blocks().blockMultiPart.stack( 1 );
+			final Block blk = AEApi.instance().definitions().blocks().multiPart().get().block();
+			final ItemStack what = AEApi.instance().definitions().blocks().multiPart().get().stack( 1 );
 
 			try
 			{

--- a/src/main/java/appeng/integration/modules/NEIHelpers/NEIFacadeRecipeHandler.java
+++ b/src/main/java/appeng/integration/modules/NEIHelpers/NEIFacadeRecipeHandler.java
@@ -42,8 +42,8 @@ import appeng.items.parts.ItemFacade;
 public class NEIFacadeRecipeHandler extends TemplateRecipeHandler
 {
 
-	final ItemFacade ifa = (ItemFacade) AEApi.instance().items().itemFacade.item();
-	final ItemStack cable_anchor = AEApi.instance().parts().partCableAnchor.stack( 1 );
+	final ItemFacade ifa = (ItemFacade) AEApi.instance().definitions().items().facade().get().item();
+	final ItemStack cable_anchor = AEApi.instance().definitions().parts().cableAnchor().get().stack( 1 );
 
 	@Override
 	public void loadTransferRects()
@@ -68,7 +68,7 @@ public class NEIFacadeRecipeHandler extends TemplateRecipeHandler
 	{
 		if ( (outputId.equals( "crafting" )) && (this.getClass() == NEIFacadeRecipeHandler.class) )
 		{
-			ItemFacade ifa = (ItemFacade) AEApi.instance().items().itemFacade.item();
+			ItemFacade ifa = (ItemFacade) AEApi.instance().definitions().items().facade().get().item();
 			List<ItemStack> facades = ifa.getFacades();
 			for (ItemStack is : facades)
 			{

--- a/src/main/java/appeng/integration/modules/NEIHelpers/NEIWorldCraftingHandler.java
+++ b/src/main/java/appeng/integration/modules/NEIHelpers/NEIWorldCraftingHandler.java
@@ -68,29 +68,29 @@ public class NEIWorldCraftingHandler implements ICraftingHandler, IUsageHandler
 	{
 
 		if ( AEConfig.instance.isFeatureEnabled( AEFeature.CertusQuartzWorldGen ) )
-			this.addRecipe( AEApi.instance().materials().materialCertusQuartzCrystalCharged,
+			this.addRecipe( AEApi.instance().definitions().materials().certusQuartzCrystalCharged().get(),
 					GuiText.ChargedQuartz.getLocal() + "\n\n" + GuiText.ChargedQuartzFind.getLocal() );
 		else
-			this.addRecipe( AEApi.instance().materials().materialCertusQuartzCrystalCharged, GuiText.ChargedQuartzFind.getLocal() );
+			this.addRecipe( AEApi.instance().definitions().materials().certusQuartzCrystalCharged().get(), GuiText.ChargedQuartzFind.getLocal() );
 
 		if ( AEConfig.instance.isFeatureEnabled( AEFeature.MeteoriteWorldGen ) )
 		{
-			this.addRecipe( AEApi.instance().materials().materialLogicProcessorPress, GuiText.inWorldCraftingPresses.getLocal() );
-			this.addRecipe( AEApi.instance().materials().materialCalcProcessorPress, GuiText.inWorldCraftingPresses.getLocal() );
-			this.addRecipe( AEApi.instance().materials().materialEngProcessorPress, GuiText.inWorldCraftingPresses.getLocal() );
+			this.addRecipe( AEApi.instance().definitions().materials().logicProcessorPress().get(), GuiText.inWorldCraftingPresses.getLocal() );
+			this.addRecipe( AEApi.instance().definitions().materials().calcProcessorPress().get(), GuiText.inWorldCraftingPresses.getLocal() );
+			this.addRecipe( AEApi.instance().definitions().materials().engProcessorPress().get(), GuiText.inWorldCraftingPresses.getLocal() );
 		}
 
 		if ( AEConfig.instance.isFeatureEnabled( AEFeature.inWorldFluix ) )
-			this.addRecipe( AEApi.instance().materials().materialFluixCrystal, GuiText.inWorldFluix.getLocal() );
+			this.addRecipe( AEApi.instance().definitions().materials().fluixCrystal().get(), GuiText.inWorldFluix.getLocal() );
 
 		if ( AEConfig.instance.isFeatureEnabled( AEFeature.inWorldSingularity ) )
-			this.addRecipe( AEApi.instance().materials().materialQESingularity, GuiText.inWorldSingularity.getLocal() );
+			this.addRecipe( AEApi.instance().definitions().materials().qESingularity().get(), GuiText.inWorldSingularity.getLocal() );
 
 		if ( AEConfig.instance.isFeatureEnabled( AEFeature.inWorldPurification ) )
 		{
-			this.addRecipe( AEApi.instance().materials().materialPurifiedCertusQuartzCrystal, GuiText.inWorldPurificationCertus.getLocal() );
-			this.addRecipe( AEApi.instance().materials().materialPurifiedNetherQuartzCrystal, GuiText.inWorldPurificationNether.getLocal() );
-			this.addRecipe( AEApi.instance().materials().materialPurifiedFluixCrystal, GuiText.inWorldPurificationFluix.getLocal() );
+			this.addRecipe( AEApi.instance().definitions().materials().purifiedCertusQuartzCrystal().get(), GuiText.inWorldPurificationCertus.getLocal() );
+			this.addRecipe( AEApi.instance().definitions().materials().purifiedNetherQuartzCrystal().get(), GuiText.inWorldPurificationNether.getLocal() );
+			this.addRecipe( AEApi.instance().definitions().materials().purifiedFluixCrystal().get(), GuiText.inWorldPurificationFluix.getLocal() );
 		}
 	}
 

--- a/src/main/java/appeng/items/misc/ItemCrystalSeed.java
+++ b/src/main/java/appeng/items/misc/ItemCrystalSeed.java
@@ -124,11 +124,11 @@ public class ItemCrystalSeed extends AEBaseItem implements IGrowableCrystal
 		int newDamage = this.getProgress( is ) + 1;
 
 		if ( newDamage == Certus + SINGLE_OFFSET )
-			return AEApi.instance().materials().materialPurifiedCertusQuartzCrystal.stack( is.stackSize );
+			return AEApi.instance().definitions().materials().purifiedCertusQuartzCrystal().get().stack( is.stackSize );
 		if ( newDamage == Nether + SINGLE_OFFSET )
-			return AEApi.instance().materials().materialPurifiedNetherQuartzCrystal.stack( is.stackSize );
+			return AEApi.instance().definitions().materials().purifiedNetherQuartzCrystal().get().stack( is.stackSize );
 		if ( newDamage == Fluix + SINGLE_OFFSET )
-			return AEApi.instance().materials().materialPurifiedFluixCrystal.stack( is.stackSize );
+			return AEApi.instance().definitions().materials().purifiedFluixCrystal().get().stack( is.stackSize );
 		if ( newDamage > END )
 			return null;
 
@@ -275,7 +275,7 @@ public class ItemCrystalSeed extends AEBaseItem implements IGrowableCrystal
 
 	public static ResolverResult getResolver(int certus2)
 	{
-		ItemStack is = AEApi.instance().items().itemCrystalSeed.stack( 1 );
+		ItemStack is = AEApi.instance().definitions().items().crystalSeed().get().stack( 1 );
 		is.setItemDamage( certus2 );
 		is = newStyle( is );
 		return new ResolverResult( "ItemCrystalSeed", is.getItemDamage(), is.getTagCompound() );

--- a/src/main/java/appeng/items/misc/ItemEncodedPattern.java
+++ b/src/main/java/appeng/items/misc/ItemEncodedPattern.java
@@ -66,7 +66,7 @@ public class ItemEncodedPattern extends AEBaseItem implements ICraftingPatternIt
 			{
 				if ( inv.getStackInSlot( s ) == stack )
 				{
-					inv.setInventorySlotContents( s, AEApi.instance().materials().materialBlankPattern.stack( stack.stackSize ) );
+					inv.setInventorySlotContents( s, AEApi.instance().definitions().materials().blankPattern().get().stack( stack.stackSize ) );
 					return true;
 				}
 			}

--- a/src/main/java/appeng/items/parts/ItemFacade.java
+++ b/src/main/java/appeng/items/parts/ItemFacade.java
@@ -110,7 +110,7 @@ public class ItemFacade extends AEBaseItem implements IFacadeItem, IAlphaPassIte
 
 	public ItemStack createFromIDs(int[] ids)
 	{
-		ItemStack is = new ItemStack( AEApi.instance().items().itemFacade.item() );
+		ItemStack is = new ItemStack( AEApi.instance().definitions().items().facade().get().item() );
 		NBTTagCompound data = new NBTTagCompound();
 		data.setIntArray( "x", ids.clone() );
 		is.setTagCompound( data );

--- a/src/main/java/appeng/items/parts/ItemMultiPart.java
+++ b/src/main/java/appeng/items/parts/ItemMultiPart.java
@@ -41,7 +41,9 @@ import cpw.mods.fml.relauncher.SideOnly;
 import appeng.api.AEApi;
 import appeng.api.implementations.items.IItemGroup;
 import appeng.api.parts.IPart;
+import appeng.api.parts.IPartHelper;
 import appeng.api.parts.IPartItem;
+import appeng.api.util.AEColor;
 import appeng.core.AEConfig;
 import appeng.core.AELog;
 import appeng.core.features.AEFeature;
@@ -67,10 +69,10 @@ public class ItemMultiPart extends AEBaseItem implements IPartItem, IItemGroup
 
 	public static ItemMultiPart instance;
 
-	public ItemMultiPart() {
+	public ItemMultiPart( IPartHelper partHelper ) {
 		super( ItemMultiPart.class );
 		this.setFeature( EnumSet.of( AEFeature.Core ) );
-		AEApi.instance().partHelper().setItemBusRenderer( this );
+		partHelper.setItemBusRenderer( this );
 		this.setHasSubtypes( true );
 		instance = this;
 	}
@@ -176,7 +178,7 @@ public class ItemMultiPart extends AEBaseItem implements IPartItem, IItemGroup
 		if ( pt == null )
 			return "Unnamed";
 
-		Enum[] variants = pt.getVariants();
+		AEColor[] variants = pt.getVariants();
 
 		if ( variants != null )
 			return super.getItemStackDisplayName( is ) + " - " + variants[this.dmgToPart.get( is.getItemDamage() ).variant].toString();

--- a/src/main/java/appeng/items/parts/PartType.java
+++ b/src/main/java/appeng/items/parts/PartType.java
@@ -144,7 +144,7 @@ public enum PartType
 		this.baseDamage = baseMetaValue;
 	}
 
-	public Enum<AEColor>[] getVariants()
+	public AEColor[] getVariants()
 	{
 		if ( this == CableSmart || this == CableCovered || this == CableGlass || this == CableDense )
 			return AEColor.values();

--- a/src/main/java/appeng/items/storage/ItemBasicStorageCell.java
+++ b/src/main/java/appeng/items/storage/ItemBasicStorageCell.java
@@ -240,7 +240,7 @@ public class ItemBasicStorageCell extends AEBaseItem implements IStorageCell, II
 					playerInventory.setInventorySlotContents( playerInventory.currentItem, null );
 
 					ItemStack extraB = ia.addItems( this.component.stack( 1 ) );
-					ItemStack extraA = ia.addItems( AEApi.instance().materials().materialEmptyStorageCell.stack( 1 ) );
+					ItemStack extraA = ia.addItems( AEApi.instance().definitions().materials().emptyStorageCell().get().stack( 1 ) );
 
 					if ( extraA != null )
 						player.dropPlayerItemWithRandomChoice( extraA, false );
@@ -266,7 +266,7 @@ public class ItemBasicStorageCell extends AEBaseItem implements IStorageCell, II
 	@Override
 	public ItemStack getContainerItem( ItemStack itemStack )
 	{
-		return AEApi.instance().materials().materialEmptyStorageCell.stack( 1 );
+		return AEApi.instance().definitions().materials().emptyStorageCell().get().stack( 1 );
 	}
 
 	@Override

--- a/src/main/java/appeng/items/tools/powered/ToolMassCannon.java
+++ b/src/main/java/appeng/items/tools/powered/ToolMassCannon.java
@@ -297,7 +297,7 @@ public class ToolMassCannon extends AEBasePoweredItem implements IStorageCell
 				Block whatsThere = w.getBlock( x, y, z );
 				if ( whatsThere.isReplaceable( w, x, y, z ) && w.isAirBlock( x, y, z ) )
 				{
-					w.setBlock( x, y, z, AEApi.instance().blocks().blockPaint.block(), 0, 3 );
+					w.setBlock( x, y, z, AEApi.instance().definitions().blocks().paint().get().block(), 0, 3 );
 				}
 
 				TileEntity te = w.getTileEntity( x, y, z );

--- a/src/main/java/appeng/items/tools/powered/ToolWirelessTerminal.java
+++ b/src/main/java/appeng/items/tools/powered/ToolWirelessTerminal.java
@@ -98,7 +98,7 @@ public class ToolWirelessTerminal extends AEBasePoweredItem implements IWireless
 	@Override
 	public boolean canHandle( ItemStack is )
 	{
-		return AEApi.instance().items().itemWirelessTerminal.sameAsStack( is );
+		return AEApi.instance().definitions().items().wirelessTerminal().get().sameAsStack( is );
 	}
 
 	@Override

--- a/src/main/java/appeng/items/tools/quartz/ToolQuartzCuttingKnife.java
+++ b/src/main/java/appeng/items/tools/quartz/ToolQuartzCuttingKnife.java
@@ -42,11 +42,11 @@ public class ToolQuartzCuttingKnife extends AEBaseItem implements IGuiItem
 
 	final AEFeature type;
 
-	public ToolQuartzCuttingKnife( AEFeature Type )
+	public ToolQuartzCuttingKnife( AEFeature type )
 	{
-		super( ToolQuartzCuttingKnife.class, Optional.of( Type.name() ) );
+		super( ToolQuartzCuttingKnife.class, Optional.of( type.name() ) );
 
-		this.setFeature( EnumSet.of( this.type = Type, AEFeature.QuartzKnife ) );
+		this.setFeature( EnumSet.of( this.type = type, AEFeature.QuartzKnife ) );
 		this.setMaxDamage( 50 );
 		this.setMaxStackSize( 1 );
 	}

--- a/src/main/java/appeng/me/cluster/implementations/QuantumCalculator.java
+++ b/src/main/java/appeng/me/cluster/implementations/QuantumCalculator.java
@@ -131,12 +131,12 @@ public class QuantumCalculator extends MBCalculator
 					num++;
 					if ( num == 5 )
 					{
-						if ( !Platform.blockAtLocationIs( w, x, y, z, AEApi.instance().blocks().blockQuantumLink ) )
+						if ( !Platform.blockAtLocationIs( w, x, y, z, AEApi.instance().definitions().blocks().quantumLink().get() ) )
 							return false;
 					}
 					else
 					{
-						if ( !Platform.blockAtLocationIs( w, x, y, z, AEApi.instance().blocks().blockQuantumRing ) )
+						if ( !Platform.blockAtLocationIs( w, x, y, z, AEApi.instance().definitions().blocks().quantumRing().get() ) )
 							return false;
 					}
 

--- a/src/main/java/appeng/me/storage/SecurityInventory.java
+++ b/src/main/java/appeng/me/storage/SecurityInventory.java
@@ -63,7 +63,7 @@ public class SecurityInventory implements IMEInventoryHandler<IAEItemStack>
 	@Override
 	public IAEItemStack injectItems(IAEItemStack input, Actionable type, BaseActionSource src)
 	{
-		if ( this.hasPermission( src ) && AEApi.instance().items().itemBiometricCard.sameAsStack( input.getItemStack() ) )
+		if ( this.hasPermission( src ) && AEApi.instance().definitions().items().biometricCard().get().sameAsStack( input.getItemStack() ) )
 		{
 			if ( this.canAccept( input ) )
 			{

--- a/src/main/java/appeng/parts/AEBasePart.java
+++ b/src/main/java/appeng/parts/AEBasePart.java
@@ -386,8 +386,8 @@ public class AEBasePart implements IPart, IGridProxyable, IActionHost, IUpgradea
 			ItemStack is = this.getItemStack( PartItemStack.Network );
 
 			// Blocks and parts share the same soul!
-			if ( AEApi.instance().parts().partInterface.sameAsStack( is ) )
-				is = AEApi.instance().blocks().blockInterface.stack( 1 );
+			if ( AEApi.instance().definitions().parts().iface().get().sameAsStack( is ) )
+				is = AEApi.instance().definitions().blocks().iface().get().stack( 1 );
 
 			String name = is.getUnlocalizedName();
 

--- a/src/main/java/appeng/parts/PartPlacement.java
+++ b/src/main/java/appeng/parts/PartPlacement.java
@@ -41,7 +41,7 @@ import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.TickEvent;
 
 import appeng.api.AEApi;
-import appeng.api.definitions.Items;
+import appeng.api.definitions.IItems;
 import appeng.api.parts.IFacadePart;
 import appeng.api.parts.IPartHost;
 import appeng.api.parts.IPartItem;
@@ -96,10 +96,10 @@ public class PartPlacement
 			else
 			{
 				ItemStack held = event.entityPlayer.getHeldItem();
-				final Items items = AEApi.instance().items();
+				final IItems items = AEApi.instance().definitions().items();
 
-				final boolean sameAsMemoryCard = items.itemMemoryCard != null && items.itemMemoryCard.sameAsStack( held );
-				final boolean sameAsColorApp = items.itemColorApplicator != null && items.itemColorApplicator.sameAsStack( held );
+				final boolean sameAsMemoryCard = items.memoryCard().isPresent() && items.memoryCard().get().sameAsStack( held );
+				final boolean sameAsColorApp = items.colorApplicator().isPresent() && items.colorApplicator().get().sameAsStack( held );
 
 				final boolean supportedItem = sameAsMemoryCard || sameAsColorApp;
 
@@ -283,7 +283,7 @@ public class PartPlacement
 
 		if ( host == null && pass == PlaceType.PLACE_ITEM )
 		{
-			ItemStack is = AEApi.instance().blocks().blockMultiPart.stack( 1 );
+			ItemStack is = AEApi.instance().definitions().blocks().multiPart().get().stack( 1 );
 			ItemBlock ib = (ItemBlock) is.getItem();
 			ForgeDirection offset = ForgeDirection.UNKNOWN;
 
@@ -309,7 +309,7 @@ public class PartPlacement
 			if ( host == null && tile != null && AppEng.instance.isIntegrationEnabled( IntegrationType.ImmibisMicroblocks ) )
 				host = ((IImmibisMicroblocks) AppEng.instance.getIntegration( IntegrationType.ImmibisMicroblocks )).getOrCreateHost( player, face, tile );
 
-			if ( host == null && AEApi.instance().blocks().blockMultiPart.block().canPlaceBlockAt( world, te_x, te_y, te_z )
+			if ( host == null && AEApi.instance().definitions().blocks().multiPart().get().block().canPlaceBlockAt( world, te_x, te_y, te_z )
 					&& ib.placeBlockAt( is, player, world, te_x, te_y, te_z, side.ordinal(), 0.5f, 0.5f, 0.5f, 0 ) )
 			{
 				if ( !world.isRemote )
@@ -379,7 +379,7 @@ public class PartPlacement
 			ForgeDirection mySide = host.addPart( held, side, player );
 			if ( mySide != null )
 			{
-				SoundType ss = AEApi.instance().blocks().blockMultiPart.block().stepSound;
+				SoundType ss = AEApi.instance().definitions().blocks().multiPart().get().block().stepSound;
 
 				// ss.getPlaceSound()
 				world.playSoundEffect( 0.5 + x, 0.5 + y, 0.5 + z, ss.func_150496_b(), (ss.getVolume() + 1.0F) / 2.0F, ss.getPitch() * 0.8F );

--- a/src/main/java/appeng/parts/networking/PartCable.java
+++ b/src/main/java/appeng/parts/networking/PartCable.java
@@ -127,8 +127,8 @@ public class PartCable extends AEBasePart implements IPartCable
 			return CableBusTextures.MECable_Yellow.getIcon();
 		default:
 		}
-		return AEApi.instance().parts().partCableGlass.item( AEColor.Transparent ).getIconIndex(
-				AEApi.instance().parts().partCableGlass.stack( AEColor.Transparent, 1 ) );
+		return AEApi.instance().definitions().parts().cableGlass().get().item( AEColor.Transparent ).getIconIndex(
+				AEApi.instance().definitions().parts().cableGlass().get().stack( AEColor.Transparent, 1 ) );
 	}
 
 	public IIcon getTexture(AEColor c)
@@ -174,8 +174,8 @@ public class PartCable extends AEBasePart implements IPartCable
 			return CableBusTextures.MECovered_Yellow.getIcon();
 		default:
 		}
-		return AEApi.instance().parts().partCableCovered.item( AEColor.Transparent ).getIconIndex(
-				AEApi.instance().parts().partCableCovered.stack( AEColor.Transparent, 1 ) );
+		return AEApi.instance().definitions().parts().cableCovered().get().item( AEColor.Transparent ).getIconIndex(
+				AEApi.instance().definitions().parts().cableCovered().get().stack( AEColor.Transparent, 1 ) );
 	}
 
 	public IIcon getSmartTexture(AEColor c)
@@ -216,8 +216,8 @@ public class PartCable extends AEBasePart implements IPartCable
 			return CableBusTextures.MESmart_Yellow.getIcon();
 		default:
 		}
-		return AEApi.instance().parts().partCableCovered.item( AEColor.Transparent ).getIconIndex(
-				AEApi.instance().parts().partCableSmart.stack( AEColor.Transparent, 1 ) );
+		return AEApi.instance().definitions().parts().cableCovered().get().item( AEColor.Transparent ).getIconIndex(
+				AEApi.instance().definitions().parts().cableSmart().get().stack( AEColor.Transparent, 1 ) );
 	}
 
 	@Override
@@ -997,13 +997,13 @@ public class PartCable extends AEBasePart implements IPartCable
 			ItemStack newPart = null;
 
 			if ( this.getCableConnectionType() == AECableType.GLASS )
-				newPart = AEApi.instance().parts().partCableGlass.stack( newColor, 1 );
+				newPart = AEApi.instance().definitions().parts().cableGlass().get().stack( newColor, 1 );
 			else if ( this.getCableConnectionType() == AECableType.COVERED )
-				newPart = AEApi.instance().parts().partCableCovered.stack( newColor, 1 );
+				newPart = AEApi.instance().definitions().parts().cableCovered().get().stack( newColor, 1 );
 			else if ( this.getCableConnectionType() == AECableType.SMART )
-				newPart = AEApi.instance().parts().partCableSmart.stack( newColor, 1 );
+				newPart = AEApi.instance().definitions().parts().cableSmart().get().stack( newColor, 1 );
 			else if ( this.getCableConnectionType() == AECableType.DENSE )
-				newPart = AEApi.instance().parts().partCableDense.stack( newColor, 1 );
+				newPart = AEApi.instance().definitions().parts().cableDense().get().stack( newColor, 1 );
 
 			boolean hasPermission = true;
 

--- a/src/main/java/appeng/parts/networking/PartDenseCable.java
+++ b/src/main/java/appeng/parts/networking/PartDenseCable.java
@@ -92,7 +92,7 @@ public class PartDenseCable extends PartCable
 	public IIcon getTexture(AEColor c)
 	{
 		if ( c == AEColor.Transparent )
-			return AEApi.instance().parts().partCableSmart.stack( AEColor.Transparent, 1 ).getIconIndex();
+			return AEApi.instance().definitions().parts().cableSmart().get().stack( AEColor.Transparent, 1 ).getIconIndex();
 
 		return this.getSmartTexture( c );
 	}

--- a/src/main/java/appeng/parts/p2p/PartP2PTunnel.java
+++ b/src/main/java/appeng/parts/p2p/PartP2PTunnel.java
@@ -147,35 +147,35 @@ public class PartP2PTunnel<T extends PartP2PTunnel> extends PartBasicState
 			switch (tt)
 			{
 			case LIGHT:
-				newType = AEApi.instance().parts().partP2PTunnelLight.stack( 1 );
+				newType = AEApi.instance().definitions().parts().p2PTunnelLight().get().stack( 1 );
 				break;
 
 			case RF_POWER:
-				newType = AEApi.instance().parts().partP2PTunnelRF.stack( 1 );
+				newType = AEApi.instance().definitions().parts().p2PTunnelRF().get().stack( 1 );
 				break;
 
 			case BC_POWER:
-				newType = AEApi.instance().parts().partP2PTunnelMJ.stack( 1 );
+				newType = AEApi.instance().definitions().parts().p2PTunnelMJ().get().stack( 1 );
 				break;
 
 			case FLUID:
-				newType = AEApi.instance().parts().partP2PTunnelLiquids.stack( 1 );
+				newType = AEApi.instance().definitions().parts().p2PTunnelLiquids().get().stack( 1 );
 				break;
 
 			case IC2_POWER:
-				newType = AEApi.instance().parts().partP2PTunnelEU.stack( 1 );
+				newType = AEApi.instance().definitions().parts().p2PTunnelEU().get().stack( 1 );
 				break;
 
 			case ITEM:
-				newType = AEApi.instance().parts().partP2PTunnelItems.stack( 1 );
+				newType = AEApi.instance().definitions().parts().p2PTunnelItems().get().stack( 1 );
 				break;
 
 			case ME:
-				newType = AEApi.instance().parts().partP2PTunnelME.stack( 1 );
+				newType = AEApi.instance().definitions().parts().p2PTunnelME().get().stack( 1 );
 				break;
 
 			case REDSTONE:
-				newType = AEApi.instance().parts().partP2PTunnelRedstone.stack( 1 );
+				newType = AEApi.instance().definitions().parts().p2PTunnelRedstone().get().stack( 1 );
 				break;
 
 			default:
@@ -272,7 +272,7 @@ public class PartP2PTunnel<T extends PartP2PTunnel> extends PartBasicState
 		if ( type == PartItemStack.World || type == PartItemStack.Network || type == PartItemStack.Wrench || type == PartItemStack.Pick )
 			return super.getItemStack( type );
 
-		return AEApi.instance().parts().partP2PTunnelME.stack( 1 );
+		return AEApi.instance().definitions().parts().p2PTunnelME().get().stack( 1 );
 	}
 
 	public TunnelCollection<T> getCollection(Collection<PartP2PTunnel> collection, Class<? extends PartP2PTunnel> c)
@@ -335,7 +335,7 @@ public class PartP2PTunnel<T extends PartP2PTunnel> extends PartBasicState
 
 	protected IIcon getTypeTexture()
 	{
-		return AEApi.instance().blocks().blockQuartz.block().getIcon( 0, 0 );
+		return AEApi.instance().definitions().blocks().quartz().get().block().getIcon( 0, 0 );
 	}
 
 	@Override

--- a/src/main/java/appeng/recipes/AEItemResolver.java
+++ b/src/main/java/appeng/recipes/AEItemResolver.java
@@ -45,52 +45,52 @@ public class AEItemResolver implements ISubItemResolver
 		{
 			if ( itemName.startsWith( "PaintBall." ) )
 			{
-				return this.paintBall( AEApi.instance().items().itemPaintBall, itemName.substring( itemName.indexOf( "." ) + 1 ), false );
+				return this.paintBall( AEApi.instance().definitions().items().coloredPaintBall().get(), itemName.substring( itemName.indexOf( "." ) + 1 ), false );
 			}
 
 			if ( itemName.startsWith( "LumenPaintBall." ) )
 			{
-				return this.paintBall( AEApi.instance().items().itemPaintBall, itemName.substring( itemName.indexOf( "." ) + 1 ), true );
+				return this.paintBall( AEApi.instance().definitions().items().coloredLumenPaintBall().get(), itemName.substring( itemName.indexOf( "." ) + 1 ), true );
 			}
 
 			if ( itemName.equals( "CableGlass" ) )
 			{
-				return new ResolverResultSet( "CableGlass", AEApi.instance().parts().partCableGlass.allStacks( 1 ) );
+				return new ResolverResultSet( "CableGlass", AEApi.instance().definitions().parts().cableGlass().get().allStacks( 1 ) );
 			}
 
 			if ( itemName.startsWith( "CableGlass." ) )
 			{
-				return this.cableItem( AEApi.instance().parts().partCableGlass, itemName.substring( itemName.indexOf( "." ) + 1 ) );
+				return this.cableItem( AEApi.instance().definitions().parts().cableGlass().get(), itemName.substring( itemName.indexOf( "." ) + 1 ) );
 			}
 
 			if ( itemName.equals( "CableCovered" ) )
 			{
-				return new ResolverResultSet( "CableCovered", AEApi.instance().parts().partCableCovered.allStacks( 1 ) );
+				return new ResolverResultSet( "CableCovered", AEApi.instance().definitions().parts().cableCovered().get().allStacks( 1 ) );
 			}
 
 			if ( itemName.startsWith( "CableCovered." ) )
 			{
-				return this.cableItem( AEApi.instance().parts().partCableCovered, itemName.substring( itemName.indexOf( "." ) + 1 ) );
+				return this.cableItem( AEApi.instance().definitions().parts().cableCovered().get(), itemName.substring( itemName.indexOf( "." ) + 1 ) );
 			}
 
 			if ( itemName.equals( "CableSmart" ) )
 			{
-				return new ResolverResultSet( "CableSmart", AEApi.instance().parts().partCableSmart.allStacks( 1 ) );
+				return new ResolverResultSet( "CableSmart", AEApi.instance().definitions().parts().cableSmart().get().allStacks( 1 ) );
 			}
 
 			if ( itemName.startsWith( "CableSmart." ) )
 			{
-				return this.cableItem( AEApi.instance().parts().partCableSmart, itemName.substring( itemName.indexOf( "." ) + 1 ) );
+				return this.cableItem( AEApi.instance().definitions().parts().cableSmart().get(), itemName.substring( itemName.indexOf( "." ) + 1 ) );
 			}
 
 			if ( itemName.equals( "CableDense" ) )
 			{
-				return new ResolverResultSet( "CableDense", AEApi.instance().parts().partCableDense.allStacks( 1 ) );
+				return new ResolverResultSet( "CableDense", AEApi.instance().definitions().parts().cableDense().get().allStacks( 1 ) );
 			}
 
 			if ( itemName.startsWith( "CableDense." ) )
 			{
-				return this.cableItem( AEApi.instance().parts().partCableDense, itemName.substring( itemName.indexOf( "." ) + 1 ) );
+				return this.cableItem( AEApi.instance().definitions().parts().cableDense().get(), itemName.substring( itemName.indexOf( "." ) + 1 ) );
 			}
 
 			if ( itemName.startsWith( "ItemCrystalSeed." ) )

--- a/src/main/java/appeng/recipes/RecipeHandler.java
+++ b/src/main/java/appeng/recipes/RecipeHandler.java
@@ -258,7 +258,7 @@ public class RecipeHandler implements IRecipeHandler
 		if ( !id.modId.equals( AppEng.MOD_ID ) && !id.modId.equals( "minecraft" ) )
 			throw new RecipeError( "Not applicable for website" );
 
-		if ( is.getItem() == AEApi.instance().items().itemCrystalSeed.item() )
+		if ( is.getItem() == AEApi.instance().definitions().items().crystalSeed().get().item() )
 		{
 			int dmg = is.getItemDamage();
 			if ( dmg < ItemCrystalSeed.Nether )
@@ -268,7 +268,7 @@ public class RecipeHandler implements IRecipeHandler
 			else if ( dmg < ItemCrystalSeed.END )
 				realName += ".Fluix";
 		}
-		else if ( is.getItem() == AEApi.instance().blocks().blockSkyStone.item() )
+		else if ( is.getItem() == AEApi.instance().definitions().blocks().skyStone().get().item() )
 		{
 			switch (is.getItemDamage())
 			{
@@ -284,7 +284,7 @@ public class RecipeHandler implements IRecipeHandler
 			default:
 			}
 		}
-		else if ( is.getItem() == AEApi.instance().blocks().blockCraftingStorage1k.item() )
+		else if ( is.getItem() == AEApi.instance().definitions().blocks().craftingStorage1k().get().item() )
 		{
 			switch (is.getItemDamage())
 			{
@@ -300,7 +300,7 @@ public class RecipeHandler implements IRecipeHandler
 			default:
 			}
 		}
-		else if ( is.getItem() == AEApi.instance().blocks().blockCraftingUnit.item() )
+		else if ( is.getItem() == AEApi.instance().definitions().blocks().craftingUnit().get().item() )
 		{
 			switch (is.getItemDamage())
 			{
@@ -310,7 +310,7 @@ public class RecipeHandler implements IRecipeHandler
 			default:
 			}
 		}
-		else if ( is.getItem() == AEApi.instance().blocks().blockSkyChest.item() )
+		else if ( is.getItem() == AEApi.instance().definitions().blocks().skyChest().get().item() )
 		{
 			switch (is.getItemDamage())
 			{

--- a/src/main/java/appeng/recipes/game/DisassembleRecipe.java
+++ b/src/main/java/appeng/recipes/game/DisassembleRecipe.java
@@ -24,9 +24,9 @@ import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.world.World;
 
 import appeng.api.AEApi;
-import appeng.api.definitions.Blocks;
-import appeng.api.definitions.Items;
-import appeng.api.definitions.Materials;
+import appeng.api.definitions.IBlocks;
+import appeng.api.definitions.IItems;
+import appeng.api.definitions.IMaterials;
 import appeng.api.storage.IMEInventory;
 import appeng.api.storage.StorageChannel;
 import appeng.api.storage.data.IAEItemStack;
@@ -35,9 +35,9 @@ import appeng.api.storage.data.IItemList;
 public class DisassembleRecipe implements IRecipe
 {
 
-	private final Materials mats = AEApi.instance().materials();
-	private final Items items = AEApi.instance().items();
-	private final Blocks blocks = AEApi.instance().blocks();
+	private final IMaterials mats = AEApi.instance().definitions().materials();
+	private final IItems items = AEApi.instance().definitions().items();
+	private final IBlocks blocks = AEApi.instance().definitions().blocks();
 
 	private ItemStack getOutput(InventoryCrafting inv, boolean createFacade)
 	{
@@ -51,17 +51,17 @@ public class DisassembleRecipe implements IRecipe
 				if ( hasCell != null )
 					return null;
 
-				if ( this.items.itemCell1k.sameAsStack( is ) )
-					hasCell = this.mats.materialCell1kPart.stack( 1 );
+				if ( this.items.cell1k().get().sameAsStack( is ) )
+					hasCell = this.mats.cell16kPart().get().stack( 1 );
 
-				if ( this.items.itemCell4k.sameAsStack( is ) )
-					hasCell = this.mats.materialCell4kPart.stack( 1 );
+				if ( this.items.cell4k().get().sameAsStack( is ) )
+					hasCell = this.mats.cell4kPart().get().stack( 1 );
 
-				if ( this.items.itemCell16k.sameAsStack( is ) )
-					hasCell = this.mats.materialCell16kPart.stack( 1 );
+				if ( this.items.cell16k().get().sameAsStack( is ) )
+					hasCell = this.mats.cell16kPart().get().stack( 1 );
 
-				if ( this.items.itemCell64k.sameAsStack( is ) )
-					hasCell = this.mats.materialCell64kPart.stack( 1 );
+				if ( this.items.cell64k().get().sameAsStack( is ) )
+					hasCell = this.mats.cell64kPart().get().stack( 1 );
 
 				// make sure the storage cell is empty...
 				if ( hasCell != null )
@@ -75,20 +75,20 @@ public class DisassembleRecipe implements IRecipe
 					}
 				}
 
-				if ( this.items.itemEncodedPattern.sameAsStack( is ) )
-					hasCell = this.mats.materialBlankPattern.stack( 1 );
+				if ( this.items.encodedPattern().get().sameAsStack( is ) )
+					hasCell = this.mats.blankPattern().get().stack( 1 );
 
-				if ( this.blocks.blockCraftingStorage1k.sameAsStack( is ) )
-					hasCell = this.mats.materialCell1kPart.stack( 1 );
+				if ( this.blocks.craftingStorage1k().get().sameAsStack( is ) )
+					hasCell = this.mats.cell1kPart().get().stack( 1 );
 
-				if ( this.blocks.blockCraftingStorage4k.sameAsStack( is ) )
-					hasCell = this.mats.materialCell4kPart.stack( 1 );
+				if ( this.blocks.craftingStorage4k().get().sameAsStack( is ) )
+					hasCell = this.mats.cell4kPart().get().stack( 1 );
 
-				if ( this.blocks.blockCraftingStorage16k.sameAsStack( is ) )
-					hasCell = this.mats.materialCell16kPart.stack( 1 );
+				if ( this.blocks.craftingStorage16k().get().sameAsStack( is ) )
+					hasCell = this.mats.cell16kPart().get().stack( 1 );
 
-				if ( this.blocks.blockCraftingStorage64k.sameAsStack( is ) )
-					hasCell = this.mats.materialCell64kPart.stack( 1 );
+				if ( this.blocks.craftingStorage64k().get().sameAsStack( is ) )
+					hasCell = this.mats.cell64kPart().get().stack( 1 );
 
 				if ( hasCell == null )
 					return null;

--- a/src/main/java/appeng/recipes/game/FacadeRecipe.java
+++ b/src/main/java/appeng/recipes/game/FacadeRecipe.java
@@ -41,8 +41,8 @@ public class FacadeRecipe implements IRecipe
 
 	public FacadeRecipe()
 	{
-		this.maybeFacade = Optional.fromNullable( AEApi.instance().items().itemFacade );
-		this.maybeAnchor = Optional.fromNullable( AEApi.instance().parts().partCableAnchor );
+		this.maybeFacade = AEApi.instance().definitions().items().facade();
+		this.maybeAnchor = AEApi.instance().definitions().parts().cableAnchor();
 	}
 
 	@Override
@@ -61,7 +61,7 @@ public class FacadeRecipe implements IRecipe
 			if ( anchorDefinition.sameAsStack( inv.getStackInSlot( 1 ) ) && anchorDefinition.sameAsStack( inv.getStackInSlot( 3 ) ) && anchorDefinition.sameAsStack( inv.getStackInSlot( 5 ) ) && anchorDefinition.sameAsStack( inv.getStackInSlot( 7 ) ) )
 			{
 				final Item itemDefinition = facadeDefinition.item();
-				final ItemFacade facade = (ItemFacade) itemDefinition;
+				final ItemFacade facade = ( ItemFacade ) itemDefinition;
 
 				ItemStack facades = facade.createFacadeForItem( inv.getStackInSlot( 4 ), !createFacade );
 				if ( facades != null && createFacade )

--- a/src/main/java/appeng/server/AECommand.java
+++ b/src/main/java/appeng/server/AECommand.java
@@ -69,10 +69,12 @@ public class AECommand extends CommandBase
 					throw new WrongUsageException( c.command.getHelp( this.srv ) );
 				}
 			}
+			catch ( WrongUsageException wrong )
+			{
+				throw wrong;
+			}
 			catch (Throwable er)
 			{
-				if ( er instanceof WrongUsageException )
-					throw (WrongUsageException) er;
 				throw new WrongUsageException( "commands.ae2.usage" );
 			}
 		}
@@ -90,10 +92,12 @@ public class AECommand extends CommandBase
 				else
 					throw new WrongUsageException( "commands.ae2.permissions" );
 			}
+			catch ( WrongUsageException wrong )
+			{
+				throw wrong;
+			}
 			catch (Throwable er)
 			{
-				if ( er instanceof WrongUsageException )
-					throw (WrongUsageException) er;
 				throw new WrongUsageException( "commands.ae2.usage" );
 			}
 		}

--- a/src/main/java/appeng/services/CompassService.java
+++ b/src/main/java/appeng/services/CompassService.java
@@ -230,7 +230,7 @@ public class CompassService implements ThreadFactory
 		int low_y = cdy << 5;
 		int hi_y = low_y + 32;
 
-		Block skystone = AEApi.instance().blocks().blockSkyStone.block();
+		Block skystone = AEApi.instance().definitions().blocks().skyStone().get().block();
 
 		// lower level...
 		Chunk c = w.getChunkFromBlockCoords( x, z );

--- a/src/main/java/appeng/spatial/CachedPlane.java
+++ b/src/main/java/appeng/spatial/CachedPlane.java
@@ -130,7 +130,7 @@ public class CachedPlane
 	final LinkedList<NextTickListEntry> ticks = new LinkedList<NextTickListEntry>();
 
 	final World world;
-	final Block matrixFrame = AEApi.instance().blocks().blockMatrixFrame.block();
+	final Block matrixFrame = AEApi.instance().definitions().blocks().matrixFrame().get().block();
 	final IMovableRegistry reg = AEApi.instance().registries().movable();
 
 	final LinkedList<WorldCoord> updates = new LinkedList<WorldCoord>();
@@ -220,7 +220,7 @@ public class CachedPlane
 				}
 
 				long k = this.world.getTotalWorldTime();
-				List list = this.world.getPendingBlockUpdates( c, false );
+				List<?> list = this.world.getPendingBlockUpdates( c, false );
 				if ( list != null )
 				{
 					for (Object o : list)

--- a/src/main/java/appeng/spatial/StorageChunkProvider.java
+++ b/src/main/java/appeng/spatial/StorageChunkProvider.java
@@ -40,7 +40,7 @@ public class StorageChunkProvider extends ChunkProviderGenerate
 
 		BLOCKS = new Block[255 * 256];
 
-		Block matrixFrame = AEApi.instance().blocks().blockMatrixFrame.block();
+		Block matrixFrame = AEApi.instance().definitions().blocks().matrixFrame().get().block();
 		for (int x = 0; x < BLOCKS.length; x++)
 			BLOCKS[x] = matrixFrame;
 

--- a/src/main/java/appeng/spatial/StorageHelper.java
+++ b/src/main/java/appeng/spatial/StorageHelper.java
@@ -289,7 +289,7 @@ public class StorageHelper
 	, World dst /** storage cell **/
 	, int x, int y, int z, int i, int j, int k, int scaleX, int scaleY, int scaleZ)
 	{
-		BlockMatrixFrame blkMF = (BlockMatrixFrame) AEApi.instance().blocks().blockMatrixFrame.block();
+		BlockMatrixFrame blkMF = (BlockMatrixFrame) AEApi.instance().definitions().blocks().matrixFrame().get().block();
 
 		this.transverseEdges( i - 1, j - 1, k - 1, i + scaleX + 1, j + scaleY + 1, k + scaleZ + 1, new WrapInMatrixFrame( blkMF, 0, dst ) );
 

--- a/src/main/java/appeng/tile/crafting/TileCraftingStorageTile.java
+++ b/src/main/java/appeng/tile/crafting/TileCraftingStorageTile.java
@@ -25,9 +25,9 @@ import appeng.api.AEApi;
 public class TileCraftingStorageTile extends TileCraftingTile
 {
 
-	static final ItemStack STACK_4K_STORAGE = AEApi.instance().blocks().blockCraftingStorage4k.stack( 1 );
-	static final ItemStack STACK_16K_STORAGE = AEApi.instance().blocks().blockCraftingStorage16k.stack( 1 );
-	static final ItemStack STACK_64K_STORAGE = AEApi.instance().blocks().blockCraftingStorage64k.stack( 1 );
+	static final ItemStack STACK_4K_STORAGE = AEApi.instance().definitions().blocks().craftingStorage4k().get().stack( 1 );
+	static final ItemStack STACK_16K_STORAGE = AEApi.instance().definitions().blocks().craftingStorage16k().get().stack( 1 );
+	static final ItemStack STACK_64K_STORAGE = AEApi.instance().definitions().blocks().craftingStorage64k().get().stack( 1 );
 
 	@Override
 	protected ItemStack getItemFromTile(Object obj)

--- a/src/main/java/appeng/tile/crafting/TileCraftingTile.java
+++ b/src/main/java/appeng/tile/crafting/TileCraftingTile.java
@@ -63,7 +63,7 @@ public class TileCraftingTile extends AENetworkTile implements IAEMultiBlock, IP
 	public NBTTagCompound previousState = null;
 	public boolean isCoreBlock = false;
 
-	static final ItemStack STACK_CO_PROCESSOR = AEApi.instance().blocks().blockCraftingAccelerator.stack( 1 );
+	static final ItemStack STACK_CO_PROCESSOR = AEApi.instance().definitions().blocks().craftingAccelerator().get().stack( 1 );
 
 	@Override
 	protected AENetworkProxy createProxy()

--- a/src/main/java/appeng/tile/crafting/TileMolecularAssembler.java
+++ b/src/main/java/appeng/tile/crafting/TileMolecularAssembler.java
@@ -78,7 +78,7 @@ public class TileMolecularAssembler extends AENetworkInvTile implements IUpgrade
 {
 
 	private static final int[] SIDES = new int[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
-	private static final ItemStack STACK_ASSEMBLER = AEApi.instance().blocks().blockMolecularAssembler.stack( 1 );
+	private static final ItemStack STACK_ASSEMBLER = AEApi.instance().definitions().blocks().molecularAssembler().get().stack( 1 );
 
 	private final InventoryCrafting craftingInv = new InventoryCrafting( new ContainerNull(), 3, 3 );
 	private final AppEngInternalInventory inv = new AppEngInternalInventory( this, 9 + 2 );

--- a/src/main/java/appeng/tile/misc/TileCharger.java
+++ b/src/main/java/appeng/tile/misc/TileCharger.java
@@ -138,12 +138,12 @@ public class TileCharger extends AENetworkPowerTile implements ICrankable
 				this.tickTickTimer = 20; // keep ticking...
 			}
 		}
-		else if ( this.internalCurrentPower > 1499 && AEApi.instance().materials().materialCertusQuartzCrystal.sameAsStack( myItem ) )
+		else if ( this.internalCurrentPower > 1499 && AEApi.instance().definitions().materials().certusQuartzCrystal().get().sameAsStack( myItem ) )
 		{
 			if ( Platform.getRandomFloat() > 0.8f ) // simulate wait
 			{
 				this.extractAEPower( this.internalMaxPower, Actionable.MODULATE, PowerMultiplier.CONFIG );// 1500
-				this.setInventorySlotContents( 0, AEApi.instance().materials().materialCertusQuartzCrystalCharged.stack( myItem.stackSize ) );
+				this.setInventorySlotContents( 0, AEApi.instance().definitions().materials().certusQuartzCrystalCharged().get().stack( myItem.stackSize ) );
 			}
 		}
 	}
@@ -175,10 +175,10 @@ public class TileCharger extends AENetworkPowerTile implements ICrankable
 		this.injectExternalPower( PowerUnits.AE, 150 );
 
 		ItemStack myItem = this.getStackInSlot( 0 );
-		if ( this.internalCurrentPower > 1499 && AEApi.instance().materials().materialCertusQuartzCrystal.sameAsStack( myItem ) )
+		if ( this.internalCurrentPower > 1499 && AEApi.instance().definitions().materials().certusQuartzCrystal().get().sameAsStack( myItem ) )
 		{
 			this.extractAEPower( this.internalMaxPower, Actionable.MODULATE, PowerMultiplier.CONFIG );// 1500
-			this.setInventorySlotContents( 0, AEApi.instance().materials().materialCertusQuartzCrystalCharged.stack( myItem.stackSize ) );
+			this.setInventorySlotContents( 0, AEApi.instance().definitions().materials().certusQuartzCrystalCharged().get().stack( myItem.stackSize ) );
 		}
 	}
 
@@ -215,7 +215,7 @@ public class TileCharger extends AENetworkPowerTile implements ICrankable
 	@Override
 	public boolean isItemValidForSlot(int i, ItemStack itemstack)
 	{
-		return Platform.isChargeable( itemstack ) || AEApi.instance().materials().materialCertusQuartzCrystal.sameAsStack( itemstack );
+		return Platform.isChargeable( itemstack ) || AEApi.instance().definitions().materials().certusQuartzCrystal().get().sameAsStack( itemstack );
 	}
 
 	@Override
@@ -228,7 +228,7 @@ public class TileCharger extends AENetworkPowerTile implements ICrankable
 				return true;
 		}
 
-		return AEApi.instance().materials().materialCertusQuartzCrystalCharged.sameAsStack( itemstack );
+		return AEApi.instance().definitions().materials().certusQuartzCrystalCharged().get().sameAsStack( itemstack );
 	}
 
 	public void activate(EntityPlayer player)
@@ -240,7 +240,7 @@ public class TileCharger extends AENetworkPowerTile implements ICrankable
 		if ( myItem == null )
 		{
 			ItemStack held = player.inventory.getCurrentItem();
-			if ( AEApi.instance().materials().materialCertusQuartzCrystal.sameAsStack( held ) || Platform.isChargeable( held ) )
+			if ( AEApi.instance().definitions().materials().certusQuartzCrystal().get().sameAsStack( held ) || Platform.isChargeable( held ) )
 			{
 				held = player.inventory.decrStackSize( player.inventory.currentItem, 1 );
 				this.setInventorySlotContents( 0, held );

--- a/src/main/java/appeng/tile/misc/TileCondenser.java
+++ b/src/main/java/appeng/tile/misc/TileCondenser.java
@@ -133,9 +133,9 @@ public class TileCondenser extends AEBaseInvTile implements IFluidHandler, IConf
 		switch ((CondenserOutput) this.cm.getSetting( Settings.CONDENSER_OUTPUT ))
 		{
 		case MATTER_BALLS:
-			return AEApi.instance().materials().materialMatterBall.stack( 1 );
+			return AEApi.instance().definitions().materials().matterBall().get().stack( 1 );
 		case SINGULARITY:
-			return AEApi.instance().materials().materialSingularity.stack( 1 );
+			return AEApi.instance().definitions().materials().singularity().get().stack( 1 );
 		case TRASH:
 		default:
 		}

--- a/src/main/java/appeng/tile/misc/TileInscriber.java
+++ b/src/main/java/appeng/tile/misc/TileInscriber.java
@@ -78,7 +78,7 @@ public class TileInscriber extends AENetworkPowerTile implements IGridTickable, 
 
 	public long clientStart;
 
-	static final ItemStack STACK_INSCRIBER = AEApi.instance().blocks().blockInscriber.stack( 1 );
+	static final ItemStack STACK_INSCRIBER = AEApi.instance().definitions().blocks().inscriber().get().stack( 1 );
 	private final IConfigManager settings = new ConfigManager( this );
 	private final UpgradeInventory upgrades = new UpgradeInventory( STACK_INSCRIBER, this, this.getUpgradeSlots() );
 
@@ -204,7 +204,7 @@ public class TileInscriber extends AENetworkPowerTile implements IGridTickable, 
 
 		if ( i == 0 || i == 1 )
 		{
-			if ( AEApi.instance().materials().materialNamePress.sameAsStack( itemstack ) )
+			if ( AEApi.instance().definitions().materials().namePress().get().sameAsStack( itemstack ) )
 				return true;
 
 			for (ItemStack s : Inscribe.PLATES )
@@ -269,8 +269,8 @@ public class TileInscriber extends AENetworkPowerTile implements IGridTickable, 
 		if ( renamedItem != null && renamedItem.stackSize > 1 )
 			return null;
 
-		boolean isNameA = AEApi.instance().materials().materialNamePress.sameAsStack( PlateA );
-		boolean isNameB = AEApi.instance().materials().materialNamePress.sameAsStack( PlateB );
+		boolean isNameA = AEApi.instance().definitions().materials().namePress().get().sameAsStack( PlateA );
+		boolean isNameB = AEApi.instance().definitions().materials().namePress().get().sameAsStack( PlateB );
 
 		if ( (isNameA || isNameB) && (isNameA || PlateA == null) && (isNameB || PlateB == null) )
 		{

--- a/src/main/java/appeng/tile/networking/TileWireless.java
+++ b/src/main/java/appeng/tile/networking/TileWireless.java
@@ -193,7 +193,7 @@ public class TileWireless extends AENetworkInvTile implements IWirelessAccessPoi
 	@Override
 	public boolean isItemValidForSlot( int i, ItemStack itemstack )
 	{
-		return AEApi.instance().materials().materialWirelessBooster.sameAsStack( itemstack );
+		return AEApi.instance().definitions().materials().wirelessBooster().get().sameAsStack( itemstack );
 	}
 
 	@Override

--- a/src/main/java/appeng/tile/qnb/TileQuantumBridge.java
+++ b/src/main/java/appeng/tile/qnb/TileQuantumBridge.java
@@ -49,7 +49,7 @@ import appeng.util.Platform;
 public class TileQuantumBridge extends AENetworkInvTile implements IAEMultiBlock
 {
 
-	final private static ItemStack RING_STACK = ( AEApi.instance().blocks().blockQuantumRing != null ) ? AEApi.instance().blocks().blockQuantumRing.stack( 1 ) : null;
+	final private static ItemStack RING_STACK = ( AEApi.instance().definitions().blocks().quantumRing().isPresent() ) ? AEApi.instance().definitions().blocks().quantumRing().get().stack( 1 ) : null;
 
 	final int[] sidesRing = new int[] { };
 	final int[] sidesLink = new int[] { 0 };
@@ -170,7 +170,7 @@ public class TileQuantumBridge extends AENetworkInvTile implements IAEMultiBlock
 	public void onReady()
 	{
 		super.onReady();
-		if ( this.worldObj.getBlock( this.xCoord, this.yCoord, this.zCoord ) == AEApi.instance().blocks().blockQuantumRing.block() )
+		if ( this.worldObj.getBlock( this.xCoord, this.yCoord, this.zCoord ) == AEApi.instance().definitions().blocks().quantumRing().get().block() )
 			this.gridProxy.setVisualRepresentation( RING_STACK );
 	}
 
@@ -223,7 +223,7 @@ public class TileQuantumBridge extends AENetworkInvTile implements IAEMultiBlock
 
 	public boolean isCenter()
 	{
-		return this.getBlockType() == AEApi.instance().blocks().blockQuantumLink.block();
+		return this.getBlockType() == AEApi.instance().definitions().blocks().quantumLink().get().block();
 	}
 
 	public boolean isCorner()

--- a/src/main/java/appeng/tile/storage/TileIOPort.java
+++ b/src/main/java/appeng/tile/storage/TileIOPort.java
@@ -78,7 +78,7 @@ public class TileIOPort extends AENetworkInvTile implements IUpgradeableHost, IC
 	final int[] outputSlots = { 6, 7, 8, 9, 10, 11 };
 
 	final AppEngInternalInventory cells = new AppEngInternalInventory( this, 12 );
-	final UpgradeInventory upgrades = new UpgradeInventory( AEApi.instance().blocks().blockIOPort.block(), this, 3 );
+	final UpgradeInventory upgrades = new UpgradeInventory( AEApi.instance().definitions().blocks().iOPort().get().block(), this, 3 );
 
 	final BaseActionSource mySrc = new MachineSource( this );
 

--- a/src/main/java/appeng/util/Platform.java
+++ b/src/main/java/appeng/util/Platform.java
@@ -1755,7 +1755,7 @@ public class Platform
 			return false;
 
 		if ( type == AEFeature.CertusQuartzTools )
-			return AEApi.instance().materials().materialCertusQuartzCrystal.sameAsStack( b );
+			return AEApi.instance().definitions().materials().certusQuartzCrystal().get().sameAsStack( b );
 
 		if ( type == AEFeature.NetherQuartzTools )
 			return Items.quartz == b.getItem();
@@ -1767,16 +1767,16 @@ public class Platform
 	{
 		for (ItemStack stack : is)
 		{
-			if ( AEApi.instance().parts().partCableGlass.sameAs( AEColor.Transparent, stack ) )
+			if ( AEApi.instance().definitions().parts().cableGlass().get().sameAs( AEColor.Transparent, stack ) )
 				return stack;
 
-			if ( AEApi.instance().parts().partCableCovered.sameAs( AEColor.Transparent, stack ) )
+			if ( AEApi.instance().definitions().parts().cableCovered().get().sameAs( AEColor.Transparent, stack ) )
 				return stack;
 
-			if ( AEApi.instance().parts().partCableSmart.sameAs( AEColor.Transparent, stack ) )
+			if ( AEApi.instance().definitions().parts().cableSmart().get().sameAs( AEColor.Transparent, stack ) )
 				return stack;
 
-			if ( AEApi.instance().parts().partCableDense.sameAs( AEColor.Transparent, stack ) )
+			if ( AEApi.instance().definitions().parts().cableDense().get().sameAs( AEColor.Transparent, stack ) )
 				return stack;
 		}
 
@@ -1865,8 +1865,8 @@ public class Platform
 
 	public static boolean isRecipePrioritized(ItemStack what)
 	{
-		return AEApi.instance().materials().materialPurifiedCertusQuartzCrystal.sameAsStack( what )
-				|| AEApi.instance().materials().materialPurifiedFluixCrystal.sameAsStack( what )
-				|| AEApi.instance().materials().materialPurifiedNetherQuartzCrystal.sameAsStack( what );
+		return AEApi.instance().definitions().materials().purifiedCertusQuartzCrystal().get().sameAsStack( what )
+				|| AEApi.instance().definitions().materials().purifiedFluixCrystal().get().sameAsStack( what )
+				|| AEApi.instance().definitions().materials().purifiedNetherQuartzCrystal().get().sameAsStack( what );
 	}
 }


### PR DESCRIPTION
The work is mostly done by @thatsIch, my contribution is just the small changes to migrate AE2 itself to the new api and squash his comments to be a bit more compact.

This will change the API greatly. This should be normally avoided in a non alpha state, but it is necessary to solve many issues with disabled feature in a sane way as well being able to push a stable build finally.
There is still a backward compatibility layer, so rv2 addons will not break.
For addon devs it is possibly the best option to use the deprecated way for now and plan a switch with rv3.

I personally would mark it for removal with the end of rv3 alpha/start of rv3 beta.
But I could see it stick around for rv3 completely.