### PR TITLE
Updated Forge and other dependencies

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -8,17 +8,17 @@ archivesBaseName=appliedenergistics2
 # Versions                                              #
 #########################################################
 minecraft_version=1.7.10
-forge_version=10.13.2.1230
+forge_version=10.13.2.1291
 
 #########################################################
 # APIs used for development                             #
 #########################################################
 cb_minecraft_version=1.7.10
-fmp_version=1.1.0.311
-code_chicken_lib_version=1.1.1.105
-code_chicken_core_version=1.0.4.29
-nei_version=1.0.3.66
-waila_version=1.5.7a_1.7.10
+fmp_version=1.1.1.321
+code_chicken_lib_version=1.1.1.110
+code_chicken_core_version=1.0.4.35
+nei_version=1.0.4.90
+waila_version=1.5.9_1.7.10
 
 #########################################################
 # API Stubs                                             #


### PR DESCRIPTION
Updating forge to the newest recommended build is necessary for #932. It is probably possible to just update to the version adding the ExplosionEvent, but I personally prefer to just stick with a recommended version. (if possible).
As this is a hard dependency, people will need to update their forge version. Not ideal as we are in a beta phase, but there are already other mods depending on 1291 (like TE/TD). So we are not the only one pushing it.

CCC and NEI are not recommended builds and the WAILA version is also not really necessary.
Both the combination of these three is breaking NEI and making it unusable in the dev environment.
WAILA 1.5.8/9 adds some potentially interesting features, if we decide to use them. But it requires NEI 1.0.4.+ and to really work again also a newer CCC version.
And while I am already bumping, I have also bumped CCL and FMP.
As these are soft dependencies and we are currently not using newer features, there should be no reason to expect it to break.
