### PR TITLE
Fixes #889 possible dupe bug

### DIFF
--- a/src/main/java/appeng/client/gui/implementations/GuiMEPortableCell.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiMEPortableCell.java
@@ -30,7 +30,7 @@ public class GuiMEPortableCell extends GuiMEMonitorable
 
 	public GuiMEPortableCell( InventoryPlayer inventoryPlayer, IPortableCell te )
 	{
-		super( inventoryPlayer, te, new ContainerMEPortableCell( inventoryPlayer, null ) );
+		super( inventoryPlayer, te, new ContainerMEPortableCell( inventoryPlayer, te ) );
 	}
 
 	int defaultGetMaxRows()

--- a/src/main/java/appeng/container/implementations/ContainerMEPortableCell.java
+++ b/src/main/java/appeng/container/implementations/ContainerMEPortableCell.java
@@ -25,20 +25,33 @@ import net.minecraft.item.ItemStack;
 import appeng.api.config.Actionable;
 import appeng.api.config.PowerMultiplier;
 import appeng.api.implementations.guiobjects.IPortableCell;
+import appeng.container.interfaces.IInventorySlotAware;
 import appeng.util.Platform;
 
 
 public class ContainerMEPortableCell extends ContainerMEMonitorable
 {
 
-	final IPortableCell civ;
-	double powerMultiplier = 0.5;
-	int ticks = 0;
+	public double powerMultiplier = 0.5;
+
+	private final IPortableCell civ;
+	private int ticks = 0;
+	private final int slot;
 
 	public ContainerMEPortableCell( InventoryPlayer ip, IPortableCell monitorable )
 	{
 		super( ip, monitorable, false );
-		this.lockPlayerInventorySlot( ip.currentItem );
+		if( monitorable instanceof IInventorySlotAware )
+		{
+			int slotIndex = ( (IInventorySlotAware) monitorable ).getInventorySlot();
+			this.lockPlayerInventorySlot( slotIndex );
+			this.slot = slotIndex;
+		}
+		else
+		{
+			this.slot = -1;
+			this.lockPlayerInventorySlot( ip.currentItem );
+		}
 		this.civ = monitorable;
 		this.bindPlayerInventory( ip, 0, 0 );
 	}
@@ -46,7 +59,7 @@ public class ContainerMEPortableCell extends ContainerMEMonitorable
 	@Override
 	public void detectAndSendChanges()
 	{
-		ItemStack currentItem = this.getPlayerInv().getCurrentItem();
+		ItemStack currentItem = slot < 0 ? this.getPlayerInv().getCurrentItem() : this.getPlayerInv().getStackInSlot( slot );
 
 		if( this.civ != null )
 		{

--- a/src/main/java/appeng/container/interfaces/IInventorySlotAware.java
+++ b/src/main/java/appeng/container/interfaces/IInventorySlotAware.java
@@ -1,0 +1,37 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.container.interfaces;
+
+
+/**
+ * Any item providing a GUI and depending on an exact inventory slot.
+ *
+ * This interface is likely a volatile one until a general GUI refactoring occurred.
+ * Use it with care and expect changes.
+ *
+ */
+public interface IInventorySlotAware
+{
+	/**
+	 * This is needed to select the correct slot index.
+	 *
+	 * @return the inventory index of this portable cell.
+	 */
+	int getInventorySlot();
+}

--- a/src/main/java/appeng/core/sync/GuiBridge.java
+++ b/src/main/java/appeng/core/sync/GuiBridge.java
@@ -250,15 +250,21 @@ public enum GuiBridge implements IGuiHandler
 		ForgeDirection side = ForgeDirection.getOrientation( ID_ORDINAL & 0x07 );
 		GuiBridge ID = values()[ID_ORDINAL >> 4];
 		boolean stem = ( ( ID_ORDINAL >> 3 ) & 1 ) == 1;
-
-		if( ID.type.isItem() && stem )
+		if( ID.type.isItem() )
 		{
-			ItemStack it = player.inventory.getCurrentItem();
+			ItemStack it = null;
+			if( stem )
+			{
+				it = player.inventory.getCurrentItem();
+			}
+			else if( x >= 0 && x < player.inventory.mainInventory.length )
+			{
+				it = player.inventory.getStackInSlot( x );
+			}
 			Object myItem = this.getGuiObject( it, player, w, x, y, z );
 			if( myItem != null && ID.CorrectTileOrPart( myItem ) )
 				return this.updateGui( ID.ConstructContainer( player.inventory, side, myItem ), w, x, y, z, side, myItem );
 		}
-
 		if( ID.type.isTile() )
 		{
 			TileEntity TE = w.getTileEntity( x, y, z );
@@ -275,7 +281,6 @@ public enum GuiBridge implements IGuiHandler
 					return this.updateGui( ID.ConstructContainer( player.inventory, side, TE ), w, x, y, z, side, TE );
 			}
 		}
-
 		return new ContainerNull();
 	}
 
@@ -411,19 +416,24 @@ public enum GuiBridge implements IGuiHandler
 		ForgeDirection side = ForgeDirection.getOrientation( ID_ORDINAL & 0x07 );
 		GuiBridge ID = values()[ID_ORDINAL >> 4];
 		boolean stem = ( ( ID_ORDINAL >> 3 ) & 1 ) == 1;
-
-		if( ID.type.isItem() && stem )
+		if( ID.type.isItem() )
 		{
-			ItemStack it = player.inventory.getCurrentItem();
+			ItemStack it = null;
+			if( stem )
+			{
+				it = player.inventory.getCurrentItem();
+			}
+			else if( x >= 0 && x < player.inventory.mainInventory.length )
+			{
+				it = player.inventory.getStackInSlot( x );
+			}
 			Object myItem = this.getGuiObject( it, player, w, x, y, z );
-			if( ID.CorrectTileOrPart( myItem ) )
+			if( myItem != null && ID.CorrectTileOrPart( myItem ) )
 				return ID.ConstructGui( player.inventory, side, myItem );
 		}
-
 		if( ID.type.isTile() )
 		{
 			TileEntity TE = w.getTileEntity( x, y, z );
-
 			if( TE instanceof IPartHost )
 			{
 				( (IPartHost) TE ).getPart( side );
@@ -437,7 +447,6 @@ public enum GuiBridge implements IGuiHandler
 					return ID.ConstructGui( player.inventory, side, TE );
 			}
 		}
-
 		return new GuiNull( new ContainerNull() );
 	}
 

--- a/src/main/java/appeng/helpers/WirelessTerminalGuiObject.java
+++ b/src/main/java/appeng/helpers/WirelessTerminalGuiObject.java
@@ -48,10 +48,11 @@ import appeng.api.storage.data.IItemList;
 import appeng.api.util.AECableType;
 import appeng.api.util.DimensionalCoord;
 import appeng.api.util.IConfigManager;
+import appeng.container.interfaces.IInventorySlotAware;
 import appeng.tile.networking.TileWireless;
 
 
-public class WirelessTerminalGuiObject implements IPortableCell, IActionHost
+public class WirelessTerminalGuiObject implements IPortableCell, IActionHost, IInventorySlotAware
 {
 
 	public final ItemStack effectiveItem;
@@ -64,6 +65,7 @@ public class WirelessTerminalGuiObject implements IPortableCell, IActionHost
 	IWirelessAccessPoint myWap;
 	double sqRange = Double.MAX_VALUE;
 	double myRange = Double.MAX_VALUE;
+	private final int inventorySlot;
 
 	public WirelessTerminalGuiObject( IWirelessTermHandler wh, ItemStack is, EntityPlayer ep, World w, int x, int y, int z )
 	{
@@ -71,6 +73,7 @@ public class WirelessTerminalGuiObject implements IPortableCell, IActionHost
 		this.effectiveItem = is;
 		this.myPlayer = ep;
 		this.wth = wh;
+		this.inventorySlot = x;
 
 		ILocatable obj = null;
 
@@ -332,4 +335,11 @@ public class WirelessTerminalGuiObject implements IPortableCell, IActionHost
 		}
 		return false;
 	}
+
+	@Override
+	public int getInventorySlot()
+	{
+		return inventorySlot;
+	}
+
 }

--- a/src/main/java/appeng/items/contents/PortableCellViewer.java
+++ b/src/main/java/appeng/items/contents/PortableCellViewer.java
@@ -35,23 +35,32 @@ import appeng.api.storage.MEMonitorHandler;
 import appeng.api.storage.data.IAEFluidStack;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.api.util.IConfigManager;
+import appeng.container.interfaces.IInventorySlotAware;
 import appeng.me.storage.CellInventory;
 import appeng.util.ConfigManager;
 import appeng.util.IConfigManagerHost;
 import appeng.util.Platform;
 
 
-public class PortableCellViewer extends MEMonitorHandler<IAEItemStack> implements IPortableCell
+public class PortableCellViewer extends MEMonitorHandler<IAEItemStack> implements IPortableCell, IInventorySlotAware
 {
 
 	private final ItemStack target;
 	private final IAEItemPowerStorage ips;
+	private final int inventorySlot;
 
-	public PortableCellViewer( ItemStack is )
+	public PortableCellViewer( ItemStack is, int slot )
 	{
 		super( CellInventory.getCell( is, null ) );
 		this.ips = (IAEItemPowerStorage) is.getItem();
 		this.target = is;
+		this.inventorySlot = slot;
+	}
+
+	@Override
+	public int getInventorySlot()
+	{
+		return inventorySlot;
 	}
 
 	@Override

--- a/src/main/java/appeng/items/tools/powered/ToolPortableCell.java
+++ b/src/main/java/appeng/items/tools/powered/ToolPortableCell.java
@@ -186,6 +186,6 @@ public class ToolPortableCell extends AEBasePoweredItem implements IStorageCell,
 	@Override
 	public IGuiItemObject getGuiObject( ItemStack is, World w, int x, int y, int z )
 	{
-		return new PortableCellViewer( is );
+		return new PortableCellViewer( is, x );
 	}
 }

--- a/src/main/java/appeng/util/Platform.java
+++ b/src/main/java/appeng/util/Platform.java
@@ -326,8 +326,10 @@ public class Platform
 
 		if( ( type.getType().isItem() && tile == null ) || type.hasPermissions( tile, x, y, z, side, p ) )
 		{
-			if( tile == null || type.getType() == GuiHostType.ITEM )
-				p.openGui( AppEng.instance, type.ordinal() << 4 | ( 1 << 3 ), p.getEntityWorld(), x, y, z );
+			if( tile != null && type.getType() == GuiHostType.ITEM )
+				p.openGui( AppEng.instance, type.ordinal() << 4 | (1 << 3) , p.getEntityWorld(), x, y, z );
+			else if ( tile == null && type.getType() == GuiHostType.ITEM )
+				p.openGui( AppEng.instance, type.ordinal() << 4 | (0 << 3), p.getEntityWorld(), p.inventory.currentItem, 0, 0 );
 			else
 				p.openGui( AppEng.instance, type.ordinal() << 4 | ( side.ordinal() ), tile.getWorldObj(), x, y, z );
 		}


### PR DESCRIPTION
Adds a hotfix to prevent duping with portable cells.
Should possibly fix the NPE crash with switching slots on laggy servers. #574 (Might not fix every possible combination)

It is mostly a hotfix to prevent the bug.
The new API interface is mostly tentative and subject to change.

There should be a general GUI refactoring possibly using a registry/factory to create the GUIs instead of using reflection. This can potentially also allow AE2 addons to better reuse our GUIs (like crafting)