### PR TITLE
Introduction to the new Optional API

### DIFF
--- a/src/api/java/appeng/api/AEApi.java
+++ b/src/api/java/appeng/api/AEApi.java
@@ -23,39 +23,44 @@
 
 package appeng.api;
 
+
+import appeng.api.exceptions.CouldNotAccessCoreAPI;
+
+
 /**
- *
  * Entry point for api.
  *
  * Available IMCs:
- *
  */
 public class AEApi
 {
+	private static final String CORE_API_PATH = "appeng.core.Api";
+	private static final String API_INSTANCE_NAME = "INSTANCE";
 
-	static private IAppEngApi api = null;
+	private static IAppEngApi instance = null;
 
 	/**
 	 * API Entry Point.
 	 *
-	 * @return the {@link IAppEngApi} or null if the INSTANCE could not be retrieved
+	 * @return the {@link IAppEngApi}
+	 *
+	 * @throws CouldNotAccessCoreAPI if the INSTANCE could not be retrieved
 	 */
 	public static IAppEngApi instance()
 	{
-		if ( api == null )
+		if ( instance == null )
 		{
 			try
 			{
-				Class c = Class.forName( "appeng.core.Api" );
-				api = (IAppEngApi) c.getField( "INSTANCE" ).get( c );
+				Class<?> c = Class.forName( CORE_API_PATH );
+				instance = (IAppEngApi) c.getField( API_INSTANCE_NAME ).get( c );
 			}
-			catch (Throwable e)
+			catch ( Throwable e )
 			{
-				return null;
+				throw new CouldNotAccessCoreAPI( "Either core API was not in " + CORE_API_PATH + " or " + API_INSTANCE_NAME + " was not accessible" );
 			}
 		}
 
-		return api;
+		return instance;
 	}
-
 }

--- a/src/api/java/appeng/api/IAppEngApi.java
+++ b/src/api/java/appeng/api/IAppEngApi.java
@@ -23,7 +23,9 @@
 
 package appeng.api;
 
+
 import appeng.api.definitions.Blocks;
+import appeng.api.definitions.IDefinitions;
 import appeng.api.definitions.Items;
 import appeng.api.definitions.Materials;
 import appeng.api.definitions.Parts;
@@ -31,10 +33,10 @@ import appeng.api.exceptions.FailedConnection;
 import appeng.api.features.IRegistryContainer;
 import appeng.api.networking.IGridBlock;
 import appeng.api.networking.IGridConnection;
-import appeng.api.networking.IGridHost;
 import appeng.api.networking.IGridNode;
 import appeng.api.parts.IPartHelper;
 import appeng.api.storage.IStorageHelper;
+
 
 public interface IAppEngApi
 {
@@ -56,39 +58,57 @@ public interface IAppEngApi
 
 	/**
 	 * @return an accessible list of all of AE's Items
+	 *
+	 * @deprecated use {@link appeng.api.definitions.IDefinitions#items()}
 	 */
+	@Deprecated
 	Items items();
 
 	/**
 	 * @return an accessible list of all of AE's materials; materials are items
+	 *
+	 * @deprecated use {@link appeng.api.definitions.IDefinitions#materials()}
 	 */
+	@Deprecated
 	Materials materials();
 
 	/**
 	 * @return an accessible list of all of AE's blocks
+	 *
+	 * @deprecated use {@link appeng.api.definitions.IDefinitions#blocks()}
 	 */
+	@Deprecated
 	Blocks blocks();
 
 	/**
 	 * @return an accessible list of all of AE's parts, parts are items
+	 *
+	 * @deprecated use {@link appeng.api.definitions.IDefinitions#parts()}
 	 */
+	@Deprecated
 	Parts parts();
 
 	/**
-	 * create a grid node for your {@link IGridHost}
-	 *
-	 * @param block grid block
-	 * @return grid node of block
+	 * @return an accessible list of all AE definitions
 	 */
-	IGridNode createGridNode(IGridBlock block);
+	IDefinitions definitions();
 
 	/**
-	 * create a connection between two {@link IGridNode}
+	 * create a grid node for your {@link appeng.api.networking.IGridHost}
+	 *
+	 * @param block grid block
+	 *
+	 * @return grid node of block
+	 */
+	IGridNode createGridNode( IGridBlock block );
+
+	/**
+	 * create a connection between two {@link appeng.api.networking.IGridNode}
 	 *
 	 * @param a to be connected gridnode
 	 * @param b to be connected gridnode
-	 * @throws FailedConnection
+	 *
+	 * @throws appeng.api.exceptions.FailedConnection
 	 */
-	IGridConnection createGridConnection(IGridNode a, IGridNode b) throws FailedConnection;
-
+	IGridConnection createGridConnection( IGridNode a, IGridNode b ) throws FailedConnection;
 }

--- a/src/api/java/appeng/api/config/AccessRestriction.java
+++ b/src/api/java/appeng/api/config/AccessRestriction.java
@@ -23,49 +23,51 @@
 
 package appeng.api.config;
 
+
 public enum AccessRestriction
 {
-	NO_ACCESS(0), READ(1), WRITE(2), READ_WRITE(3);
+	NO_ACCESS( 0 ), READ( 1 ), WRITE( 2 ), READ_WRITE( 3 );
 
 	private final int permissionBit;
 
-	private AccessRestriction(int v) {
+	private AccessRestriction( int v )
+	{
 		this.permissionBit = v;
 	}
 
-	public boolean hasPermission(AccessRestriction ar)
+	public boolean hasPermission( AccessRestriction ar )
 	{
-		return ( this.permissionBit & ar.permissionBit) == ar.permissionBit;
+		return ( this.permissionBit & ar.permissionBit ) == ar.permissionBit;
 	}
 
-	public AccessRestriction restrictPermissions(AccessRestriction ar)
+	public AccessRestriction restrictPermissions( AccessRestriction ar )
 	{
-		return this.getPermByBit( this.permissionBit & ar.permissionBit);
+		return this.getPermByBit( this.permissionBit & ar.permissionBit );
 	}
 
-	public AccessRestriction addPermissions(AccessRestriction ar)
+	public AccessRestriction addPermissions( AccessRestriction ar )
 	{
-		return this.getPermByBit( this.permissionBit | ar.permissionBit);
+		return this.getPermByBit( this.permissionBit | ar.permissionBit );
 	}
 
-	public AccessRestriction removePermissions(AccessRestriction ar)
+	public AccessRestriction removePermissions( AccessRestriction ar )
 	{
-		return this.getPermByBit( this.permissionBit & (~ar.permissionBit) );
+		return this.getPermByBit( this.permissionBit & ( ~ar.permissionBit ) );
 	}
 
-	private AccessRestriction getPermByBit(int bit)
+	private AccessRestriction getPermByBit( int bit )
 	{
-		switch (bit)
+		switch ( bit )
 		{
-		default:
-		case 0:
-			return NO_ACCESS;
-		case 1:
-			return READ;
-		case 2:
-			return WRITE;
-		case 3:
-			return READ_WRITE;
+			default:
+			case 0:
+				return NO_ACCESS;
+			case 1:
+				return READ;
+			case 2:
+				return WRITE;
+			case 3:
+				return READ_WRITE;
 		}
 	}
 }

--- a/src/api/java/appeng/api/config/ActionItems.java
+++ b/src/api/java/appeng/api/config/ActionItems.java
@@ -23,6 +23,7 @@
 
 package appeng.api.config;
 
+
 public enum ActionItems
 {
 	WRENCH, CLOSE, STASH, ENCODE, SUBSTITUTION

--- a/src/api/java/appeng/api/config/Actionable.java
+++ b/src/api/java/appeng/api/config/Actionable.java
@@ -23,6 +23,7 @@
 
 package appeng.api.config;
 
+
 public enum Actionable
 {
 	/**

--- a/src/api/java/appeng/api/config/CopyMode.java
+++ b/src/api/java/appeng/api/config/CopyMode.java
@@ -23,6 +23,7 @@
 
 package appeng.api.config;
 
+
 public enum CopyMode
 {
 	CLEAR_ON_REMOVE, KEEP_ON_REMOVE

--- a/src/api/java/appeng/api/config/FullnessMode.java
+++ b/src/api/java/appeng/api/config/FullnessMode.java
@@ -23,6 +23,7 @@
 
 package appeng.api.config;
 
+
 public enum FullnessMode
 {
 	EMPTY, HALF, FULL

--- a/src/api/java/appeng/api/config/FuzzyMode.java
+++ b/src/api/java/appeng/api/config/FuzzyMode.java
@@ -23,22 +23,24 @@
 
 package appeng.api.config;
 
+
 public enum FuzzyMode
 {
 	// Note that percentage damaged, is the inverse of percentage durability.
-	IGNORE_ALL(-1), PERCENT_99(0), PERCENT_75(25), PERCENT_50(50), PERCENT_25(75);
+	IGNORE_ALL( -1 ), PERCENT_99( 0 ), PERCENT_75( 25 ), PERCENT_50( 50 ), PERCENT_25( 75 );
 
 	final public float breakPoint;
 	final public float percentage;
 
-	private FuzzyMode(float p) {
+	private FuzzyMode( float p )
+	{
 		this.percentage = p;
 		this.breakPoint = p / 100.0f;
 	}
 
-	public int calculateBreakPoint(int maxDamage)
+	public int calculateBreakPoint( int maxDamage )
 	{
-		return (int) (( this.percentage * maxDamage) / 100.0f);
+		return (int) ( ( this.percentage * maxDamage ) / 100.0f );
 	}
 
 }

--- a/src/api/java/appeng/api/config/IncludeExclude.java
+++ b/src/api/java/appeng/api/config/IncludeExclude.java
@@ -23,6 +23,7 @@
 
 package appeng.api.config;
 
+
 public enum IncludeExclude
 {
 	WHITELIST, BLACKLIST

--- a/src/api/java/appeng/api/config/LevelEmitterMode.java
+++ b/src/api/java/appeng/api/config/LevelEmitterMode.java
@@ -23,6 +23,7 @@
 
 package appeng.api.config;
 
+
 public enum LevelEmitterMode
 {
 

--- a/src/api/java/appeng/api/config/LevelType.java
+++ b/src/api/java/appeng/api/config/LevelType.java
@@ -23,6 +23,7 @@
 
 package appeng.api.config;
 
+
 public enum LevelType
 {
 

--- a/src/api/java/appeng/api/config/ModSettings.java
+++ b/src/api/java/appeng/api/config/ModSettings.java
@@ -23,6 +23,7 @@
 
 package appeng.api.config;
 
+
 public enum ModSettings
 {
 

--- a/src/api/java/appeng/api/config/NetworkEmitterMode.java
+++ b/src/api/java/appeng/api/config/NetworkEmitterMode.java
@@ -23,6 +23,7 @@
 
 package appeng.api.config;
 
+
 public enum NetworkEmitterMode
 {
 

--- a/src/api/java/appeng/api/config/OperationMode.java
+++ b/src/api/java/appeng/api/config/OperationMode.java
@@ -23,6 +23,7 @@
 
 package appeng.api.config;
 
+
 public enum OperationMode
 {
 	FILL, EMPTY

--- a/src/api/java/appeng/api/config/OutputMode.java
+++ b/src/api/java/appeng/api/config/OutputMode.java
@@ -23,6 +23,7 @@
 
 package appeng.api.config;
 
+
 public enum OutputMode
 {
 	EXPORT_ONLY, EXPORT_OR_CRAFT, CRAFT_ONLY

--- a/src/api/java/appeng/api/config/PowerMultiplier.java
+++ b/src/api/java/appeng/api/config/PowerMultiplier.java
@@ -23,6 +23,7 @@
 
 package appeng.api.config;
 
+
 public enum PowerMultiplier
 {
 	ONE, CONFIG;
@@ -32,12 +33,12 @@ public enum PowerMultiplier
 	 */
 	public double multiplier = 1.0;
 
-	public double multiply(double in)
+	public double multiply( double in )
 	{
 		return in * this.multiplier;
 	}
 
-	public double divide(double in)
+	public double divide( double in )
 	{
 		return in / this.multiplier;
 	}

--- a/src/api/java/appeng/api/config/PowerUnits.java
+++ b/src/api/java/appeng/api/config/PowerUnits.java
@@ -23,16 +23,18 @@
 
 package appeng.api.config;
 
+
 public enum PowerUnits
 {
-	AE("gui.appliedenergistics2.units.appliedenergstics"), // Native Units - AE Energy
-	MJ("gui.appliedenergistics2.units.buildcraft"), // BuildCraft - Minecraft Joules
-	EU("gui.appliedenergistics2.units.ic2"), // IndustrialCraft 2 - Energy Units
-	WA("gui.appliedenergistics2.units.rotarycraft"), // RotaryCraft - Watts
-	RF("gui.appliedenergistics2.units.thermalexpansion"), // ThermalExpansion - Redstone Flux
-	MK("gui.appliedenergistics2.units.mekanism"); // Mekanism - Joules
+	AE( "gui.appliedenergistics2.units.appliedenergstics" ), // Native Units - AE Energy
+	MJ( "gui.appliedenergistics2.units.buildcraft" ), // BuildCraft - Minecraft Joules
+	EU( "gui.appliedenergistics2.units.ic2" ), // IndustrialCraft 2 - Energy Units
+	WA( "gui.appliedenergistics2.units.rotarycraft" ), // RotaryCraft - Watts
+	RF( "gui.appliedenergistics2.units.thermalexpansion" ), // ThermalExpansion - Redstone Flux
+	MK( "gui.appliedenergistics2.units.mekanism" ); // Mekanism - Joules
 
-	private PowerUnits(String un) {
+	private PowerUnits( String un )
+	{
 		this.unlocalizedName = un;
 	}
 
@@ -54,12 +56,13 @@ public enum PowerUnits
 	 * will normally returns 64, as it will convert the EU, to AE with AE's power settings.
 	 *
 	 * @param target target power unit
-	 * @param value value
+	 * @param value  value
+	 *
 	 * @return value converted to target units, from this units.
 	 */
-	public double convertTo(PowerUnits target, double value)
+	public double convertTo( PowerUnits target, double value )
 	{
-		return (value * this.conversionRatio ) / target.conversionRatio;
+		return ( value * this.conversionRatio ) / target.conversionRatio;
 	}
 
 }

--- a/src/api/java/appeng/api/config/RedstoneMode.java
+++ b/src/api/java/appeng/api/config/RedstoneMode.java
@@ -23,6 +23,7 @@
 
 package appeng.api.config;
 
+
 public enum RedstoneMode
 {
 	IGNORE, LOW_SIGNAL, HIGH_SIGNAL, SIGNAL_PULSE

--- a/src/api/java/appeng/api/config/RelativeDirection.java
+++ b/src/api/java/appeng/api/config/RelativeDirection.java
@@ -23,6 +23,7 @@
 
 package appeng.api.config;
 
+
 public enum RelativeDirection
 {
 	LEFT, RIGHT, UP, DOW

--- a/src/api/java/appeng/api/config/SearchBoxMode.java
+++ b/src/api/java/appeng/api/config/SearchBoxMode.java
@@ -23,6 +23,7 @@
 
 package appeng.api.config;
 
+
 public enum SearchBoxMode
 {
 	AUTOSEARCH, MANUAL_SEARCH, NEI_AUTOSEARCH, NEI_MANUAL_SEARCH

--- a/src/api/java/appeng/api/config/SecurityPermissions.java
+++ b/src/api/java/appeng/api/config/SecurityPermissions.java
@@ -23,6 +23,7 @@
 
 package appeng.api.config;
 
+
 /**
  * Represent the security systems basic permissions, these are not for anti-griefing, they are part of the mod as a
  * gameplay feature.

--- a/src/api/java/appeng/api/config/SortDir.java
+++ b/src/api/java/appeng/api/config/SortDir.java
@@ -23,6 +23,7 @@
 
 package appeng.api.config;
 
+
 public enum SortDir
 {
 	ASCENDING, DESCENDING

--- a/src/api/java/appeng/api/config/SortOrder.java
+++ b/src/api/java/appeng/api/config/SortOrder.java
@@ -23,6 +23,7 @@
 
 package appeng.api.config;
 
+
 public enum SortOrder
 {
 	NAME, AMOUNT, MOD, INVTWEAKS

--- a/src/api/java/appeng/api/config/StorageFilter.java
+++ b/src/api/java/appeng/api/config/StorageFilter.java
@@ -23,6 +23,7 @@
 
 package appeng.api.config;
 
+
 public enum StorageFilter
 {
 

--- a/src/api/java/appeng/api/config/TerminalStyle.java
+++ b/src/api/java/appeng/api/config/TerminalStyle.java
@@ -23,6 +23,7 @@
 
 package appeng.api.config;
 
+
 public enum TerminalStyle
 {
 

--- a/src/api/java/appeng/api/config/TunnelType.java
+++ b/src/api/java/appeng/api/config/TunnelType.java
@@ -23,6 +23,7 @@
 
 package appeng.api.config;
 
+
 public enum TunnelType
 {
 	ME, // Network Tunnel

--- a/src/api/java/appeng/api/config/Upgrades.java
+++ b/src/api/java/appeng/api/config/Upgrades.java
@@ -26,6 +26,8 @@ package appeng.api.config;
 
 import java.util.HashMap;
 
+import javax.annotation.Nonnull;
+
 import net.minecraft.item.ItemStack;
 
 import appeng.api.util.AEItemDefinition;
@@ -59,9 +61,7 @@ public enum Upgrades
 		return this.supportedMax;
 	}
 
-
-
-	public void registerItem( AEItemDefinition myItem, int maxSupported )
+	public void registerItem( @Nonnull AEItemDefinition myItem, int maxSupported )
 	{
 		if ( myItem != null )
 		{

--- a/src/api/java/appeng/api/config/ViewItems.java
+++ b/src/api/java/appeng/api/config/ViewItems.java
@@ -23,6 +23,7 @@
 
 package appeng.api.config;
 
+
 public enum ViewItems
 {
 	ALL, STORED, CRAFTABLE

--- a/src/api/java/appeng/api/config/YesNo.java
+++ b/src/api/java/appeng/api/config/YesNo.java
@@ -23,6 +23,7 @@
 
 package appeng.api.config;
 
+
 public enum YesNo
 {
 	YES, NO, UNDECIDED

--- a/src/api/java/appeng/api/definitions/Blocks.java
+++ b/src/api/java/appeng/api/definitions/Blocks.java
@@ -23,90 +23,155 @@
 
 package appeng.api.definitions;
 
+
+import javax.annotation.Nullable;
+
 import appeng.api.util.AEItemDefinition;
+
 
 public class Blocks
 {
-
-	/*
-	 * World Gen
-	 */
+	@Nullable
 	public AEItemDefinition blockQuartzOre;
+
+	@Nullable
 	public AEItemDefinition blockQuartzOreCharged;
+
+	@Nullable
 	public AEItemDefinition blockMatrixFrame;
 
-	/*
-	 * Decorative
-	 */
+	@Nullable
 	public AEItemDefinition blockQuartz;
+
+	@Nullable
 	public AEItemDefinition blockQuartzPillar;
+
+	@Nullable
 	public AEItemDefinition blockQuartzChiseled;
+
+	@Nullable
 	public AEItemDefinition blockQuartzGlass;
+
+	@Nullable
 	public AEItemDefinition blockQuartzVibrantGlass;
+
+	@Nullable
 	public AEItemDefinition blockQuartzTorch;
+
+	@Nullable
 	public AEItemDefinition blockFluix;
+
+	@Nullable
 	public AEItemDefinition blockSkyStone;
+
+	@Nullable
 	public AEItemDefinition blockSkyChest;
+
+	@Nullable
 	public AEItemDefinition blockSkyCompass;
 
-	/*
-	 * Misc
-	 */
+	@Nullable
 	public AEItemDefinition blockGrindStone;
+
+	@Nullable
 	public AEItemDefinition blockCrankHandle;
+
+	@Nullable
 	public AEItemDefinition blockInscriber;
+
+	@Nullable
 	public AEItemDefinition blockWireless;
+
+	@Nullable
 	public AEItemDefinition blockCharger;
+
+	@Nullable
 	public AEItemDefinition blockTinyTNT;
+
+	@Nullable
 	public AEItemDefinition blockSecurity;
 
-	/*
-	 * Quantum Network Bridge
-	 */
+	@Nullable
 	public AEItemDefinition blockQuantumRing;
+
+	@Nullable
 	public AEItemDefinition blockQuantumLink;
 
-	/*
-	 * Spatial IO
-	 */
+	@Nullable
 	public AEItemDefinition blockSpatialPylon;
+
+	@Nullable
 	public AEItemDefinition blockSpatialIOPort;
 
-	/*
-	 * Bus / Cables
-	 */
+	@Nullable
 	public AEItemDefinition blockMultiPart;
 
-	/*
-	 * Machines
-	 */
+	@Nullable
 	public AEItemDefinition blockController;
+
+	@Nullable
 	public AEItemDefinition blockDrive;
+
+	@Nullable
 	public AEItemDefinition blockChest;
+
+	@Nullable
 	public AEItemDefinition blockInterface;
+
+	@Nullable
 	public AEItemDefinition blockCellWorkbench;
+
+	@Nullable
 	public AEItemDefinition blockIOPort;
+
+	@Nullable
 	public AEItemDefinition blockCondenser;
+
+	@Nullable
 	public AEItemDefinition blockEnergyAcceptor;
+
+	@Nullable
 	public AEItemDefinition blockVibrationChamber;
+
+	@Nullable
 	public AEItemDefinition blockQuartzGrowthAccelerator;
 
+	@Nullable
 	public AEItemDefinition blockEnergyCell;
+
+	@Nullable
 	public AEItemDefinition blockEnergyCellDense;
+
+	@Nullable
 	public AEItemDefinition blockEnergyCellCreative;
 
-	// rv1
+	@Nullable
 	public AEItemDefinition blockCraftingUnit;
+
+	@Nullable
 	public AEItemDefinition blockCraftingAccelerator;
+
+	@Nullable
 	public AEItemDefinition blockCraftingStorage1k;
+
+	@Nullable
 	public AEItemDefinition blockCraftingStorage4k;
+
+	@Nullable
 	public AEItemDefinition blockCraftingStorage16k;
+
+	@Nullable
 	public AEItemDefinition blockCraftingStorage64k;
+
+	@Nullable
 	public AEItemDefinition blockCraftingMonitor;
 
+	@Nullable
 	public AEItemDefinition blockMolecularAssembler;
 
+	@Nullable
 	public AEItemDefinition blockLightDetector;
-	public AEItemDefinition blockPaint;
 
+	@Nullable
+	public AEItemDefinition blockPaint;
 }

--- a/src/api/java/appeng/api/definitions/IBlocks.java
+++ b/src/api/java/appeng/api/definitions/IBlocks.java
@@ -1,0 +1,170 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2013 AlgorithmX2
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package appeng.api.definitions;
+
+
+import com.google.common.base.Optional;
+
+import appeng.api.util.AEItemDefinition;
+
+
+/**
+ * All access is optional due to the ability to disable certain functionality via a configuration file.
+ * This needs to be caught on the used side.
+ */
+public interface IBlocks
+{
+	/*
+	 * world gen
+	 */
+	Optional<AEItemDefinition> quartzOre();
+
+	Optional<AEItemDefinition> quartzOreCharged();
+
+	Optional<AEItemDefinition> matrixFrame();
+
+	/*
+	 * decorative
+	 */
+	Optional<AEItemDefinition> quartz();
+
+	Optional<AEItemDefinition> quartzPillar();
+
+	Optional<AEItemDefinition> quartzChiseled();
+
+	Optional<AEItemDefinition> quartzGlass();
+
+	Optional<AEItemDefinition> quartzVibrantGlass();
+
+	Optional<AEItemDefinition> quartzTorch();
+
+	Optional<AEItemDefinition> fluix();
+
+	Optional<AEItemDefinition> skyStone();
+
+	Optional<AEItemDefinition> skyChest();
+
+	Optional<AEItemDefinition> skyCompass();
+
+	Optional<AEItemDefinition> skyStoneStair();
+
+	Optional<AEItemDefinition> skyStoneBlockStair();
+
+	Optional<AEItemDefinition> skyStoneBrickStair();
+
+	Optional<AEItemDefinition> skyStoneSmallBrickStair();
+
+	Optional<AEItemDefinition> fluixStair();
+
+	Optional<AEItemDefinition> quartzStair();
+
+	Optional<AEItemDefinition> chiseledQuartzStair();
+
+	Optional<AEItemDefinition> quartzPillarStair();
+
+	/*
+	 * misc
+	 */
+	Optional<AEItemDefinition> grindStone();
+
+	Optional<AEItemDefinition> crankHandle();
+
+	Optional<AEItemDefinition> inscriber();
+
+	Optional<AEItemDefinition> wireless();
+
+	Optional<AEItemDefinition> charger();
+
+	Optional<AEItemDefinition> tinyTNT();
+
+	Optional<AEItemDefinition> security();
+
+	/*
+	 * quantum Network Bridge
+	 */
+	Optional<AEItemDefinition> quantumRing();
+
+	Optional<AEItemDefinition> quantumLink();
+
+	/*
+	 * spatial iO
+	 */
+	Optional<AEItemDefinition> spatialPylon();
+
+	Optional<AEItemDefinition> spatialIOPort();
+
+	/*
+	 * Bus / cables
+	 */
+	Optional<AEItemDefinition> multiPart();
+
+	/*
+	 * machines
+	 */
+	Optional<AEItemDefinition> controller();
+
+	Optional<AEItemDefinition> drive();
+
+	Optional<AEItemDefinition> chest();
+
+	Optional<AEItemDefinition> iface();
+
+	Optional<AEItemDefinition> cellWorkbench();
+
+	Optional<AEItemDefinition> iOPort();
+
+	Optional<AEItemDefinition> condenser();
+
+	Optional<AEItemDefinition> energyAcceptor();
+
+	Optional<AEItemDefinition> vibrationChamber();
+
+	Optional<AEItemDefinition> quartzGrowthAccelerator();
+
+	Optional<AEItemDefinition> energyCell();
+
+	Optional<AEItemDefinition> energyCellDense();
+
+	Optional<AEItemDefinition> energyCellCreative();
+
+	// rv1
+	Optional<AEItemDefinition> craftingUnit();
+
+	Optional<AEItemDefinition> craftingAccelerator();
+
+	Optional<AEItemDefinition> craftingStorage1k();
+
+	Optional<AEItemDefinition> craftingStorage4k();
+
+	Optional<AEItemDefinition> craftingStorage16k();
+
+	Optional<AEItemDefinition> craftingStorage64k();
+
+	Optional<AEItemDefinition> craftingMonitor();
+
+	Optional<AEItemDefinition> molecularAssembler();
+
+	Optional<AEItemDefinition> lightDetector();
+
+	Optional<AEItemDefinition> paint();
+}

--- a/src/api/java/appeng/api/definitions/IDefinitions.java
+++ b/src/api/java/appeng/api/definitions/IDefinitions.java
@@ -1,0 +1,47 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2013 AlgorithmX2
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package appeng.api.definitions;
+
+
+public interface IDefinitions
+{
+	/**
+	 * @return an accessible list of all of AE's blocks
+	 */
+	IBlocks blocks();
+
+	/**
+	 * @return an accessible list of all of AE's Items
+	 */
+	IItems items();
+
+	/**
+	 * @return an accessible list of all of AE's materials; materials are items
+	 */
+	IMaterials materials();
+
+	/**
+	 * @return an accessible list of all of AE's parts, parts are items
+	 */
+	IParts parts();
+}

--- a/src/api/java/appeng/api/definitions/IItems.java
+++ b/src/api/java/appeng/api/definitions/IItems.java
@@ -1,0 +1,108 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2013 AlgorithmX2
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package appeng.api.definitions;
+
+
+import com.google.common.base.Optional;
+
+import appeng.api.util.AEColoredItemDefinition;
+import appeng.api.util.AEItemDefinition;
+
+
+public interface IItems
+{
+	Optional<AEItemDefinition> certusQuartzAxe();
+
+	Optional<AEItemDefinition> certusQuartzHoe();
+
+	Optional<AEItemDefinition> certusQuartzShovel();
+
+	Optional<AEItemDefinition> certusQuartzPick();
+
+	Optional<AEItemDefinition> certusQuartzSword();
+
+	Optional<AEItemDefinition> certusQuartzWrench();
+
+	Optional<AEItemDefinition> certusQuartzKnife();
+
+	Optional<AEItemDefinition> netherQuartzAxe();
+
+	Optional<AEItemDefinition> netherQuartzHoe();
+
+	Optional<AEItemDefinition> netherQuartzShovel();
+
+	Optional<AEItemDefinition> netherQuartzPick();
+
+	Optional<AEItemDefinition> netherQuartzSword();
+
+	Optional<AEItemDefinition> netherQuartzWrench();
+
+	Optional<AEItemDefinition> netherQuartzKnife();
+
+	Optional<AEItemDefinition> entropyManipulator();
+
+	Optional<AEItemDefinition> wirelessTerminal();
+
+	Optional<AEItemDefinition> biometricCard();
+
+	Optional<AEItemDefinition> chargedStaff();
+
+	Optional<AEItemDefinition> massCannon();
+
+	Optional<AEItemDefinition> memoryCard();
+
+	Optional<AEItemDefinition> networkTool();
+
+	Optional<AEItemDefinition> portableCell();
+
+	Optional<AEItemDefinition> cellCreative();
+
+	Optional<AEItemDefinition> viewCell();
+
+	Optional<AEItemDefinition> cell1k();
+
+	Optional<AEItemDefinition> cell4k();
+
+	Optional<AEItemDefinition> cell16k();
+
+	Optional<AEItemDefinition> cell64k();
+
+	Optional<AEItemDefinition> spatialCell2();
+
+	Optional<AEItemDefinition> spatialCell16();
+
+	Optional<AEItemDefinition> spatialCell128();
+
+	Optional<AEItemDefinition> facade();
+
+	Optional<AEItemDefinition> crystalSeed();
+
+	// rv1
+	Optional<AEItemDefinition> encodedPattern();
+
+	Optional<AEItemDefinition> colorApplicator();
+
+	Optional<AEColoredItemDefinition> coloredPaintBall();
+
+	Optional<AEColoredItemDefinition> coloredLumenPaintBall();
+}

--- a/src/api/java/appeng/api/definitions/IMaterials.java
+++ b/src/api/java/appeng/api/definitions/IMaterials.java
@@ -1,0 +1,140 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2013 AlgorithmX2
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package appeng.api.definitions;
+
+
+import com.google.common.base.Optional;
+
+import appeng.api.util.AEItemDefinition;
+
+
+public interface IMaterials
+{
+	Optional<AEItemDefinition> cell2SpatialPart();
+
+	Optional<AEItemDefinition> cell16SpatialPart();
+
+	Optional<AEItemDefinition> cell128SpatialPart();
+
+	Optional<AEItemDefinition> silicon();
+
+	Optional<AEItemDefinition> skyDust();
+
+	Optional<AEItemDefinition> calcProcessorPress();
+
+	Optional<AEItemDefinition> engProcessorPress();
+
+	Optional<AEItemDefinition> logicProcessorPress();
+
+	Optional<AEItemDefinition> calcProcessorPrint();
+
+	Optional<AEItemDefinition> engProcessorPrint();
+
+	Optional<AEItemDefinition> logicProcessorPrint();
+
+	Optional<AEItemDefinition> siliconPress();
+
+	Optional<AEItemDefinition> siliconPrint();
+
+	Optional<AEItemDefinition> namePress();
+
+	Optional<AEItemDefinition> logicProcessor();
+
+	Optional<AEItemDefinition> calcProcessor();
+
+	Optional<AEItemDefinition> engProcessor();
+
+	Optional<AEItemDefinition> basicCard();
+
+	Optional<AEItemDefinition> advCard();
+
+	Optional<AEItemDefinition> purifiedCertusQuartzCrystal();
+
+	Optional<AEItemDefinition> purifiedNetherQuartzCrystal();
+
+	Optional<AEItemDefinition> purifiedFluixCrystal();
+
+	Optional<AEItemDefinition> cell1kPart();
+
+	Optional<AEItemDefinition> cell4kPart();
+
+	Optional<AEItemDefinition> cell16kPart();
+
+	Optional<AEItemDefinition> cell64kPart();
+
+	Optional<AEItemDefinition> emptyStorageCell();
+
+	Optional<AEItemDefinition> cardRedstone();
+
+	Optional<AEItemDefinition> cardSpeed();
+
+	Optional<AEItemDefinition> cardCapacity();
+
+	Optional<AEItemDefinition> cardFuzzy();
+
+	Optional<AEItemDefinition> cardInverter();
+
+	Optional<AEItemDefinition> cardCrafting();
+
+	Optional<AEItemDefinition> enderDust();
+
+	Optional<AEItemDefinition> flour();
+
+	Optional<AEItemDefinition> goldDust();
+
+	Optional<AEItemDefinition> ironDust();
+
+	Optional<AEItemDefinition> fluixDust();
+
+	Optional<AEItemDefinition> certusQuartzDust();
+
+	Optional<AEItemDefinition> netherQuartzDust();
+
+	Optional<AEItemDefinition> matterBall();
+
+	Optional<AEItemDefinition> ironNugget();
+
+	Optional<AEItemDefinition> certusQuartzCrystal();
+
+	Optional<AEItemDefinition> certusQuartzCrystalCharged();
+
+	Optional<AEItemDefinition> fluixCrystal();
+
+	Optional<AEItemDefinition> fluixPearl();
+
+	Optional<AEItemDefinition> woodenGear();
+
+	Optional<AEItemDefinition> wireless();
+
+	Optional<AEItemDefinition> wirelessBooster();
+
+	Optional<AEItemDefinition> annihilationCore();
+
+	Optional<AEItemDefinition> formationCore();
+
+	Optional<AEItemDefinition> singularity();
+
+	Optional<AEItemDefinition> qESingularity();
+
+	Optional<AEItemDefinition> blankPattern();
+}

--- a/src/api/java/appeng/api/definitions/IParts.java
+++ b/src/api/java/appeng/api/definitions/IParts.java
@@ -1,0 +1,105 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2013 AlgorithmX2
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package appeng.api.definitions;
+
+
+import com.google.common.base.Optional;
+
+import appeng.api.util.AEColoredItemDefinition;
+import appeng.api.util.AEItemDefinition;
+
+
+public interface IParts
+{
+	Optional<AEColoredItemDefinition> cableSmart();
+
+	Optional<AEColoredItemDefinition> cableCovered();
+
+	Optional<AEColoredItemDefinition> cableGlass();
+
+	Optional<AEColoredItemDefinition> cableDense();
+
+	Optional<AEColoredItemDefinition> lumenCableSmart();
+
+	Optional<AEColoredItemDefinition> lumenCableCovered();
+
+	Optional<AEColoredItemDefinition> lumenCableGlass();
+
+	Optional<AEColoredItemDefinition> lumenCableDense();
+
+	Optional<AEItemDefinition> quartzFiber();
+
+	Optional<AEItemDefinition> toggleBus();
+
+	Optional<AEItemDefinition> invertedToggleBus();
+
+	Optional<AEItemDefinition> storageBus();
+
+	Optional<AEItemDefinition> importBus();
+
+	Optional<AEItemDefinition> exportBus();
+
+	Optional<AEItemDefinition> iface();
+
+	Optional<AEItemDefinition> levelEmitter();
+
+	Optional<AEItemDefinition> annihilationPlane();
+
+	Optional<AEItemDefinition> formationPlane();
+
+	Optional<AEItemDefinition> p2PTunnelME();
+
+	Optional<AEItemDefinition> p2PTunnelRedstone();
+
+	Optional<AEItemDefinition> p2PTunnelItems();
+
+	Optional<AEItemDefinition> p2PTunnelLiquids();
+
+	Optional<AEItemDefinition> p2PTunnelMJ();
+
+	Optional<AEItemDefinition> p2PTunnelEU();
+
+	Optional<AEItemDefinition> p2PTunnelRF();
+
+	Optional<AEItemDefinition> p2PTunnelLight();
+
+	Optional<AEItemDefinition> cableAnchor();
+
+	Optional<AEItemDefinition> monitor();
+
+	Optional<AEItemDefinition> semiDarkMonitor();
+
+	Optional<AEItemDefinition> darkMonitor();
+
+	Optional<AEItemDefinition> interfaceTerminal();
+
+	Optional<AEItemDefinition> patternTerminal();
+
+	Optional<AEItemDefinition> craftingTerminal();
+
+	Optional<AEItemDefinition> terminal();
+
+	Optional<AEItemDefinition> storageMonitor();
+
+	Optional<AEItemDefinition> conversionMonitor();
+}

--- a/src/api/java/appeng/api/definitions/Items.java
+++ b/src/api/java/appeng/api/definitions/Items.java
@@ -23,55 +23,124 @@
 
 package appeng.api.definitions;
 
+
+import javax.annotation.Nullable;
+
 import appeng.api.util.AEColoredItemDefinition;
 import appeng.api.util.AEItemDefinition;
 
+
+
 public class Items
 {
-
+	@Nullable
 	public AEItemDefinition itemCertusQuartzAxe;
+
+	@Nullable
 	public AEItemDefinition itemCertusQuartzHoe;
+
+	@Nullable
 	public AEItemDefinition itemCertusQuartzShovel;
+
+	@Nullable
 	public AEItemDefinition itemCertusQuartzPick;
+
+	@Nullable
 	public AEItemDefinition itemCertusQuartzSword;
+
+	@Nullable
 	public AEItemDefinition itemCertusQuartzWrench;
+
+	@Nullable
 	public AEItemDefinition itemCertusQuartzKnife;
 
+	@Nullable
 	public AEItemDefinition itemNetherQuartzAxe;
+
+	@Nullable
 	public AEItemDefinition itemNetherQuartzHoe;
+
+	@Nullable
 	public AEItemDefinition itemNetherQuartzShovel;
+
+	@Nullable
 	public AEItemDefinition itemNetherQuartzPick;
+
+	@Nullable
 	public AEItemDefinition itemNetherQuartzSword;
+
+	@Nullable
 	public AEItemDefinition itemNetherQuartzWrench;
+
+	@Nullable
 	public AEItemDefinition itemNetherQuartzKnife;
 
+	@Nullable
 	public AEItemDefinition itemEntropyManipulator;
+
+	@Nullable
 	public AEItemDefinition itemWirelessTerminal;
+
+	@Nullable
 	public AEItemDefinition itemBiometricCard;
+
+	@Nullable
 	public AEItemDefinition itemChargedStaff;
+
+	@Nullable
 	public AEItemDefinition itemMassCannon;
+
+	@Nullable
 	public AEItemDefinition itemMemoryCard;
+
+	@Nullable
 	public AEItemDefinition itemNetworkTool;
+
+	@Nullable
 	public AEItemDefinition itemPortableCell;
 
+	@Nullable
 	public AEItemDefinition itemCellCreative;
+
+	@Nullable
 	public AEItemDefinition itemViewCell;
 
+	@Nullable
 	public AEItemDefinition itemCell1k;
+
+	@Nullable
 	public AEItemDefinition itemCell4k;
+
+	@Nullable
 	public AEItemDefinition itemCell16k;
+
+	@Nullable
 	public AEItemDefinition itemCell64k;
 
+	@Nullable
 	public AEItemDefinition itemSpatialCell2;
+
+	@Nullable
 	public AEItemDefinition itemSpatialCell16;
+
+	@Nullable
 	public AEItemDefinition itemSpatialCell128;
 
+	@Nullable
 	public AEItemDefinition itemFacade;
+
+	@Nullable
 	public AEItemDefinition itemCrystalSeed;
 
-	// rv1
+	@Nullable
 	public AEItemDefinition itemEncodedPattern;
+
+	@Nullable
 	public AEItemDefinition itemColorApplicator;
+
+	@Nullable
 	public AEColoredItemDefinition itemPaintBall;
+
+	@Nullable
 	public AEColoredItemDefinition itemLumenPaintBall;
 }

--- a/src/api/java/appeng/api/definitions/Materials.java
+++ b/src/api/java/appeng/api/definitions/Materials.java
@@ -23,81 +23,173 @@
 
 package appeng.api.definitions;
 
+
+import javax.annotation.Nullable;
+
 import appeng.api.util.AEItemDefinition;
+
 
 public class Materials
 {
-
+	@Nullable
 	public AEItemDefinition materialCell2SpatialPart;
+
+	@Nullable
 	public AEItemDefinition materialCell16SpatialPart;
+
+	@Nullable
 	public AEItemDefinition materialCell128SpatialPart;
 
+	@Nullable
 	public AEItemDefinition materialSilicon;
+
+	@Nullable
 	public AEItemDefinition materialSkyDust;
 
+	@Nullable
 	public AEItemDefinition materialCalcProcessorPress;
+
+	@Nullable
 	public AEItemDefinition materialEngProcessorPress;
+
+	@Nullable
 	public AEItemDefinition materialLogicProcessorPress;
 
+	@Nullable
 	public AEItemDefinition materialCalcProcessorPrint;
+
+	@Nullable
 	public AEItemDefinition materialEngProcessorPrint;
+
+	@Nullable
 	public AEItemDefinition materialLogicProcessorPrint;
 
+	@Nullable
 	public AEItemDefinition materialSiliconPress;
+
+	@Nullable
 	public AEItemDefinition materialSiliconPrint;
 
+	@Nullable
 	public AEItemDefinition materialNamePress;
 
+	@Nullable
 	public AEItemDefinition materialLogicProcessor;
+
+	@Nullable
 	public AEItemDefinition materialCalcProcessor;
+
+	@Nullable
 	public AEItemDefinition materialEngProcessor;
 
+	@Nullable
 	public AEItemDefinition materialBasicCard;
+
+	@Nullable
 	public AEItemDefinition materialAdvCard;
 
+	@Nullable
 	public AEItemDefinition materialPurifiedCertusQuartzCrystal;
+
+	@Nullable
 	public AEItemDefinition materialPurifiedNetherQuartzCrystal;
+
+	@Nullable
 	public AEItemDefinition materialPurifiedFluixCrystal;
 
+	@Nullable
 	public AEItemDefinition materialCell1kPart;
+
+	@Nullable
 	public AEItemDefinition materialCell4kPart;
+
+	@Nullable
 	public AEItemDefinition materialCell16kPart;
+
+	@Nullable
 	public AEItemDefinition materialCell64kPart;
+
+	@Nullable
 	public AEItemDefinition materialEmptyStorageCell;
 
+	@Nullable
 	public AEItemDefinition materialCardRedstone;
+
+	@Nullable
 	public AEItemDefinition materialCardSpeed;
+
+	@Nullable
 	public AEItemDefinition materialCardCapacity;
+
+	@Nullable
 	public AEItemDefinition materialCardFuzzy;
+
+	@Nullable
 	public AEItemDefinition materialCardInverter;
+
+	@Nullable
 	public AEItemDefinition materialCardCrafting;
 
+	@Nullable
 	public AEItemDefinition materialEnderDust;
+
+	@Nullable
 	public AEItemDefinition materialFlour;
+
+	@Nullable
 	public AEItemDefinition materialGoldDust;
+
+	@Nullable
 	public AEItemDefinition materialIronDust;
+
+	@Nullable
 	public AEItemDefinition materialFluixDust;
+
+	@Nullable
 	public AEItemDefinition materialCertusQuartzDust;
+
+	@Nullable
 	public AEItemDefinition materialNetherQuartzDust;
 
+	@Nullable
 	public AEItemDefinition materialMatterBall;
+
+	@Nullable
 	public AEItemDefinition materialIronNugget;
 
+	@Nullable
 	public AEItemDefinition materialCertusQuartzCrystal;
+
+	@Nullable
 	public AEItemDefinition materialCertusQuartzCrystalCharged;
+
+	@Nullable
 	public AEItemDefinition materialFluixCrystal;
+
+	@Nullable
 	public AEItemDefinition materialFluixPearl;
 
+	@Nullable
 	public AEItemDefinition materialWoodenGear;
 
+	@Nullable
 	public AEItemDefinition materialWireless;
+
+	@Nullable
 	public AEItemDefinition materialWirelessBooster;
 
+	@Nullable
 	public AEItemDefinition materialAnnihilationCore;
+
+	@Nullable
 	public AEItemDefinition materialFormationCore;
 
+	@Nullable
 	public AEItemDefinition materialSingularity;
-	public AEItemDefinition materialQESingularity;
-	public AEItemDefinition materialBlankPattern;
 
+	@Nullable
+	public AEItemDefinition materialQESingularity;
+
+	@Nullable
+	public AEItemDefinition materialBlankPattern;
 }

--- a/src/api/java/appeng/api/definitions/Parts.java
+++ b/src/api/java/appeng/api/definitions/Parts.java
@@ -23,54 +23,120 @@
 
 package appeng.api.definitions;
 
+
+import javax.annotation.Nullable;
+
 import appeng.api.util.AEColoredItemDefinition;
 import appeng.api.util.AEItemDefinition;
 
+
 public class Parts
 {
-
+	@Nullable
 	public AEColoredItemDefinition partCableSmart;
+
+	@Nullable
 	public AEColoredItemDefinition partCableCovered;
+
+	@Nullable
 	public AEColoredItemDefinition partCableGlass;
+
+	@Nullable
 	public AEColoredItemDefinition partCableDense;
 
+	@Nullable
 	public AEColoredItemDefinition partLumenCableSmart;
+
+	@Nullable
 	public AEColoredItemDefinition partLumenCableCovered;
+
+	@Nullable
 	public AEColoredItemDefinition partLumenCableGlass;
+
+	@Nullable
 	public AEColoredItemDefinition partLumenCableDense;
 
+	@Nullable
 	public AEItemDefinition partQuartzFiber;
+
+	@Nullable
 	public AEItemDefinition partToggleBus;
+
+	@Nullable
 	public AEItemDefinition partInvertedToggleBus;
 
+	@Nullable
 	public AEItemDefinition partStorageBus;
+
+	@Nullable
 	public AEItemDefinition partImportBus;
+
+	@Nullable
 	public AEItemDefinition partExportBus;
+
+	@Nullable
 	public AEItemDefinition partInterface;
 
+	@Nullable
 	public AEItemDefinition partLevelEmitter;
 
+	@Nullable
 	public AEItemDefinition partAnnihilationPlane;
+
+	@Nullable
 	public AEItemDefinition partFormationPlane;
 
+	@Nullable
 	public AEItemDefinition partP2PTunnelME;
+
+	@Nullable
 	public AEItemDefinition partP2PTunnelRedstone;
+
+	@Nullable
 	public AEItemDefinition partP2PTunnelItems;
+
+	@Nullable
 	public AEItemDefinition partP2PTunnelLiquids;
+
+	@Nullable
 	public AEItemDefinition partP2PTunnelMJ;
+
+	@Nullable
 	public AEItemDefinition partP2PTunnelEU;
+
+	@Nullable
 	public AEItemDefinition partP2PTunnelRF;
+
+	@Nullable
 	public AEItemDefinition partP2PTunnelLight;
 
+	@Nullable
 	public AEItemDefinition partCableAnchor;
+
+	@Nullable
 	public AEItemDefinition partMonitor;
+
+	@Nullable
 	public AEItemDefinition partSemiDarkMonitor;
+
+	@Nullable
 	public AEItemDefinition partDarkMonitor;
 
+	@Nullable
 	public AEItemDefinition partInterfaceTerminal;
+
+	@Nullable
 	public AEItemDefinition partPatternTerminal;
+
+	@Nullable
 	public AEItemDefinition partCraftingTerminal;
+
+	@Nullable
 	public AEItemDefinition partTerminal;
+
+	@Nullable
 	public AEItemDefinition partStorageMonitor;
+
+	@Nullable
 	public AEItemDefinition partConversionMonitor;
 }

--- a/src/api/java/appeng/api/events/LocatableEventAnnounce.java
+++ b/src/api/java/appeng/api/events/LocatableEventAnnounce.java
@@ -23,12 +23,15 @@
 
 package appeng.api.events;
 
-import appeng.api.features.ILocatable;
+
 import cpw.mods.fml.common.eventhandler.Event;
+
+import appeng.api.features.ILocatable;
+
 
 /**
  * Input Event:
- *
+ * 
  * Used to Notify the Location Registry of objects, and their availability.
  */
 public class LocatableEventAnnounce extends Event
@@ -40,12 +43,13 @@ public class LocatableEventAnnounce extends Event
 		Unregister // Removes the locatable from the registry
 	}
 
+
 	final public ILocatable target;
 	final public LocatableEvent change;
 
-	public LocatableEventAnnounce(ILocatable o, LocatableEvent ev) {
+	public LocatableEventAnnounce( ILocatable o, LocatableEvent ev )
+	{
 		this.target = o;
 		this.change = ev;
 	}
-
 }

--- a/src/api/java/appeng/api/exceptions/AppEngException.java
+++ b/src/api/java/appeng/api/exceptions/AppEngException.java
@@ -23,12 +23,14 @@
 
 package appeng.api.exceptions;
 
+
 public class AppEngException extends Exception
 {
 
 	private static final long serialVersionUID = -9051434206368465494L;
 
-	public AppEngException(String t) {
+	public AppEngException( String t )
+	{
 		super( t );
 	}
 }

--- a/src/api/java/appeng/api/exceptions/CouldNotAccessCoreAPI.java
+++ b/src/api/java/appeng/api/exceptions/CouldNotAccessCoreAPI.java
@@ -1,0 +1,10 @@
+package appeng.api.exceptions;
+
+
+public class CouldNotAccessCoreAPI extends RuntimeException
+{
+	public CouldNotAccessCoreAPI( String message )
+	{
+		super( message );
+	}
+}

--- a/src/api/java/appeng/api/exceptions/FailedConnection.java
+++ b/src/api/java/appeng/api/exceptions/FailedConnection.java
@@ -23,11 +23,13 @@
 
 package appeng.api.exceptions;
 
+
 public class FailedConnection extends Exception
 {
 
 	private static final long serialVersionUID = -2544208090248293753L;
 
-	public FailedConnection() {
+	public FailedConnection()
+	{
 	}
 }

--- a/src/api/java/appeng/api/exceptions/MissingDefinition.java
+++ b/src/api/java/appeng/api/exceptions/MissingDefinition.java
@@ -1,0 +1,10 @@
+package appeng.api.exceptions;
+
+
+public class MissingDefinition extends RuntimeException
+{
+	public MissingDefinition( String message )
+	{
+		super( message );
+	}
+}

--- a/src/api/java/appeng/api/exceptions/MissingIngredientError.java
+++ b/src/api/java/appeng/api/exceptions/MissingIngredientError.java
@@ -23,12 +23,14 @@
 
 package appeng.api.exceptions;
 
-public class MissingIngredientError extends Exception {
+
+public class MissingIngredientError extends Exception
+{
 
 	private static final long serialVersionUID = -998858343831371697L;
 
-	public MissingIngredientError(String n) {
+	public MissingIngredientError( String n )
+	{
 		super( n );
 	}
-
 }

--- a/src/api/java/appeng/api/exceptions/ModNotInstalled.java
+++ b/src/api/java/appeng/api/exceptions/ModNotInstalled.java
@@ -23,13 +23,14 @@
 
 package appeng.api.exceptions;
 
+
 public class ModNotInstalled extends Exception
 {
 
 	private static final long serialVersionUID = -9052435206368425494L;
 
-	public ModNotInstalled(String t) {
+	public ModNotInstalled( String t )
+	{
 		super( t );
 	}
-
 }

--- a/src/api/java/appeng/api/exceptions/RecipeError.java
+++ b/src/api/java/appeng/api/exceptions/RecipeError.java
@@ -23,13 +23,14 @@
 
 package appeng.api.exceptions;
 
+
 public class RecipeError extends Exception
 {
 
 	private static final long serialVersionUID = -6602870588617670262L;
 
-	public RecipeError(String n) {
+	public RecipeError( String n )
+	{
 		super( n );
 	}
-
 }

--- a/src/api/java/appeng/api/exceptions/RegistrationError.java
+++ b/src/api/java/appeng/api/exceptions/RegistrationError.java
@@ -23,13 +23,14 @@
 
 package appeng.api.exceptions;
 
+
 public class RegistrationError extends Exception
 {
 
 	private static final long serialVersionUID = -6602870588617670263L;
 
-	public RegistrationError(String n) {
+	public RegistrationError( String n )
+	{
 		super( n );
 	}
-
 }

--- a/src/api/java/appeng/api/features/IGrinderEntry.java
+++ b/src/api/java/appeng/api/features/IGrinderEntry.java
@@ -23,7 +23,9 @@
 
 package appeng.api.features;
 
+
 import net.minecraft.item.ItemStack;
+
 
 /**
  * Registration Records for {@link IGrinderRegistry}
@@ -43,7 +45,7 @@ public interface IGrinderEntry
 	 *
 	 * @param input input item
 	 */
-	public void setInput(ItemStack input);
+	public void setInput( ItemStack input );
 
 	/**
 	 * gets the current output
@@ -71,7 +73,7 @@ public interface IGrinderEntry
 	 *
 	 * @param output output item
 	 */
-	public void setOutput(ItemStack output);
+	public void setOutput( ItemStack output );
 
 	/**
 	 * stack, and 0.0-1.0 chance that it will be generated.
@@ -79,7 +81,7 @@ public interface IGrinderEntry
 	 * @param output output item
 	 * @param chance generation chance
 	 */
-	public void setOptionalOutput(ItemStack output, float chance);
+	public void setOptionalOutput( ItemStack output, float chance );
 
 	/**
 	 * 0.0 - 1.0 the chance that the optional output will be generated.
@@ -94,7 +96,7 @@ public interface IGrinderEntry
 	 * @param output second optional output item
 	 * @param chance second optional output chance
 	 */
-	public void setSecondOptionalOutput(ItemStack output, float chance);
+	public void setSecondOptionalOutput( ItemStack output, float chance );
 
 	/**
 	 * 0.0 - 1.0 the chance that the optional output will be generated.
@@ -115,5 +117,5 @@ public interface IGrinderEntry
 	 *
 	 * @param c number of turns to produce output.
 	 */
-	public void setEnergyCost(int c);
+	public void setEnergyCost( int c );
 }

--- a/src/api/java/appeng/api/features/IGrinderRegistry.java
+++ b/src/api/java/appeng/api/features/IGrinderRegistry.java
@@ -23,9 +23,11 @@
 
 package appeng.api.features;
 
-import net.minecraft.item.ItemStack;
 
 import java.util.List;
+
+import net.minecraft.item.ItemStack;
+
 
 /**
  * Lets you manipulate Grinder Recipes, by adding or editing existing ones.
@@ -47,7 +49,7 @@ public interface IGrinderRegistry
 	 * @param out output
 	 * @param turns amount of turns to turn the input into the output
 	 */
-	public void addRecipe(ItemStack in, ItemStack out, int turns);
+	public void addRecipe( ItemStack in, ItemStack out, int turns );
 
 	/**
 	 * add a new recipe with optional outputs, duplicates will not be added.
@@ -55,30 +57,30 @@ public interface IGrinderRegistry
 	 * @param in input
 	 * @param out output
 	 * @param optional optional output
-	 * @param chance chance to get the optional output within 0.0 - 1.0
-	 * @param turns amount of turns to turn the input into the outputs
+	 * @param chance   chance to get the optional output within 0.0 - 1.0
+	 * @param turns    amount of turns to turn the input into the outputs
 	 */
-	void addRecipe(ItemStack in, ItemStack out, ItemStack optional, float chance, int turns);
+	void addRecipe( ItemStack in, ItemStack out, ItemStack optional, float chance, int turns );
 
 	/**
 	 * add a new recipe with optional outputs, duplicates will not be added.
-	 *
+	 * 
 	 * @param in input
 	 * @param out output
 	 * @param optional optional output
 	 * @param chance chance to get the optional output within 0.0 - 1.0
 	 * @param optional2 second optional output
-	 * @param chance2 chance to get the second optional output within 0.0 - 1.0
-	 * @param turns amount of turns to turn the input into the outputs
+	 * @param chance2   chance to get the second optional output within 0.0 - 1.0
+	 * @param turns     amount of turns to turn the input into the outputs
 	 */
-	void addRecipe(ItemStack in, ItemStack out, ItemStack optional, float chance, ItemStack optional2, float chance2, int turns);
+	void addRecipe( ItemStack in, ItemStack out, ItemStack optional, float chance, ItemStack optional2, float chance2, int turns );
 
 	/**
 	 * Searches for a recipe for a given input, and returns it.
 	 *
 	 * @param input input
+	 *
 	 * @return identified recipe or null
 	 */
-	public IGrinderEntry getRecipeForInput(ItemStack input);
-
+	public IGrinderEntry getRecipeForInput( ItemStack input );
 }

--- a/src/api/java/appeng/api/features/IItemComparison.java
+++ b/src/api/java/appeng/api/features/IItemComparison.java
@@ -23,11 +23,11 @@
 
 package appeng.api.features;
 
+
 public interface IItemComparison
 {
 
-	public boolean sameAsPrecise(IItemComparison comp);
+	public boolean sameAsPrecise( IItemComparison comp );
 
-	public boolean sameAsFuzzy(IItemComparison comp);
-
+	public boolean sameAsFuzzy( IItemComparison comp );
 }

--- a/src/api/java/appeng/api/features/IItemComparisonProvider.java
+++ b/src/api/java/appeng/api/features/IItemComparisonProvider.java
@@ -23,7 +23,9 @@
 
 package appeng.api.features;
 
+
 import net.minecraft.item.ItemStack;
+
 
 /**
  * Provider for special comparisons. when an item is encountered AE Will request
@@ -38,16 +40,17 @@ public interface IItemComparisonProvider
 	 * the supplied item.
 	 *
 	 * @param is item
+	 *
 	 * @return IItemComparison, or null
 	 */
-	IItemComparison getComparison(ItemStack is);
+	IItemComparison getComparison( ItemStack is );
 
 	/**
 	 * Simple test for support ( AE generally skips this and calls the above function. )
 	 *
 	 * @param stack item
+	 *
 	 * @return true, if getComparison will return a valid IItemComparison Object
 	 */
-	public boolean canHandle(ItemStack stack);
-
+	public boolean canHandle( ItemStack stack );
 }

--- a/src/api/java/appeng/api/features/ILocatable.java
+++ b/src/api/java/appeng/api/features/ILocatable.java
@@ -23,7 +23,9 @@
 
 package appeng.api.features;
 
+
 import appeng.api.events.LocatableEventAnnounce;
+
 
 /**
  * A registration record for the {@link ILocatableRegistry} use the {@link LocatableEventAnnounce} event on the Forge
@@ -36,5 +38,4 @@ public interface ILocatable
 	 * @return the serial for a locatable object
 	 */
 	long getLocatableSerial();
-
 }

--- a/src/api/java/appeng/api/features/ILocatableRegistry.java
+++ b/src/api/java/appeng/api/features/ILocatableRegistry.java
@@ -23,6 +23,7 @@
 
 package appeng.api.features;
 
+
 /**
  * A Registry for locatable items, works based on serial numbers.
  */
@@ -34,8 +35,8 @@ public interface ILocatableRegistry
 	 * returns the object.
 	 *
 	 * @param serial serial
+	 *
 	 * @return requestedObject, or null
 	 */
-	public abstract Object findLocatableBySerial(long serial);
-
+	public abstract Object findLocatableBySerial( long serial );
 }

--- a/src/api/java/appeng/api/features/IMatterCannonAmmoRegistry.java
+++ b/src/api/java/appeng/api/features/IMatterCannonAmmoRegistry.java
@@ -23,25 +23,27 @@
 
 package appeng.api.features;
 
+
 import net.minecraft.item.ItemStack;
+
 
 public interface IMatterCannonAmmoRegistry
 {
 
 	/**
 	 * register a new ammo, generally speaking this is based off of atomic weight to make it easier to guess at
-	 *
+	 * 
 	 * @param ammo new ammo
 	 * @param weight atomic weight
 	 */
-	void registerAmmo(ItemStack ammo, double weight);
+	void registerAmmo( ItemStack ammo, double weight );
 
 	/**
 	 * get the penetration value for a particular ammo, 0 indicates a non-ammo.
 	 *
 	 * @param is ammo
+	 *
 	 * @return 0 or a valid penetration value.
 	 */
-	float getPenetration(ItemStack is);
-
+	float getPenetration( ItemStack is );
 }

--- a/src/api/java/appeng/api/features/INetworkEncodable.java
+++ b/src/api/java/appeng/api/features/INetworkEncodable.java
@@ -23,21 +23,25 @@
 
 package appeng.api.features;
 
+
 import net.minecraft.item.ItemStack;
 
-public interface INetworkEncodable {
+
+public interface INetworkEncodable
+{
 
 	/**
 	 * Used to get the current key from the item.
 	 *
 	 * @param item item
+	 *
 	 * @return string key of item
 	 */
-	String getEncryptionKey(ItemStack item);
+	String getEncryptionKey( ItemStack item );
 
 	/**
 	 * Encode the wireless frequency via the Controller.
-	 *
+	 * 
 	 * @param item
 	 *            the wireless terminal.
 	 * @param encKey
@@ -45,6 +49,5 @@ public interface INetworkEncodable {
 	 * @param name
 	 *            null for now.
 	 */
-	void setEncryptionKey(ItemStack item, String encKey, String name);
-
+	void setEncryptionKey( ItemStack item, String encKey, String name );
 }

--- a/src/api/java/appeng/api/features/IP2PTunnelRegistry.java
+++ b/src/api/java/appeng/api/features/IP2PTunnelRegistry.java
@@ -23,8 +23,11 @@
 
 package appeng.api.features;
 
+
 import net.minecraft.item.ItemStack;
+
 import appeng.api.config.TunnelType;
+
 
 /**
  * A Registry for how p2p Tunnels are attuned
@@ -35,20 +38,20 @@ public interface IP2PTunnelRegistry
 	/**
 	 * Allows third parties to register items from their mod as potential
 	 * attunements for AE's P2P Tunnels
-	 *
+	 * 
 	 * @param trigger
 	 *            - the item which triggers attunement
 	 * @param type
 	 *            - the type of tunnel
 	 */
-	public abstract void addNewAttunement(ItemStack trigger, TunnelType type);
+	public abstract void addNewAttunement( ItemStack trigger, TunnelType type );
 
 	/**
 	 * returns null if no attunement can be found.
 	 *
 	 * @param trigger attunement trigger
+	 *
 	 * @return null if no attunement can be found or attunement
 	 */
-	TunnelType getTunnelTypeByItem(ItemStack trigger);
-
+	TunnelType getTunnelTypeByItem( ItemStack trigger );
 }

--- a/src/api/java/appeng/api/features/IPlayerRegistry.java
+++ b/src/api/java/appeng/api/features/IPlayerRegistry.java
@@ -23,9 +23,11 @@
 
 package appeng.api.features;
 
+
 import net.minecraft.entity.player.EntityPlayer;
 
 import com.mojang.authlib.GameProfile;
+
 
 /**
  * Maintains a save specific list of userids and username combinations this greatly simplifies storage internally and
@@ -36,20 +38,22 @@ public interface IPlayerRegistry
 
 	/**
 	 * @param gameProfile user game profile
+	 *
 	 * @return user id of a username.
 	 */
-	int getID(GameProfile gameProfile);
+	int getID( GameProfile gameProfile );
 
 	/**
 	 * @param player player
+	 *
 	 * @return user id of a player entity.
 	 */
-	int getID(EntityPlayer player);
+	int getID( EntityPlayer player );
 
 	/**
 	 * @param playerID to be found player id
+	 *
 	 * @return PlayerEntity, or null if the player could not be found.
 	 */
-	EntityPlayer findPlayer(int playerID);
-
+	EntityPlayer findPlayer( int playerID );
 }

--- a/src/api/java/appeng/api/features/IRecipeHandlerRegistry.java
+++ b/src/api/java/appeng/api/features/IRecipeHandlerRegistry.java
@@ -23,37 +23,40 @@
 
 package appeng.api.features;
 
+
 import appeng.api.recipes.ICraftHandler;
 import appeng.api.recipes.IRecipeHandler;
 import appeng.api.recipes.ISubItemResolver;
+
 
 public interface IRecipeHandlerRegistry
 {
 
 	/**
 	 * Add a new Recipe Handler to the parser.
-	 *
+	 * 
 	 * MUST BE CALLED IN PRE-INIT
-	 *
+	 * 
 	 * @param name name of crafthandler
 	 * @param handler class of crafthandler
 	 */
-	void addNewCraftHandler(String name, Class<? extends ICraftHandler> handler);
+	void addNewCraftHandler( String name, Class<? extends ICraftHandler> handler );
 
 	/**
 	 * Add a new resolver to the parser.
-	 *
+	 * 
 	 * MUST BE CALLED IN PRE-INIT
 	 *
 	 * @param sir sub item resolver
 	 */
-	void addNewSubItemResolver(ISubItemResolver sir);
+	void addNewSubItemResolver( ISubItemResolver sir );
 
 	/**
 	 * @param name name of crafting handler
+	 *
 	 * @return A recipe handler by name, returns null on failure.
 	 */
-	ICraftHandler getCraftHandlerFor(String name);
+	ICraftHandler getCraftHandlerFor( String name );
 
 	/**
 	 * @return a new recipe handler, which can be used to parse, and read recipe files.
@@ -64,9 +67,9 @@ public interface IRecipeHandlerRegistry
 	 * resolve sub items by name.
 	 *
 	 * @param nameSpace namespace of item
-	 * @param itemName full name of item
+	 * @param itemName  full name of item
+	 *
 	 * @return ResolverResult or ResolverResultSet
 	 */
-	Object resolveItem(String nameSpace, String itemName);
-
+	Object resolveItem( String nameSpace, String itemName );
 }

--- a/src/api/java/appeng/api/features/IRegistryContainer.java
+++ b/src/api/java/appeng/api/features/IRegistryContainer.java
@@ -23,10 +23,12 @@
 
 package appeng.api.features;
 
+
 import appeng.api.movable.IMovableRegistry;
 import appeng.api.networking.IGridCacheRegistry;
 import appeng.api.storage.ICellRegistry;
 import appeng.api.storage.IExternalStorageRegistry;
+
 
 public interface IRegistryContainer
 {

--- a/src/api/java/appeng/api/features/ISpecialComparisonRegistry.java
+++ b/src/api/java/appeng/api/features/ISpecialComparisonRegistry.java
@@ -23,11 +23,12 @@
 
 package appeng.api.features;
 
+
 import net.minecraft.item.ItemStack;
+
 
 /**
  * A Registry of any special comparison handlers for AE To use.
- *
  */
 public interface ISpecialComparisonRegistry
 {
@@ -36,15 +37,15 @@ public interface ISpecialComparisonRegistry
 	 * return TheHandler or null.
 	 *
 	 * @param stack item
+	 *
 	 * @return a handler it found for a specific item
 	 */
-	IItemComparison getSpecialComparison(ItemStack stack);
+	IItemComparison getSpecialComparison( ItemStack stack );
 
 	/**
 	 * Register a new special comparison function with AE.
 	 *
 	 * @param prov comparison provider
 	 */
-	public void addComparisonProvider(IItemComparisonProvider prov);
-
+	public void addComparisonProvider( IItemComparisonProvider prov );
 }

--- a/src/api/java/appeng/api/features/IWirelessTermHandler.java
+++ b/src/api/java/appeng/api/features/IWirelessTermHandler.java
@@ -23,9 +23,12 @@
 
 package appeng.api.features;
 
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
+
 import appeng.api.util.IConfigManager;
+
 
 /**
  * A handler for a wireless terminal.
@@ -35,35 +38,37 @@ public interface IWirelessTermHandler extends INetworkEncodable
 
 	/**
 	 * @param is wireless terminal
+	 *
 	 * @return true, if usePower, hasPower, etc... can be called for the provided item
 	 */
-	boolean canHandle(ItemStack is);
+	boolean canHandle( ItemStack is );
 
 	/**
 	 * use an amount of power, in AE units
-	 *
+	 * 
 	 * @param amount
 	 *            is in AE units ( 5 per MJ ), if you return false, the item should be dead and return false for
 	 *            hasPower
 	 * @param is wireless terminal
 	 * @return true if wireless terminal uses power
 	 */
-	boolean usePower(EntityPlayer player, double amount, ItemStack is);
+	boolean usePower( EntityPlayer player, double amount, ItemStack is );
 
 	/**
 	 * gets the power status of the item.
 	 *
 	 * @param is wireless terminal
+	 *
 	 * @return returns true if there is any power left.
 	 */
-	boolean hasPower(EntityPlayer player, double amount, ItemStack is);
+	boolean hasPower( EntityPlayer player, double amount, ItemStack is );
 
 	/**
 	 * Return the config manager for the wireless terminal.
 	 *
 	 * @param is wireless terminal
+	 *
 	 * @return config manager of wireless terminal
 	 */
-	IConfigManager getConfigManager(ItemStack is);
-
+	IConfigManager getConfigManager( ItemStack is );
 }

--- a/src/api/java/appeng/api/features/IWirelessTermRegistry.java
+++ b/src/api/java/appeng/api/features/IWirelessTermRegistry.java
@@ -23,9 +23,11 @@
 
 package appeng.api.features;
 
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
+
 
 /**
  * Registration record for a Custom Cell handler.
@@ -38,25 +40,26 @@ public interface IWirelessTermRegistry
 	 *
 	 * @param handler wireless handler
 	 */
-	void registerWirelessHandler(IWirelessTermHandler handler);
+	void registerWirelessHandler( IWirelessTermHandler handler );
 
 	/**
 	 * @param is item which might have a handler
+	 *
 	 * @return true if there is a handler for this item
 	 */
-	boolean isWirelessTerminal(ItemStack is);
+	boolean isWirelessTerminal( ItemStack is );
 
 	/**
 	 * @param is item with handler
+	 *
 	 * @return a register handler for the item in question, or null if there
-	 *         isn't one
+	 * isn't one
 	 */
-	IWirelessTermHandler getWirelessTerminalHandler(ItemStack is);
+	IWirelessTermHandler getWirelessTerminalHandler( ItemStack is );
 
 	/**
 	 * opens the wireless terminal gui, the wireless terminal item, must be in
 	 * the active slot on the tool bar.
 	 */
-	void openWirelessTerminalGui(ItemStack item, World w, EntityPlayer player);
-
+	void openWirelessTerminalGui( ItemStack item, World w, EntityPlayer player );
 }

--- a/src/api/java/appeng/api/features/IWorldGen.java
+++ b/src/api/java/appeng/api/features/IWorldGen.java
@@ -23,8 +23,10 @@
 
 package appeng.api.features;
 
+
 import net.minecraft.world.World;
 import net.minecraft.world.WorldProvider;
+
 
 public interface IWorldGen
 {
@@ -34,12 +36,11 @@ public interface IWorldGen
 		CertusQuartz, ChargedCertusQuartz, Meteorites
 	}
 
-	public void disableWorldGenForProviderID(WorldGenType type, Class<? extends WorldProvider> provider);
+	public void disableWorldGenForProviderID( WorldGenType type, Class<? extends WorldProvider> provider );
 
-	public void enableWorldGenForDimension(WorldGenType type, int dimID);
+	public void enableWorldGenForDimension( WorldGenType type, int dimID );
 
-	public void disableWorldGenForDimension(WorldGenType type, int dimID);
+	public void disableWorldGenForDimension( WorldGenType type, int dimID );
 
-	boolean isWorldGenEnabled(WorldGenType type, World w);
-
+	boolean isWorldGenEnabled( WorldGenType type, World w );
 }

--- a/src/api/java/appeng/api/implementations/ICraftingPatternItem.java
+++ b/src/api/java/appeng/api/implementations/ICraftingPatternItem.java
@@ -23,10 +23,13 @@
 
 package appeng.api.implementations;
 
+
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
+
 import appeng.api.networking.crafting.ICraftingPatternDetails;
+
 
 /**
  * Implemented on {@link Item}
@@ -38,8 +41,9 @@ public interface ICraftingPatternItem
 	 * Access Details about a pattern
 	 *
 	 * @param is pattern
-	 * @param w crafting world
+	 * @param w  crafting world
+	 *
 	 * @return details of pattern
 	 */
-	ICraftingPatternDetails getPatternForItem(ItemStack is, World w);
+	ICraftingPatternDetails getPatternForItem( ItemStack is, World w );
 }

--- a/src/api/java/appeng/api/implementations/IPowerChannelState.java
+++ b/src/api/java/appeng/api/implementations/IPowerChannelState.java
@@ -23,6 +23,7 @@
 
 package appeng.api.implementations;
 
+
 /**
  * This is intended for use on the client side to provide details to WAILA.
  */
@@ -38,5 +39,4 @@ public interface IPowerChannelState
 	 * @return true if the part/tile isActive
 	 */
 	boolean isActive();
-
 }

--- a/src/api/java/appeng/api/implementations/IUpgradeableHost.java
+++ b/src/api/java/appeng/api/implementations/IUpgradeableHost.java
@@ -23,10 +23,13 @@
 
 package appeng.api.implementations;
 
-import appeng.api.util.IConfigurableObject;
+
 import net.minecraft.tileentity.TileEntity;
+
 import appeng.api.config.Upgrades;
 import appeng.api.implementations.tiles.ISegmentedInventory;
+import appeng.api.util.IConfigurableObject;
+
 
 public interface IUpgradeableHost extends IConfigurableObject, ISegmentedInventory
 {
@@ -34,7 +37,7 @@ public interface IUpgradeableHost extends IConfigurableObject, ISegmentedInvento
 	/**
 	 * determine how many of an upgrade are installed.
 	 */
-	int getInstalledUpgrades(Upgrades u);
+	int getInstalledUpgrades( Upgrades u );
 
 	/**
 	 * the tile...
@@ -42,5 +45,4 @@ public interface IUpgradeableHost extends IConfigurableObject, ISegmentedInvento
 	 * @return tile entity
 	 */
 	TileEntity getTile();
-
 }

--- a/src/api/java/appeng/api/implementations/TransitionResult.java
+++ b/src/api/java/appeng/api/implementations/TransitionResult.java
@@ -23,6 +23,7 @@
 
 package appeng.api.implementations;
 
+
 /**
  * Defines the result of performing a transition from the world into a storage
  * cell, if its possible, and what the energy usage is.
@@ -32,7 +33,8 @@ public class TransitionResult
 	public final boolean success;
 	public final double energyUsage;
 
-	public TransitionResult(boolean _success, double power) {
+	public TransitionResult( boolean _success, double power )
+	{
 		this.success = _success;
 		this.energyUsage = power;
 	}

--- a/src/api/java/appeng/api/implementations/guiobjects/IGuiItem.java
+++ b/src/api/java/appeng/api/implementations/guiobjects/IGuiItem.java
@@ -23,8 +23,10 @@
 
 package appeng.api.implementations.guiobjects;
 
+
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
+
 
 /**
  * Implemented on Item objects, to return objects used to manage, and interact
@@ -33,6 +35,5 @@ import net.minecraft.world.World;
 public interface IGuiItem
 {
 
-	IGuiItemObject getGuiObject(ItemStack is, World world, int x, int y, int z);
-
+	IGuiItemObject getGuiObject( ItemStack is, World world, int x, int y, int z );
 }

--- a/src/api/java/appeng/api/implementations/guiobjects/IGuiItemObject.java
+++ b/src/api/java/appeng/api/implementations/guiobjects/IGuiItemObject.java
@@ -23,7 +23,9 @@
 
 package appeng.api.implementations.guiobjects;
 
+
 import net.minecraft.item.ItemStack;
+
 
 public interface IGuiItemObject
 {

--- a/src/api/java/appeng/api/implementations/guiobjects/INetworkTool.java
+++ b/src/api/java/appeng/api/implementations/guiobjects/INetworkTool.java
@@ -23,8 +23,11 @@
 
 package appeng.api.implementations.guiobjects;
 
+
 import net.minecraft.inventory.IInventory;
+
 import appeng.api.networking.IGridHost;
+
 
 /**
  * Obtained via {@link IGuiItem} getGuiObject
@@ -33,5 +36,4 @@ public interface INetworkTool extends IInventory, IGuiItemObject
 {
 
 	IGridHost getGridHost(); // null for most purposes.
-
 }

--- a/src/api/java/appeng/api/implementations/guiobjects/IPortableCell.java
+++ b/src/api/java/appeng/api/implementations/guiobjects/IPortableCell.java
@@ -23,10 +23,12 @@
 
 package appeng.api.implementations.guiobjects;
 
+
 import appeng.api.networking.energy.IEnergySource;
 import appeng.api.storage.IMEMonitor;
 import appeng.api.storage.ITerminalHost;
 import appeng.api.storage.data.IAEItemStack;
+
 
 /**
  * Obtained via {@link IGuiItem} getGuiObject

--- a/src/api/java/appeng/api/implementations/items/IAEItemPowerStorage.java
+++ b/src/api/java/appeng/api/implementations/items/IAEItemPowerStorage.java
@@ -23,9 +23,12 @@
 
 package appeng.api.implementations.items;
 
+
 import net.minecraft.item.ItemStack;
+
 import appeng.api.config.AccessRestriction;
 import appeng.api.networking.energy.IAEPowerStorage;
+
 
 /**
  * Basically the same as {@link IAEPowerStorage}, but for items.
@@ -39,26 +42,27 @@ public interface IAEItemPowerStorage
 	 *
 	 * @return amount unable to be stored
 	 */
-	public double injectAEPower(ItemStack is, double amt);
+	public double injectAEPower( ItemStack is, double amt );
 
 	/**
 	 * Attempt to extract power from the device, it will extract what it can and
 	 * return it.
 	 *
 	 * @param amt to be extracted power from device
+	 *
 	 * @return what it could extract
 	 */
-	public double extractAEPower(ItemStack is, double amt);
+	public double extractAEPower( ItemStack is, double amt );
 
 	/**
 	 * @return the current maximum power ( this can change :P )
 	 */
-	public double getAEMaxPower(ItemStack is);
+	public double getAEMaxPower( ItemStack is );
 
 	/**
 	 * @return the current AE Power Level, this may exceed getMEMaxPower()
 	 */
-	public double getAECurrentPower(ItemStack is);
+	public double getAECurrentPower( ItemStack is );
 
 	/**
 	 * Control the power flow by telling what the network can do, either add? or
@@ -66,6 +70,5 @@ public interface IAEItemPowerStorage
 	 *
 	 * @return access restriction of network
 	 */
-	public AccessRestriction getPowerFlow(ItemStack is);
-
+	public AccessRestriction getPowerFlow( ItemStack is );
 }

--- a/src/api/java/appeng/api/implementations/items/IAEWrench.java
+++ b/src/api/java/appeng/api/implementations/items/IAEWrench.java
@@ -23,8 +23,10 @@
 
 package appeng.api.implementations.items;
 
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
+
 
 /**
  * Implemented on AE's wrench(s) as a substitute for if BC's API is not
@@ -37,12 +39,11 @@ public interface IAEWrench
 	 * Check if the wrench can be used.
 	 *
 	 * @param player wrenching player
-	 * @param x x pos of wrenched block
-	 * @param y y pos of wrenched block
-	 * @param z z pos of wrenched block
+	 * @param x      x pos of wrenched block
+	 * @param y      y pos of wrenched block
+	 * @param z      z pos of wrenched block
 	 *
 	 * @return true if wrench can be used
 	 */
-	boolean canWrench(ItemStack wrench, EntityPlayer player, int x, int y, int z);
-
+	boolean canWrench( ItemStack wrench, EntityPlayer player, int x, int y, int z );
 }

--- a/src/api/java/appeng/api/implementations/items/IBiometricCard.java
+++ b/src/api/java/appeng/api/implementations/items/IBiometricCard.java
@@ -23,13 +23,17 @@
 
 package appeng.api.implementations.items;
 
+
+import java.util.EnumSet;
+
+import net.minecraft.item.ItemStack;
+
+import com.mojang.authlib.GameProfile;
+
 import appeng.api.config.SecurityPermissions;
 import appeng.api.features.IPlayerRegistry;
 import appeng.api.networking.security.ISecurityRegistry;
-import com.mojang.authlib.GameProfile;
-import net.minecraft.item.ItemStack;
 
-import java.util.EnumSet;
 
 public interface IBiometricCard
 {
@@ -37,50 +41,51 @@ public interface IBiometricCard
 	/**
 	 * Set the  {@link GameProfile} to null, to clear it.
 	 */
-	void setProfile(ItemStack itemStack, GameProfile username);
+	void setProfile( ItemStack itemStack, GameProfile username );
 
 	/**
 	 * @return {@link GameProfile} of the player encoded on this card, or a blank string.
 	 */
-	GameProfile getProfile(ItemStack is);
+	GameProfile getProfile( ItemStack is );
 
 	/**
 	 * @param itemStack card
+	 *
 	 * @return the full list of permissions encoded on the card.
 	 */
-	EnumSet<SecurityPermissions> getPermissions(ItemStack itemStack);
+	EnumSet<SecurityPermissions> getPermissions( ItemStack itemStack );
 
 	/**
 	 * Check if a permission is encoded on the card.
 	 *
 	 * @param permission card
+	 *
 	 * @return true if this permission is set on the card.
 	 */
-	boolean hasPermission(ItemStack is, SecurityPermissions permission);
+	boolean hasPermission( ItemStack is, SecurityPermissions permission );
 
 	/**
 	 * remove a permission from the item stack.
-	 *
+	 * 
 	 * @param itemStack card
 	 * @param permission to be removed permission
 	 */
-	void removePermission(ItemStack itemStack, SecurityPermissions permission);
+	void removePermission( ItemStack itemStack, SecurityPermissions permission );
 
 	/**
 	 * add a permission to the item stack.
-	 *
+	 * 
 	 * @param itemStack card
 	 * @param permission to be added permission
 	 */
-	void addPermission(ItemStack itemStack, SecurityPermissions permission);
+	void addPermission( ItemStack itemStack, SecurityPermissions permission );
 
 	/**
 	 * lets you handle submission of security values on the card for custom behavior.
 	 *
 	 * @param registry security registry
-	 * @param pr player registry
-	 * @param is card
+	 * @param pr       player registry
+	 * @param is       card
 	 */
-	void registerPermissions(ISecurityRegistry registry, IPlayerRegistry pr, ItemStack is);
-
+	void registerPermissions( ISecurityRegistry registry, IPlayerRegistry pr, ItemStack is );
 }

--- a/src/api/java/appeng/api/implementations/items/IGrowableCrystal.java
+++ b/src/api/java/appeng/api/implementations/items/IGrowableCrystal.java
@@ -23,15 +23,16 @@
 
 package appeng.api.implementations.items;
 
+
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.item.ItemStack;
 
+
 public interface IGrowableCrystal
 {
 
-	ItemStack triggerGrowth(ItemStack is);
+	ItemStack triggerGrowth( ItemStack is );
 
-	float getMultiplier(Block blk, Material mat);
-
+	float getMultiplier( Block blk, Material mat );
 }

--- a/src/api/java/appeng/api/implementations/items/IItemGroup.java
+++ b/src/api/java/appeng/api/implementations/items/IItemGroup.java
@@ -23,9 +23,11 @@
 
 package appeng.api.implementations.items;
 
-import net.minecraft.item.ItemStack;
 
 import java.util.Set;
+
+import net.minecraft.item.ItemStack;
+
 
 /**
  * Lets you specify the name of the group of items this falls under.
@@ -37,8 +39,8 @@ public interface IItemGroup
 	 * returning null, is the same as not implementing the interface at all.
 	 *
 	 * @param is item
+	 *
 	 * @return an unlocalized string to use for the items group name.
 	 */
-	String getUnlocalizedGroupName(Set<ItemStack> otherItems, ItemStack is);
-
+	String getUnlocalizedGroupName( Set<ItemStack> otherItems, ItemStack is );
 }

--- a/src/api/java/appeng/api/implementations/items/IMemoryCard.java
+++ b/src/api/java/appeng/api/implementations/items/IMemoryCard.java
@@ -23,13 +23,15 @@
 
 package appeng.api.implementations.items;
 
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 
+
 /**
  * Memory Card API
- *
+ * 
  * AE's Memory Card Item Class implements this interface.
  */
 public interface IMemoryCard
@@ -38,7 +40,7 @@ public interface IMemoryCard
 	/**
 	 * Configures the data stored on the memory card, the SettingsName, will be
 	 * localized when displayed.
-	 *
+	 * 
 	 * @param is item
 	 * @param SettingsName
 	 *            unlocalized string that represents the tile entity.
@@ -47,7 +49,7 @@ public interface IMemoryCard
 	 *            unlocalized string displayed after the settings name, optional
 	 *            but can be used to add details to the card for later.
 	 */
-	void setMemoryCardContents(ItemStack is, String SettingsName, NBTTagCompound data);
+	void setMemoryCardContents( ItemStack is, String SettingsName, NBTTagCompound data );
 
 	/**
 	 * returns the settings name provided by a previous call to
@@ -55,25 +57,26 @@ public interface IMemoryCard
 	 * previous call to setMemoryCardContents.
 	 *
 	 * @param is item
+	 *
 	 * @return setting name
 	 */
-	String getSettingsName(ItemStack is);
+	String getSettingsName( ItemStack is );
 
 	/**
 	 * @param is item
+	 *
 	 * @return the NBT Data previously saved by setMemoryCardContents, or an
-	 *         empty NBTCompound
+	 * empty NBTCompound
 	 */
-	NBTTagCompound getData(ItemStack is);
+	NBTTagCompound getData( ItemStack is );
 
 	/**
 	 * notify the user of a outcome related to the memory card.
-	 *
+	 * 
 	 * @param player
 	 *            that used the card.
 	 * @param msg
 	 *            which message to send.
 	 */
-	void notifyUser(EntityPlayer player, MemoryCardMessages msg);
-
+	void notifyUser( EntityPlayer player, MemoryCardMessages msg );
 }

--- a/src/api/java/appeng/api/implementations/items/ISpatialStorageCell.java
+++ b/src/api/java/appeng/api/implementations/items/ISpatialStorageCell.java
@@ -23,11 +23,14 @@
 
 package appeng.api.implementations.items;
 
+
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
+
 import appeng.api.implementations.TransitionResult;
 import appeng.api.util.WorldCoord;
+
 
 /**
  * Implemented on a {@link Item}
@@ -37,56 +40,62 @@ public interface ISpatialStorageCell
 
 	/**
 	 * @param is spatial storage cell
+	 *
 	 * @return true if this item is a spatial storage cell
 	 */
-	boolean isSpatialStorage(ItemStack is);
+	boolean isSpatialStorage( ItemStack is );
 
 	/**
 	 * @param is spatial storage cell
+	 *
 	 * @return the maximum size of the spatial storage cell along any given axis
 	 */
-	int getMaxStoredDim(ItemStack is);
+	int getMaxStoredDim( ItemStack is );
 
 	/**
 	 * @param is spatial storage cell
+	 *
 	 * @return the world for this cell
 	 */
-	World getWorld(ItemStack is);
+	World getWorld( ItemStack is );
 
 	/**
 	 * get the currently stored size.
 	 *
 	 * @param is spatial storage cell
+	 *
 	 * @return size of spatial
 	 */
-	WorldCoord getStoredSize(ItemStack is);
+	WorldCoord getStoredSize( ItemStack is );
 
 	/**
 	 * Minimum coordinates in its world for the storage cell.
 	 *
 	 * @param is spatial storage cell
+	 *
 	 * @return minimum coordinate of dimension
 	 */
-	WorldCoord getMin(ItemStack is);
+	WorldCoord getMin( ItemStack is );
 
 	/**
 	 * Maximum coordinates in its world for the storage cell.
 	 *
 	 * @param is spatial storage cell
+	 *
 	 * @return maximum coordinate of dimension
 	 */
-	WorldCoord getMax(ItemStack is);
+	WorldCoord getMax( ItemStack is );
 
 	/**
 	 * Perform a spatial swap with the contents of the cell, and the world.
-	 *
+	 * 
 	 * @param is spatial storage cell
 	 * @param w world of spatial
 	 * @param min min coord
 	 * @param max max coord
 	 * @param doTransition transition
+	 *
 	 * @return result of transition
 	 */
-	TransitionResult doSpatialTransition(ItemStack is, World w, WorldCoord min, WorldCoord max, boolean doTransition);
-
+	TransitionResult doSpatialTransition( ItemStack is, World w, WorldCoord min, WorldCoord max, boolean doTransition );
 }

--- a/src/api/java/appeng/api/implementations/items/IStorageCell.java
+++ b/src/api/java/appeng/api/implementations/items/IStorageCell.java
@@ -23,20 +23,22 @@
 
 package appeng.api.implementations.items;
 
+
 import net.minecraft.item.ItemStack;
+
 import appeng.api.storage.ICellWorkbenchItem;
 import appeng.api.storage.data.IAEItemStack;
+
 
 /**
  * Any item which implements this can be treated as an IMEInventory via
  * Util.getCell / Util.isCell It automatically handles the internals and NBT
  * data, which is both nice, and bad for you!
- *
+ * 
  * Good cause it means you don't have to do anything, bad because you have
  * little to no control over it.
- *
+ * 
  * The standard AE implementation only provides 1-63 Types
- *
  */
 public interface IStorageCell extends ICellWorkbenchItem
 {
@@ -46,37 +48,41 @@ public interface IStorageCell extends ICellWorkbenchItem
 	 * The limit is ({@link Integer#MAX_VALUE} + 1) / 8.
 	 *
 	 * @param cellItem item
+	 *
 	 * @return number of bytes
 	 */
-	int getBytes(ItemStack cellItem);
+	int getBytes( ItemStack cellItem );
 
 	/**
 	 * Determines the number of bytes used for any type included on the cell.
 	 *
 	 * @param cellItem item
+	 *
 	 * @return number of bytes
 	 */
-	int BytePerType(ItemStack cellItem);
+	int BytePerType( ItemStack cellItem );
 
 	/**
 	 * Must be between 1 and 63, indicates how many types you want to store on
 	 * the item.
 	 *
 	 * @param cellItem item
+	 *
 	 * @return number of types
 	 */
-	int getTotalTypes(ItemStack cellItem);
+	int getTotalTypes( ItemStack cellItem );
 
 	/**
 	 * Allows you to fine tune which items are allowed on a given cell, if you
 	 * don't care, just return false; As the handler for this type of cell is
 	 * still the default cells, the normal AE black list is also applied.
-	 *
+	 * 
 	 * @param cellItem item
 	 * @param requestedAddition requested addition
+	 *
 	 * @return true to preventAdditionOfItem
 	 */
-	boolean isBlackListed(ItemStack cellItem, IAEItemStack requestedAddition);
+	boolean isBlackListed( ItemStack cellItem, IAEItemStack requestedAddition );
 
 	/**
 	 * Allows you to specify if this storage cell can be stored inside other
@@ -84,8 +90,8 @@ public interface IStorageCell extends ICellWorkbenchItem
 	 * that are not general purpose storage.
 	 *
 	 * @return true if the storage cell can be stored inside other storage
-	 *         cells, this is generally false, except for certain situations
-	 *         such as the matter cannon.
+	 * cells, this is generally false, except for certain situations
+	 * such as the matter cannon.
 	 */
 	boolean storableInStorageCell();
 
@@ -94,9 +100,10 @@ public interface IStorageCell extends ICellWorkbenchItem
 	 * cell.
 	 *
 	 * @param i item
+	 *
 	 * @return if the ItemStack should behavior as a storage cell.
 	 */
-	boolean isStorageCell(ItemStack i);
+	boolean isStorageCell( ItemStack i );
 
 	/**
 	 * @return drain in ae/t this storage cell will use.

--- a/src/api/java/appeng/api/implementations/items/IStorageComponent.java
+++ b/src/api/java/appeng/api/implementations/items/IStorageComponent.java
@@ -23,8 +23,10 @@
 
 package appeng.api.implementations.items;
 
+
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+
 
 /**
  * Implemented on a {@link Item}
@@ -38,16 +40,17 @@ public interface IStorageComponent
 	 * the condenser.
 	 *
 	 * @param is item
+	 *
 	 * @return number of bytes
 	 */
-	int getBytes(ItemStack is);
+	int getBytes( ItemStack is );
 
 	/**
 	 * Just true or false for the item stack.
 	 *
 	 * @param is item
+	 *
 	 * @return true if item is a storage component
 	 */
-	boolean isStorageComponent(ItemStack is);
-
+	boolean isStorageComponent( ItemStack is );
 }

--- a/src/api/java/appeng/api/implementations/items/IUpgradeModule.java
+++ b/src/api/java/appeng/api/implementations/items/IUpgradeModule.java
@@ -23,16 +23,19 @@
 
 package appeng.api.implementations.items;
 
+
 import net.minecraft.item.ItemStack;
+
 import appeng.api.config.Upgrades;
+
 
 public interface IUpgradeModule
 {
 
 	/**
 	 * @param itemstack item with potential upgrades
+	 *
 	 * @return null, or a valid upgrade type.
 	 */
-	Upgrades getType(ItemStack itemstack);
-
+	Upgrades getType( ItemStack itemstack );
 }

--- a/src/api/java/appeng/api/implementations/items/MemoryCardMessages.java
+++ b/src/api/java/appeng/api/implementations/items/MemoryCardMessages.java
@@ -23,6 +23,7 @@
 
 package appeng.api.implementations.items;
 
+
 /**
  * Status Results for use with {@link IMemoryCard}
  */

--- a/src/api/java/appeng/api/implementations/parts/IPartCable.java
+++ b/src/api/java/appeng/api/implementations/parts/IPartCable.java
@@ -23,16 +23,19 @@
 
 package appeng.api.implementations.parts;
 
+
+import java.util.EnumSet;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraftforge.common.util.ForgeDirection;
+
 import appeng.api.networking.IGridHost;
 import appeng.api.parts.BusSupport;
 import appeng.api.parts.IPart;
 import appeng.api.parts.IPartHost;
 import appeng.api.util.AECableType;
 import appeng.api.util.AEColor;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraftforge.common.util.ForgeDirection;
 
-import java.util.EnumSet;
 
 /**
  * Implemented on the {@link IPart}s cable objects that can be placed at {@link ForgeDirection}.UNKNOWN in
@@ -60,25 +63,26 @@ public interface IPartCable extends IPart, IGridHost
 	 * Change the color of the cable, this should cost a small amount of dye, or something.
 	 *
 	 * @param newColor new color
+	 *
 	 * @return if the color change was successful.
 	 */
-	boolean changeColor(AEColor newColor, EntityPlayer who);
+	boolean changeColor( AEColor newColor, EntityPlayer who );
 
 	/**
 	 * Change sides on the cables node.
-	 *
+	 * 
 	 * Called by AE, do not invoke.
 	 *
 	 * @param sides sides of cable
 	 */
-	void setValidSides(EnumSet<ForgeDirection> sides);
+	void setValidSides( EnumSet<ForgeDirection> sides );
 
 	/**
 	 * used to tests if a cable connects to neighbors visually.
 	 *
 	 * @param side neighbor side
+	 *
 	 * @return true if this side is currently connects to an external block.
 	 */
-	boolean isConnected(ForgeDirection side);
-
+	boolean isConnected( ForgeDirection side );
 }

--- a/src/api/java/appeng/api/implementations/parts/IPartMonitor.java
+++ b/src/api/java/appeng/api/implementations/parts/IPartMonitor.java
@@ -23,8 +23,10 @@
 
 package appeng.api.implementations.parts;
 
+
 import appeng.api.networking.IGridHost;
 import appeng.api.parts.IPart;
+
 
 /**
  * Implemented by all screen like parts provided by AE.
@@ -34,8 +36,7 @@ public interface IPartMonitor extends IPart, IGridHost
 
 	/**
 	 * @return if the device is online you should check this before providing
-	 *         any other information.
+	 * any other information.
 	 */
 	boolean isPowered();
-
 }

--- a/src/api/java/appeng/api/implementations/parts/IPartStorageMonitor.java
+++ b/src/api/java/appeng/api/implementations/parts/IPartStorageMonitor.java
@@ -23,10 +23,12 @@
 
 package appeng.api.implementations.parts;
 
+
 import appeng.api.networking.IGridHost;
 import appeng.api.parts.IPart;
 import appeng.api.storage.data.IAEStack;
 import appeng.api.util.INetworkToolAgent;
+
 
 /**
  * The Storage monitor is a {@link IPart} located on the sides of a IPartHost
@@ -36,8 +38,8 @@ public interface IPartStorageMonitor extends IPartMonitor, IPart, IGridHost, INe
 
 	/**
 	 * @return the item being displayed on the storage monitor, in AEStack Form, can be either a IAEItemStack or an
-	 *         IAEFluidStack the quantity is important remember to use getStackSize() on the IAEStack, and not on the
-	 *         FluidStack/ItemStack acquired from it.
+	 * IAEFluidStack the quantity is important remember to use getStackSize() on the IAEStack, and not on the
+	 * FluidStack/ItemStack acquired from it.
 	 */
 	IAEStack<?> getDisplayed();
 
@@ -45,5 +47,4 @@ public interface IPartStorageMonitor extends IPartMonitor, IPart, IGridHost, INe
 	 * @return the current locked state of the Storage Monitor
 	 */
 	boolean isLocked();
-
 }

--- a/src/api/java/appeng/api/implementations/tiles/IColorableTile.java
+++ b/src/api/java/appeng/api/implementations/tiles/IColorableTile.java
@@ -23,15 +23,17 @@
 
 package appeng.api.implementations.tiles;
 
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraftforge.common.util.ForgeDirection;
+
 import appeng.api.util.AEColor;
+
 
 public interface IColorableTile
 {
 
 	AEColor getColor();
 
-	boolean recolourBlock(ForgeDirection side, AEColor colour, EntityPlayer who);
-
+	boolean recolourBlock( ForgeDirection side, AEColor colour, EntityPlayer who );
 }

--- a/src/api/java/appeng/api/implementations/tiles/ICraftingMachine.java
+++ b/src/api/java/appeng/api/implementations/tiles/ICraftingMachine.java
@@ -23,8 +23,10 @@
 
 package appeng.api.implementations.tiles;
 
+
 import net.minecraft.inventory.InventoryCrafting;
 import net.minecraftforge.common.util.ForgeDirection;
+
 import appeng.api.networking.crafting.ICraftingPatternDetails;
 
 public interface ICraftingMachine

--- a/src/api/java/appeng/api/implementations/tiles/ICrystalGrowthAccelerator.java
+++ b/src/api/java/appeng/api/implementations/tiles/ICrystalGrowthAccelerator.java
@@ -23,9 +23,9 @@
 
 package appeng.api.implementations.tiles;
 
+
 public interface ICrystalGrowthAccelerator
 {
 
 	boolean isPowered();
-
 }

--- a/src/api/java/appeng/api/implementations/tiles/IMEChest.java
+++ b/src/api/java/appeng/api/implementations/tiles/IMEChest.java
@@ -23,7 +23,9 @@
 
 package appeng.api.implementations.tiles;
 
+
 import appeng.api.networking.energy.IEnergySource;
+
 
 public interface IMEChest extends IChestOrDrive, ITileStorageMonitorable, IEnergySource
 {

--- a/src/api/java/appeng/api/implementations/tiles/ISegmentedInventory.java
+++ b/src/api/java/appeng/api/implementations/tiles/ISegmentedInventory.java
@@ -23,7 +23,9 @@
 
 package appeng.api.implementations.tiles;
 
+
 import net.minecraft.inventory.IInventory;
+
 
 public interface ISegmentedInventory
 {
@@ -33,8 +35,8 @@ public interface ISegmentedInventory
 	 * them a real inventories will result in duplication.
 	 *
 	 * @param name inventory name
+	 *
 	 * @return inventory with inventory name
 	 */
-	IInventory getInventoryByName(String name);
-
+	IInventory getInventoryByName( String name );
 }

--- a/src/api/java/appeng/api/implementations/tiles/ITileStorageMonitorable.java
+++ b/src/api/java/appeng/api/implementations/tiles/ITileStorageMonitorable.java
@@ -23,9 +23,12 @@
 
 package appeng.api.implementations.tiles;
 
+
 import net.minecraftforge.common.util.ForgeDirection;
+
 import appeng.api.networking.security.BaseActionSource;
 import appeng.api.storage.IStorageMonitorable;
+
 
 /**
  * Implemented on inventories that can share their inventories with other networks, best example, ME Interface.
@@ -33,6 +36,5 @@ import appeng.api.storage.IStorageMonitorable;
 public interface ITileStorageMonitorable
 {
 
-	IStorageMonitorable getMonitorable(ForgeDirection side, BaseActionSource src);
-
+	IStorageMonitorable getMonitorable( ForgeDirection side, BaseActionSource src );
 }

--- a/src/api/java/appeng/api/implementations/tiles/IViewCellStorage.java
+++ b/src/api/java/appeng/api/implementations/tiles/IViewCellStorage.java
@@ -23,7 +23,9 @@
 
 package appeng.api.implementations.tiles;
 
+
 import net.minecraft.inventory.IInventory;
+
 
 public interface IViewCellStorage
 {
@@ -34,5 +36,4 @@ public interface IViewCellStorage
 	 * @return inventory with at least 5 slot
 	 */
 	IInventory getViewCellStorage();
-
 }

--- a/src/api/java/appeng/api/implementations/tiles/IWirelessAccessPoint.java
+++ b/src/api/java/appeng/api/implementations/tiles/IWirelessAccessPoint.java
@@ -23,9 +23,11 @@
 
 package appeng.api.implementations.tiles;
 
+
 import appeng.api.networking.IGrid;
 import appeng.api.networking.security.IActionHost;
 import appeng.api.util.DimensionalCoord;
+
 
 public interface IWirelessAccessPoint extends IActionHost
 {
@@ -49,5 +51,4 @@ public interface IWirelessAccessPoint extends IActionHost
 	 * @return grid of linked WAP
 	 */
 	IGrid getGrid();
-
 }

--- a/src/api/java/appeng/api/movable/IMovableTile.java
+++ b/src/api/java/appeng/api/movable/IMovableTile.java
@@ -23,6 +23,7 @@
 
 package appeng.api.movable;
 
+
 /**
  * You can implement this, or use the IMovableRegistry to white list your tile,
  * please see the registry for more information.
@@ -42,5 +43,4 @@ public interface IMovableTile
 	 * notification that your block was moved, called after validate.
 	 */
 	void doneMoving();
-
 }

--- a/src/api/java/appeng/api/networking/GridFlags.java
+++ b/src/api/java/appeng/api/networking/GridFlags.java
@@ -23,6 +23,7 @@
 
 package appeng.api.networking;
 
+
 /**
  * Various flags to determine network node behavior.
  */

--- a/src/api/java/appeng/api/networking/GridNotification.java
+++ b/src/api/java/appeng/api/networking/GridNotification.java
@@ -23,6 +23,7 @@
 
 package appeng.api.networking;
 
+
 public enum GridNotification
 {
 	/**

--- a/src/api/java/appeng/api/networking/IGridBlock.java
+++ b/src/api/java/appeng/api/networking/IGridBlock.java
@@ -23,13 +23,15 @@
 
 package appeng.api.networking;
 
-import appeng.api.parts.IPart;
-import appeng.api.util.AEColor;
-import appeng.api.util.DimensionalCoord;
+
+import java.util.EnumSet;
+
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import java.util.EnumSet;
+import appeng.api.parts.IPart;
+import appeng.api.util.AEColor;
+import appeng.api.util.DimensionalCoord;
 
 /**
  * An Implementation is required to create your node for IGridHost

--- a/src/api/java/appeng/api/networking/IGridCacheRegistry.java
+++ b/src/api/java/appeng/api/networking/IGridCacheRegistry.java
@@ -23,7 +23,9 @@
 
 package appeng.api.networking;
 
+
 import java.util.HashMap;
+
 
 /**
  * A registry of grid caches to extend grid functionality.
@@ -36,7 +38,7 @@ public interface IGridCacheRegistry
 	 *
 	 * @param iface grid cache class
 	 */
-	void registerGridCache(Class<? extends IGridCache> iface, Class<? extends IGridCache> implementation);
+	void registerGridCache( Class<? extends IGridCache> iface, Class<? extends IGridCache> implementation );
 
 	/**
 	 * requests a new INSTANCE of a grid cache for use, used internally
@@ -45,6 +47,5 @@ public interface IGridCacheRegistry
 	 *
 	 * @return a new HashMap of IGridCaches from the registry, called from IGrid when constructing a new grid.
 	 */
-	HashMap<Class<? extends IGridCache>, IGridCache> createCacheInstance(IGrid grid);
-
+	HashMap<Class<? extends IGridCache>, IGridCache> createCacheInstance( IGrid grid );
 }

--- a/src/api/java/appeng/api/networking/IGridHost.java
+++ b/src/api/java/appeng/api/networking/IGridHost.java
@@ -23,8 +23,10 @@
 
 package appeng.api.networking;
 
+
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.util.ForgeDirection;
+
 import appeng.api.parts.IPart;
 import appeng.api.util.AECableType;
 

--- a/src/api/java/appeng/api/networking/IGridMultiblock.java
+++ b/src/api/java/appeng/api/networking/IGridMultiblock.java
@@ -23,7 +23,9 @@
 
 package appeng.api.networking;
 
+
 import java.util.Iterator;
+
 
 /**
  * An extension of IGridBlock, only means something when your getFlags() contains REQUIRE_CHANNEL, when done properly it
@@ -39,5 +41,4 @@ public interface IGridMultiblock extends IGridBlock
 	 * @return an iterator that will iterate all the nodes for the multiblock. ( read-only iterator expected. )
 	 */
 	Iterator<IGridNode> getMultiblockNodes();
-
 }

--- a/src/api/java/appeng/api/networking/IGridNode.java
+++ b/src/api/java/appeng/api/networking/IGridNode.java
@@ -23,13 +23,15 @@
 
 package appeng.api.networking;
 
-import appeng.api.IAppEngApi;
-import appeng.api.util.IReadOnlyCollection;
+
+import java.util.EnumSet;
+
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import java.util.EnumSet;
+import appeng.api.IAppEngApi;
+import appeng.api.util.IReadOnlyCollection;
 
 /**
  *

--- a/src/api/java/appeng/api/networking/IGridStorage.java
+++ b/src/api/java/appeng/api/networking/IGridStorage.java
@@ -23,7 +23,9 @@
 
 package appeng.api.networking;
 
+
 import net.minecraft.nbt.NBTTagCompound;
+
 
 public interface IGridStorage
 {
@@ -37,5 +39,4 @@ public interface IGridStorage
 	 * @return the id for this grid storage object, used internally
 	 */
 	long getID();
-
 }

--- a/src/api/java/appeng/api/networking/IMachineSet.java
+++ b/src/api/java/appeng/api/networking/IMachineSet.java
@@ -23,7 +23,9 @@
 
 package appeng.api.networking;
 
+
 import appeng.api.util.IReadOnlyCollection;
+
 
 public interface IMachineSet extends IReadOnlyCollection<IGridNode>
 {
@@ -32,5 +34,4 @@ public interface IMachineSet extends IReadOnlyCollection<IGridNode>
 	 * @return the machine class for this set.
 	 */
 	Class<? extends IGridHost> getMachineClass();
-
 }

--- a/src/api/java/appeng/api/networking/crafting/CraftingItemList.java
+++ b/src/api/java/appeng/api/networking/crafting/CraftingItemList.java
@@ -23,6 +23,7 @@
 
 package appeng.api.networking.crafting;
 
+
 public enum CraftingItemList
 {
 	ALL, STORAGE, ACTIVE, PENDING

--- a/src/api/java/appeng/api/networking/crafting/ICraftingCPU.java
+++ b/src/api/java/appeng/api/networking/crafting/ICraftingCPU.java
@@ -23,9 +23,11 @@
 
 package appeng.api.networking.crafting;
 
+
 import appeng.api.networking.security.BaseActionSource;
 import appeng.api.networking.storage.IBaseMonitor;
 import appeng.api.storage.data.IAEItemStack;
+
 
 public interface ICraftingCPU extends IBaseMonitor<IAEItemStack>
 {
@@ -54,5 +56,4 @@ public interface ICraftingCPU extends IBaseMonitor<IAEItemStack>
 	 * @return an empty string or the name of the cpu.
 	 */
 	String getName();
-
 }

--- a/src/api/java/appeng/api/networking/crafting/ICraftingGrid.java
+++ b/src/api/java/appeng/api/networking/crafting/ICraftingGrid.java
@@ -23,15 +23,18 @@
 
 package appeng.api.networking.crafting;
 
+
+import java.util.concurrent.Future;
+
+import net.minecraft.world.World;
+
+import com.google.common.collect.ImmutableCollection;
+import com.google.common.collect.ImmutableSet;
+
 import appeng.api.networking.IGrid;
 import appeng.api.networking.IGridCache;
 import appeng.api.networking.security.BaseActionSource;
 import appeng.api.storage.data.IAEItemStack;
-import com.google.common.collect.ImmutableCollection;
-import com.google.common.collect.ImmutableSet;
-import net.minecraft.world.World;
-
-import java.util.concurrent.Future;
 
 public interface ICraftingGrid extends IGridCache
 {

--- a/src/api/java/appeng/api/networking/crafting/ICraftingJob.java
+++ b/src/api/java/appeng/api/networking/crafting/ICraftingJob.java
@@ -23,15 +23,17 @@
 
 package appeng.api.networking.crafting;
 
+
 import appeng.api.storage.data.IAEItemStack;
 import appeng.api.storage.data.IItemList;
+
 
 public interface ICraftingJob
 {
 
 	/**
 	 * @return if this job is a simulation, simulations cannot be submitted and only represent 1 possible future
-	 *         crafting job with fake items.
+	 * crafting job with fake items.
 	 */
 	boolean isSimulation();
 
@@ -46,11 +48,10 @@ public interface ICraftingJob
 	 *
 	 * @param plan plan
 	 */
-	void populatePlan(IItemList<IAEItemStack> plan);
+	void populatePlan( IItemList<IAEItemStack> plan );
 
 	/**
 	 * @return the final output of the job.
 	 */
 	IAEItemStack getOutput();
-
 }

--- a/src/api/java/appeng/api/networking/crafting/ICraftingLink.java
+++ b/src/api/java/appeng/api/networking/crafting/ICraftingLink.java
@@ -23,7 +23,9 @@
 
 package appeng.api.networking.crafting;
 
+
 import net.minecraft.nbt.NBTTagCompound;
+
 
 public interface ICraftingLink
 {
@@ -53,11 +55,10 @@ public interface ICraftingLink
 	 *
 	 * @param tag to be written data
 	 */
-	void writeToNBT(NBTTagCompound tag);
+	void writeToNBT( NBTTagCompound tag );
 
 	/**
 	 * @return the crafting ID for this link.
 	 */
 	String getCraftingID();
-
 }

--- a/src/api/java/appeng/api/networking/crafting/ICraftingMedium.java
+++ b/src/api/java/appeng/api/networking/crafting/ICraftingMedium.java
@@ -23,7 +23,9 @@
 
 package appeng.api.networking.crafting;
 
+
 import net.minecraft.inventory.InventoryCrafting;
+
 
 /**
  * A place to send Items for crafting purposes, this is considered part of AE's External crafting system.
@@ -36,14 +38,14 @@ public interface ICraftingMedium
 	 * possible the output should be directed.
 	 *
 	 * @param patternDetails details
-	 * @param table crafting table
+	 * @param table          crafting table
+	 *
 	 * @return if the pattern was successfully pushed.
 	 */
-	boolean pushPattern(ICraftingPatternDetails patternDetails, InventoryCrafting table);
+	boolean pushPattern( ICraftingPatternDetails patternDetails, InventoryCrafting table );
 
 	/**
 	 * @return if this is false, the crafting engine will refuse to send new jobs to this medium.
 	 */
 	boolean isBusy();
-
 }

--- a/src/api/java/appeng/api/networking/crafting/ICraftingPatternDetails.java
+++ b/src/api/java/appeng/api/networking/crafting/ICraftingPatternDetails.java
@@ -23,9 +23,11 @@
 
 package appeng.api.networking.crafting;
 
+
 import net.minecraft.inventory.InventoryCrafting;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
+
 import appeng.api.implementations.ICraftingPatternItem;
 import appeng.api.storage.data.IAEItemStack;
 

--- a/src/api/java/appeng/api/networking/crafting/ICraftingProvider.java
+++ b/src/api/java/appeng/api/networking/crafting/ICraftingProvider.java
@@ -23,7 +23,9 @@
 
 package appeng.api.networking.crafting;
 
+
 import appeng.api.networking.events.MENetworkCraftingPatternChange;
+
 
 /**
  * Allows a IGridHost to provide crafting patterns to the network, post a {@link MENetworkCraftingPatternChange} to tell
@@ -37,6 +39,5 @@ public interface ICraftingProvider extends ICraftingMedium
 	 *
 	 * @param craftingTracker crafting helper
 	 */
-	void provideCrafting(ICraftingProviderHelper craftingTracker);
-
+	void provideCrafting( ICraftingProviderHelper craftingTracker );
 }

--- a/src/api/java/appeng/api/networking/crafting/ICraftingProviderHelper.java
+++ b/src/api/java/appeng/api/networking/crafting/ICraftingProviderHelper.java
@@ -23,7 +23,9 @@
 
 package appeng.api.networking.crafting;
 
+
 import appeng.api.storage.data.IAEItemStack;
+
 
 /**
  * Passed to a ICraftingProvider as a interface to manipulate the available crafting jobs.
@@ -34,11 +36,10 @@ public interface ICraftingProviderHelper
 	/**
 	 * Add new Pattern to AE's crafting cache.
 	 */
-	void addCraftingOption(ICraftingMedium medium, ICraftingPatternDetails api);
+	void addCraftingOption( ICraftingMedium medium, ICraftingPatternDetails api );
 
 	/**
 	 * Set an item can Emitable
 	 */
-	void setEmitable(IAEItemStack what);
-
+	void setEmitable( IAEItemStack what );
 }

--- a/src/api/java/appeng/api/networking/crafting/ICraftingRequester.java
+++ b/src/api/java/appeng/api/networking/crafting/ICraftingRequester.java
@@ -23,11 +23,12 @@
 
 package appeng.api.networking.crafting;
 
+
+import com.google.common.collect.ImmutableSet;
+
 import appeng.api.config.Actionable;
 import appeng.api.networking.security.IActionHost;
 import appeng.api.storage.data.IAEItemStack;
-
-import com.google.common.collect.ImmutableSet;
 
 public interface ICraftingRequester extends IActionHost
 {

--- a/src/api/java/appeng/api/networking/crafting/ICraftingWatcher.java
+++ b/src/api/java/appeng/api/networking/crafting/ICraftingWatcher.java
@@ -23,9 +23,11 @@
 
 package appeng.api.networking.crafting;
 
+
 import java.util.Collection;
 
 import appeng.api.storage.data.IAEStack;
+
 
 public interface ICraftingWatcher extends Collection<IAEStack>
 {

--- a/src/api/java/appeng/api/networking/crafting/ICraftingWatcherHost.java
+++ b/src/api/java/appeng/api/networking/crafting/ICraftingWatcherHost.java
@@ -23,7 +23,9 @@
 
 package appeng.api.networking.crafting;
 
+
 import appeng.api.storage.data.IAEItemStack;
+
 
 public interface ICraftingWatcherHost
 {
@@ -34,14 +36,13 @@ public interface ICraftingWatcherHost
 	 *
 	 * @param newWatcher crafting watcher for this host
 	 */
-	void updateWatcher(ICraftingWatcher newWatcher);
+	void updateWatcher( ICraftingWatcher newWatcher );
 
 	/**
 	 * Called when a crafting status changes.
 	 *
 	 * @param craftingGrid current crafting grid
-	 * @param what change
+	 * @param what         change
 	 */
-	void onRequestChange(ICraftingGrid craftingGrid, IAEItemStack what);
-
+	void onRequestChange( ICraftingGrid craftingGrid, IAEItemStack what );
 }

--- a/src/api/java/appeng/api/networking/energy/IEnergyGridProvider.java
+++ b/src/api/java/appeng/api/networking/energy/IEnergyGridProvider.java
@@ -23,9 +23,11 @@
 
 package appeng.api.networking.energy;
 
+
 import java.util.Set;
 
 import appeng.api.config.Actionable;
+
 
 /**
  * internal use only.
@@ -36,16 +38,15 @@ public interface IEnergyGridProvider
 	/**
 	 * internal use only
 	 */
-	public double extractAEPower(double amt, Actionable mode, Set<IEnergyGrid> seen);
+	public double extractAEPower( double amt, Actionable mode, Set<IEnergyGrid> seen );
 
 	/**
 	 * internal use only
 	 */
-	public double injectAEPower(double amt, Actionable mode, Set<IEnergyGrid> seen);
+	public double injectAEPower( double amt, Actionable mode, Set<IEnergyGrid> seen );
 
 	/**
 	 * internal use only
 	 */
-	public double getEnergyDemand(double d, Set<IEnergyGrid> seen);
-
+	public double getEnergyDemand( double d, Set<IEnergyGrid> seen );
 }

--- a/src/api/java/appeng/api/networking/energy/IEnergyWatcher.java
+++ b/src/api/java/appeng/api/networking/energy/IEnergyWatcher.java
@@ -23,7 +23,9 @@
 
 package appeng.api.networking.energy;
 
+
 import java.util.Collection;
+
 
 public interface IEnergyWatcher extends Collection<Double>
 {

--- a/src/api/java/appeng/api/networking/energy/IEnergyWatcherHost.java
+++ b/src/api/java/appeng/api/networking/energy/IEnergyWatcherHost.java
@@ -23,6 +23,7 @@
 
 package appeng.api.networking.energy;
 
+
 public interface IEnergyWatcherHost
 {
 
@@ -32,13 +33,12 @@ public interface IEnergyWatcherHost
 	 *
 	 * @param newWatcher new watcher
 	 */
-	void updateWatcher(IEnergyWatcher newWatcher);
+	void updateWatcher( IEnergyWatcher newWatcher );
 
 	/**
 	 * Called when a threshold is crossed.
 	 *
 	 * @param energyGrid grid
 	 */
-	void onThresholdPass(IEnergyGrid energyGrid);
-
+	void onThresholdPass( IEnergyGrid energyGrid );
 }

--- a/src/api/java/appeng/api/networking/events/MENetworkChannelChanged.java
+++ b/src/api/java/appeng/api/networking/events/MENetworkChannelChanged.java
@@ -23,7 +23,9 @@
 
 package appeng.api.networking.events;
 
+
 import appeng.api.networking.IGridNode;
+
 
 /**
  * Posted by storage devices to inform AE the channel cache that the included node has changed its mind about its
@@ -34,8 +36,8 @@ public class MENetworkChannelChanged extends MENetworkEvent
 
 	public final IGridNode node;
 
-	public MENetworkChannelChanged(IGridNode n) {
+	public MENetworkChannelChanged( IGridNode n )
+	{
 		this.node = n;
 	}
-
 }

--- a/src/api/java/appeng/api/networking/events/MENetworkControllerChange.java
+++ b/src/api/java/appeng/api/networking/events/MENetworkControllerChange.java
@@ -23,6 +23,7 @@
 
 package appeng.api.networking.events;
 
+
 /**
  * Event posted when the networks controller state changes, this can be from no
  * controller to 1 controller, or any time the network changes from conflicted

--- a/src/api/java/appeng/api/networking/events/MENetworkCraftingCpuChange.java
+++ b/src/api/java/appeng/api/networking/events/MENetworkCraftingCpuChange.java
@@ -23,15 +23,17 @@
 
 package appeng.api.networking.events;
 
+
 import appeng.api.networking.IGridNode;
+
 
 public class MENetworkCraftingCpuChange extends MENetworkEvent
 {
 
 	public final IGridNode node;
 
-	public MENetworkCraftingCpuChange(IGridNode n) {
+	public MENetworkCraftingCpuChange( IGridNode n )
+	{
 		this.node = n;
 	}
-
 }

--- a/src/api/java/appeng/api/networking/events/MENetworkCraftingPatternChange.java
+++ b/src/api/java/appeng/api/networking/events/MENetworkCraftingPatternChange.java
@@ -23,8 +23,10 @@
 
 package appeng.api.networking.events;
 
+
 import appeng.api.networking.IGridNode;
 import appeng.api.networking.crafting.ICraftingProvider;
+
 
 public class MENetworkCraftingPatternChange extends MENetworkEvent
 {
@@ -32,9 +34,9 @@ public class MENetworkCraftingPatternChange extends MENetworkEvent
 	public final ICraftingProvider provider;
 	public final IGridNode node;
 
-	public MENetworkCraftingPatternChange(ICraftingProvider p, IGridNode n) {
+	public MENetworkCraftingPatternChange( ICraftingProvider p, IGridNode n )
+	{
 		this.provider = p;
 		this.node = n;
 	}
-
 }

--- a/src/api/java/appeng/api/networking/events/MENetworkEventSubscribe.java
+++ b/src/api/java/appeng/api/networking/events/MENetworkEventSubscribe.java
@@ -23,16 +23,19 @@
 
 package appeng.api.networking.events;
 
+
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
 import appeng.api.networking.IGridCache;
 import appeng.api.networking.IGridHost;
 
+
 /**
  * Usable on any {@link IGridHost}, or {@link IGridCache}
  */
-@Retention(RetentionPolicy.RUNTIME)
-public @interface MENetworkEventSubscribe {
+@Retention( RetentionPolicy.RUNTIME )
+public @interface MENetworkEventSubscribe
+{
 
 }

--- a/src/api/java/appeng/api/networking/events/MENetworkPostCacheConstruction.java
+++ b/src/api/java/appeng/api/networking/events/MENetworkPostCacheConstruction.java
@@ -23,6 +23,7 @@
 
 package appeng.api.networking.events;
 
+
 /**
  * Posted after all the caches are available, but before the grid is fully
  * constructed, can be used to perform cross cache construction processes.

--- a/src/api/java/appeng/api/networking/events/MENetworkSecurityChange.java
+++ b/src/api/java/appeng/api/networking/events/MENetworkSecurityChange.java
@@ -23,6 +23,7 @@
 
 package appeng.api.networking.events;
 
+
 /**
  * Posted by the security framework when permissions change
  */

--- a/src/api/java/appeng/api/networking/events/MENetworkSpatialEvent.java
+++ b/src/api/java/appeng/api/networking/events/MENetworkSpatialEvent.java
@@ -20,10 +20,11 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package appeng.api.networking.events;
 
+
 import appeng.api.networking.IGridHost;
+
 
 /**
  * An event that is posted whenever a spatial IO is active, called for IGridCache
@@ -37,7 +38,7 @@ public class MENetworkSpatialEvent extends MENetworkEvent
 	 * @param SpatialIO   ( INSTANCE of the SpatialIO block )
 	 * @param EnergyUsage ( the amount of energy that the SpatialIO uses)
 	 */
-	public MENetworkSpatialEvent(IGridHost SpatialIO, double EnergyUsage)
+	public MENetworkSpatialEvent( IGridHost SpatialIO, double EnergyUsage )
 	{
 		this.host = SpatialIO;
 		this.spatialEnergyUsage = EnergyUsage;

--- a/src/api/java/appeng/api/networking/pathing/ControllerState.java
+++ b/src/api/java/appeng/api/networking/pathing/ControllerState.java
@@ -23,6 +23,7 @@
 
 package appeng.api.networking.pathing;
 
+
 public enum ControllerState
 {
 	/**

--- a/src/api/java/appeng/api/networking/pathing/IPathingGrid.java
+++ b/src/api/java/appeng/api/networking/pathing/IPathingGrid.java
@@ -23,7 +23,9 @@
 
 package appeng.api.networking.pathing;
 
+
 import appeng.api.networking.IGridCache;
+
 
 public interface IPathingGrid extends IGridCache
 {
@@ -35,7 +37,7 @@ public interface IPathingGrid extends IGridCache
 
 	/**
 	 * @return the controller state of the network, useful if you want to
-	 *         require a controller for a feature.
+	 * require a controller for a feature.
 	 */
 	ControllerState getControllerState();
 
@@ -43,5 +45,4 @@ public interface IPathingGrid extends IGridCache
 	 * trigger a network reset, booting, path-finding and all.
 	 */
 	void repath();
-
 }

--- a/src/api/java/appeng/api/networking/security/BaseActionSource.java
+++ b/src/api/java/appeng/api/networking/security/BaseActionSource.java
@@ -23,6 +23,7 @@
 
 package appeng.api.networking.security;
 
+
 public class BaseActionSource
 {
 
@@ -35,5 +36,4 @@ public class BaseActionSource
 	{
 		return false;
 	}
-
 }

--- a/src/api/java/appeng/api/networking/security/IActionHost.java
+++ b/src/api/java/appeng/api/networking/security/IActionHost.java
@@ -23,8 +23,10 @@
 
 package appeng.api.networking.security;
 
+
 import appeng.api.networking.IGridHost;
 import appeng.api.networking.IGridNode;
+
 
 public interface IActionHost extends IGridHost
 {
@@ -35,8 +37,7 @@ public interface IActionHost extends IGridHost
 	 * machine, unless the action is preformed by a non primary node.
 	 *
 	 * @return the the gridnode that actions from this IGridHost are preformed
-	 *         by.
+	 * by.
 	 */
 	IGridNode getActionableNode();
-
 }

--- a/src/api/java/appeng/api/networking/security/ISecurityGrid.java
+++ b/src/api/java/appeng/api/networking/security/ISecurityGrid.java
@@ -23,7 +23,9 @@
 
 package appeng.api.networking.security;
 
+
 import net.minecraft.entity.player.EntityPlayer;
+
 import appeng.api.config.SecurityPermissions;
 import appeng.api.networking.IGridCache;
 

--- a/src/api/java/appeng/api/networking/security/ISecurityProvider.java
+++ b/src/api/java/appeng/api/networking/security/ISecurityProvider.java
@@ -23,10 +23,12 @@
 
 package appeng.api.networking.security;
 
-import appeng.api.config.SecurityPermissions;
 
 import java.util.EnumSet;
 import java.util.HashMap;
+
+import appeng.api.config.SecurityPermissions;
+
 
 /**
  * Implemented on Security Terminal to interface with security cache.
@@ -46,7 +48,7 @@ public interface ISecurityProvider
 	 *
 	 * @param playerPerms player permissions
 	 */
-	void readPermissions(HashMap<Integer, EnumSet<SecurityPermissions>> playerPerms);
+	void readPermissions( HashMap<Integer, EnumSet<SecurityPermissions>> playerPerms );
 
 	/**
 	 * @return is security on or off?
@@ -57,5 +59,4 @@ public interface ISecurityProvider
 	 * @return player ID for who placed the security provider.
 	 */
 	int getOwner();
-
 }

--- a/src/api/java/appeng/api/networking/security/ISecurityRegistry.java
+++ b/src/api/java/appeng/api/networking/security/ISecurityRegistry.java
@@ -23,9 +23,10 @@
 
 package appeng.api.networking.security;
 
-import appeng.api.config.SecurityPermissions;
 
 import java.util.EnumSet;
+
+import appeng.api.config.SecurityPermissions;
 
 /**
  * Used by vanilla Security Terminal to post biometric data into the security cache.

--- a/src/api/java/appeng/api/networking/security/MachineSource.java
+++ b/src/api/java/appeng/api/networking/security/MachineSource.java
@@ -23,6 +23,7 @@
 
 package appeng.api.networking.security;
 
+
 public class MachineSource extends BaseActionSource
 {
 
@@ -34,8 +35,8 @@ public class MachineSource extends BaseActionSource
 		return true;
 	}
 
-	public MachineSource(IActionHost v) {
+	public MachineSource( IActionHost v )
+	{
 		this.via = v;
 	}
-
 }

--- a/src/api/java/appeng/api/networking/security/PlayerSource.java
+++ b/src/api/java/appeng/api/networking/security/PlayerSource.java
@@ -23,7 +23,9 @@
 
 package appeng.api.networking.security;
 
+
 import net.minecraft.entity.player.EntityPlayer;
+
 
 public class PlayerSource extends BaseActionSource
 {
@@ -37,9 +39,9 @@ public class PlayerSource extends BaseActionSource
 		return true;
 	}
 
-	public PlayerSource(EntityPlayer p, IActionHost v) {
+	public PlayerSource( EntityPlayer p, IActionHost v )
+	{
 		this.player = p;
 		this.via = v;
 	}
-
 }

--- a/src/api/java/appeng/api/networking/spatial/ISpatialCache.java
+++ b/src/api/java/appeng/api/networking/spatial/ISpatialCache.java
@@ -23,8 +23,10 @@
 
 package appeng.api.networking.spatial;
 
+
 import appeng.api.networking.IGridCache;
 import appeng.api.util.DimensionalCoord;
+
 
 public interface ISpatialCache extends IGridCache
 {
@@ -58,5 +60,4 @@ public interface ISpatialCache extends IGridCache
 	 * @return current 100% - 0% efficiency.
 	 */
 	float currentEfficiency();
-
 }

--- a/src/api/java/appeng/api/networking/storage/IBaseMonitor.java
+++ b/src/api/java/appeng/api/networking/storage/IBaseMonitor.java
@@ -23,8 +23,10 @@
 
 package appeng.api.networking.storage;
 
+
 import appeng.api.storage.IMEMonitorHandlerReceiver;
 import appeng.api.storage.data.IAEStack;
+
 
 public interface IBaseMonitor<T extends IAEStack>
 {
@@ -32,11 +34,10 @@ public interface IBaseMonitor<T extends IAEStack>
 	/**
 	 * add a new Listener to the monitor, be sure to properly remove yourself when your done.
 	 */
-	void addListener(IMEMonitorHandlerReceiver<T> l, Object verificationToken);
+	void addListener( IMEMonitorHandlerReceiver<T> l, Object verificationToken );
 
 	/**
 	 * remove a Listener to the monitor.
 	 */
-	void removeListener(IMEMonitorHandlerReceiver<T> l);
-
+	void removeListener( IMEMonitorHandlerReceiver<T> l );
 }

--- a/src/api/java/appeng/api/networking/storage/IStackWatcher.java
+++ b/src/api/java/appeng/api/networking/storage/IStackWatcher.java
@@ -23,9 +23,11 @@
 
 package appeng.api.networking.storage;
 
+
 import java.util.Collection;
 
 import appeng.api.storage.data.IAEStack;
+
 
 public interface IStackWatcher extends Collection<IAEStack>
 {

--- a/src/api/java/appeng/api/networking/ticking/TickRateModulation.java
+++ b/src/api/java/appeng/api/networking/ticking/TickRateModulation.java
@@ -23,6 +23,7 @@
 
 package appeng.api.networking.ticking;
 
+
 public enum TickRateModulation
 {
 	/**

--- a/src/api/java/appeng/api/package-info.java
+++ b/src/api/java/appeng/api/package-info.java
@@ -21,8 +21,8 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-@API(apiVersion = "rv2", owner = "appliedenergistics2", provides = "appliedenergistics2|API")
-package appeng.api;
+@API( apiVersion = "rv2", owner = "appliedenergistics2", provides = "appliedenergistics2|API" ) package appeng.api;
+
 
 import cpw.mods.fml.common.API;
 

--- a/src/api/java/appeng/api/parts/BusSupport.java
+++ b/src/api/java/appeng/api/parts/BusSupport.java
@@ -23,6 +23,7 @@
 
 package appeng.api.parts;
 
+
 public enum BusSupport
 {
 	CABLE,

--- a/src/api/java/appeng/api/parts/CableRenderMode.java
+++ b/src/api/java/appeng/api/parts/CableRenderMode.java
@@ -23,17 +23,19 @@
 
 package appeng.api.parts;
 
+
 public enum CableRenderMode
 {
 
-	Standard(false),
+	Standard( false ),
 
-	CableView(true);
+	CableView( true );
 
 	public final boolean transparentFacades;
 	public final boolean opaqueFacades;
 
-	private CableRenderMode(boolean hideFacades) {
+	private CableRenderMode( boolean hideFacades )
+	{
 		this.transparentFacades = hideFacades;
 		this.opaqueFacades = !hideFacades;
 	}

--- a/src/api/java/appeng/api/parts/IAlphaPassItem.java
+++ b/src/api/java/appeng/api/parts/IAlphaPassItem.java
@@ -23,7 +23,9 @@
 
 package appeng.api.parts;
 
+
 import net.minecraft.item.ItemStack;
+
 
 public interface IAlphaPassItem
 {
@@ -32,8 +34,8 @@ public interface IAlphaPassItem
 	 * Extend, and return true to enable a second pass for your parts in the bus rendering pipe line.
 	 *
 	 * @param is item
+	 *
 	 * @return true to enable a second pass for your parts in the bus rendering pipe line.
 	 */
-	boolean useAlphaPass(ItemStack is);
-
+	boolean useAlphaPass( ItemStack is );
 }

--- a/src/api/java/appeng/api/parts/IBoxProvider.java
+++ b/src/api/java/appeng/api/parts/IBoxProvider.java
@@ -23,6 +23,7 @@
 
 package appeng.api.parts;
 
+
 public interface IBoxProvider
 {
 
@@ -31,6 +32,5 @@ public interface IBoxProvider
 	 *
 	 * @param boxes collision boxes
 	 */
-	void getBoxes(IPartCollisionHelper boxes);
-
+	void getBoxes( IPartCollisionHelper boxes );
 }

--- a/src/api/java/appeng/api/parts/IFacadeContainer.java
+++ b/src/api/java/appeng/api/parts/IFacadeContainer.java
@@ -23,11 +23,13 @@
 
 package appeng.api.parts;
 
-import io.netty.buffer.ByteBuf;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraftforge.common.util.ForgeDirection;
 
 import java.io.IOException;
+
+import io.netty.buffer.ByteBuf;
+
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.common.util.ForgeDirection;
 
 /**
  * Used Internally.

--- a/src/api/java/appeng/api/parts/IFacadePart.java
+++ b/src/api/java/appeng/api/parts/IFacadePart.java
@@ -23,12 +23,14 @@
 
 package appeng.api.parts;
 
+
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.entity.Entity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraftforge.common.util.ForgeDirection;
+
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 

--- a/src/api/java/appeng/api/parts/IPart.java
+++ b/src/api/java/appeng/api/parts/IPart.java
@@ -23,10 +23,13 @@
 
 package appeng.api.parts;
 
-import appeng.api.networking.IGridNode;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Random;
+
 import io.netty.buffer.ByteBuf;
+
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
@@ -39,9 +42,11 @@ import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.Random;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
+import appeng.api.networking.IGridNode;
+
 
 public interface IPart extends IBoxProvider
 {
@@ -49,7 +54,7 @@ public interface IPart extends IBoxProvider
 	/**
 	 * get an ItemStack that represents the bus, should contain the settings for whatever, can also be used in
 	 * conjunction with removePart to take a part off and drop it or something.
-	 *
+	 * <p/>
 	 * This is used to drop the bus, and to save the bus, when saving the bus, wrenched is false, and writeToNBT will be
 	 * called to save important details about the part, if the part is wrenched include in your NBT Data any settings
 	 * you might want to keep around, you can restore those settings when constructing your part.
@@ -58,52 +63,52 @@ public interface IPart extends IBoxProvider
 	 *
 	 * @return item of part
 	 */
-	ItemStack getItemStack(PartItemStack type);
+	ItemStack getItemStack( PartItemStack type );
 
 	/**
 	 * render item form for inventory, or entity.
-	 *
+	 * <p/>
 	 * GL Available
 	 *
 	 * @param rh       helper
 	 * @param renderer renderer
 	 */
-	@SideOnly(Side.CLIENT)
-	void renderInventory(IPartRenderHelper rh, RenderBlocks renderer);
+	@SideOnly( Side.CLIENT )
+	void renderInventory( IPartRenderHelper rh, RenderBlocks renderer );
 
 	/**
 	 * render world renderer ( preferred )
-	 *
+	 * <p/>
 	 * GL is NOT Available
 	 *
-	 * @param x x coord
-	 * @param y y coord
-	 * @param z z coord
-	 * @param rh helper
+	 * @param x        x coord
+	 * @param y        y coord
+	 * @param z        z coord
+	 * @param rh       helper
 	 * @param renderer renderer
 	 */
-	@SideOnly(Side.CLIENT)
-	void renderStatic(int x, int y, int z, IPartRenderHelper rh, RenderBlocks renderer);
+	@SideOnly( Side.CLIENT )
+	void renderStatic( int x, int y, int z, IPartRenderHelper rh, RenderBlocks renderer );
 
 	/**
 	 * render TESR.
-	 *
+	 * <p/>
 	 * GL Available
 	 *
-	 * @param x x coord
-	 * @param y y coord
-	 * @param z z coord
-	 * @param rh helper
+	 * @param x        x coord
+	 * @param y        y coord
+	 * @param z        z coord
+	 * @param rh       helper
 	 * @param renderer renderer
 	 */
-	@SideOnly(Side.CLIENT)
-	void renderDynamic(double x, double y, double z, IPartRenderHelper rh, RenderBlocks renderer);
+	@SideOnly( Side.CLIENT )
+	void renderDynamic( double x, double y, double z, IPartRenderHelper rh, RenderBlocks renderer );
 
 	/**
 	 * @return the Block sheet icon used when rendering the breaking particles, return null to use the ItemStack
 	 * texture.
 	 */
-	@SideOnly(Side.CLIENT)
+	@SideOnly( Side.CLIENT )
 	IIcon getBreakingTexture();
 
 	/**
@@ -129,14 +134,14 @@ public interface IPart extends IBoxProvider
 	 *
 	 * @param data to be written nbt data
 	 */
-	void writeToNBT(NBTTagCompound data);
+	void writeToNBT( NBTTagCompound data );
 
 	/**
 	 * Read the previously written NBT Data. this is the mirror for writeToNBT
 	 *
 	 * @param data to be read nbt data
 	 */
-	void readFromNBT(NBTTagCompound data);
+	void readFromNBT( NBTTagCompound data );
 
 	/**
 	 * @return get the amount of light produced by the bus
@@ -150,7 +155,7 @@ public interface IPart extends IBoxProvider
 	 *
 	 * @return true if entity can climb
 	 */
-	boolean isLadder(EntityLivingBase entity);
+	boolean isLadder( EntityLivingBase entity );
 
 	/**
 	 * a block around the bus's host has been changed.
@@ -174,7 +179,7 @@ public interface IPart extends IBoxProvider
 	 *
 	 * @throws IOException
 	 */
-	void writeToStream(ByteBuf data) throws IOException;
+	void writeToStream( ByteBuf data ) throws IOException;
 
 	/**
 	 * read data from bus packet.
@@ -185,12 +190,12 @@ public interface IPart extends IBoxProvider
 	 *
 	 * @throws IOException
 	 */
-	boolean readFromStream(ByteBuf data) throws IOException;
+	boolean readFromStream( ByteBuf data ) throws IOException;
 
 	/**
 	 * get the Grid Node for the Bus, be sure your IGridBlock is NOT isWorldAccessible, if it is your going to cause
 	 * crashes.
-	 *
+	 * <p/>
 	 * or null if you don't have a grid node.
 	 *
 	 * @return grid node
@@ -202,7 +207,7 @@ public interface IPart extends IBoxProvider
 	 *
 	 * @param entity colliding entity
 	 */
-	void onEntityCollision(Entity entity);
+	void onEntityCollision( Entity entity );
 
 	/**
 	 * called when your part is being removed from the world.
@@ -228,36 +233,36 @@ public interface IPart extends IBoxProvider
 	 * @param host part side
 	 * @param tile tile entity of part
 	 */
-	void setPartHostInfo(ForgeDirection side, IPartHost host, TileEntity tile);
+	void setPartHostInfo( ForgeDirection side, IPartHost host, TileEntity tile );
 
 	/**
 	 * Called when you right click the part, very similar to Block.onActivateBlock
 	 *
 	 * @param player right clicking player
-	 * @param pos position of block
+	 * @param pos    position of block
 	 *
 	 * @return if your activate method performed something.
 	 */
-	boolean onActivate(EntityPlayer player, Vec3 pos);
+	boolean onActivate( EntityPlayer player, Vec3 pos );
 
 	/**
 	 * Called when you right click the part, very similar to Block.onActivateBlock
 	 *
 	 * @param player shift right clicking player
-	 * @param pos position of block
+	 * @param pos    position of block
 	 *
 	 * @return if your activate method performed something, you should use false unless you really need it.
 	 */
-	boolean onShiftActivate(EntityPlayer player, Vec3 pos);
+	boolean onShiftActivate( EntityPlayer player, Vec3 pos );
 
 	/**
 	 * Add drops to the items being dropped into the world, if your item stores its contents when wrenched use the
 	 * wrenched boolean to control what data is saved vs dropped when it is broken.
 	 *
-	 * @param drops item drops if wrenched
+	 * @param drops    item drops if wrenched
 	 * @param wrenched control flag for wrenched vs broken
 	 */
-	void getDrops(List<ItemStack> drops, boolean wrenched);
+	void getDrops( List<ItemStack> drops, boolean wrenched );
 
 	/**
 	 * @return 0 - 8, reasonable default 3-4, this controls the cable connection to the node.
@@ -268,21 +273,21 @@ public interface IPart extends IBoxProvider
 	 * same as Block.randomDisplayTick, for but parts.
 	 *
 	 * @param world world of block
-	 * @param x x coord of block
-	 * @param y y coord of block
-	 * @param z z coord of block
-	 * @param r random
+	 * @param x     x coord of block
+	 * @param y     y coord of block
+	 * @param z     z coord of block
+	 * @param r     random
 	 */
-	void randomDisplayTick(World world, int x, int y, int z, Random r);
+	void randomDisplayTick( World world, int x, int y, int z, Random r );
 
 	/**
 	 * Called when placed in the world by a player, this happens before addWorld.
 	 *
 	 * @param player placing player
-	 * @param held held item
-	 * @param side placing side
+	 * @param held   held item
+	 * @param side   placing side
 	 */
-	void onPlacement(EntityPlayer player, ItemStack held, ForgeDirection side);
+	void onPlacement( EntityPlayer player, ItemStack held, ForgeDirection side );
 
 	/**
 	 * Used to determine which parts can be placed on what cables.
@@ -291,6 +296,5 @@ public interface IPart extends IBoxProvider
 	 *
 	 * @return true if the part can be placed on this support.
 	 */
-	boolean canBePlacedOn(BusSupport what);
-
+	boolean canBePlacedOn( BusSupport what );
 }

--- a/src/api/java/appeng/api/parts/IPartHost.java
+++ b/src/api/java/appeng/api/parts/IPartHost.java
@@ -23,15 +23,17 @@
 
 package appeng.api.parts;
 
-import appeng.api.util.AEColor;
-import appeng.api.util.DimensionalCoord;
+
+import java.util.Set;
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Vec3;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import java.util.Set;
+import appeng.api.util.AEColor;
+import appeng.api.util.DimensionalCoord;
 
 /**
  * Implemented on AE's TileEntity or AE's FMP Part.

--- a/src/api/java/appeng/api/parts/IPartItem.java
+++ b/src/api/java/appeng/api/parts/IPartItem.java
@@ -23,7 +23,9 @@
 
 package appeng.api.parts;
 
+
 import net.minecraft.item.ItemStack;
+
 
 //@formatter:off
 /**
@@ -58,8 +60,8 @@ public interface IPartItem
 	 * create a new part INSTANCE, from the item stack.
 	 *
 	 * @param is item
+	 *
 	 * @return part from item
 	 */
-	IPart createPartFromItemStack(ItemStack is);
-
+	IPart createPartFromItemStack( ItemStack is );
 }

--- a/src/api/java/appeng/api/parts/IPartRenderHelper.java
+++ b/src/api/java/appeng/api/parts/IPartRenderHelper.java
@@ -23,14 +23,16 @@
 
 package appeng.api.parts;
 
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
+
+import java.util.EnumSet;
+
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.util.IIcon;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import java.util.EnumSet;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 
 public interface IPartRenderHelper
 {

--- a/src/api/java/appeng/api/parts/LayerBase.java
+++ b/src/api/java/appeng/api/parts/LayerBase.java
@@ -23,10 +23,11 @@
 
 package appeng.api.parts;
 
-import net.minecraft.tileentity.TileEntity;
-import net.minecraftforge.common.util.ForgeDirection;
 
 import java.util.Set;
+
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.util.ForgeDirection;
 
 /**
  * All Layers must extends this, this get part implementation is provided to interface with the parts, however a real

--- a/src/api/java/appeng/api/parts/LayerFlags.java
+++ b/src/api/java/appeng/api/parts/LayerFlags.java
@@ -23,6 +23,7 @@
 
 package appeng.api.parts;
 
+
 public enum LayerFlags
 {
 

--- a/src/api/java/appeng/api/parts/PartItemStack.java
+++ b/src/api/java/appeng/api/parts/PartItemStack.java
@@ -23,6 +23,7 @@
 
 package appeng.api.parts;
 
+
 public enum PartItemStack
 {
 	Pick,

--- a/src/api/java/appeng/api/parts/SelectedPart.java
+++ b/src/api/java/appeng/api/parts/SelectedPart.java
@@ -23,7 +23,9 @@
 
 package appeng.api.parts;
 
+
 import net.minecraftforge.common.util.ForgeDirection;
+
 
 /**
  * Reports a selected part from th IPartHost
@@ -46,22 +48,24 @@ public class SelectedPart
 	 */
 	public final ForgeDirection side;
 
-	public SelectedPart() {
+	public SelectedPart()
+	{
 		this.part = null;
 		this.facade = null;
 		this.side = ForgeDirection.UNKNOWN;
 	}
 
-	public SelectedPart(IPart part, ForgeDirection side) {
+	public SelectedPart( IPart part, ForgeDirection side )
+	{
 		this.part = part;
 		this.facade = null;
 		this.side = side;
 	}
 
-	public SelectedPart(IFacadePart facade, ForgeDirection side) {
+	public SelectedPart( IFacadePart facade, ForgeDirection side )
+	{
 		this.part = null;
 		this.facade = facade;
 		this.side = side;
 	}
-
 }

--- a/src/api/java/appeng/api/recipes/ICraftHandler.java
+++ b/src/api/java/appeng/api/recipes/ICraftHandler.java
@@ -23,11 +23,12 @@
 
 package appeng.api.recipes;
 
+
+import java.util.List;
+
 import appeng.api.exceptions.MissingIngredientError;
 import appeng.api.exceptions.RecipeError;
 import appeng.api.exceptions.RegistrationError;
-
-import java.util.List;
 
 public interface ICraftHandler
 {

--- a/src/api/java/appeng/api/recipes/IIngredient.java
+++ b/src/api/java/appeng/api/recipes/IIngredient.java
@@ -23,7 +23,9 @@
 
 package appeng.api.recipes;
 
+
 import net.minecraft.item.ItemStack;
+
 import appeng.api.exceptions.MissingIngredientError;
 import appeng.api.exceptions.RegistrationError;
 

--- a/src/api/java/appeng/api/recipes/IRecipeHandler.java
+++ b/src/api/java/appeng/api/recipes/IRecipeHandler.java
@@ -23,6 +23,7 @@
 
 package appeng.api.recipes;
 
+
 /**
  * Represents the AE2 Recipe Loading/Reading Class
  */
@@ -33,13 +34,12 @@ public interface IRecipeHandler
 	 * Call when you want to read recipes in from a file based on a loader
 	 *
 	 * @param loader recipe loader
-	 * @param path path of file
+	 * @param path   path of file
 	 */
-	void parseRecipes(IRecipeLoader loader, String path);
+	void parseRecipes( IRecipeLoader loader, String path );
 
 	/**
 	 * this loads the read recipes into minecraft, should be called in Init.
 	 */
 	void injectRecipes();
-
 }

--- a/src/api/java/appeng/api/recipes/IRecipeLoader.java
+++ b/src/api/java/appeng/api/recipes/IRecipeLoader.java
@@ -23,11 +23,12 @@
 
 package appeng.api.recipes;
 
+
 import java.io.BufferedReader;
+
 
 public interface IRecipeLoader
 {
 
-	BufferedReader getFile(String s) throws Exception;
-
+	BufferedReader getFile( String s ) throws Exception;
 }

--- a/src/api/java/appeng/api/recipes/ISubItemResolver.java
+++ b/src/api/java/appeng/api/recipes/ISubItemResolver.java
@@ -23,14 +23,15 @@
 
 package appeng.api.recipes;
 
+
 public interface ISubItemResolver
 {
 
 	/**
 	 * @param namespace namespace of sub item
-	 * @param fullName name of sub item
+	 * @param fullName  name of sub item
+	 *
 	 * @return either a ResolveResult, or a ResolverResultSet
 	 */
-	public Object resolveItemByName(String namespace, String fullName);
-
+	public Object resolveItemByName( String namespace, String fullName );
 }

--- a/src/api/java/appeng/api/recipes/ResolverResult.java
+++ b/src/api/java/appeng/api/recipes/ResolverResult.java
@@ -23,7 +23,9 @@
 
 package appeng.api.recipes;
 
+
 import net.minecraft.nbt.NBTTagCompound;
+
 
 public class ResolverResult
 {
@@ -32,16 +34,17 @@ public class ResolverResult
 	final public int damageValue;
 	final public NBTTagCompound compound;
 
-	public ResolverResult(String name, int damage) {
+	public ResolverResult( String name, int damage )
+	{
 		this.itemName = name;
 		this.damageValue = damage;
 		this.compound = null;
 	}
 
-	public ResolverResult(String name, int damage, NBTTagCompound data) {
+	public ResolverResult( String name, int damage, NBTTagCompound data )
+	{
 		this.itemName = name;
 		this.damageValue = damage;
 		this.compound = data;
 	}
-
 }

--- a/src/api/java/appeng/api/recipes/ResolverResultSet.java
+++ b/src/api/java/appeng/api/recipes/ResolverResultSet.java
@@ -23,10 +23,12 @@
 
 package appeng.api.recipes;
 
+
 import java.util.Arrays;
 import java.util.List;
 
 import net.minecraft.item.ItemStack;
+
 
 public class ResolverResultSet
 {
@@ -34,9 +36,9 @@ public class ResolverResultSet
 	public final String name;
 	public final List<ItemStack> results;
 
-	public ResolverResultSet(String myName, ItemStack... set) {
+	public ResolverResultSet( String myName, ItemStack... set )
+	{
 		this.results = Arrays.asList( set );
 		this.name = myName;
 	}
-
 }

--- a/src/api/java/appeng/api/storage/ICellContainer.java
+++ b/src/api/java/appeng/api/storage/ICellContainer.java
@@ -23,7 +23,9 @@
 
 package appeng.api.storage;
 
+
 import appeng.api.networking.security.IActionHost;
+
 
 /**
  * Represents an {@link appeng.api.networking.IGridHost} that contributes to storage, such as a ME Chest, or ME Drive.
@@ -36,6 +38,5 @@ public interface ICellContainer extends IActionHost, ICellProvider, ISaveProvide
 	 *
 	 * @param slot slot index
 	 */
-	void blinkCell(int slot);
-
+	void blinkCell( int slot );
 }

--- a/src/api/java/appeng/api/storage/ICellHandler.java
+++ b/src/api/java/appeng/api/storage/ICellHandler.java
@@ -23,12 +23,15 @@
 
 package appeng.api.storage;
 
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
-import appeng.api.implementations.tiles.IChestOrDrive;
+
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+
+import appeng.api.implementations.tiles.IChestOrDrive;
 
 /**
  * Registration record for {@link ICellRegistry}

--- a/src/api/java/appeng/api/storage/ICellInventory.java
+++ b/src/api/java/appeng/api/storage/ICellInventory.java
@@ -23,10 +23,13 @@
 
 package appeng.api.storage;
 
+
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
+
 import appeng.api.config.FuzzyMode;
 import appeng.api.storage.data.IAEItemStack;
+
 
 public interface ICellInventory extends IMEInventory<IAEItemStack>
 {
@@ -115,5 +118,4 @@ public interface ICellInventory extends IMEInventory<IAEItemStack>
 	 * @return the status number for this drive.
 	 */
 	int getStatusForCell();
-
 }

--- a/src/api/java/appeng/api/storage/ICellInventoryHandler.java
+++ b/src/api/java/appeng/api/storage/ICellInventoryHandler.java
@@ -23,8 +23,10 @@
 
 package appeng.api.storage;
 
+
 import appeng.api.config.IncludeExclude;
 import appeng.api.storage.data.IAEItemStack;
+
 
 public interface ICellInventoryHandler extends IMEInventoryHandler<IAEItemStack>
 {
@@ -39,5 +41,4 @@ public interface ICellInventoryHandler extends IMEInventoryHandler<IAEItemStack>
 	boolean isFuzzy();
 
 	IncludeExclude getIncludeExcludeMode();
-
 }

--- a/src/api/java/appeng/api/storage/ICellRegistry.java
+++ b/src/api/java/appeng/api/storage/ICellRegistry.java
@@ -23,7 +23,9 @@
 
 package appeng.api.storage;
 
+
 import net.minecraft.item.ItemStack;
+
 import appeng.api.IAppEngApi;
 
 /**

--- a/src/api/java/appeng/api/storage/ICellWorkbenchItem.java
+++ b/src/api/java/appeng/api/storage/ICellWorkbenchItem.java
@@ -23,8 +23,10 @@
 
 package appeng.api.storage;
 
+
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
+
 import appeng.api.config.FuzzyMode;
 
 public interface ICellWorkbenchItem

--- a/src/api/java/appeng/api/storage/IExternalStorageHandler.java
+++ b/src/api/java/appeng/api/storage/IExternalStorageHandler.java
@@ -23,8 +23,10 @@
 
 package appeng.api.storage;
 
+
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.util.ForgeDirection;
+
 import appeng.api.networking.security.BaseActionSource;
 
 /**

--- a/src/api/java/appeng/api/storage/IExternalStorageRegistry.java
+++ b/src/api/java/appeng/api/storage/IExternalStorageRegistry.java
@@ -23,8 +23,10 @@
 
 package appeng.api.storage;
 
+
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.util.ForgeDirection;
+
 import appeng.api.IAppEngApi;
 import appeng.api.networking.security.BaseActionSource;
 

--- a/src/api/java/appeng/api/storage/IMEMonitor.java
+++ b/src/api/java/appeng/api/storage/IMEMonitor.java
@@ -23,9 +23,11 @@
 
 package appeng.api.storage;
 
+
 import appeng.api.networking.storage.IBaseMonitor;
 import appeng.api.storage.data.IAEStack;
 import appeng.api.storage.data.IItemList;
+
 
 public interface IMEMonitor<T extends IAEStack> extends IMEInventoryHandler<T>, IBaseMonitor<T>
 {
@@ -34,8 +36,7 @@ public interface IMEMonitor<T extends IAEStack> extends IMEInventoryHandler<T>, 
 	@Deprecated
 	/**
 	 * This method is discouraged when accessing data via a IMEMonitor
-	 */
-	public IItemList<T> getAvailableItems(IItemList out);
+	 */ public IItemList<T> getAvailableItems( IItemList out );
 
 	/**
 	 * Get access to the full item list of the network, preferred over {@link IMEInventory} .getAvailableItems(...)
@@ -43,5 +44,4 @@ public interface IMEMonitor<T extends IAEStack> extends IMEInventoryHandler<T>, 
 	 * @return full storage list.
 	 */
 	IItemList<T> getStorageList();
-
 }

--- a/src/api/java/appeng/api/storage/IMEMonitorHandlerReceiver.java
+++ b/src/api/java/appeng/api/storage/IMEMonitorHandlerReceiver.java
@@ -23,9 +23,11 @@
 
 package appeng.api.storage;
 
+
 import appeng.api.networking.security.BaseActionSource;
 import appeng.api.networking.storage.IBaseMonitor;
 import appeng.api.storage.data.IAEStack;
+
 
 public interface IMEMonitorHandlerReceiver<StackType extends IAEStack>
 {
@@ -34,20 +36,20 @@ public interface IMEMonitorHandlerReceiver<StackType extends IAEStack>
 	 * return true if this object should remain as a listener.
 	 *
 	 * @param verificationToken to be checked object
+	 *
 	 * @return true if object should remain as a listener
 	 */
-	boolean isValid(Object verificationToken);
+	boolean isValid( Object verificationToken );
 
 	/**
 	 * called when changes are made to the Monitor, but only if listener is still valid.
 	 *
 	 * @param change done change
 	 */
-	void postChange(IBaseMonitor<StackType> monitor, Iterable<StackType> change, BaseActionSource actionSource);
+	void postChange( IBaseMonitor<StackType> monitor, Iterable<StackType> change, BaseActionSource actionSource );
 
 	/**
 	 * called when the list updates its contents, this is mostly for handling power events.
 	 */
 	void onListUpdate();
-
 }

--- a/src/api/java/appeng/api/storage/ISaveProvider.java
+++ b/src/api/java/appeng/api/storage/ISaveProvider.java
@@ -27,6 +27,5 @@ package appeng.api.storage;
 public interface ISaveProvider
 {
 
-	void saveChanges(IMEInventory cellInventory);
-
+	void saveChanges( IMEInventory cellInventory );
 }

--- a/src/api/java/appeng/api/storage/IStorageHelper.java
+++ b/src/api/java/appeng/api/storage/IStorageHelper.java
@@ -23,6 +23,15 @@
 
 package appeng.api.storage;
 
+
+import java.io.IOException;
+
+import io.netty.buffer.ByteBuf;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.fluids.FluidStack;
+
 import appeng.api.networking.crafting.ICraftingLink;
 import appeng.api.networking.crafting.ICraftingRequester;
 import appeng.api.networking.energy.IEnergySource;
@@ -30,12 +39,6 @@ import appeng.api.networking.security.BaseActionSource;
 import appeng.api.storage.data.IAEFluidStack;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.api.storage.data.IItemList;
-import io.netty.buffer.ByteBuf;
-import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraftforge.fluids.FluidStack;
-
-import java.io.IOException;
 
 public interface IStorageHelper
 {

--- a/src/api/java/appeng/api/storage/ITerminalHost.java
+++ b/src/api/java/appeng/api/storage/ITerminalHost.java
@@ -23,7 +23,9 @@
 
 package appeng.api.storage;
 
+
 import appeng.api.util.IConfigurableObject;
+
 
 public interface ITerminalHost extends IStorageMonitorable, IConfigurableObject
 {

--- a/src/api/java/appeng/api/storage/MEMonitorHandler.java
+++ b/src/api/java/appeng/api/storage/MEMonitorHandler.java
@@ -23,16 +23,18 @@
 
 package appeng.api.storage;
 
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map.Entry;
+
+import com.google.common.collect.ImmutableList;
+
 import appeng.api.config.AccessRestriction;
 import appeng.api.config.Actionable;
 import appeng.api.networking.security.BaseActionSource;
 import appeng.api.storage.data.IAEStack;
 import appeng.api.storage.data.IItemList;
-import com.google.common.collect.ImmutableList;
-
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map.Entry;
 
 /**
  * Common implementation of a simple class that monitors injection/extraction of a inventory to send events to a list of

--- a/src/api/java/appeng/api/storage/StorageChannel.java
+++ b/src/api/java/appeng/api/storage/StorageChannel.java
@@ -23,11 +23,13 @@
 
 package appeng.api.storage;
 
+
 import appeng.api.AEApi;
 import appeng.api.storage.data.IAEFluidStack;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.api.storage.data.IAEStack;
 import appeng.api.storage.data.IItemList;
+
 
 public enum StorageChannel
 {
@@ -43,11 +45,13 @@ public enum StorageChannel
 
 	public final Class<? extends IAEStack> type;
 
-	private StorageChannel( Class<? extends IAEStack> t ) {
+	private StorageChannel( Class<? extends IAEStack> t )
+	{
 		this.type = t;
 	}
 
-	public IItemList createList() {
+	public IItemList createList()
+	{
 		if ( this == ITEMS )
 			return AEApi.instance().storage().createItemList();
 		else

--- a/src/api/java/appeng/api/storage/data/IAEStack.java
+++ b/src/api/java/appeng/api/storage/data/IAEStack.java
@@ -23,12 +23,15 @@
 
 package appeng.api.storage.data;
 
-import appeng.api.config.FuzzyMode;
-import appeng.api.storage.StorageChannel;
-import io.netty.buffer.ByteBuf;
-import net.minecraft.nbt.NBTTagCompound;
 
 import java.io.IOException;
+
+import io.netty.buffer.ByteBuf;
+
+import net.minecraft.nbt.NBTTagCompound;
+
+import appeng.api.config.FuzzyMode;
+import appeng.api.storage.StorageChannel;
 
 public interface IAEStack<StackType extends IAEStack>
 {

--- a/src/api/java/appeng/api/storage/data/IAETagCompound.java
+++ b/src/api/java/appeng/api/storage/data/IAETagCompound.java
@@ -23,7 +23,9 @@
 
 package appeng.api.storage.data;
 
+
 import net.minecraft.nbt.NBTTagCompound;
+
 import appeng.api.features.IItemComparison;
 
 /**

--- a/src/api/java/appeng/api/storage/data/IItemContainer.java
+++ b/src/api/java/appeng/api/storage/data/IItemContainer.java
@@ -23,9 +23,10 @@
 
 package appeng.api.storage.data;
 
-import appeng.api.config.FuzzyMode;
 
 import java.util.Collection;
+
+import appeng.api.config.FuzzyMode;
 
 /**
  * Represents a list of items in AE.

--- a/src/api/java/appeng/api/util/AECableType.java
+++ b/src/api/java/appeng/api/util/AECableType.java
@@ -23,6 +23,7 @@
 
 package appeng.api.util;
 
+
 public enum AECableType
 {
 	/**

--- a/src/api/java/appeng/api/util/AEColor.java
+++ b/src/api/java/appeng/api/util/AEColor.java
@@ -23,7 +23,12 @@
 
 package appeng.api.util;
 
+
+import java.util.Arrays;
+import java.util.List;
+
 import net.minecraft.util.StatCollector;
+
 
 /**
  * List of all colors supported by AE, their names, and various colors for display.
@@ -66,6 +71,8 @@ public enum AEColor
 	Black("gui.appliedenergistics2.Black", 0x2B2B2B, 0x565656, 0x848484),
 
 	Transparent("gui.appliedenergistics2.Fluix", 0x1B2344, 0x895CA8, 0xD7BBEC);
+
+	public static final List<AEColor> VALID_COLORS = Arrays.asList( White, Orange, Magenta, LightBlue, Yellow, Lime, Pink, Gray, LightGray, Cyan, Purple, Blue, Brown, Green, Red, Black );
 
 	/**
 	 * Unlocalized name for color.

--- a/src/api/java/appeng/api/util/AEColoredItemDefinition.java
+++ b/src/api/java/appeng/api/util/AEColoredItemDefinition.java
@@ -23,10 +23,12 @@
 
 package appeng.api.util;
 
+
 import net.minecraft.block.Block;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
+
 
 public interface AEColoredItemDefinition
 {
@@ -34,37 +36,37 @@ public interface AEColoredItemDefinition
 	/**
 	 * @return the {@link Block} Implementation if applicable
 	 */
-	Block block(AEColor color);
+	Block block( AEColor color );
 
 	/**
 	 * @return the {@link Item} Implementation if applicable
 	 */
-	Item item(AEColor color);
+	Item item( AEColor color );
 
 	/**
 	 * @return the {@link TileEntity} Class if applicable.
 	 */
-	Class<? extends TileEntity> entity(AEColor color);
+	Class<? extends TileEntity> entity( AEColor color );
 
 	/**
 	 * @return an {@link ItemStack} with specified quantity of this item.
 	 */
-	ItemStack stack(AEColor color, int stackSize);
+	ItemStack stack( AEColor color, int stackSize );
 
 	/**
-	 * @param stackSize
-	 *            - stack size of the result.
+	 * @param stackSize - stack size of the result.
+	 *
 	 * @return an array of all colors.
 	 */
-	ItemStack[] allStacks(int stackSize);
+	ItemStack[] allStacks( int stackSize );
 
 	/**
 	 * Compare {@link ItemStack} with this {@link AEItemDefinition}
 	 *
-	 * @param color compared color of item
+	 * @param color          compared color of item
 	 * @param comparableItem compared item
+	 *
 	 * @return true if the item stack is a matching item.
 	 */
-	boolean sameAs(AEColor color, ItemStack comparableItem);
-
+	boolean sameAs( AEColor color, ItemStack comparableItem );
 }

--- a/src/api/java/appeng/api/util/DimensionalCoord.java
+++ b/src/api/java/appeng/api/util/DimensionalCoord.java
@@ -23,8 +23,10 @@
 
 package appeng.api.util;
 
+
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
+
 
 /**
  * Represents a location in the Minecraft Universe
@@ -35,19 +37,22 @@ public class DimensionalCoord extends WorldCoord
 	private final World w;
 	private final int dimId;
 
-	public DimensionalCoord(DimensionalCoord s) {
+	public DimensionalCoord( DimensionalCoord s )
+	{
 		super( s.x, s.y, s.z );
 		this.w = s.w;
 		this.dimId = s.dimId;
 	}
 
-	public DimensionalCoord(TileEntity s) {
+	public DimensionalCoord( TileEntity s )
+	{
 		super( s );
 		this.w = s.getWorldObj();
 		this.dimId = this.w.provider.dimensionId;
 	}
 
-	public DimensionalCoord(World _w, int _x, int _y, int _z) {
+	public DimensionalCoord( World _w, int _x, int _y, int _z )
+	{
 		super( _x, _y, _z );
 		this.w = _w;
 		this.dimId = _w.provider.dimensionId;
@@ -59,15 +64,15 @@ public class DimensionalCoord extends WorldCoord
 		return new DimensionalCoord( this );
 	}
 
-	public boolean isEqual(DimensionalCoord c)
+	public boolean isEqual( DimensionalCoord c )
 	{
 		return this.x == c.x && this.y == c.y && this.z == c.z && c.w == this.w;
 	}
 
 	@Override
-	public boolean equals(Object obj)
+	public boolean equals( Object obj )
 	{
-		return obj instanceof DimensionalCoord && this.isEqual((DimensionalCoord) obj);
+		return obj instanceof DimensionalCoord && this.isEqual( (DimensionalCoord) obj );
 	}
 
 	@Override
@@ -76,7 +81,7 @@ public class DimensionalCoord extends WorldCoord
 		return super.hashCode() ^ this.dimId;
 	}
 
-	public boolean isInWorld(World world)
+	public boolean isInWorld( World world )
 	{
 		return this.w == world;
 	}

--- a/src/api/java/appeng/api/util/ICommonTile.java
+++ b/src/api/java/appeng/api/util/ICommonTile.java
@@ -23,10 +23,12 @@
 
 package appeng.api.util;
 
+
+import java.util.ArrayList;
+
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 
-import java.util.ArrayList;
 
 public interface ICommonTile
 {
@@ -36,11 +38,10 @@ public interface ICommonTile
 	 * the block itself.
 	 *
 	 * @param world world of tile entity
-	 * @param x x pos of tile entity
-	 * @param y y pos of tile entity
-	 * @param z z pos of tile entity
+	 * @param x     x pos of tile entity
+	 * @param y     y pos of tile entity
+	 * @param z     z pos of tile entity
 	 * @param drops drops of tile entity
 	 */
-	void getDrops(World world, int x, int y, int z, ArrayList<ItemStack> drops);
-
+	void getDrops( World world, int x, int y, int z, ArrayList<ItemStack> drops );
 }

--- a/src/api/java/appeng/api/util/IConfigManager.java
+++ b/src/api/java/appeng/api/util/IConfigManager.java
@@ -23,9 +23,10 @@
 
 package appeng.api.util;
 
-import net.minecraft.nbt.NBTTagCompound;
 
 import java.util.Set;
+
+import net.minecraft.nbt.NBTTagCompound;
 
 /**
  * Used to adjust settings on an object,

--- a/src/api/java/appeng/api/util/IConfigurableObject.java
+++ b/src/api/java/appeng/api/util/IConfigurableObject.java
@@ -23,6 +23,7 @@
 
 package appeng.api.util;
 
+
 /**
  * Implemented by various Tiles or Parts in AE
  */
@@ -33,5 +34,4 @@ public interface IConfigurableObject
 	 * get the config manager for the object.
 	 */
 	IConfigManager getConfigManager();
-
 }

--- a/src/api/java/appeng/api/util/INetworkToolAgent.java
+++ b/src/api/java/appeng/api/util/INetworkToolAgent.java
@@ -23,7 +23,9 @@
 
 package appeng.api.util;
 
+
 import net.minecraft.util.MovingObjectPosition;
+
 
 /**
  * Implement on Tile or part to customize if the info gui opens, or an action is preformed.
@@ -31,6 +33,5 @@ import net.minecraft.util.MovingObjectPosition;
 public interface INetworkToolAgent
 {
 
-	boolean showNetworkInfo(MovingObjectPosition where);
-
+	boolean showNetworkInfo( MovingObjectPosition where );
 }

--- a/src/api/java/appeng/api/util/IOrientableBlock.java
+++ b/src/api/java/appeng/api/util/IOrientableBlock.java
@@ -23,7 +23,9 @@
 
 package appeng.api.util;
 
+
 import net.minecraft.world.IBlockAccess;
+
 
 /**
  * Implemented on many of AE's non Tile Entity Blocks as a way to get a IOrientable.
@@ -38,11 +40,11 @@ public interface IOrientableBlock
 
 	/**
 	 * @param world world of block
-	 * @param x x pos of block
-	 * @param y y pos of block
-	 * @param z z pos of block
+	 * @param x     x pos of block
+	 * @param y     y pos of block
+	 * @param z     z pos of block
+	 *
 	 * @return a IOrientable if applicable
 	 */
-	IOrientable getOrientable(IBlockAccess world, int x, int y, int z);
-
+	IOrientable getOrientable( IBlockAccess world, int x, int y, int z );
 }

--- a/src/api/java/appeng/api/util/IReadOnlyCollection.java
+++ b/src/api/java/appeng/api/util/IReadOnlyCollection.java
@@ -23,6 +23,7 @@
 
 package appeng.api.util;
 
+
 public interface IReadOnlyCollection<T> extends Iterable<T>
 {
 
@@ -39,6 +40,5 @@ public interface IReadOnlyCollection<T> extends Iterable<T>
 	/**
 	 * @return return true if the object is part of the set.
 	 */
-	boolean contains(Object node);
-
+	boolean contains( Object node );
 }

--- a/src/api/java/appeng/api/util/WorldCoord.java
+++ b/src/api/java/appeng/api/util/WorldCoord.java
@@ -23,8 +23,10 @@
 
 package appeng.api.util;
 
+
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.util.ForgeDirection;
+
 
 /**
  * Represents a relative coordinate, either relative to another object, or
@@ -37,7 +39,7 @@ public class WorldCoord
 	public int y;
 	public int z;
 
-	public WorldCoord add(ForgeDirection direction, int length)
+	public WorldCoord add( ForgeDirection direction, int length )
 	{
 		this.x += direction.offsetX * length;
 		this.y += direction.offsetY * length;
@@ -45,7 +47,7 @@ public class WorldCoord
 		return this;
 	}
 
-	public WorldCoord subtract(ForgeDirection direction, int length)
+	public WorldCoord subtract( ForgeDirection direction, int length )
 	{
 		this.x -= direction.offsetX * length;
 		this.y -= direction.offsetY * length;
@@ -53,7 +55,7 @@ public class WorldCoord
 		return this;
 	}
 
-	public WorldCoord add(int _x, int _y, int _z)
+	public WorldCoord add( int _x, int _y, int _z )
 	{
 		this.x += _x;
 		this.y += _y;
@@ -61,7 +63,7 @@ public class WorldCoord
 		return this;
 	}
 
-	public WorldCoord subtract(int _x, int _y, int _z)
+	public WorldCoord subtract( int _x, int _y, int _z )
 	{
 		this.x -= _x;
 		this.y -= _y;
@@ -69,7 +71,7 @@ public class WorldCoord
 		return this;
 	}
 
-	public WorldCoord multiple(int _x, int _y, int _z)
+	public WorldCoord multiple( int _x, int _y, int _z )
 	{
 		this.x *= _x;
 		this.y *= _y;
@@ -77,7 +79,7 @@ public class WorldCoord
 		return this;
 	}
 
-	public WorldCoord divide(int _x, int _y, int _z)
+	public WorldCoord divide( int _x, int _y, int _z )
 	{
 		this.x /= _x;
 		this.y /= _y;
@@ -85,20 +87,22 @@ public class WorldCoord
 		return this;
 	}
 
-	public WorldCoord(int _x, int _y, int _z) {
+	public WorldCoord( int _x, int _y, int _z )
+	{
 		this.x = _x;
 		this.y = _y;
 		this.z = _z;
 	}
 
-	public WorldCoord(TileEntity s) {
+	public WorldCoord( TileEntity s )
+	{
 		this( s.xCoord, s.yCoord, s.zCoord );
 	}
 
 	/**
 	 * Will Return NULL if it's at some diagonal!
 	 */
-	public ForgeDirection directionTo(WorldCoord loc)
+	public ForgeDirection directionTo( WorldCoord loc )
 	{
 		int ox = this.x - loc.x;
 		int oy = this.y - loc.y;
@@ -129,7 +133,7 @@ public class WorldCoord
 		return null;
 	}
 
-	public boolean isEqual(WorldCoord c)
+	public boolean isEqual( WorldCoord c )
 	{
 		return this.x == c.x && this.y == c.y && this.z == c.z;
 	}
@@ -140,9 +144,9 @@ public class WorldCoord
 	}
 
 	@Override
-	public boolean equals(Object obj)
+	public boolean equals( Object obj )
 	{
-		return obj instanceof WorldCoord && this.isEqual((WorldCoord) obj);
+		return obj instanceof WorldCoord && this.isEqual( (WorldCoord) obj );
 	}
 
 	@Override
@@ -154,6 +158,6 @@ public class WorldCoord
 	@Override
 	public int hashCode()
 	{
-		return ( this.y << 24) ^ this.x ^ this.z;
+		return ( this.y << 24 ) ^ this.x ^ this.z;
 	}
 }

--- a/src/main/java/appeng/block/AEBaseItemBlockChargeable.java
+++ b/src/main/java/appeng/block/AEBaseItemBlockChargeable.java
@@ -30,10 +30,13 @@ import net.minecraft.nbt.NBTTagCompound;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
-import appeng.api.AEApi;
+import com.google.common.base.Optional;
+
 import appeng.api.config.AccessRestriction;
 import appeng.api.config.PowerUnits;
 import appeng.api.implementations.items.IAEItemPowerStorage;
+import appeng.api.util.AEItemDefinition;
+import appeng.core.Api;
 import appeng.core.localization.GuiText;
 import appeng.util.Platform;
 
@@ -66,11 +69,21 @@ public class AEBaseItemBlockChargeable extends AEBaseItemBlock implements IAEIte
 
 	private double getMaxEnergyCapacity()
 	{
-		Block blk = Block.getBlockFromItem( this );
-		if ( blk == AEApi.instance().blocks().blockEnergyCell.block() )
-			return 200000;
-		else
-			return 8 * 200000;
+		Block blockID = Block.getBlockFromItem( this );
+		final Optional<AEItemDefinition> maybeEnergyCell = Api.INSTANCE.definitions().blocks().energyCell();
+		if ( maybeEnergyCell.isPresent() )
+		{
+			if ( blockID == maybeEnergyCell.get().block() )
+			{
+				return 200000;
+			}
+			else
+			{
+				return 8 * 200000;
+			}
+		}
+
+		return 0;
 	}
 
 	private double getInternal(ItemStack is)

--- a/src/main/java/appeng/block/crafting/BlockCraftingMonitor.java
+++ b/src/main/java/appeng/block/crafting/BlockCraftingMonitor.java
@@ -18,6 +18,7 @@
 
 package appeng.block.crafting;
 
+
 import java.util.List;
 
 import net.minecraft.creativetab.CreativeTabs;
@@ -29,19 +30,46 @@ import net.minecraftforge.common.util.ForgeDirection;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
-import appeng.api.AEApi;
+import com.google.common.base.Optional;
+
+import appeng.api.util.AEItemDefinition;
 import appeng.client.render.BaseBlockRender;
 import appeng.client.render.blocks.RenderBlockCraftingCPUMonitor;
 import appeng.client.texture.ExtraBlockTextures;
+import appeng.core.Api;
 import appeng.tile.crafting.TileCraftingMonitorTile;
+
 
 public class BlockCraftingMonitor extends BlockCraftingUnit
 {
 
-	public BlockCraftingMonitor() {
+	public BlockCraftingMonitor()
+	{
 		super( BlockCraftingMonitor.class );
 
 		this.setTileEntity( TileCraftingMonitorTile.class );
+	}
+
+	@Override
+	public IIcon getIcon( int direction, int metadata )
+	{
+		final Optional<AEItemDefinition> maybeCraftingUnit = Api.INSTANCE.definitions().blocks().craftingUnit();
+		if ( maybeCraftingUnit.isPresent() )
+		{
+			if ( direction != ForgeDirection.SOUTH.ordinal() )
+			{
+				return maybeCraftingUnit.get().block().getIcon( direction, metadata );
+			}
+		}
+
+		switch ( metadata )
+		{
+			default:
+			case 0:
+				return super.getIcon( 0, 0 );
+			case FLAG_FORMED:
+				return ExtraBlockTextures.BlockCraftingMonitorFit_Light.getIcon();
+		}
 	}
 
 	@Override
@@ -51,24 +79,8 @@ public class BlockCraftingMonitor extends BlockCraftingUnit
 	}
 
 	@Override
-	public IIcon getIcon(int direction, int metadata)
-	{
-		if ( direction != ForgeDirection.SOUTH.ordinal() )
-			return AEApi.instance().blocks().blockCraftingUnit.block().getIcon( direction, metadata );
-
-		switch (metadata)
-		{
-		default:
-		case 0:
-			return super.getIcon( 0, 0 );
-		case FLAG_FORMED:
-			return ExtraBlockTextures.BlockCraftingMonitorFit_Light.getIcon();
-		}
-	}
-
-	@Override
-	@SideOnly(Side.CLIENT)
-	public void getCheckedSubBlocks(Item item, CreativeTabs tabs, List<ItemStack> itemStacks)
+	@SideOnly( Side.CLIENT )
+	public void getCheckedSubBlocks( Item item, CreativeTabs tabs, List<ItemStack> itemStacks )
 	{
 		itemStacks.add( new ItemStack( this, 1, 0 ) );
 	}

--- a/src/main/java/appeng/block/crafting/ItemCraftingStorage.java
+++ b/src/main/java/appeng/block/crafting/ItemCraftingStorage.java
@@ -22,6 +22,8 @@ import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
 
 import appeng.api.AEApi;
+import appeng.api.exceptions.MissingDefinition;
+import appeng.api.util.AEItemDefinition;
 import appeng.block.AEBaseItemBlock;
 import appeng.core.AEConfig;
 import appeng.core.features.AEFeature;
@@ -42,7 +44,12 @@ public class ItemCraftingStorage extends AEBaseItemBlock
 	@Override
 	public ItemStack getContainerItem(ItemStack itemStack)
 	{
-		return AEApi.instance().blocks().blockCraftingUnit.stack( 1 );
+		for ( AEItemDefinition definition : AEApi.instance().definitions().blocks().craftingUnit().asSet() )
+		{
+			return definition.stack( 1 );
+		}
+
+		throw new MissingDefinition( "No crafting unit." );
 	}
 
 }

--- a/src/main/java/appeng/block/misc/BlockCharger.java
+++ b/src/main/java/appeng/block/misc/BlockCharger.java
@@ -36,6 +36,7 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
 import appeng.api.AEApi;
+import appeng.api.util.AEItemDefinition;
 import appeng.block.AEBaseBlock;
 import appeng.client.render.BaseBlockRender;
 import appeng.client.render.blocks.RenderBlockCharger;
@@ -97,22 +98,24 @@ public class BlockCharger extends AEBaseBlock implements ICustomCollision
 		if ( tile instanceof TileCharger )
 		{
 			TileCharger tc = (TileCharger) tile;
-			if ( AEApi.instance().materials().materialCertusQuartzCrystalCharged.sameAsStack( tc.getStackInSlot( 0 ) ) )
+
+			for ( AEItemDefinition definition : AEApi.instance().definitions().materials().certusQuartzCrystalCharged().asSet() )
 			{
-
-				double xOff = 0.0;
-				double yOff = 0.0;
-				double zOff = 0.0;
-
-				for (int bolts = 0; bolts < 3; bolts++)
+				if ( definition.sameAsStack( tc.getStackInSlot( 0 ) ) )
 				{
-					if ( CommonHelper.proxy.shouldAddParticles( r ) )
+					double xOff = 0.0;
+					double yOff = 0.0;
+					double zOff = 0.0;
+
+					for (int bolts = 0; bolts < 3; bolts++)
 					{
-						LightningFX fx = new LightningFX( w, xOff + 0.5 + x, yOff + 0.5 + y, zOff + 0.5 + z, 0.0D, 0.0D, 0.0D );
-						Minecraft.getMinecraft().effectRenderer.addEffect( fx );
+						if ( CommonHelper.proxy.shouldAddParticles( r ) )
+						{
+							LightningFX fx = new LightningFX( w, xOff + 0.5 + x, yOff + 0.5 + y, zOff + 0.5 + z, 0.0D, 0.0D, 0.0D );
+							Minecraft.getMinecraft().effectRenderer.addEffect( fx );
+						}
 					}
 				}
-
 			}
 		}
 	}

--- a/src/main/java/appeng/block/networking/BlockCableBus.java
+++ b/src/main/java/appeng/block/networking/BlockCableBus.java
@@ -424,10 +424,10 @@ public class BlockCableBus extends AEBaseBlock implements IRedNetConnection
 
 	public void setupTile()
 	{
-		this.setTileEntity( noTesrTile = Api.INSTANCE.partHelper.getCombinedInstance( TileCableBus.class.getName() ) );
+		this.setTileEntity( noTesrTile = Api.INSTANCE.getPartHelper().getCombinedInstance( TileCableBus.class.getName() ) );
 		if ( Platform.isClient() )
 		{
-			tesrTile = Api.INSTANCE.partHelper.getCombinedInstance( TileCableBusTESR.class.getName() );
+			tesrTile = Api.INSTANCE.getPartHelper().getCombinedInstance( TileCableBusTESR.class.getName() );
 			GameRegistry.registerTileEntity( tesrTile, "ClientOnly_TESR_CableBus" );
 			CommonHelper.proxy.bindTileEntitySpecialRenderer( tesrTile, this );
 		}

--- a/src/main/java/appeng/block/solids/OreQuartz.java
+++ b/src/main/java/appeng/block/solids/OreQuartz.java
@@ -30,6 +30,8 @@ import net.minecraft.world.World;
 import net.minecraftforge.oredict.OreDictionary;
 
 import appeng.api.AEApi;
+import appeng.api.exceptions.MissingDefinition;
+import appeng.api.util.AEItemDefinition;
 import appeng.block.AEBaseBlock;
 import appeng.client.render.BaseBlockRender;
 import appeng.client.render.blocks.RenderQuartzOre;
@@ -37,12 +39,11 @@ import appeng.core.features.AEFeature;
 
 public class OreQuartz extends AEBaseBlock
 {
+	private int boostBrightnessLow;
+	private int boostBrightnessHigh;
+	private boolean enhanceBrightness;
 
-	public int boostBrightnessLow;
-	public int boostBrightnessHigh;
-	public boolean enhanceBrightness;
-
-	public OreQuartz(Class self) {
+	public OreQuartz(Class<? extends OreQuartz> self) {
 		super( self, Material.rock );
 		this.setFeature( EnumSet.of( AEFeature.Core ) );
 		this.setHardness( 3.0F );
@@ -73,9 +74,13 @@ public class OreQuartz extends AEBaseBlock
 			j1 = Math.max( j1 >> 20, j1 >> 4 );
 
 			if ( j1 > 4 )
+			{
 				j1 += this.boostBrightnessHigh;
+			}
 			else
+			{
 				j1 += this.boostBrightnessLow;
+			}
 
 			if ( j1 > 15 )
 				j1 = 15;
@@ -90,7 +95,12 @@ public class OreQuartz extends AEBaseBlock
 
 	ItemStack getItemDropped()
 	{
-		return AEApi.instance().materials().materialCertusQuartzCrystal.stack( 1 );
+		for ( AEItemDefinition definition : AEApi.instance().definitions().materials().certusQuartzCrystal().asSet() )
+		{
+			return definition.stack( 1 );
+		}
+
+		throw new MissingDefinition( "Tried to access certus quartz crystal.");
 	}
 
 	@Override
@@ -144,4 +154,18 @@ public class OreQuartz extends AEBaseBlock
 		}
 	}
 
+	public void setBoostBrightnessLow( int boostBrightnessLow )
+	{
+		this.boostBrightnessLow = boostBrightnessLow;
+	}
+
+	public void setBoostBrightnessHigh( int boostBrightnessHigh )
+	{
+		this.boostBrightnessHigh = boostBrightnessHigh;
+	}
+
+	public void setEnhanceBrightness( boolean enhanceBrightness )
+	{
+		this.enhanceBrightness = enhanceBrightness;
+	}
 }

--- a/src/main/java/appeng/block/solids/OreQuartzCharged.java
+++ b/src/main/java/appeng/block/solids/OreQuartzCharged.java
@@ -28,6 +28,8 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
 import appeng.api.AEApi;
+import appeng.api.exceptions.MissingDefinition;
+import appeng.api.util.AEItemDefinition;
 import appeng.client.render.effects.ChargedOreFX;
 import appeng.core.AEConfig;
 import appeng.core.CommonHelper;
@@ -37,14 +39,19 @@ public class OreQuartzCharged extends OreQuartz
 
 	public OreQuartzCharged() {
 		super( OreQuartzCharged.class );
-		this.boostBrightnessLow = 2;
-		this.boostBrightnessHigh = 5;
+		this.setBoostBrightnessLow( 2 );
+		this.setBoostBrightnessHigh( 5 );
 	}
 
 	@Override
 	ItemStack getItemDropped()
 	{
-		return AEApi.instance().materials().materialCertusQuartzCrystalCharged.stack( 1 );
+		for ( AEItemDefinition definition : AEApi.instance().definitions().materials().certusQuartzCrystalCharged().asSet() )
+		{
+			return definition.stack( 1 );
+		}
+
+		throw new MissingDefinition( "Wanted to access charged certus quartz crystal" );
 	}
 
 	@Override

--- a/src/main/java/appeng/block/stair/ChiseledQuartzStairBlock.java
+++ b/src/main/java/appeng/block/stair/ChiseledQuartzStairBlock.java
@@ -21,14 +21,15 @@ package appeng.block.stair;
 
 import java.util.EnumSet;
 
+import net.minecraft.block.Block;
+
 import appeng.block.AEBaseStairBlock;
-import appeng.block.solids.BlockQuartzChiseled;
 import appeng.core.features.AEFeature;
 
 
 public class ChiseledQuartzStairBlock extends AEBaseStairBlock
 {
-	public ChiseledQuartzStairBlock( BlockQuartzChiseled block )
+	public ChiseledQuartzStairBlock( Block block )
 	{
 		super( block, 0, EnumSet.of( AEFeature.Core ) );
 	}

--- a/src/main/java/appeng/block/stair/QuartzPillarStairBlock.java
+++ b/src/main/java/appeng/block/stair/QuartzPillarStairBlock.java
@@ -21,14 +21,15 @@ package appeng.block.stair;
 
 import java.util.EnumSet;
 
+import net.minecraft.block.Block;
+
 import appeng.block.AEBaseStairBlock;
-import appeng.block.solids.BlockQuartzPillar;
 import appeng.core.features.AEFeature;
 
 
 public class QuartzPillarStairBlock extends AEBaseStairBlock
 {
-	public QuartzPillarStairBlock( BlockQuartzPillar block )
+	public QuartzPillarStairBlock( Block block )
 	{
 		super( block, 0, EnumSet.of( AEFeature.Core ) );
 	}

--- a/src/main/java/appeng/block/stair/QuartzStairBlock.java
+++ b/src/main/java/appeng/block/stair/QuartzStairBlock.java
@@ -21,14 +21,15 @@ package appeng.block.stair;
 
 import java.util.EnumSet;
 
+import net.minecraft.block.Block;
+
 import appeng.block.AEBaseStairBlock;
-import appeng.block.solids.BlockQuartz;
 import appeng.core.features.AEFeature;
 
 
 public class QuartzStairBlock extends AEBaseStairBlock
 {
-	public QuartzStairBlock( BlockQuartz block )
+	public QuartzStairBlock( Block block )
 	{
 		super( block, 0, EnumSet.of( AEFeature.Core ) );
 	}

--- a/src/main/java/appeng/block/storage/BlockSkyChest.java
+++ b/src/main/java/appeng/block/storage/BlockSkyChest.java
@@ -39,7 +39,10 @@ import net.minecraftforge.common.util.ForgeDirection;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
+import com.google.common.base.Optional;
+
 import appeng.api.AEApi;
+import appeng.api.util.AEItemDefinition;
 import appeng.block.AEBaseBlock;
 import appeng.client.render.BaseBlockRender;
 import appeng.client.render.blocks.RenderBlockSkyChest;
@@ -81,9 +84,15 @@ public class BlockSkyChest extends AEBaseBlock implements ICustomCollision
 	@SideOnly(Side.CLIENT)
 	public IIcon getIcon(int direction, int metadata)
 	{
-		if ( metadata == 1 )
-			return AEApi.instance().blocks().blockSkyStone.block().getIcon( direction, 1 );
-		return AEApi.instance().blocks().blockSkyStone.block().getIcon( direction, metadata );
+		final Optional<AEItemDefinition> maybeSkystone = AEApi.instance().definitions().blocks().skyStone();
+		IIcon icon = null;
+
+		for ( AEItemDefinition definition : maybeSkystone.asSet() )
+		{
+			icon = definition.block().getIcon( direction, metadata );
+		}
+
+		return icon;
 	}
 
 	@Override

--- a/src/main/java/appeng/client/gui/implementations/GuiCraftAmount.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiCraftAmount.java
@@ -23,7 +23,10 @@ import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.item.ItemStack;
 
 import appeng.api.AEApi;
+import appeng.api.definitions.IDefinitions;
+import appeng.api.definitions.IParts;
 import appeng.api.storage.ITerminalHost;
+import appeng.api.util.AEItemDefinition;
 import appeng.client.gui.AEBaseGui;
 import appeng.client.gui.widgets.GuiNumberBox;
 import appeng.client.gui.widgets.GuiTabButton;
@@ -81,33 +84,49 @@ public class GuiCraftAmount extends AEBaseGui
 
 		ItemStack myIcon = null;
 		Object target = ((AEBaseContainer) this.inventorySlots).getTarget();
+		final IDefinitions definitions = AEApi.instance().definitions();
+		final IParts parts = definitions.parts();
 
 		if ( target instanceof WirelessTerminalGuiObject )
 		{
-			myIcon = AEApi.instance().items().itemWirelessTerminal.stack( 1 );
-			this.OriginalGui = GuiBridge.GUI_WIRELESS_TERM;
+			for ( AEItemDefinition definition : definitions.items().wirelessTerminal().asSet() )
+			{
+				myIcon = definition.stack( 1 );
+				this.OriginalGui = GuiBridge.GUI_WIRELESS_TERM;
+			}
 		}
 
 		if ( target instanceof PartTerminal )
 		{
-			myIcon = AEApi.instance().parts().partTerminal.stack( 1 );
-			this.OriginalGui = GuiBridge.GUI_ME;
+			for ( AEItemDefinition definition : parts.terminal().asSet() )
+			{
+				myIcon = definition.stack( 1 );
+				this.OriginalGui = GuiBridge.GUI_ME;
+			}
 		}
 
 		if ( target instanceof PartCraftingTerminal )
 		{
-			myIcon = AEApi.instance().parts().partCraftingTerminal.stack( 1 );
-			this.OriginalGui = GuiBridge.GUI_CRAFTING_TERMINAL;
+			for ( AEItemDefinition definition : parts.craftingTerminal().asSet() )
+			{
+				myIcon = definition.stack( 1 );
+				this.OriginalGui = GuiBridge.GUI_CRAFTING_TERMINAL;
+			}
 		}
 
 		if ( target instanceof PartPatternTerminal )
 		{
-			myIcon = AEApi.instance().parts().partPatternTerminal.stack( 1 );
-			this.OriginalGui = GuiBridge.GUI_PATTERN_TERMINAL;
+			for ( AEItemDefinition definition : parts.patternTerminal().asSet() )
+			{
+				myIcon = definition.stack( 1 );
+				this.OriginalGui = GuiBridge.GUI_PATTERN_TERMINAL;
+			}
 		}
 
-		if ( this.OriginalGui != null )
+		if ( this.OriginalGui != null && myIcon != null )
+		{
 			this.buttonList.add( this.originalGuiBtn = new GuiTabButton( this.guiLeft + 154, this.guiTop, myIcon, myIcon.getDisplayName(), itemRender ) );
+		}
 
 		this.amountToCraft = new GuiNumberBox( this.fontRendererObj, this.guiLeft + 62, this.guiTop + 57, 59, this.fontRendererObj.FONT_HEIGHT, Integer.class );
 		this.amountToCraft.setEnableBackgroundDrawing( false );
@@ -154,22 +173,22 @@ public class GuiCraftAmount extends AEBaseGui
 	{
 		try
 		{
-			String Out = this.amountToCraft.getText();
+			String out = this.amountToCraft.getText();
 
-			boolean Fixed = false;
-			while (Out.startsWith( "0" ) && Out.length() > 1)
+			boolean fixed = false;
+			while (out.startsWith( "0" ) && out.length() > 1)
 			{
-				Out = Out.substring( 1 );
-				Fixed = true;
+				out = out.substring( 1 );
+				fixed = true;
 			}
 
-			if ( Fixed )
-				this.amountToCraft.setText( Out );
+			if ( fixed )
+				this.amountToCraft.setText( out );
 
-			if ( Out.length() == 0 )
-				Out = "0";
+			if ( out.length() == 0 )
+				out = "0";
 
-			long result = Integer.parseInt( Out );
+			long result = Integer.parseInt( out );
 
 			if ( result == 1 && i > 1 )
 				result = 0;
@@ -178,9 +197,9 @@ public class GuiCraftAmount extends AEBaseGui
 			if ( result < 1 )
 				result = 1;
 
-			Out = Long.toString( result );
-			Integer.parseInt( Out );
-			this.amountToCraft.setText( Out );
+			out = Long.toString( result );
+			Integer.parseInt( out );
+			this.amountToCraft.setText( out );
 		}
 		catch (NumberFormatException e)
 		{
@@ -202,22 +221,22 @@ public class GuiCraftAmount extends AEBaseGui
 			{
 				try
 				{
-					String Out = this.amountToCraft.getText();
+					String out = this.amountToCraft.getText();
 
-					boolean Fixed = false;
-					while (Out.startsWith( "0" ) && Out.length() > 1)
+					boolean fixed = false;
+					while (out.startsWith( "0" ) && out.length() > 1)
 					{
-						Out = Out.substring( 1 );
-						Fixed = true;
+						out = out.substring( 1 );
+						fixed = true;
 					}
 
-					if ( Fixed )
-						this.amountToCraft.setText( Out );
+					if ( fixed )
+						this.amountToCraft.setText( out );
 
-					if ( Out.length() == 0 )
-						Out = "0";
+					if ( out.length() == 0 )
+						out = "0";
 
-					long result = Long.parseLong( Out );
+					long result = Long.parseLong( out );
 					if ( result < 0 )
 					{
 						this.amountToCraft.setText( "1" );

--- a/src/main/java/appeng/client/gui/implementations/GuiCraftConfirm.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiCraftConfirm.java
@@ -128,7 +128,7 @@ public class GuiCraftConfirm extends AEBaseGui
 	private void updateCPUButtonText()
 	{
 		String btnTextText = GuiText.CraftingCPU.getLocal() + ": " + GuiText.Automatic.getLocal();
-		if ( this.ccc.selectedCpu >= 0 )// && ccc.selectedCpu < ccc.cpus.size() )
+		if ( this.ccc.selectedCpu >= 0 )// && status.selectedCpu < status.cpus.size() )
 		{
 			if ( this.ccc.myName.length() > 0 )
 			{

--- a/src/main/java/appeng/client/gui/implementations/GuiCraftingStatus.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiCraftingStatus.java
@@ -30,7 +30,10 @@ import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.item.ItemStack;
 
 import appeng.api.AEApi;
+import appeng.api.definitions.IDefinitions;
+import appeng.api.definitions.IParts;
 import appeng.api.storage.ITerminalHost;
+import appeng.api.util.AEItemDefinition;
 import appeng.client.gui.widgets.GuiTabButton;
 import appeng.container.implementations.ContainerCraftingStatus;
 import appeng.core.AELog;
@@ -47,41 +50,55 @@ import appeng.parts.reporting.PartTerminal;
 public class GuiCraftingStatus extends GuiCraftingCPU
 {
 
-	final ContainerCraftingStatus ccc;
+	final ContainerCraftingStatus status;
 	GuiButton selectCPU;
 
 	GuiTabButton originalGuiBtn;
-	GuiBridge OriginalGui;
+	GuiBridge originalGui;
 	ItemStack myIcon = null;
 
 	public GuiCraftingStatus(InventoryPlayer inventoryPlayer, ITerminalHost te) {
 		super( new ContainerCraftingStatus( inventoryPlayer, te ) );
 
-		this.ccc = (ContainerCraftingStatus) this.inventorySlots;
-		Object target = this.ccc.getTarget();
+		this.status = (ContainerCraftingStatus) this.inventorySlots;
+		Object target = this.status.getTarget();
+		final IDefinitions definitions = AEApi.instance().definitions();
+		final IParts parts = definitions.parts();
 
 		if ( target instanceof WirelessTerminalGuiObject )
 		{
-			this.myIcon = AEApi.instance().items().itemWirelessTerminal.stack( 1 );
-			this.OriginalGui = GuiBridge.GUI_WIRELESS_TERM;
+			for ( AEItemDefinition definition : definitions.items().wirelessTerminal().asSet() )
+			{
+				this.myIcon = definition.stack( 1 );
+				this.originalGui = GuiBridge.GUI_WIRELESS_TERM;
+			}
 		}
 
 		if ( target instanceof PartTerminal )
 		{
-			this.myIcon = AEApi.instance().parts().partTerminal.stack( 1 );
-			this.OriginalGui = GuiBridge.GUI_ME;
+			for ( AEItemDefinition definition : parts.terminal().asSet() )
+			{
+				this.myIcon = definition.stack( 1 );
+				this.originalGui = GuiBridge.GUI_ME;
+			}
 		}
 
 		if ( target instanceof PartCraftingTerminal )
 		{
-			this.myIcon = AEApi.instance().parts().partCraftingTerminal.stack( 1 );
-			this.OriginalGui = GuiBridge.GUI_CRAFTING_TERMINAL;
+			for ( AEItemDefinition definition : parts.craftingTerminal().asSet() )
+			{
+				this.myIcon = definition.stack( 1 );
+				this.originalGui = GuiBridge.GUI_CRAFTING_TERMINAL;
+			}
 		}
 
 		if ( target instanceof PartPatternTerminal )
 		{
-			this.myIcon = AEApi.instance().parts().partPatternTerminal.stack( 1 );
-			this.OriginalGui = GuiBridge.GUI_PATTERN_TERMINAL;
+			for ( AEItemDefinition definition : parts.patternTerminal().asSet() )
+			{
+				this.myIcon = definition.stack( 1 );
+				this.originalGui = GuiBridge.GUI_PATTERN_TERMINAL;
+			}
 		}
 	}
 
@@ -106,7 +123,7 @@ public class GuiCraftingStatus extends GuiCraftingCPU
 
 		if ( btn == this.originalGuiBtn )
 		{
-			NetworkHandler.instance.sendToServer( new PacketSwitchGuis( this.OriginalGui ) );
+			NetworkHandler.instance.sendToServer( new PacketSwitchGuis( this.originalGui ) );
 		}
 	}
 
@@ -136,27 +153,27 @@ public class GuiCraftingStatus extends GuiCraftingCPU
 	{
 		String btnTextText = GuiText.NoCraftingJobs.getLocal();
 
-		if ( this.ccc.selectedCpu >= 0 )// && ccc.selectedCpu < ccc.cpus.size() )
+		if ( this.status.selectedCpu >= 0 )// && status.selectedCpu < status.cpus.size() )
 		{
-			if ( this.ccc.myName.length() > 0 )
+			if ( this.status.myName.length() > 0 )
 			{
-				String name = this.ccc.myName.substring( 0, Math.min( 20, this.ccc.myName.length() ) );
+				String name = this.status.myName.substring( 0, Math.min( 20, this.status.myName.length() ) );
 				btnTextText = GuiText.CPUs.getLocal() + ": " + name;
 			}
 			else
-				btnTextText = GuiText.CPUs.getLocal() + ": #" + this.ccc.selectedCpu;
+				btnTextText = GuiText.CPUs.getLocal() + ": #" + this.status.selectedCpu;
 		}
 
-		if ( this.ccc.noCPU )
+		if ( this.status.noCPU )
 			btnTextText = GuiText.NoCraftingJobs.getLocal();
 
 		this.selectCPU.displayString = btnTextText;
 	}
 
 	@Override
-	public void drawScreen(int mouse_x, int mouse_y, float btn)
+	public void drawScreen(int mouseX, int mouseY, float btn)
 	{
 		this.updateCPUButtonText();
-		super.drawScreen( mouse_x, mouse_y, btn );
+		super.drawScreen( mouseX, mouseY, btn );
 	}
 }

--- a/src/main/java/appeng/client/gui/implementations/GuiIOPort.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiIOPort.java
@@ -28,6 +28,8 @@ import appeng.api.config.FullnessMode;
 import appeng.api.config.OperationMode;
 import appeng.api.config.RedstoneMode;
 import appeng.api.config.Settings;
+import appeng.api.definitions.IDefinitions;
+import appeng.api.util.AEItemDefinition;
 import appeng.client.gui.widgets.GuiImgButton;
 import appeng.container.implementations.ContainerIOPort;
 import appeng.core.localization.GuiText;
@@ -50,8 +52,18 @@ public class GuiIOPort extends GuiUpgradeable
 	public void drawBG(int offsetX, int offsetY, int mouseX, int mouseY)
 	{
 		super.drawBG( offsetX, offsetY, mouseX, mouseY );
-		this.drawItem( offsetX + 66 - 8, offsetY + 17, AEApi.instance().items().itemCell1k.stack( 1 ) );
-		this.drawItem( offsetX + 94 + 8, offsetY + 17, AEApi.instance().blocks().blockDrive.stack( 1 ) );
+
+		final IDefinitions definitions = AEApi.instance().definitions();
+
+		for ( AEItemDefinition definition : definitions.items().cell1k().asSet() )
+		{
+			this.drawItem( offsetX + 66 - 8, offsetY + 17, definition.stack( 1 ) );
+		}
+
+		for ( AEItemDefinition definition : definitions.blocks().drive().asSet() )
+		{
+			this.drawItem( offsetX + 94 + 8, offsetY + 17, definition.stack( 1 ) );
+		}
 	}
 
 	@Override

--- a/src/main/java/appeng/client/gui/implementations/GuiPriority.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiPriority.java
@@ -25,6 +25,10 @@ import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.item.ItemStack;
 
 import appeng.api.AEApi;
+import appeng.api.definitions.IBlocks;
+import appeng.api.definitions.IDefinitions;
+import appeng.api.definitions.IParts;
+import appeng.api.util.AEItemDefinition;
 import appeng.client.gui.AEBaseGui;
 import appeng.client.gui.widgets.GuiNumberBox;
 import appeng.client.gui.widgets.GuiTabButton;
@@ -82,44 +86,65 @@ public class GuiPriority extends AEBaseGui
 
 		ItemStack myIcon = null;
 		Object target = ((AEBaseContainer) this.inventorySlots).getTarget();
+		final IDefinitions definitions = AEApi.instance().definitions();
+		final IParts parts = definitions.parts();
+		final IBlocks blocks = definitions.blocks();
 
 		if ( target instanceof PartStorageBus )
 		{
-			myIcon = AEApi.instance().parts().partStorageBus.stack( 1 );
-			this.OriginalGui = GuiBridge.GUI_STORAGEBUS;
+			for ( AEItemDefinition definition : parts.storageBus().asSet() )
+			{
+				myIcon = definition.stack( 1 );
+				this.OriginalGui = GuiBridge.GUI_STORAGEBUS;
+			}
 		}
 
 		if ( target instanceof PartFormationPlane )
 		{
-			myIcon = AEApi.instance().parts().partFormationPlane.stack( 1 );
-			this.OriginalGui = GuiBridge.GUI_FORMATION_PLANE;
+			for ( AEItemDefinition definition : parts.formationPlane().asSet() )
+			{
+				myIcon = definition.stack( 1 );
+				this.OriginalGui = GuiBridge.GUI_FORMATION_PLANE;
+			}
 		}
 
 		if ( target instanceof TileDrive )
 		{
-			myIcon = AEApi.instance().blocks().blockDrive.stack( 1 );
-			this.OriginalGui = GuiBridge.GUI_DRIVE;
+			for ( AEItemDefinition definition : blocks.drive().asSet() )
+			{
+				myIcon = definition.stack( 1 );
+				this.OriginalGui = GuiBridge.GUI_DRIVE;
+			}
 		}
 
 		if ( target instanceof TileChest )
 		{
-			myIcon = AEApi.instance().blocks().blockChest.stack( 1 );
-			this.OriginalGui = GuiBridge.GUI_CHEST;
+			for ( AEItemDefinition definition : blocks.chest().asSet() )
+			{
+				myIcon = definition.stack( 1 );
+				this.OriginalGui = GuiBridge.GUI_CHEST;
+			}
 		}
 
 		if ( target instanceof TileInterface )
 		{
-			myIcon = AEApi.instance().blocks().blockInterface.stack( 1 );
-			this.OriginalGui = GuiBridge.GUI_INTERFACE;
+			for ( AEItemDefinition definition : blocks.iface().asSet() )
+			{
+				myIcon = definition.stack( 1 );
+				this.OriginalGui = GuiBridge.GUI_INTERFACE;
+			}
 		}
 
 		if ( target instanceof PartInterface )
 		{
-			myIcon = AEApi.instance().parts().partInterface.stack( 1 );
-			this.OriginalGui = GuiBridge.GUI_INTERFACE;
+			for ( AEItemDefinition definition : parts.iface().asSet() )
+			{
+				myIcon = definition.stack( 1 );
+				this.OriginalGui = GuiBridge.GUI_INTERFACE;
+			}
 		}
 
-		if ( this.OriginalGui != null )
+		if ( this.OriginalGui != null && myIcon != null )
 			this.buttonList.add( this.originalGuiBtn = new GuiTabButton( this.guiLeft + 154, this.guiTop, myIcon, myIcon.getDisplayName(), itemRender ) );
 
 		this.priority = new GuiNumberBox( this.fontRendererObj, this.guiLeft + 62, this.guiTop + 57, 59, this.fontRendererObj.FONT_HEIGHT, Long.class );
@@ -152,27 +177,27 @@ public class GuiPriority extends AEBaseGui
 	{
 		try
 		{
-			String Out = this.priority.getText();
+			String out = this.priority.getText();
 
-			boolean Fixed = false;
-			while (Out.startsWith( "0" ) && Out.length() > 1)
+			boolean fixed = false;
+			while (out.startsWith( "0" ) && out.length() > 1)
 			{
-				Out = Out.substring( 1 );
-				Fixed = true;
+				out = out.substring( 1 );
+				fixed = true;
 			}
 
-			if ( Fixed )
-				this.priority.setText( Out );
+			if ( fixed )
+				this.priority.setText( out );
 
-			if ( Out.length() == 0 )
-				Out = "0";
+			if ( out.length() == 0 )
+				out = "0";
 
-			long result = Long.parseLong( Out );
+			long result = Long.parseLong( out );
 			result += i;
 
-			this.priority.setText( Out = Long.toString( result ) );
+			this.priority.setText( out = Long.toString( result ) );
 
-			NetworkHandler.instance.sendToServer( new PacketValueConfig( "PriorityHost.Priority", Out ) );
+			NetworkHandler.instance.sendToServer( new PacketValueConfig( "PriorityHost.Priority", out ) );
 		}
 		catch(NumberFormatException e )
 		{
@@ -195,22 +220,22 @@ public class GuiPriority extends AEBaseGui
 			{
 				try
 				{
-					String Out = this.priority.getText();
+					String out = this.priority.getText();
 
-					boolean Fixed = false;
-					while (Out.startsWith( "0" ) && Out.length() > 1)
+					boolean fixed = false;
+					while (out.startsWith( "0" ) && out.length() > 1)
 					{
-						Out = Out.substring( 1 );
-						Fixed = true;
+						out = out.substring( 1 );
+						fixed = true;
 					}
 
-					if ( Fixed )
-						this.priority.setText( Out );
+					if ( fixed )
+						this.priority.setText( out );
 
-					if ( Out.length() == 0 )
-						Out = "0";
+					if ( out.length() == 0 )
+						out = "0";
 
-					NetworkHandler.instance.sendToServer( new PacketValueConfig( "PriorityHost.Priority", Out ) );
+					NetworkHandler.instance.sendToServer( new PacketValueConfig( "PriorityHost.Priority", out ) );
 				}
 				catch (IOException e)
 				{

--- a/src/main/java/appeng/client/render/BusRenderHelper.java
+++ b/src/main/java/appeng/client/render/BusRenderHelper.java
@@ -30,10 +30,12 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
 import appeng.api.AEApi;
+import appeng.api.exceptions.MissingDefinition;
 import appeng.api.parts.IBoxProvider;
 import appeng.api.parts.IPartCollisionHelper;
 import appeng.api.parts.IPartRenderHelper;
 import appeng.api.parts.ISimplifiedBundle;
+import appeng.api.util.AEItemDefinition;
 import appeng.block.AEBaseBlock;
 import appeng.block.networking.BlockCableBus;
 import appeng.core.AEConfig;
@@ -52,8 +54,8 @@ public class BusRenderHelper implements IPartRenderHelper
 	double maxY = 16;
 	double maxZ = 16;
 
-	final AEBaseBlock blk = (AEBaseBlock) AEApi.instance().blocks().blockMultiPart.block();
-	final BaseBlockRender bbr = new BaseBlockRender();
+	private final AEBaseBlock blk = (AEBaseBlock) ((AEApi.instance().definitions().blocks().multiPart().isPresent() ) ? AEApi.instance().definitions().blocks().multiPart().get().block() : null );
+	private final BaseBlockRender bbr = new BaseBlockRender();
 
 	private ForgeDirection ax = ForgeDirection.EAST;
 	private ForgeDirection ay = ForgeDirection.UP;
@@ -348,35 +350,47 @@ public class BusRenderHelper implements IPartRenderHelper
 		if ( !this.renderThis() )
 			return;
 
-		AEBaseBlock blk = (AEBaseBlock) AEApi.instance().blocks().blockMultiPart.block();
-		BlockRenderInfo info = blk.getRendererInstance();
-		ForgeDirection forward = BusRenderHelper.INSTANCE.az;
-		ForgeDirection up = BusRenderHelper.INSTANCE.ay;
+		for ( AEItemDefinition definition : AEApi.instance().definitions().blocks().multiPart().asSet() )
+		{
+			final AEBaseBlock block = (AEBaseBlock) definition.block();
 
-		renderer.uvRotateBottom = info.getTexture( ForgeDirection.DOWN ).setFlip( BaseBlockRender.getOrientation( ForgeDirection.DOWN, forward, up ) );
-		renderer.uvRotateTop = info.getTexture( ForgeDirection.UP ).setFlip( BaseBlockRender.getOrientation( ForgeDirection.UP, forward, up ) );
+			BlockRenderInfo info = block.getRendererInstance();
+			ForgeDirection forward = BusRenderHelper.INSTANCE.az;
+			ForgeDirection up = BusRenderHelper.INSTANCE.ay;
 
-		renderer.uvRotateEast = info.getTexture( ForgeDirection.EAST ).setFlip( BaseBlockRender.getOrientation( ForgeDirection.EAST, forward, up ) );
-		renderer.uvRotateWest = info.getTexture( ForgeDirection.WEST ).setFlip( BaseBlockRender.getOrientation( ForgeDirection.WEST, forward, up ) );
+			renderer.uvRotateBottom = info.getTexture( ForgeDirection.DOWN ).setFlip( BaseBlockRender.getOrientation( ForgeDirection.DOWN, forward, up ) );
+			renderer.uvRotateTop = info.getTexture( ForgeDirection.UP ).setFlip( BaseBlockRender.getOrientation( ForgeDirection.UP, forward, up ) );
 
-		renderer.uvRotateNorth = info.getTexture( ForgeDirection.NORTH ).setFlip( BaseBlockRender.getOrientation( ForgeDirection.NORTH, forward, up ) );
-		renderer.uvRotateSouth = info.getTexture( ForgeDirection.SOUTH ).setFlip( BaseBlockRender.getOrientation( ForgeDirection.SOUTH, forward, up ) );
+			renderer.uvRotateEast = info.getTexture( ForgeDirection.EAST ).setFlip( BaseBlockRender.getOrientation( ForgeDirection.EAST, forward, up ) );
+			renderer.uvRotateWest = info.getTexture( ForgeDirection.WEST ).setFlip( BaseBlockRender.getOrientation( ForgeDirection.WEST, forward, up ) );
 
-		this.bbr.renderBlockBounds( renderer, this.minX, this.minY, this.minZ, this.maxX, this.maxY, this.maxZ, this.ax, this.ay, this.az );
+			renderer.uvRotateNorth = info.getTexture( ForgeDirection.NORTH ).setFlip( BaseBlockRender.getOrientation( ForgeDirection.NORTH, forward, up ) );
+			renderer.uvRotateSouth = info.getTexture( ForgeDirection.SOUTH ).setFlip( BaseBlockRender.getOrientation( ForgeDirection.SOUTH, forward, up ) );
 
-		renderer.renderStandardBlock( blk, x, y, z );
+			this.bbr.renderBlockBounds( renderer, this.minX, this.minY, this.minZ, this.maxX, this.maxY, this.maxZ, this.ax, this.ay, this.az );
+
+			renderer.renderStandardBlock( block, x, y, z );
+		}
 	}
 
 	@Override
 	public Block getBlock()
 	{
-		return AEApi.instance().blocks().blockMultiPart.block();
+		for ( AEItemDefinition definition : AEApi.instance().definitions().blocks().multiPart().asSet() )
+		{
+			return definition.block();
+		}
+
+		throw new MissingDefinition( "No multi part." );
 	}
 
 	public void setRenderColor(int color)
 	{
-		BlockCableBus blk = (BlockCableBus) AEApi.instance().blocks().blockMultiPart.block();
-		blk.setRenderColor( color );
+		for ( AEItemDefinition definition : AEApi.instance().definitions().blocks().multiPart().asSet() )
+		{
+			final BlockCableBus block = (BlockCableBus) definition.block();
+			block.setRenderColor( color );
+		}
 	}
 
 	public void prepareBounds(RenderBlocks renderer)

--- a/src/main/java/appeng/client/render/blocks/RenderBlockCraftingCPU.java
+++ b/src/main/java/appeng/client/render/blocks/RenderBlockCraftingCPU.java
@@ -29,6 +29,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 
 import appeng.api.AEApi;
 import appeng.api.util.AEColor;
+import appeng.api.util.AEItemDefinition;
 import appeng.block.AEBaseBlock;
 import appeng.block.crafting.BlockCraftingMonitor;
 import appeng.block.crafting.BlockCraftingUnit;
@@ -70,7 +71,12 @@ public class RenderBlockCraftingCPU extends BaseBlockRender
 
 		IIcon nonForward = theIcon;
 		if ( isMonitor )
-			nonForward = AEApi.instance().blocks().blockCraftingUnit.block().getIcon( 0, meta | (formed ? 8 : 0) );
+		{
+			for ( AEItemDefinition definition : AEApi.instance().definitions().blocks().craftingUnit().asSet() )
+			{
+				nonForward = definition.block().getIcon( 0, meta | ( formed ? 8 : 0 ) );
+			}
+		}
 
 		if ( formed && renderer.overrideBlockTexture == null )
 		{

--- a/src/main/java/appeng/client/render/blocks/RenderQNB.java
+++ b/src/main/java/appeng/client/render/blocks/RenderQNB.java
@@ -18,6 +18,7 @@
 
 package appeng.client.render.blocks;
 
+import java.util.Collection;
 import java.util.EnumSet;
 
 import net.minecraft.client.renderer.RenderBlocks;
@@ -30,6 +31,9 @@ import net.minecraftforge.client.IItemRenderer.ItemRenderType;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import appeng.api.AEApi;
+import appeng.api.definitions.IBlocks;
+import appeng.api.definitions.IDefinitions;
+import appeng.api.definitions.IParts;
 import appeng.api.util.AEColor;
 import appeng.api.util.AEColoredItemDefinition;
 import appeng.block.AEBaseBlock;
@@ -40,50 +44,50 @@ import appeng.tile.qnb.TileQuantumBridge;
 public class RenderQNB extends BaseBlockRender
 {
 
-	public void renderCableAt(double Thickness, IBlockAccess world, int x, int y, int z, AEBaseBlock block, RenderBlocks renderer, IIcon texture, double pull,
-			EnumSet<ForgeDirection> connections)
+	public void renderCableAt(double thickness, IBlockAccess world, int x, int y, int z, AEBaseBlock block, RenderBlocks renderer, IIcon texture, double pull,
+			Collection<ForgeDirection> connections)
 	{
 		block.getRendererInstance().setTemporaryRenderIcon( texture );
 
 		if ( connections.contains( ForgeDirection.UNKNOWN ) )
 		{
-			renderer.setRenderBounds( 0.5D - Thickness, 0.5D - Thickness, 0.5D - Thickness, 0.5D + Thickness, 0.5D + Thickness, 0.5D + Thickness );
+			renderer.setRenderBounds( 0.5D - thickness, 0.5D - thickness, 0.5D - thickness, 0.5D + thickness, 0.5D + thickness, 0.5D + thickness );
 			renderer.renderStandardBlock( block, x, y, z );
 		}
 
 		if ( connections.contains( ForgeDirection.WEST ) )
 		{
-			renderer.setRenderBounds( 0.0D, 0.5D - Thickness, 0.5D - Thickness, 0.5D - Thickness - pull, 0.5D + Thickness, 0.5D + Thickness );
+			renderer.setRenderBounds( 0.0D, 0.5D - thickness, 0.5D - thickness, 0.5D - thickness - pull, 0.5D + thickness, 0.5D + thickness );
 			renderer.renderStandardBlock( block, x, y, z );
 		}
 
 		if ( connections.contains( ForgeDirection.EAST ) )
 		{
-			renderer.setRenderBounds( 0.5D + Thickness + pull, 0.5D - Thickness, 0.5D - Thickness, 1.0D, 0.5D + Thickness, 0.5D + Thickness );
+			renderer.setRenderBounds( 0.5D + thickness + pull, 0.5D - thickness, 0.5D - thickness, 1.0D, 0.5D + thickness, 0.5D + thickness );
 			renderer.renderStandardBlock( block, x, y, z );
 		}
 
 		if ( connections.contains( ForgeDirection.NORTH ) )
 		{
-			renderer.setRenderBounds( 0.5D - Thickness, 0.5D - Thickness, 0.0D, 0.5D + Thickness, 0.5D + Thickness, 0.5D - Thickness - pull );
+			renderer.setRenderBounds( 0.5D - thickness, 0.5D - thickness, 0.0D, 0.5D + thickness, 0.5D + thickness, 0.5D - thickness - pull );
 			renderer.renderStandardBlock( block, x, y, z );
 		}
 
 		if ( connections.contains( ForgeDirection.SOUTH ) )
 		{
-			renderer.setRenderBounds( 0.5D - Thickness, 0.5D - Thickness, 0.5D + Thickness + pull, 0.5D + Thickness, 0.5D + Thickness, 1.0D );
+			renderer.setRenderBounds( 0.5D - thickness, 0.5D - thickness, 0.5D + thickness + pull, 0.5D + thickness, 0.5D + thickness, 1.0D );
 			renderer.renderStandardBlock( block, x, y, z );
 		}
 
 		if ( connections.contains( ForgeDirection.DOWN ) )
 		{
-			renderer.setRenderBounds( 0.5D - Thickness, 0.0D, 0.5D - Thickness, 0.5D + Thickness, 0.5D - Thickness - pull, 0.5D + Thickness );
+			renderer.setRenderBounds( 0.5D - thickness, 0.0D, 0.5D - thickness, 0.5D + thickness, 0.5D - thickness - pull, 0.5D + thickness );
 			renderer.renderStandardBlock( block, x, y, z );
 		}
 
 		if ( connections.contains( ForgeDirection.UP ) )
 		{
-			renderer.setRenderBounds( 0.5D - Thickness, 0.5D + Thickness + pull, 0.5D - Thickness, 0.5D + Thickness, 1.0D, 0.5D + Thickness );
+			renderer.setRenderBounds( 0.5D - thickness, 0.5D + thickness + pull, 0.5D - thickness, 0.5D + thickness, 1.0D, 0.5D + thickness );
 			renderer.renderStandardBlock( block, x, y, z );
 		}
 
@@ -109,26 +113,33 @@ public class RenderQNB extends BaseBlockRender
 
 		renderer.renderAllFaces = true;
 
-		if ( tqb.getBlockType() == AEApi.instance().blocks().blockQuantumLink.block() )
+		final IDefinitions definitions = AEApi.instance().definitions();
+		final IBlocks blocks = definitions.blocks();
+		final IParts parts = definitions.parts();
+
+		if ( blocks.quantumLink().isPresent() && tqb.getBlockType() == blocks.quantumLink().get().block() )
 		{
 			if ( tqb.isFormed() )
 			{
-				AEColoredItemDefinition glassCableDefinition = AEApi.instance().parts().partCableGlass;
-				Item transparentGlassCable = glassCableDefinition.item( AEColor.Transparent );
-
-				AEColoredItemDefinition coveredCableDefinition = AEApi.instance().parts().partCableCovered;
-				Item transparentCoveredCable = coveredCableDefinition.item( AEColor.Transparent );
-
 				EnumSet<ForgeDirection> sides = tqb.getConnections();
-				this.renderCableAt( 0.11D, world, x, y, z, block, renderer, transparentGlassCable.getIconIndex( glassCableDefinition.stack( AEColor.Transparent, 1 ) ), 0.141D, sides );
-				this.renderCableAt( 0.188D, world, x, y, z, block, renderer, transparentCoveredCable.getIconIndex( coveredCableDefinition.stack( AEColor.Transparent, 1 ) ), 0.1875D, sides );
+
+				for ( AEColoredItemDefinition definition : parts.cableGlass().asSet() )
+				{
+					Item transGlassCable = definition.item( AEColor.Transparent );
+					this.renderCableAt( 0.11D, world, x, y, z, block, renderer, transGlassCable.getIconIndex( definition.stack( AEColor.Transparent, 1 ) ), 0.141D, sides );
+				}
+
+				for ( AEColoredItemDefinition definition : parts.cableCovered().asSet() )
+				{
+					Item transCoveredCable = definition.item( AEColor.Transparent );
+					this.renderCableAt( 0.188D, world, x, y, z, block, renderer, transCoveredCable.getIconIndex( definition.stack( AEColor.Transparent, 1 ) ), 0.1875D, sides );
+				}
 			}
 
 			float renderMin = 2.0f / 16.0f;
 			float renderMax = 14.0f / 16.0f;
 			renderer.setRenderBounds( renderMin, renderMin, renderMin, renderMax, renderMax, renderMax );
 			renderer.renderStandardBlock( block, x, y, z );
-			// super.renderWorldBlock(world, x, y, z, block, modelId, renderer);
 		}
 		else
 		{
@@ -141,14 +152,12 @@ public class RenderQNB extends BaseBlockRender
 			}
 			else if ( tqb.isCorner() )
 			{
-				// renderCableAt(0.11D, world, x, y, z, block, modelId,
-				// renderer,
-				// AppEngTextureRegistry.Blocks.MECable.get(), true, 0.0D);
-				AEColoredItemDefinition coveredCableDefinition = AEApi.instance().parts().partCableCovered;
-				Item transparentCoveredCable = coveredCableDefinition.item( AEColor.Transparent );
-
-				this.renderCableAt( 0.188D, world, x, y, z, block, renderer, transparentCoveredCable.getIconIndex( coveredCableDefinition.stack( AEColor.Transparent, 1 ) ), 0.05D,
-						tqb.getConnections() );
+				for ( AEColoredItemDefinition definition : parts.cableCovered().asSet() )
+				{
+					Item transCoveredCable = definition.item( AEColor.Transparent );
+					this.renderCableAt( 0.188D, world, x, y, z, block, renderer, transCoveredCable.getIconIndex( definition.stack( AEColor.Transparent, 1 ) ), 0.05D,
+							tqb.getConnections() );
+				}
 
 				float renderMin = 4.0f / 16.0f;
 				float renderMax = 12.0f / 16.0f;

--- a/src/main/java/appeng/client/render/blocks/RenderQuartzGlass.java
+++ b/src/main/java/appeng/client/render/blocks/RenderQuartzGlass.java
@@ -20,6 +20,7 @@ package appeng.client.render.blocks;
 
 import java.util.Random;
 
+import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.IBlockAccess;
@@ -27,6 +28,8 @@ import net.minecraftforge.client.IItemRenderer.ItemRenderType;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import appeng.api.AEApi;
+import appeng.api.definitions.IBlocks;
+import appeng.api.util.AEItemDefinition;
 import appeng.block.AEBaseBlock;
 import appeng.client.render.BaseBlockRender;
 import appeng.client.texture.ExtraBlockTextures;
@@ -56,8 +59,29 @@ public class RenderQuartzGlass extends BaseBlockRender
 
 	boolean isGlass(AEBaseBlock imb, IBlockAccess world, int x, int y, int z)
 	{
-		return world.getBlock( x, y, z ) == AEApi.instance().blocks().blockQuartzGlass.block()
-				|| world.getBlock( x, y, z ) == AEApi.instance().blocks().blockQuartzVibrantGlass.block();
+		final Block block = world.getBlock( x, y, z );
+
+		return this.isQuartzGlass( block ) || this.isVibrantQuartzGlass( block );
+	}
+
+	private boolean isQuartzGlass( Block block )
+	{
+		for ( AEItemDefinition definition : AEApi.instance().definitions().blocks().quartzGlass().asSet() )
+		{
+			return block == definition.block();
+		}
+
+		return false;
+	}
+
+	private boolean isVibrantQuartzGlass( Block block )
+	{
+		for ( AEItemDefinition definition : AEApi.instance().definitions().blocks().quartzVibrantGlass().asSet() )
+		{
+			return block == definition.block();
+		}
+
+		return false;
 	}
 
 	void renderEdge(AEBaseBlock imb, IBlockAccess world, int x, int y, int z, RenderBlocks renderer, ForgeDirection side, ForgeDirection direction)

--- a/src/main/java/appeng/client/render/blocks/RenderQuartzOre.java
+++ b/src/main/java/appeng/client/render/blocks/RenderQuartzOre.java
@@ -48,9 +48,9 @@ public class RenderQuartzOre extends BaseBlockRender
 	public boolean renderInWorld(AEBaseBlock block, IBlockAccess world, int x, int y, int z, RenderBlocks renderer)
 	{
 		OreQuartz blk = (OreQuartz) block;
-		blk.enhanceBrightness = true;
+		blk.setEnhanceBrightness( true );
 		super.renderInWorld( block, world, x, y, z, renderer );
-		blk.enhanceBrightness = false;
+		blk.setEnhanceBrightness( false );
 
 		blk.getRendererInstance().setTemporaryRenderIcon( ExtraBlockTextures.OreQuartzStone.getIcon() );
 		boolean out = super.renderInWorld( block, world, x, y, z, renderer );

--- a/src/main/java/appeng/container/implementations/ContainerInscriber.java
+++ b/src/main/java/appeng/container/implementations/ContainerInscriber.java
@@ -22,7 +22,10 @@ import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 
+import com.google.common.base.Optional;
+
 import appeng.api.AEApi;
+import appeng.api.util.AEItemDefinition;
 import appeng.container.guisync.GuiSync;
 import appeng.container.interfaces.IProgressProvider;
 import appeng.container.slot.SlotOutput;
@@ -140,8 +143,13 @@ public class ContainerInscriber extends ContainerUpgradeable implements IProgres
 				otherSlot = this.top.getStack();
 
 			// name presses
-			if ( AEApi.instance().materials().materialNamePress.sameAsStack( otherSlot ) )
-				return AEApi.instance().materials().materialNamePress.sameAsStack( is );
+			for ( AEItemDefinition definition : AEApi.instance().definitions().materials().namePress().asSet() )
+			{
+				if ( definition.sameAsStack( otherSlot ) )
+				{
+					return definition.sameAsStack( is );
+				}
+			}
 
 			// everything else
 			for (InscriberRecipe i : Inscribe.RECIPES )

--- a/src/main/java/appeng/container/implementations/ContainerPatternTerm.java
+++ b/src/main/java/appeng/container/implementations/ContainerPatternTerm.java
@@ -39,11 +39,13 @@ import net.minecraftforge.common.util.ForgeDirection;
 
 import appeng.api.AEApi;
 import appeng.api.config.Actionable;
+import appeng.api.definitions.IDefinitions;
 import appeng.api.networking.security.MachineSource;
 import appeng.api.storage.IMEMonitor;
 import appeng.api.storage.ITerminalHost;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.api.storage.data.IItemList;
+import appeng.api.util.AEItemDefinition;
 import appeng.container.ContainerNull;
 import appeng.container.guisync.GuiSync;
 import appeng.container.slot.IOptionalSlotHost;
@@ -218,7 +220,11 @@ public class ContainerPatternTerm extends ContainerMEMonitorable implements IAEA
 				this.patternSlotIN.putStack( null );
 
 			// add a new encoded pattern.
-			this.patternSlotOUT.putStack( output = AEApi.instance().items().itemEncodedPattern.stack( 1 ) );
+			for ( AEItemDefinition definition : AEApi.instance().definitions().items().encodedPattern().asSet() )
+			{
+				output = definition.stack( 1 );
+				this.patternSlotOUT.putStack( output );
+			}
 		}
 
 		// encode the slot.
@@ -303,7 +309,20 @@ public class ContainerPatternTerm extends ContainerMEMonitorable implements IAEA
 		if ( output == null )
 			return false;
 
-		return AEApi.instance().items().itemEncodedPattern.sameAsStack( output ) || AEApi.instance().materials().materialBlankPattern.sameAsStack( output );
+		final IDefinitions definitions = AEApi.instance().definitions();
+		boolean isPattern = false;
+
+		for ( AEItemDefinition definition : definitions.items().encodedPattern().asSet() )
+		{
+			isPattern |= definition.sameAsStack( output );
+		}
+
+		for ( AEItemDefinition definition : definitions.materials().blankPattern().asSet() )
+		{
+			isPattern |= definition.sameAsStack( output );
+		}
+
+		return isPattern;
 	}
 
 	@Override

--- a/src/main/java/appeng/container/implementations/ContainerQuartzKnife.java
+++ b/src/main/java/appeng/container/implementations/ContainerQuartzKnife.java
@@ -27,6 +27,7 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.player.PlayerDestroyItemEvent;
 
 import appeng.api.AEApi;
+import appeng.api.util.AEItemDefinition;
 import appeng.container.AEBaseContainer;
 import appeng.container.slot.QuartzKnifeOutput;
 import appeng.container.slot.SlotRestrictedInput;
@@ -120,10 +121,14 @@ public class ContainerQuartzKnife extends AEBaseContainer implements IAEAppEngIn
 		{
 			if ( this.myName.length() > 0 )
 			{
-				ItemStack name = AEApi.instance().materials().materialNamePress.stack( 1 );
-				NBTTagCompound c = Platform.openNbtData( name );
-				c.setString( "InscribeName", this.myName );
-				return name;
+				for ( AEItemDefinition definition : AEApi.instance().definitions().materials().namePress().asSet() )
+				{
+					ItemStack name = definition.stack( 1 );
+					NBTTagCompound c = Platform.openNbtData( name );
+					c.setString( "InscribeName", this.myName );
+
+					return name;
+				}
 			}
 		}
 

--- a/src/main/java/appeng/core/AELog.java
+++ b/src/main/java/appeng/core/AELog.java
@@ -26,10 +26,10 @@ import appeng.core.features.AEFeature;
 import appeng.tile.AEBaseTile;
 import appeng.util.Platform;
 
-public class AELog
+public final class AELog
 {
 
-	public static final FMLRelaunchLog instance = FMLRelaunchLog.log;
+	public static final FMLRelaunchLog INSTANCE = FMLRelaunchLog.log;
 
 	private AELog() {
 	}

--- a/src/main/java/appeng/core/Api.java
+++ b/src/main/java/appeng/core/Api.java
@@ -18,10 +18,12 @@
 
 package appeng.core;
 
+
 import net.minecraftforge.common.util.ForgeDirection;
 
 import appeng.api.IAppEngApi;
 import appeng.api.definitions.Blocks;
+import appeng.api.definitions.IDefinitions;
 import appeng.api.definitions.Items;
 import appeng.api.definitions.Materials;
 import appeng.api.definitions.Parts;
@@ -39,30 +41,50 @@ import appeng.me.GridConnection;
 import appeng.me.GridNode;
 import appeng.util.Platform;
 
-public class Api implements IAppEngApi
-{
 
+public final class Api implements IAppEngApi
+{
 	public static final Api INSTANCE = new Api();
 
-	private Api() {
-
-	}
+	private final ApiPart partHelper;
 
 	// private MovableTileRegistry MovableRegistry = new MovableTileRegistry();
-	private final RegistryContainer rc = new RegistryContainer();
-	private final ApiStorage storageHelper = new ApiStorage();
+	private final IRegistryContainer registryContainer;
+	private final IStorageHelper storageHelper;
+	private final Materials materials;
+	private final Items items;
+	private final Blocks blocks;
+	private final Parts parts;
+	private final ApiDefinitions definitions;
 
-	public final ApiPart partHelper = new ApiPart();
-
-	private final Materials materials = new Materials();
-	private final Items items = new Items();
-	private final Blocks blocks = new Blocks();
-	private final Parts parts = new Parts();
+	private Api()
+	{
+		this.parts = new Parts();
+		this.blocks = new Blocks();
+		this.items = new Items();
+		this.materials = new Materials();
+		this.storageHelper = new ApiStorage();
+		this.registryContainer = new RegistryContainer();
+		this.partHelper = new ApiPart();
+		this.definitions = new ApiDefinitions( this.partHelper );
+	}
 
 	@Override
 	public IRegistryContainer registries()
 	{
-		return this.rc;
+		return this.registryContainer;
+	}
+
+	@Override
+	public IStorageHelper storage()
+	{
+		return this.storageHelper;
+	}
+
+	@Override
+	public IPartHelper partHelper()
+	{
+		return this.partHelper;
 	}
 
 	@Override
@@ -90,19 +112,13 @@ public class Api implements IAppEngApi
 	}
 
 	@Override
-	public IStorageHelper storage()
+	public ApiDefinitions definitions()
 	{
-		return this.storageHelper;
+		return this.definitions;
 	}
 
 	@Override
-	public IPartHelper partHelper()
-	{
-		return this.partHelper;
-	}
-
-	@Override
-	public IGridNode createGridNode(IGridBlock blk)
+	public IGridNode createGridNode( IGridBlock blk )
 	{
 		if ( Platform.isClient() )
 			throw new RuntimeException( "Grid Features are Server Side Only." );
@@ -110,9 +126,13 @@ public class Api implements IAppEngApi
 	}
 
 	@Override
-	public IGridConnection createGridConnection(IGridNode a, IGridNode b) throws FailedConnection
+	public IGridConnection createGridConnection( IGridNode a, IGridNode b ) throws FailedConnection
 	{
 		return new GridConnection( a, b, ForgeDirection.UNKNOWN );
 	}
 
+	public ApiPart getPartHelper()
+	{
+		return this.partHelper;
+	}
 }

--- a/src/main/java/appeng/core/ApiDefinitions.java
+++ b/src/main/java/appeng/core/ApiDefinitions.java
@@ -1,0 +1,90 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.core;
+
+
+import appeng.api.definitions.IBlocks;
+import appeng.api.definitions.IDefinitions;
+import appeng.api.definitions.IItems;
+import appeng.api.definitions.IMaterials;
+import appeng.api.definitions.IParts;
+import appeng.api.parts.IPartHelper;
+import appeng.core.api.definitions.ApiBlocks;
+import appeng.core.api.definitions.ApiItems;
+import appeng.core.api.definitions.ApiMaterials;
+import appeng.core.api.definitions.ApiParts;
+
+
+/**
+ * Internal implementation of the definitions for the API
+ */
+public final class ApiDefinitions implements IDefinitions
+{
+	private final IBlocks blocks;
+	private final IItems items;
+	private final IMaterials materials;
+	private final IParts parts;
+	private final FeatureHandlerRegistry handlers;
+	private final FeatureRegistry features;
+
+	public ApiDefinitions( IPartHelper partHelper )
+	{
+		this.features = new FeatureRegistry();
+		this.handlers = new FeatureHandlerRegistry();
+
+		this.blocks = new ApiBlocks( this.features, this.handlers );
+		this.items = new ApiItems( this.features, this.handlers );
+		this.materials = new ApiMaterials( this.features, this.handlers );
+		this.parts = new ApiParts( this.features, this.handlers, partHelper );
+	}
+
+	public FeatureHandlerRegistry getFeatureHandlerRegistry()
+	{
+		return this.handlers;
+	}
+
+	public FeatureRegistry getFeatureRegistry()
+	{
+		return this.features;
+	}
+
+	@Override
+	public IBlocks blocks()
+	{
+		return this.blocks;
+	}
+
+	@Override
+	public IItems items()
+	{
+		return this.items;
+	}
+
+	@Override
+	public IMaterials materials()
+	{
+		return this.materials;
+	}
+
+	@Override
+	public IParts parts()
+	{
+		return this.parts;
+	}
+}

--- a/src/main/java/appeng/core/AppEng.java
+++ b/src/main/java/appeng/core/AppEng.java
@@ -22,8 +22,6 @@ package appeng.core;
 import java.io.File;
 import java.util.concurrent.TimeUnit;
 
-import com.google.common.base.Stopwatch;
-
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.Mod;
@@ -36,6 +34,8 @@ import cpw.mods.fml.common.event.FMLServerAboutToStartEvent;
 import cpw.mods.fml.common.event.FMLServerStartingEvent;
 import cpw.mods.fml.common.event.FMLServerStoppingEvent;
 import cpw.mods.fml.common.network.NetworkRegistry;
+
+import com.google.common.base.Stopwatch;
 
 import appeng.core.crash.CrashEnhancement;
 import appeng.core.crash.CrashInfo;
@@ -182,7 +182,7 @@ public class AppEng
 	}
 
 	@EventHandler
-	public void serverStarting( FMLServerAboutToStartEvent evt )
+	public void serverAboutToStart( FMLServerAboutToStartEvent evt )
 	{
 		WorldSettings.getInstance().init();
 	}

--- a/src/main/java/appeng/core/CreativeTab.java
+++ b/src/main/java/appeng/core/CreativeTab.java
@@ -24,8 +24,14 @@ import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
+import com.google.common.base.Optional;
+
 import appeng.api.AEApi;
 import appeng.api.IAppEngApi;
+import appeng.api.definitions.IBlocks;
+import appeng.api.definitions.IDefinitions;
+import appeng.api.definitions.IItems;
+import appeng.api.definitions.IMaterials;
 import appeng.api.definitions.Items;
 import appeng.api.definitions.Materials;
 import appeng.api.util.AEItemDefinition;
@@ -55,24 +61,24 @@ public final class CreativeTab extends CreativeTabs
 	@Override
 	public ItemStack getIconItemStack()
 	{
-		final IAppEngApi api = AEApi.instance();
-		final appeng.api.definitions.Blocks blocks = api.blocks();
-		final Items items = api.items();
-		final Materials materials = api.materials();
+		final IDefinitions definitions = AEApi.instance().definitions();
+		final IBlocks blocks = definitions.blocks();
+		final IItems items = definitions.items();
+		final IMaterials materials = definitions.materials();
 
-		return this.findFirst( blocks.blockController, blocks.blockChest, blocks.blockCellWorkbench, blocks.blockFluix, items.itemCell1k, items.itemNetworkTool, materials.materialFluixCrystal, materials.materialCertusQuartzCrystal );
+		return this.findFirst( blocks.controller(), blocks.chest(), blocks.cellWorkbench(), blocks.fluix(), items.cell1k(), items.networkTool(), materials.fluixCrystal(), materials.certusQuartzCrystal() );
 	}
 
-	private ItemStack findFirst( AEItemDefinition... choices )
+	private ItemStack findFirst( Optional<AEItemDefinition>... choices )
 	{
-		for ( AEItemDefinition a : choices )
+		for ( Optional<AEItemDefinition> maybe : choices )
 		{
-			if ( a != null )
+			for ( AEItemDefinition definition : maybe.asSet() )
 			{
-				ItemStack is = a.stack( 1 );
-				if ( is != null )
+				final ItemStack stack = definition.stack( 1 );
+				if ( stack != null )
 				{
-					return is;
+					return stack;
 				}
 			}
 		}

--- a/src/main/java/appeng/core/CreativeTabFacade.java
+++ b/src/main/java/appeng/core/CreativeTabFacade.java
@@ -19,10 +19,12 @@
 package appeng.core;
 
 import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
 import appeng.api.AEApi;
+import appeng.api.util.AEItemDefinition;
 import appeng.items.parts.ItemFacade;
 
 public final class CreativeTabFacade extends CreativeTabs
@@ -43,7 +45,12 @@ public final class CreativeTabFacade extends CreativeTabs
 	@Override
 	public ItemStack getIconItemStack()
 	{
-		return ((ItemFacade) AEApi.instance().items().itemFacade.item()).getCreativeTabIcon();
+		for ( AEItemDefinition definition : AEApi.instance().definitions().items().facade().asSet() )
+		{
+			return ( (ItemFacade) definition.item() ).getCreativeTabIcon();
+		}
+
+		return new ItemStack( Blocks.planks );
 	}
 
 	public static void init()

--- a/src/main/java/appeng/core/FeatureHandlerRegistry.java
+++ b/src/main/java/appeng/core/FeatureHandlerRegistry.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.core;
+
+
+import java.util.HashSet;
+import java.util.Set;
+
+import appeng.core.features.IFeatureHandler;
+
+
+public class FeatureHandlerRegistry
+{
+	private final Set<IFeatureHandler> registry = new HashSet<IFeatureHandler>();
+
+	public void addFeatureHandler( IFeatureHandler feature )
+	{
+		this.registry.add( feature );
+	}
+
+	public Set<IFeatureHandler> getRegisteredFeatureHandlers()
+	{
+		return this.registry;
+	}
+}

--- a/src/main/java/appeng/core/FeatureRegistry.java
+++ b/src/main/java/appeng/core/FeatureRegistry.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.core;
+
+
+import java.util.HashSet;
+import java.util.Set;
+
+import appeng.core.features.IAEFeature;
+
+
+public class FeatureRegistry
+{
+	private final Set<IAEFeature> registry = new HashSet<IAEFeature>();
+
+	public void addFeature( IAEFeature feature )
+	{
+		this.registry.add( feature );
+	}
+
+	public Set<IAEFeature> getRegisteredFeatures()
+	{
+		return this.registry;
+	}
+}

--- a/src/main/java/appeng/core/Registration.java
+++ b/src/main/java/appeng/core/Registration.java
@@ -19,12 +19,6 @@
 package appeng.core;
 
 
-import java.lang.reflect.Field;
-
-import com.google.common.base.Optional;
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimap;
-
 import net.minecraft.item.crafting.CraftingManager;
 import net.minecraft.util.WeightedRandomChestContent;
 import net.minecraft.world.biome.BiomeGenBase;
@@ -41,10 +35,20 @@ import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.common.registry.VillagerRegistry;
 
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+
 import appeng.api.AEApi;
 import appeng.api.IAppEngApi;
 import appeng.api.config.Upgrades;
 import appeng.api.definitions.Blocks;
+import appeng.api.definitions.IBlocks;
+import appeng.api.definitions.IDefinitions;
+import appeng.api.definitions.IItems;
+import appeng.api.definitions.IMaterials;
+import appeng.api.definitions.IParts;
 import appeng.api.definitions.Items;
 import appeng.api.definitions.Materials;
 import appeng.api.definitions.Parts;
@@ -62,116 +66,23 @@ import appeng.api.networking.spatial.ISpatialCache;
 import appeng.api.networking.storage.IStorageGrid;
 import appeng.api.networking.ticking.ITickManager;
 import appeng.api.parts.IPartHelper;
-import appeng.api.util.AEColor;
 import appeng.api.util.AEItemDefinition;
-import appeng.block.crafting.BlockCraftingMonitor;
-import appeng.block.crafting.BlockCraftingStorage;
-import appeng.block.crafting.BlockCraftingUnit;
-import appeng.block.crafting.BlockMolecularAssembler;
-import appeng.block.grindstone.BlockCrank;
-import appeng.block.grindstone.BlockGrinder;
-import appeng.block.misc.BlockCellWorkbench;
-import appeng.block.misc.BlockCharger;
-import appeng.block.misc.BlockCondenser;
-import appeng.block.misc.BlockInscriber;
-import appeng.block.misc.BlockInterface;
-import appeng.block.misc.BlockLightDetector;
-import appeng.block.misc.BlockPaint;
-import appeng.block.misc.BlockQuartzGrowthAccelerator;
-import appeng.block.misc.BlockQuartzTorch;
-import appeng.block.misc.BlockSecurity;
-import appeng.block.misc.BlockSkyCompass;
-import appeng.block.misc.BlockTinyTNT;
-import appeng.block.misc.BlockVibrationChamber;
 import appeng.block.networking.BlockCableBus;
-import appeng.block.networking.BlockController;
-import appeng.block.networking.BlockCreativeEnergyCell;
-import appeng.block.networking.BlockDenseEnergyCell;
-import appeng.block.networking.BlockEnergyAcceptor;
-import appeng.block.networking.BlockEnergyCell;
-import appeng.block.networking.BlockWireless;
-import appeng.block.qnb.BlockQuantumLinkChamber;
-import appeng.block.qnb.BlockQuantumRing;
-import appeng.block.solids.BlockFluix;
-import appeng.block.solids.BlockQuartz;
-import appeng.block.solids.BlockQuartzChiseled;
-import appeng.block.solids.BlockQuartzGlass;
-import appeng.block.solids.BlockQuartzLamp;
-import appeng.block.solids.BlockQuartzPillar;
-import appeng.block.solids.BlockSkyStone;
-import appeng.block.solids.OreQuartz;
-import appeng.block.solids.OreQuartzCharged;
-import appeng.block.spatial.BlockMatrixFrame;
-import appeng.block.spatial.BlockSpatialIOPort;
-import appeng.block.spatial.BlockSpatialPylon;
-import appeng.block.stair.ChiseledQuartzStairBlock;
-import appeng.block.stair.FluixStairBlock;
-import appeng.block.stair.QuartzPillarStairBlock;
-import appeng.block.stair.QuartzStairBlock;
-import appeng.block.stair.SkyStoneBlockStairBlock;
-import appeng.block.stair.SkyStoneBrickStairBlock;
-import appeng.block.stair.SkyStoneSmallBrickStairBlock;
-import appeng.block.stair.SkyStoneStairBlock;
-import appeng.block.storage.BlockChest;
-import appeng.block.storage.BlockDrive;
-import appeng.block.storage.BlockIOPort;
-import appeng.block.storage.BlockSkyChest;
 import appeng.core.features.AEFeature;
-import appeng.core.features.ColoredItemDefinition;
-import appeng.core.features.DamagedItemDefinition;
 import appeng.core.features.IAEFeature;
 import appeng.core.features.IFeatureHandler;
-import appeng.core.features.IStackSrc;
-import appeng.core.features.ItemStackSrc;
-import appeng.core.features.NullItemDefinition;
-import appeng.core.features.WrappedDamageItemDefinition;
 import appeng.core.features.registries.P2PTunnelRegistry;
 import appeng.core.features.registries.entries.BasicCellHandler;
 import appeng.core.features.registries.entries.CreativeCellHandler;
 import appeng.core.localization.GuiText;
 import appeng.core.localization.PlayerMessages;
 import appeng.core.stats.PlayerStatsRegistration;
-import appeng.debug.BlockChunkloader;
-import appeng.debug.BlockCubeGenerator;
-import appeng.debug.BlockItemGen;
-import appeng.debug.BlockPhantomNode;
-import appeng.debug.ToolDebugCard;
-import appeng.debug.ToolEraser;
-import appeng.debug.ToolMeteoritePlacer;
-import appeng.debug.ToolReplicatorCard;
 import appeng.hooks.AETrading;
 import appeng.hooks.MeteoriteWorldGen;
 import appeng.hooks.QuartzWorldGen;
 import appeng.hooks.TickHandler;
 import appeng.integration.IntegrationType;
 import appeng.items.materials.ItemMultiMaterial;
-import appeng.items.materials.MaterialType;
-import appeng.items.misc.ItemCrystalSeed;
-import appeng.items.misc.ItemEncodedPattern;
-import appeng.items.misc.ItemPaintBall;
-import appeng.items.parts.ItemFacade;
-import appeng.items.parts.ItemMultiPart;
-import appeng.items.parts.PartType;
-import appeng.items.storage.ItemBasicStorageCell;
-import appeng.items.storage.ItemCreativeStorageCell;
-import appeng.items.storage.ItemSpatialStorageCell;
-import appeng.items.storage.ItemViewCell;
-import appeng.items.tools.ToolBiometricCard;
-import appeng.items.tools.ToolMemoryCard;
-import appeng.items.tools.ToolNetworkTool;
-import appeng.items.tools.powered.ToolChargedStaff;
-import appeng.items.tools.powered.ToolColorApplicator;
-import appeng.items.tools.powered.ToolEntropyManipulator;
-import appeng.items.tools.powered.ToolMassCannon;
-import appeng.items.tools.powered.ToolPortableCell;
-import appeng.items.tools.powered.ToolWirelessTerminal;
-import appeng.items.tools.quartz.ToolQuartzAxe;
-import appeng.items.tools.quartz.ToolQuartzCuttingKnife;
-import appeng.items.tools.quartz.ToolQuartzHoe;
-import appeng.items.tools.quartz.ToolQuartzPickaxe;
-import appeng.items.tools.quartz.ToolQuartzSpade;
-import appeng.items.tools.quartz.ToolQuartzSword;
-import appeng.items.tools.quartz.ToolQuartzWrench;
 import appeng.me.cache.CraftingGridCache;
 import appeng.me.cache.EnergyGridCache;
 import appeng.me.cache.GridStorageCache;
@@ -207,7 +118,6 @@ import appeng.recipes.ores.OreDictionaryHandler;
 import appeng.spatial.BiomeGenStorage;
 import appeng.spatial.StorageWorldProvider;
 import appeng.tile.AEBaseTile;
-import appeng.util.ClassInstantiation;
 import appeng.util.Platform;
 
 
@@ -216,37 +126,20 @@ public final class Registration
 	final public static Registration INSTANCE = new Registration();
 
 	private final RecipeHandler recipeHandler;
-	private final Multimap<AEFeature, Class<? extends IAEFeature>> featuresToEntities;
 	public BiomeGenBase storageBiome;
 
 	private Registration()
 	{
 		this.recipeHandler = new RecipeHandler();
-		this.featuresToEntities = ArrayListMultimap.create();
 	}
 
 	public void preInitialize( FMLPreInitializationEvent event )
 	{
 		this.registerSpatial( false );
 
-		IRecipeHandlerRegistry recipeRegistry = AEApi.instance().registries().recipes();
-		recipeRegistry.addNewSubItemResolver( new AEItemResolver() );
-
-		recipeRegistry.addNewCraftHandler( "hccrusher", HCCrusher.class );
-		recipeRegistry.addNewCraftHandler( "mekcrusher", MekCrusher.class );
-		recipeRegistry.addNewCraftHandler( "mekechamber", MekEnrichment.class );
-		recipeRegistry.addNewCraftHandler( "grind", Grind.class );
-		recipeRegistry.addNewCraftHandler( "crusher", Crusher.class );
-		recipeRegistry.addNewCraftHandler( "grindfz", GrindFZ.class );
-		recipeRegistry.addNewCraftHandler( "pulverizer", Pulverizer.class );
-		recipeRegistry.addNewCraftHandler( "macerator", Macerator.class );
-
-		recipeRegistry.addNewCraftHandler( "smelt", Smelt.class );
-		recipeRegistry.addNewCraftHandler( "inscribe", Inscribe.class );
-		recipeRegistry.addNewCraftHandler( "press", Press.class );
-
-		recipeRegistry.addNewCraftHandler( "shaped", Shaped.class );
-		recipeRegistry.addNewCraftHandler( "shapeless", Shapeless.class );
+		final Api api = Api.INSTANCE;
+		IRecipeHandlerRegistry recipeRegistry = api.registries().recipes();
+		this.registerCraftHandlers( recipeRegistry );
 
 		RecipeSorter.register( "AE2-Facade", FacadeRecipe.class, Category.SHAPED, "" );
 		RecipeSorter.register( "AE2-Shaped", ShapedRecipe.class, Category.SHAPED, "" );
@@ -254,219 +147,33 @@ public final class Registration
 
 		MinecraftForge.EVENT_BUS.register( OreDictionaryHandler.INSTANCE );
 
-		Items items = Api.INSTANCE.items();
-		Materials materials = Api.INSTANCE.materials();
-		Parts parts = Api.INSTANCE.parts();
-		Blocks blocks = Api.INSTANCE.blocks();
+		final ApiDefinitions definitions = api.definitions();
 
-		AEItemDefinition materialItem = this.addFeature( ItemMultiMaterial.class );
+		final IBlocks apiBlocks = definitions.blocks();
+		final IItems apiItems = definitions.items();
+		final IMaterials apiMaterials = definitions.materials();
+		final IParts apiParts = definitions.parts();
 
-		Class<?> materialClass = materials.getClass();
-		for ( MaterialType mat : MaterialType.values() )
+		final Items items = api.items();
+		final Materials materials = api.materials();
+		final Parts parts = api.parts();
+		final Blocks blocks = api.blocks();
+
+		this.assignMaterials( materials, apiMaterials );
+		this.assignParts( parts, apiParts );
+		this.assignBlocks( blocks, apiBlocks );
+		this.assignItems( items, apiItems );
+
+		// Register all detected handlers and features (items, blocks) in pre-init
+		for ( IFeatureHandler handler : definitions.getFeatureHandlerRegistry().getRegisteredFeatureHandlers() )
 		{
-			try
-			{
-				if ( mat == MaterialType.InvalidType )
-					( ( ItemMultiMaterial ) materialItem.item() ).createMaterial( mat );
-				else
-				{
-					Field f = materialClass.getField( "material" + mat.name() );
-					IStackSrc is = ( ( ItemMultiMaterial ) materialItem.item() ).createMaterial( mat );
-					if ( is != null )
-						f.set( materials, new DamagedItemDefinition( is ) );
-					else
-						f.set( materials, new NullItemDefinition() );
-				}
-			}
-			catch ( Throwable err )
-			{
-				AELog.severe( "Error creating material: " + mat.name() );
-				throw new RuntimeException( err );
-			}
+			handler.register();
 		}
 
-		AEItemDefinition partItem = this.addFeature( ItemMultiPart.class );
-
-		Class<?> partClass = parts.getClass();
-		for ( PartType type : PartType.values() )
+		for ( IAEFeature feature : definitions.getFeatureRegistry().getRegisteredFeatures() )
 		{
-			try
-			{
-				if ( type == PartType.InvalidType )
-					( ( ItemMultiPart ) partItem.item() ).createPart( type, null );
-				else
-				{
-					Field f = partClass.getField( "part" + type.name() );
-					Enum<AEColor>[] variants = type.getVariants();
-					if ( variants == null )
-					{
-						ItemStackSrc is = ( ( ItemMultiPart ) partItem.item() ).createPart( type, null );
-						if ( is != null )
-							f.set( parts, new DamagedItemDefinition( is ) );
-						else
-							f.set( parts, new NullItemDefinition() );
-					}
-					else
-					{
-						if ( variants[0] instanceof AEColor )
-						{
-							ColoredItemDefinition def = new ColoredItemDefinition();
-
-							for ( Enum<AEColor> v : variants )
-							{
-								ItemStackSrc is = ( ( ItemMultiPart ) partItem.item() ).createPart( type, v );
-								if ( is != null )
-									def.add( ( AEColor ) v, is );
-							}
-
-							f.set( parts, def );
-						}
-					}
-				}
-			}
-			catch ( Throwable err )
-			{
-				AELog.severe( "Error creating part: " + type.name() );
-				throw new RuntimeException( err );
-			}
+			feature.postInit();
 		}
-
-		// very important block!
-		blocks.blockMultiPart = this.addFeature( BlockCableBus.class );
-
-		blocks.blockCraftingUnit = this.addFeature( BlockCraftingUnit.class );
-		blocks.blockCraftingAccelerator = new WrappedDamageItemDefinition( blocks.blockCraftingUnit, 1 );
-		blocks.blockCraftingMonitor = this.addFeature( BlockCraftingMonitor.class );
-		blocks.blockCraftingStorage1k = this.addFeature( BlockCraftingStorage.class );
-		blocks.blockCraftingStorage4k = new WrappedDamageItemDefinition( blocks.blockCraftingStorage1k, 1 );
-		blocks.blockCraftingStorage16k = new WrappedDamageItemDefinition( blocks.blockCraftingStorage1k, 2 );
-		blocks.blockCraftingStorage64k = new WrappedDamageItemDefinition( blocks.blockCraftingStorage1k, 3 );
-		blocks.blockMolecularAssembler = this.addFeature( BlockMolecularAssembler.class );
-
-		blocks.blockQuartzOre = this.addFeature( OreQuartz.class );
-		blocks.blockQuartzOreCharged = this.addFeature( OreQuartzCharged.class );
-		blocks.blockMatrixFrame = this.addFeature( BlockMatrixFrame.class );
-		blocks.blockQuartz = this.addFeature( BlockQuartz.class );
-		blocks.blockFluix = this.addFeature( BlockFluix.class );
-		blocks.blockSkyStone = this.addFeature( BlockSkyStone.class );
-		blocks.blockSkyChest = this.addFeature( BlockSkyChest.class );
-		blocks.blockSkyCompass = this.addFeature( BlockSkyCompass.class );
-
-		blocks.blockQuartzGlass = this.addFeature( BlockQuartzGlass.class );
-		blocks.blockQuartzVibrantGlass = this.addFeature( BlockQuartzLamp.class );
-		blocks.blockQuartzPillar = this.addFeature( BlockQuartzPillar.class );
-		blocks.blockQuartzChiseled = this.addFeature( BlockQuartzChiseled.class );
-		blocks.blockQuartzTorch = this.addFeature( BlockQuartzTorch.class );
-		blocks.blockLightDetector = this.addFeature( BlockLightDetector.class );
-		blocks.blockCharger = this.addFeature( BlockCharger.class );
-		blocks.blockQuartzGrowthAccelerator = this.addFeature( BlockQuartzGrowthAccelerator.class );
-
-		blocks.blockGrindStone = this.addFeature( BlockGrinder.class );
-		blocks.blockCrankHandle = this.addFeature( BlockCrank.class );
-		blocks.blockInscriber = this.addFeature( BlockInscriber.class );
-		blocks.blockWireless = this.addFeature( BlockWireless.class );
-		blocks.blockTinyTNT = this.addFeature( BlockTinyTNT.class );
-
-		blocks.blockQuantumRing = this.addFeature( BlockQuantumRing.class );
-		blocks.blockQuantumLink = this.addFeature( BlockQuantumLinkChamber.class );
-
-		blocks.blockSpatialPylon = this.addFeature( BlockSpatialPylon.class );
-		blocks.blockSpatialIOPort = this.addFeature( BlockSpatialIOPort.class );
-
-		blocks.blockController = this.addFeature( BlockController.class );
-		blocks.blockDrive = this.addFeature( BlockDrive.class );
-		blocks.blockChest = this.addFeature( BlockChest.class );
-		blocks.blockInterface = this.addFeature( BlockInterface.class );
-		blocks.blockCellWorkbench = this.addFeature( BlockCellWorkbench.class );
-		blocks.blockIOPort = this.addFeature( BlockIOPort.class );
-		blocks.blockCondenser = this.addFeature( BlockCondenser.class );
-		blocks.blockEnergyAcceptor = this.addFeature( BlockEnergyAcceptor.class );
-		blocks.blockVibrationChamber = this.addFeature( BlockVibrationChamber.class );
-
-		blocks.blockEnergyCell = this.addFeature( BlockEnergyCell.class );
-		blocks.blockEnergyCellDense = this.addFeature( BlockDenseEnergyCell.class );
-		blocks.blockEnergyCellCreative = this.addFeature( BlockCreativeEnergyCell.class );
-
-		blocks.blockSecurity = this.addFeature( BlockSecurity.class );
-		blocks.blockPaint = this.addFeature( BlockPaint.class );
-
-		items.itemCellCreative = this.addFeature( ItemCreativeStorageCell.class );
-		items.itemViewCell = this.addFeature( ItemViewCell.class );
-		items.itemEncodedPattern = this.addFeature( ItemEncodedPattern.class );
-
-		items.itemCell1k = this.addFeature( ItemBasicStorageCell.class, MaterialType.Cell1kPart, 1 );
-		items.itemCell4k = this.addFeature( ItemBasicStorageCell.class, MaterialType.Cell4kPart, 4 );
-		items.itemCell16k = this.addFeature( ItemBasicStorageCell.class, MaterialType.Cell16kPart, 16 );
-		items.itemCell64k = this.addFeature( ItemBasicStorageCell.class, MaterialType.Cell64kPart, 64 );
-
-		items.itemSpatialCell2 = this.addFeature( ItemSpatialStorageCell.class, MaterialType.Cell2SpatialPart, 2 );
-		items.itemSpatialCell16 = this.addFeature( ItemSpatialStorageCell.class, MaterialType.Cell16SpatialPart, 16 );
-		items.itemSpatialCell128 = this.addFeature( ItemSpatialStorageCell.class, MaterialType.Cell128SpatialPart, 128 );
-
-		items.itemCertusQuartzKnife = this.addFeature( ToolQuartzCuttingKnife.class, AEFeature.CertusQuartzTools );
-		items.itemCertusQuartzWrench = this.addFeature( ToolQuartzWrench.class, AEFeature.CertusQuartzTools );
-		items.itemCertusQuartzAxe = this.addFeature( ToolQuartzAxe.class, AEFeature.CertusQuartzTools );
-		items.itemCertusQuartzHoe = this.addFeature( ToolQuartzHoe.class, AEFeature.CertusQuartzTools );
-		items.itemCertusQuartzPick = this.addFeature( ToolQuartzPickaxe.class, AEFeature.CertusQuartzTools );
-		items.itemCertusQuartzShovel = this.addFeature( ToolQuartzSpade.class, AEFeature.CertusQuartzTools );
-		items.itemCertusQuartzSword = this.addFeature( ToolQuartzSword.class, AEFeature.CertusQuartzTools );
-
-		items.itemNetherQuartzKnife = this.addFeature( ToolQuartzCuttingKnife.class, AEFeature.NetherQuartzTools );
-		items.itemNetherQuartzWrench = this.addFeature( ToolQuartzWrench.class, AEFeature.NetherQuartzTools );
-		items.itemNetherQuartzAxe = this.addFeature( ToolQuartzAxe.class, AEFeature.NetherQuartzTools );
-		items.itemNetherQuartzHoe = this.addFeature( ToolQuartzHoe.class, AEFeature.NetherQuartzTools );
-		items.itemNetherQuartzPick = this.addFeature( ToolQuartzPickaxe.class, AEFeature.NetherQuartzTools );
-		items.itemNetherQuartzShovel = this.addFeature( ToolQuartzSpade.class, AEFeature.NetherQuartzTools );
-		items.itemNetherQuartzSword = this.addFeature( ToolQuartzSword.class, AEFeature.NetherQuartzTools );
-
-		items.itemMassCannon = this.addFeature( ToolMassCannon.class );
-		items.itemMemoryCard = this.addFeature( ToolMemoryCard.class );
-		items.itemChargedStaff = this.addFeature( ToolChargedStaff.class );
-		items.itemEntropyManipulator = this.addFeature( ToolEntropyManipulator.class );
-		items.itemColorApplicator = this.addFeature( ToolColorApplicator.class );
-
-		items.itemWirelessTerminal = this.addFeature( ToolWirelessTerminal.class );
-		items.itemNetworkTool = this.addFeature( ToolNetworkTool.class );
-		items.itemPortableCell = this.addFeature( ToolPortableCell.class );
-		items.itemBiometricCard = this.addFeature( ToolBiometricCard.class );
-
-		items.itemFacade = this.addFeature( ItemFacade.class );
-		items.itemCrystalSeed = this.addFeature( ItemCrystalSeed.class );
-
-		ColoredItemDefinition paintBall;
-		ColoredItemDefinition lumenPaintBall;
-		items.itemPaintBall = paintBall = new ColoredItemDefinition();
-		items.itemLumenPaintBall = lumenPaintBall = new ColoredItemDefinition();
-		AEItemDefinition pb = this.addFeature( ItemPaintBall.class );
-
-		for ( AEColor c : AEColor.values() )
-		{
-			if ( c != AEColor.Transparent )
-			{
-				paintBall.add( c, new ItemStackSrc( pb.item(), c.ordinal() ) );
-				lumenPaintBall.add( c, new ItemStackSrc( pb.item(), 20 + c.ordinal() ) );
-			}
-		}
-
-		// stairs
-		this.addFeature( SkyStoneStairBlock.class, blocks.blockSkyStone.block(), 0 );
-		this.addFeature( SkyStoneBlockStairBlock.class, blocks.blockSkyStone.block(), 1 );
-		this.addFeature( SkyStoneBrickStairBlock.class, blocks.blockSkyStone.block(), 2 );
-		this.addFeature( SkyStoneSmallBrickStairBlock.class, blocks.blockSkyStone.block(), 3 );
-		this.addFeature( FluixStairBlock.class, blocks.blockFluix.block() );
-		this.addFeature( QuartzStairBlock.class, blocks.blockQuartz.block() );
-		this.addFeature( ChiseledQuartzStairBlock.class, blocks.blockQuartzChiseled.block() );
-		this.addFeature( QuartzPillarStairBlock.class, blocks.blockQuartzPillar.block() );
-
-		// unsupported developer tools
-		this.addFeature( ToolEraser.class );
-		this.addFeature( ToolMeteoritePlacer.class );
-		this.addFeature( ToolDebugCard.class );
-		this.addFeature( ToolReplicatorCard.class );
-		this.addFeature( BlockItemGen.class );
-		this.addFeature( BlockChunkloader.class );
-		this.addFeature( BlockPhantomNode.class );
-		this.addFeature( BlockCubeGenerator.class );
 	}
 
 	private void registerSpatial( boolean force )
@@ -508,40 +215,286 @@ public final class Registration
 		}
 	}
 
-	private AEItemDefinition addFeature( Class<? extends IAEFeature> featureClass, Object... args )
+	private void registerCraftHandlers( IRecipeHandlerRegistry registry )
 	{
-		final ClassInstantiation<IAEFeature> instantiation = new ClassInstantiation<IAEFeature>( featureClass, args );
-		final Optional<IAEFeature> instance = instantiation.get();
+		registry.addNewSubItemResolver( new AEItemResolver() );
 
-		if ( instance.isPresent() )
-		{
-			final IAEFeature feature = instance.get();
-			final IFeatureHandler handler = feature.handler();
-			if ( handler.isFeatureAvailable() )
-			{
-				for ( AEFeature f : handler.getFeatures() )
-				{
-					this.featuresToEntities.put( f, featureClass );
-				}
+		registry.addNewCraftHandler( "hccrusher", HCCrusher.class );
+		registry.addNewCraftHandler( "mekcrusher", MekCrusher.class );
+		registry.addNewCraftHandler( "mekechamber", MekEnrichment.class );
+		registry.addNewCraftHandler( "grind", Grind.class );
+		registry.addNewCraftHandler( "crusher", Crusher.class );
+		registry.addNewCraftHandler( "grindfz", GrindFZ.class );
+		registry.addNewCraftHandler( "pulverizer", Pulverizer.class );
+		registry.addNewCraftHandler( "macerator", Macerator.class );
 
-				handler.register();
-				feature.postInit();
+		registry.addNewCraftHandler( "smelt", Smelt.class );
+		registry.addNewCraftHandler( "inscribe", Inscribe.class );
+		registry.addNewCraftHandler( "press", Press.class );
 
-				return handler.getDefinition();
-			}
-			else
-			{
-				return null;
-			}
-		}
-		else
-		{
-			throw new RuntimeException( "Error upon Class Instantiation with Feature: " + featureClass.getName() );
-		}
+		registry.addNewCraftHandler( "shaped", Shaped.class );
+		registry.addNewCraftHandler( "shapeless", Shapeless.class );
+	}
+
+	/**
+	 * Assigns materials from the new API to the old API
+	 *
+	 * @param target old API
+	 * @param source new API
+	 *
+	 * @deprecated to be removed when the public definition API is removed
+	 */
+	@Deprecated
+	private void assignMaterials( Materials target, IMaterials source )
+	{
+		target.materialCell2SpatialPart = source.cell2SpatialPart().orNull();
+		target.materialCell16SpatialPart = source.cell16SpatialPart().orNull();
+		target.materialCell128SpatialPart = source.cell128SpatialPart().orNull();
+
+		target.materialSilicon = source.silicon().orNull();
+		target.materialSkyDust = source.skyDust().orNull();
+
+		target.materialCalcProcessorPress = source.calcProcessorPress().orNull();
+		target.materialEngProcessorPress = source.engProcessorPress().orNull();
+		target.materialLogicProcessorPress = source.logicProcessorPress().orNull();
+
+		target.materialCalcProcessorPrint = source.calcProcessorPrint().orNull();
+		target.materialEngProcessorPrint = source.engProcessorPrint().orNull();
+		target.materialLogicProcessorPrint = source.logicProcessorPrint().orNull();
+
+		target.materialSiliconPress = source.siliconPress().orNull();
+		target.materialSiliconPrint = source.siliconPrint().orNull();
+
+		target.materialNamePress = source.namePress().orNull();
+
+		target.materialLogicProcessor = source.logicProcessor().orNull();
+		target.materialCalcProcessor = source.calcProcessor().orNull();
+		target.materialEngProcessor = source.engProcessor().orNull();
+
+		target.materialBasicCard = source.basicCard().orNull();
+		target.materialAdvCard = source.advCard().orNull();
+
+		target.materialPurifiedCertusQuartzCrystal = source.purifiedCertusQuartzCrystal().orNull();
+		target.materialPurifiedNetherQuartzCrystal = source.purifiedNetherQuartzCrystal().orNull();
+		target.materialPurifiedFluixCrystal = source.purifiedFluixCrystal().orNull();
+
+		target.materialCell1kPart = source.cell1kPart().orNull();
+		target.materialCell4kPart = source.cell4kPart().orNull();
+		target.materialCell16kPart = source.cell16kPart().orNull();
+		target.materialCell64kPart = source.cell64kPart().orNull();
+		target.materialEmptyStorageCell = source.emptyStorageCell().orNull();
+
+		target.materialCardRedstone = source.cardRedstone().orNull();
+		target.materialCardSpeed = source.cardSpeed().orNull();
+		target.materialCardCapacity = source.cardCapacity().orNull();
+		target.materialCardFuzzy = source.cardFuzzy().orNull();
+		target.materialCardInverter = source.cardInverter().orNull();
+		target.materialCardCrafting = source.cardCrafting().orNull();
+
+		target.materialEnderDust = source.enderDust().orNull();
+		target.materialFlour = source.flour().orNull();
+		target.materialGoldDust = source.goldDust().orNull();
+		target.materialIronDust = source.ironDust().orNull();
+		target.materialFluixDust = source.fluixDust().orNull();
+		target.materialCertusQuartzDust = source.certusQuartzDust().orNull();
+		target.materialNetherQuartzDust = source.netherQuartzDust().orNull();
+
+		target.materialMatterBall = source.matterBall().orNull();
+		target.materialIronNugget = source.ironNugget().orNull();
+
+		target.materialCertusQuartzCrystal = source.certusQuartzCrystal().orNull();
+		target.materialCertusQuartzCrystalCharged = source.certusQuartzCrystalCharged().orNull();
+		target.materialFluixCrystal = source.fluixCrystal().orNull();
+		target.materialFluixPearl = source.fluixPearl().orNull();
+
+		target.materialWoodenGear = source.woodenGear().orNull();
+
+		target.materialWireless = source.wireless().orNull();
+		target.materialWirelessBooster = source.wirelessBooster().orNull();
+
+		target.materialAnnihilationCore = source.annihilationCore().orNull();
+		target.materialFormationCore = source.formationCore().orNull();
+
+		target.materialSingularity = source.singularity().orNull();
+		target.materialQESingularity = source.qESingularity().orNull();
+		target.materialBlankPattern = source.blankPattern().orNull();
+	}
+
+	/**
+	 * Assigns parts from the new API to the old API
+	 *
+	 * @param target old API
+	 * @param source new API
+	 *
+	 * @deprecated to be removed when the public definition API is removed
+	 */
+	@Deprecated
+	private void assignParts( Parts target, IParts source )
+	{
+		target.partCableSmart = source.cableSmart().orNull();
+		target.partCableCovered = source.cableCovered().orNull();
+		target.partCableGlass = source.cableGlass().orNull();
+		target.partCableDense = source.cableDense().orNull();
+		target.partLumenCableSmart = source.lumenCableSmart().orNull();
+		target.partLumenCableCovered = source.lumenCableCovered().orNull();
+		target.partLumenCableGlass = source.lumenCableGlass().orNull();
+		target.partLumenCableDense = source.lumenCableDense().orNull();
+		target.partQuartzFiber = source.quartzFiber().orNull();
+		target.partToggleBus = source.toggleBus().orNull();
+		target.partInvertedToggleBus = source.invertedToggleBus().orNull();
+		target.partStorageBus = source.storageBus().orNull();
+		target.partImportBus = source.importBus().orNull();
+		target.partExportBus = source.exportBus().orNull();
+		target.partInterface = source.iface().orNull();
+		target.partLevelEmitter = source.levelEmitter().orNull();
+		target.partAnnihilationPlane = source.annihilationPlane().orNull();
+		target.partFormationPlane = source.formationPlane().orNull();
+		target.partP2PTunnelME = target.partP2PTunnelRedstone = target.partP2PTunnelItems = target.partP2PTunnelLiquids = target.partP2PTunnelMJ = target.partP2PTunnelEU = target.partP2PTunnelRF = target.partP2PTunnelLight = target.partCableAnchor = source.cableAnchor().orNull();
+		target.partMonitor = source.monitor().orNull();
+		target.partSemiDarkMonitor = source.semiDarkMonitor().orNull();
+		target.partDarkMonitor = source.darkMonitor().orNull();
+		target.partInterfaceTerminal = source.interfaceTerminal().orNull();
+		target.partPatternTerminal = source.patternTerminal().orNull();
+		target.partCraftingTerminal = source.craftingTerminal().orNull();
+		target.partTerminal = source.terminal().orNull();
+		target.partStorageMonitor = source.storageMonitor().orNull();
+		target.partConversionMonitor = source.conversionMonitor().orNull();
+	}
+
+	/**
+	 * Assigns blocks from the new API to the old API
+	 *
+	 * @param target old API
+	 * @param source new API
+	 *
+	 * @deprecated to be removed when the public definition API is removed
+	 */
+	@Deprecated
+	private void assignBlocks( Blocks target, IBlocks source )
+	{
+		target.blockMultiPart = source.multiPart().orNull();
+
+		target.blockCraftingUnit = source.craftingUnit().orNull();
+		target.blockCraftingAccelerator = source.craftingAccelerator().orNull();
+		target.blockCraftingMonitor = source.craftingMonitor().orNull();
+		target.blockCraftingStorage1k = source.craftingStorage1k().orNull();
+		target.blockCraftingStorage4k = source.craftingStorage4k().orNull();
+		target.blockCraftingStorage16k = source.craftingStorage16k().orNull();
+		target.blockCraftingStorage64k = source.craftingStorage64k().orNull();
+		target.blockMolecularAssembler = source.molecularAssembler().orNull();
+
+		target.blockQuartzOre = source.quartzOre().orNull();
+		target.blockQuartzOreCharged = source.quartzOreCharged().orNull();
+		target.blockMatrixFrame = source.matrixFrame().orNull();
+		target.blockQuartz = source.quartz().orNull();
+		target.blockFluix = source.fluix().orNull();
+		target.blockSkyStone = source.skyStone().orNull();
+		target.blockSkyChest = source.skyChest().orNull();
+		target.blockSkyCompass = source.skyCompass().orNull();
+
+		target.blockQuartzGlass = source.quartzGlass().orNull();
+		target.blockQuartzVibrantGlass = source.quartzVibrantGlass().orNull();
+		target.blockQuartzPillar = source.quartzPillar().orNull();
+		target.blockQuartzChiseled = source.quartzChiseled().orNull();
+		target.blockQuartzTorch = source.quartzTorch().orNull();
+		target.blockLightDetector = source.lightDetector().orNull();
+		target.blockCharger = source.charger().orNull();
+		target.blockQuartzGrowthAccelerator = source.quartzGrowthAccelerator().orNull();
+
+		target.blockGrindStone = source.grindStone().orNull();
+		target.blockCrankHandle = source.crankHandle().orNull();
+		target.blockInscriber = source.inscriber().orNull();
+		target.blockWireless = source.wireless().orNull();
+		target.blockTinyTNT = source.tinyTNT().orNull();
+
+		target.blockQuantumRing = source.quantumRing().orNull();
+		target.blockQuantumLink = source.quantumLink().orNull();
+
+		target.blockSpatialPylon = source.spatialPylon().orNull();
+		target.blockSpatialIOPort = source.spatialIOPort().orNull();
+
+		target.blockController = source.controller().orNull();
+		target.blockDrive = source.drive().orNull();
+		target.blockChest = source.chest().orNull();
+		target.blockInterface = source.iface().orNull();
+		target.blockCellWorkbench = source.cellWorkbench().orNull();
+		target.blockIOPort = source.iOPort().orNull();
+		target.blockCondenser = source.condenser().orNull();
+		target.blockEnergyAcceptor = source.energyAcceptor().orNull();
+		target.blockVibrationChamber = source.vibrationChamber().orNull();
+
+		target.blockEnergyCell = source.energyCell().orNull();
+		target.blockEnergyCellDense = source.energyCellDense().orNull();
+		target.blockEnergyCellCreative = source.energyCellCreative().orNull();
+
+		target.blockSecurity = source.security().orNull();
+		target.blockPaint = source.paint().orNull();
+	}
+
+	/**
+	 * Assigns materials from the new API to the old API
+	 *
+	 * @param target old API
+	 * @param source new API
+	 *
+	 * @deprecated to be removed when the public definition API is removed
+	 */
+	@Deprecated
+	private void assignItems( Items target, IItems source )
+	{
+		target.itemCellCreative = source.cellCreative().orNull();
+		target.itemViewCell = source.viewCell().orNull();
+		target.itemEncodedPattern = source.encodedPattern().orNull();
+
+		target.itemCell1k = source.cell1k().orNull();
+		target.itemCell4k = source.cell4k().orNull();
+		target.itemCell16k = source.cell16k().orNull();
+		target.itemCell64k = source.cell64k().orNull();
+
+		target.itemSpatialCell2 = source.spatialCell2().orNull();
+		target.itemSpatialCell16 = source.spatialCell16().orNull();
+		target.itemSpatialCell128 = source.spatialCell128().orNull();
+
+		target.itemCertusQuartzKnife = source.certusQuartzKnife().orNull();
+		target.itemCertusQuartzWrench = source.certusQuartzWrench().orNull();
+		target.itemCertusQuartzAxe = source.certusQuartzAxe().orNull();
+		target.itemCertusQuartzHoe = source.certusQuartzHoe().orNull();
+		target.itemCertusQuartzPick = source.certusQuartzPick().orNull();
+		target.itemCertusQuartzShovel = source.certusQuartzShovel().orNull();
+		target.itemCertusQuartzSword = source.certusQuartzSword().orNull();
+
+		target.itemNetherQuartzKnife = source.netherQuartzKnife().orNull();
+		target.itemNetherQuartzWrench = source.netherQuartzWrench().orNull();
+		target.itemNetherQuartzAxe = source.netherQuartzAxe().orNull();
+		target.itemNetherQuartzHoe = source.netherQuartzHoe().orNull();
+		target.itemNetherQuartzPick = source.netherQuartzPick().orNull();
+		target.itemNetherQuartzShovel = source.netherQuartzShovel().orNull();
+		target.itemNetherQuartzSword = source.netherQuartzSword().orNull();
+
+		target.itemMassCannon = source.massCannon().orNull();
+		target.itemMemoryCard = source.memoryCard().orNull();
+		target.itemChargedStaff = source.chargedStaff().orNull();
+		target.itemEntropyManipulator = source.entropyManipulator().orNull();
+		target.itemColorApplicator = source.colorApplicator().orNull();
+
+		target.itemWirelessTerminal = source.wirelessTerminal().orNull();
+		target.itemNetworkTool = source.networkTool().orNull();
+		target.itemPortableCell = source.portableCell().orNull();
+		target.itemBiometricCard = source.biometricCard().orNull();
+
+		target.itemFacade = source.facade().orNull();
+		target.itemCrystalSeed = source.crystalSeed().orNull();
+
+		target.itemPaintBall = source.coloredPaintBall().orNull();
+		target.itemLumenPaintBall = source.coloredLumenPaintBall().orNull();
 	}
 
 	public void initialize( FMLInitializationEvent event )
 	{
+		final IAppEngApi api = AEApi.instance();
+		final IPartHelper partHelper = api.partHelper();
+		final IRegistryContainer registries = api.registries();
+
 		// Perform ore camouflage!
 		ItemMultiMaterial.instance.makeUnique();
 
@@ -550,28 +503,27 @@ public final class Registration
 		else
 			this.recipeHandler.parseRecipes( new JarLoader( "/assets/appliedenergistics2/recipes/" ), "index.recipe" );
 
-		IPartHelper ph = AEApi.instance().partHelper();
-		ph.registerNewLayer( "appeng.parts.layers.LayerISidedInventory", "net.minecraft.inventory.ISidedInventory" );
-		ph.registerNewLayer( "appeng.parts.layers.LayerIFluidHandler", "net.minecraftforge.fluids.IFluidHandler" );
-		ph.registerNewLayer( "appeng.parts.layers.LayerITileStorageMonitorable", "appeng.api.implementations.tiles.ITileStorageMonitorable" );
+		partHelper.registerNewLayer( "appeng.parts.layers.LayerISidedInventory", "net.minecraft.inventory.ISidedInventory" );
+		partHelper.registerNewLayer( "appeng.parts.layers.LayerIFluidHandler", "net.minecraftforge.fluids.IFluidHandler" );
+		partHelper.registerNewLayer( "appeng.parts.layers.LayerITileStorageMonitorable", "appeng.api.implementations.tiles.ITileStorageMonitorable" );
 
 		if ( AppEng.instance.isIntegrationEnabled( IntegrationType.IC2 ) )
 		{
-			ph.registerNewLayer( "appeng.parts.layers.LayerIEnergySink", "ic2.api.energy.tile.IEnergySink" );
-			ph.registerNewLayer( "appeng.parts.layers.LayerIEnergySource", "ic2.api.energy.tile.IEnergySource" );
+			partHelper.registerNewLayer( "appeng.parts.layers.LayerIEnergySink", "ic2.api.energy.tile.IEnergySink" );
+			partHelper.registerNewLayer( "appeng.parts.layers.LayerIEnergySource", "ic2.api.energy.tile.IEnergySource" );
 		}
 
 		if ( AppEng.instance.isIntegrationEnabled( IntegrationType.MJ5 ) )
 		{
-			ph.registerNewLayer( "appeng.parts.layers.LayerIPowerEmitter", "buildcraft.api.power.IPowerEmitter" );
-			ph.registerNewLayer( "appeng.parts.layers.LayerIPowerReceptor", "buildcraft.api.power.IPowerReceptor" );
+			partHelper.registerNewLayer( "appeng.parts.layers.LayerIPowerEmitter", "buildcraft.api.power.IPowerEmitter" );
+			partHelper.registerNewLayer( "appeng.parts.layers.LayerIPowerReceptor", "buildcraft.api.power.IPowerReceptor" );
 		}
 
 		if ( AppEng.instance.isIntegrationEnabled( IntegrationType.MJ6 ) )
-			ph.registerNewLayer( "appeng.parts.layers.LayerIBatteryProvider", "buildcraft.api.mj.IBatteryProvider" );
+			partHelper.registerNewLayer( "appeng.parts.layers.LayerIBatteryProvider", "buildcraft.api.mj.IBatteryProvider" );
 
 		if ( AppEng.instance.isIntegrationEnabled( IntegrationType.RF ) )
-			ph.registerNewLayer( "appeng.parts.layers.LayerIEnergyHandler", "cofh.api.energy.IEnergyReceiver" );
+			partHelper.registerNewLayer( "appeng.parts.layers.LayerIEnergyHandler", "cofh.api.energy.IEnergyReceiver" );
 
 		FMLCommonHandler.instance().bus().register( TickHandler.INSTANCE );
 		MinecraftForge.EVENT_BUS.register( TickHandler.INSTANCE );
@@ -580,7 +532,7 @@ public final class Registration
 		MinecraftForge.EVENT_BUS.register( pp );
 		FMLCommonHandler.instance().bus().register( pp );
 
-		IGridCacheRegistry gcr = AEApi.instance().registries().gridCache();
+		IGridCacheRegistry gcr = registries.gridCache();
 		gcr.registerGridCache( ITickManager.class, TickManagerCache.class );
 		gcr.registerGridCache( IEnergyGrid.class, EnergyGridCache.class );
 		gcr.registerGridCache( IPathingGrid.class, PathGridCache.class );
@@ -590,12 +542,15 @@ public final class Registration
 		gcr.registerGridCache( ISecurityGrid.class, SecurityCache.class );
 		gcr.registerGridCache( ICraftingGrid.class, CraftingGridCache.class );
 
-		AEApi.instance().registries().externalStorage().addExternalStorageInterface( new AEExternalHandler() );
+		registries.externalStorage().addExternalStorageInterface( new AEExternalHandler() );
 
-		AEApi.instance().registries().cell().addCellHandler( new BasicCellHandler() );
-		AEApi.instance().registries().cell().addCellHandler( new CreativeCellHandler() );
+		registries.cell().addCellHandler( new BasicCellHandler() );
+		registries.cell().addCellHandler( new CreativeCellHandler() );
 
-		AEApi.instance().registries().matterCannon().registerAmmo( AEApi.instance().materials().materialMatterBall.stack( 1 ), 32.0 );
+		for ( AEItemDefinition definition : api.definitions().materials().matterBall().asSet() )
+		{
+			registries.matterCannon().registerAmmo( definition.stack( 1 ), 32.0 );
+		}
 
 		this.recipeHandler.injectRecipes();
 
@@ -616,95 +571,161 @@ public final class Registration
 
 		final IAppEngApi api = AEApi.instance();
 		final IRegistryContainer registries = api.registries();
-		final Parts parts = api.parts();
-		final Blocks blocks = api.blocks();
-		final Items items = api.items();
+		final IDefinitions definitions = api.definitions();
+		final IParts parts = definitions.parts();
+		final IBlocks blocks = definitions.blocks();
+		final IItems items = definitions.items();
 
 		// default settings..
-		( ( P2PTunnelRegistry ) registries.p2pTunnel() ).configure();
+		( (P2PTunnelRegistry) registries.p2pTunnel() ).configure();
 
 		// add to localization..
 		PlayerMessages.values();
 		GuiText.values();
 
-		Api.INSTANCE.partHelper.initFMPSupport();
-		( ( BlockCableBus ) blocks.blockMultiPart.block() ).setupTile();
+		Api.INSTANCE.getPartHelper().initFMPSupport();
+		for ( AEItemDefinition definition : blocks.multiPart().asSet() )
+		{
+			( (BlockCableBus) definition.block() ).setupTile();
+		}
 
 		// Interface
-		Upgrades.CRAFTING.registerItem( parts.partInterface, 1 );
-		Upgrades.CRAFTING.registerItem( blocks.blockInterface, 1 );
+		for ( AEItemDefinition definition : parts.iface().asSet() )
+		{
+			Upgrades.CRAFTING.registerItem( definition, 1 );
+		}
+
+		for ( AEItemDefinition definition : blocks.iface().asSet() )
+		{
+			Upgrades.CRAFTING.registerItem( definition, 1 );
+		}
 
 		// IO Port!
-		Upgrades.SPEED.registerItem( blocks.blockIOPort, 3 );
-		Upgrades.REDSTONE.registerItem( blocks.blockIOPort, 1 );
+		for ( AEItemDefinition definition : blocks.iOPort().asSet() )
+		{
+			Upgrades.SPEED.registerItem( definition, 3 );
+			Upgrades.REDSTONE.registerItem( definition, 1 );
+		}
 
 		// Level Emitter!
-		Upgrades.FUZZY.registerItem( parts.partLevelEmitter, 1 );
-		Upgrades.CRAFTING.registerItem( parts.partLevelEmitter, 1 );
+		for ( AEItemDefinition definition : parts.levelEmitter().asSet() )
+		{
+			Upgrades.FUZZY.registerItem( definition, 1 );
+			Upgrades.CRAFTING.registerItem( definition, 1 );
+		}
 
 		// Import Bus
-		Upgrades.FUZZY.registerItem( parts.partImportBus, 1 );
-		Upgrades.REDSTONE.registerItem( parts.partImportBus, 1 );
-		Upgrades.CAPACITY.registerItem( parts.partImportBus, 2 );
-		Upgrades.SPEED.registerItem( parts.partImportBus, 4 );
+		for ( AEItemDefinition definition : parts.importBus().asSet() )
+		{
+			Upgrades.FUZZY.registerItem( definition, 1 );
+			Upgrades.REDSTONE.registerItem( definition, 1 );
+			Upgrades.CAPACITY.registerItem( definition, 2 );
+			Upgrades.SPEED.registerItem( definition, 4 );
+		}
 
 		// Export Bus
-		Upgrades.FUZZY.registerItem( parts.partExportBus, 1 );
-		Upgrades.REDSTONE.registerItem( parts.partExportBus, 1 );
-		Upgrades.CAPACITY.registerItem( parts.partExportBus, 2 );
-		Upgrades.SPEED.registerItem( parts.partExportBus, 4 );
-		Upgrades.CRAFTING.registerItem( parts.partExportBus, 1 );
+		for ( AEItemDefinition definition : parts.exportBus().asSet() )
+		{
+			Upgrades.FUZZY.registerItem( definition, 1 );
+			Upgrades.REDSTONE.registerItem( definition, 1 );
+			Upgrades.CAPACITY.registerItem( definition, 2 );
+			Upgrades.SPEED.registerItem( definition, 4 );
+			Upgrades.CRAFTING.registerItem( definition, 1 );
+		}
 
 		// Storage Cells
-		Upgrades.FUZZY.registerItem( items.itemCell1k, 1 );
-		Upgrades.INVERTER.registerItem( items.itemCell1k, 1 );
+		for ( AEItemDefinition definition : items.cell1k().asSet() )
+		{
+			Upgrades.FUZZY.registerItem( definition, 1 );
+			Upgrades.INVERTER.registerItem( definition, 1 );
+		}
 
-		Upgrades.FUZZY.registerItem( items.itemCell4k, 1 );
-		Upgrades.INVERTER.registerItem( items.itemCell4k, 1 );
+		for ( AEItemDefinition definition : items.cell4k().asSet() )
+		{
+			Upgrades.FUZZY.registerItem( definition, 1 );
+			Upgrades.INVERTER.registerItem( definition, 1 );
+		}
 
-		Upgrades.FUZZY.registerItem( items.itemCell16k, 1 );
-		Upgrades.INVERTER.registerItem( items.itemCell16k, 1 );
+		for ( AEItemDefinition definition : items.cell16k().asSet() )
+		{
+			Upgrades.FUZZY.registerItem( definition, 1 );
+			Upgrades.INVERTER.registerItem( definition, 1 );
+		}
 
-		Upgrades.FUZZY.registerItem( items.itemCell64k, 1 );
-		Upgrades.INVERTER.registerItem( items.itemCell64k, 1 );
+		for ( AEItemDefinition definition : items.cell64k().asSet() )
+		{
+			Upgrades.FUZZY.registerItem( definition, 1 );
+			Upgrades.INVERTER.registerItem( definition, 1 );
+		}
 
-		Upgrades.FUZZY.registerItem( items.itemPortableCell, 1 );
-		Upgrades.INVERTER.registerItem( items.itemPortableCell, 1 );
+		for ( AEItemDefinition definition : items.portableCell().asSet() )
+		{
+			Upgrades.FUZZY.registerItem( definition, 1 );
+			Upgrades.INVERTER.registerItem( definition, 1 );
+		}
 
-		Upgrades.FUZZY.registerItem( items.itemViewCell, 1 );
-		Upgrades.INVERTER.registerItem( items.itemViewCell, 1 );
+		for ( AEItemDefinition definition : items.viewCell().asSet() )
+		{
+			Upgrades.FUZZY.registerItem( definition, 1 );
+			Upgrades.INVERTER.registerItem( definition, 1 );
+		}
 
 		// Storage Bus
-		Upgrades.FUZZY.registerItem( parts.partStorageBus, 1 );
-		Upgrades.INVERTER.registerItem( parts.partStorageBus, 1 );
-		Upgrades.CAPACITY.registerItem( parts.partStorageBus, 5 );
+		for ( AEItemDefinition definition : parts.storageBus().asSet() )
+		{
+			Upgrades.FUZZY.registerItem( definition, 1 );
+			Upgrades.INVERTER.registerItem( definition, 1 );
+			Upgrades.CAPACITY.registerItem( definition, 5 );
+		}
 
 		// Formation Plane
-		Upgrades.FUZZY.registerItem( parts.partFormationPlane, 1 );
-		Upgrades.INVERTER.registerItem( parts.partFormationPlane, 1 );
-		Upgrades.CAPACITY.registerItem( parts.partFormationPlane, 5 );
+		for ( AEItemDefinition definition : parts.formationPlane().asSet() )
+		{
+			Upgrades.FUZZY.registerItem( definition, 1 );
+			Upgrades.INVERTER.registerItem( definition, 1 );
+			Upgrades.CAPACITY.registerItem( definition, 5 );
+		}
+
 
 		// Matter Cannon
-		Upgrades.FUZZY.registerItem( items.itemMassCannon, 1 );
-		Upgrades.INVERTER.registerItem( items.itemMassCannon, 1 );
-		Upgrades.SPEED.registerItem( items.itemMassCannon, 4 );
+		for ( AEItemDefinition definition : items.massCannon().asSet() )
+		{
+			Upgrades.FUZZY.registerItem( definition, 1 );
+			Upgrades.INVERTER.registerItem( definition, 1 );
+			Upgrades.SPEED.registerItem( definition, 4 );
+		}
 
 		// Molecular Assembler
-		Upgrades.SPEED.registerItem( blocks.blockMolecularAssembler, 5 );
+		for ( AEItemDefinition definition : blocks.molecularAssembler().asSet() )
+		{
+			Upgrades.SPEED.registerItem( definition, 5 );
+		}
 
 		// Inscriber
-		Upgrades.SPEED.registerItem( blocks.blockInscriber, 3 );
-
-		if ( items.itemWirelessTerminal != null )
+		for ( AEItemDefinition definition : blocks.inscriber().asSet() )
 		{
-			registries.wireless().registerWirelessHandler( ( IWirelessTermHandler ) items.itemWirelessTerminal.item() );
+			Upgrades.SPEED.registerItem( definition, 3 );
+		}
+
+		for ( AEItemDefinition definition : items.wirelessTerminal().asSet() )
+		{
+			registries.wireless().registerWirelessHandler( (IWirelessTermHandler) definition.item() );
 		}
 
 		if ( AEConfig.instance.isFeatureEnabled( AEFeature.ChestLoot ) )
 		{
 			ChestGenHooks d = ChestGenHooks.getInfo( ChestGenHooks.MINESHAFT_CORRIDOR );
-			d.addItem( new WeightedRandomChestContent( api.materials().materialCertusQuartzCrystal.stack( 1 ), 1, 4, 2 ) );
-			d.addItem( new WeightedRandomChestContent( api.materials().materialCertusQuartzDust.stack( 1 ), 1, 4, 2 ) );
+
+			final IMaterials materials = definitions.materials();
+
+			for ( AEItemDefinition definition : materials.certusQuartzCrystal().asSet() )
+			{
+				d.addItem( new WeightedRandomChestContent( definition.stack( 1 ), 1, 4, 2 ) );
+			}
+			for ( AEItemDefinition definition : materials.certusQuartzDust().asSet() )
+			{
+				d.addItem( new WeightedRandomChestContent( definition.stack( 1 ), 1, 4, 2 ) );
+			}
 		}
 
 		// add villager trading to black smiths for a few basic materials

--- a/src/main/java/appeng/core/WorldSettings.java
+++ b/src/main/java/appeng/core/WorldSettings.java
@@ -92,7 +92,7 @@ public class WorldSettings extends Configuration
 		}
 
 		final ConfigCategory playerList = this.getCategory( "players" );
-		this.mappings = new PlayerMappings( playerList, AELog.instance );
+		this.mappings = new PlayerMappings( playerList, AELog.INSTANCE );
 	}
 
 	public static WorldSettings getInstance()

--- a/src/main/java/appeng/core/api/definitions/ApiBlocks.java
+++ b/src/main/java/appeng/core/api/definitions/ApiBlocks.java
@@ -1,0 +1,697 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.core.api.definitions;
+
+
+import java.util.Set;
+import javax.annotation.Nullable;
+
+import net.minecraft.block.Block;
+
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableSet;
+
+import appeng.api.definitions.IBlocks;
+import appeng.api.util.AEItemDefinition;
+import appeng.api.util.IOrientableBlock;
+import appeng.block.crafting.BlockCraftingMonitor;
+import appeng.block.crafting.BlockCraftingStorage;
+import appeng.block.crafting.BlockCraftingUnit;
+import appeng.block.crafting.BlockMolecularAssembler;
+import appeng.block.grindstone.BlockCrank;
+import appeng.block.grindstone.BlockGrinder;
+import appeng.block.misc.BlockCellWorkbench;
+import appeng.block.misc.BlockCharger;
+import appeng.block.misc.BlockCondenser;
+import appeng.block.misc.BlockInscriber;
+import appeng.block.misc.BlockInterface;
+import appeng.block.misc.BlockLightDetector;
+import appeng.block.misc.BlockPaint;
+import appeng.block.misc.BlockQuartzGrowthAccelerator;
+import appeng.block.misc.BlockQuartzTorch;
+import appeng.block.misc.BlockSecurity;
+import appeng.block.misc.BlockSkyCompass;
+import appeng.block.misc.BlockTinyTNT;
+import appeng.block.misc.BlockVibrationChamber;
+import appeng.block.networking.BlockCableBus;
+import appeng.block.networking.BlockController;
+import appeng.block.networking.BlockCreativeEnergyCell;
+import appeng.block.networking.BlockDenseEnergyCell;
+import appeng.block.networking.BlockEnergyAcceptor;
+import appeng.block.networking.BlockEnergyCell;
+import appeng.block.networking.BlockWireless;
+import appeng.block.qnb.BlockQuantumLinkChamber;
+import appeng.block.qnb.BlockQuantumRing;
+import appeng.block.solids.BlockFluix;
+import appeng.block.solids.BlockQuartz;
+import appeng.block.solids.BlockQuartzChiseled;
+import appeng.block.solids.BlockQuartzGlass;
+import appeng.block.solids.BlockQuartzLamp;
+import appeng.block.solids.BlockQuartzPillar;
+import appeng.block.solids.BlockSkyStone;
+import appeng.block.solids.OreQuartz;
+import appeng.block.solids.OreQuartzCharged;
+import appeng.block.spatial.BlockMatrixFrame;
+import appeng.block.spatial.BlockSpatialIOPort;
+import appeng.block.spatial.BlockSpatialPylon;
+import appeng.block.stair.ChiseledQuartzStairBlock;
+import appeng.block.stair.FluixStairBlock;
+import appeng.block.stair.QuartzPillarStairBlock;
+import appeng.block.stair.QuartzStairBlock;
+import appeng.block.stair.SkyStoneBlockStairBlock;
+import appeng.block.stair.SkyStoneBrickStairBlock;
+import appeng.block.stair.SkyStoneSmallBrickStairBlock;
+import appeng.block.stair.SkyStoneStairBlock;
+import appeng.block.storage.BlockChest;
+import appeng.block.storage.BlockDrive;
+import appeng.block.storage.BlockIOPort;
+import appeng.block.storage.BlockSkyChest;
+import appeng.core.FeatureHandlerRegistry;
+import appeng.core.FeatureRegistry;
+import appeng.core.features.IAEFeature;
+import appeng.core.features.IFeatureHandler;
+import appeng.core.features.WrappedDamageItemDefinition;
+import appeng.debug.BlockChunkloader;
+import appeng.debug.BlockCubeGenerator;
+import appeng.debug.BlockItemGen;
+import appeng.debug.BlockPhantomNode;
+
+
+/**
+ * Internal implementation for the API blocks
+ */
+public final class ApiBlocks implements IBlocks
+{
+	private final FeatureRegistry features;
+	private final FeatureHandlerRegistry handlers;
+
+	private final Optional<AEItemDefinition> quartzOre;
+	private final Optional<AEItemDefinition> quartzOreCharged;
+	private final Optional<AEItemDefinition> matrixFrame;
+	private final Optional<AEItemDefinition> quartz;
+	private final Optional<AEItemDefinition> quartzPillar;
+	private final Optional<AEItemDefinition> quartzChiseled;
+	private final Optional<AEItemDefinition> quartzGlass;
+	private final Optional<AEItemDefinition> quartzVibrantGlass;
+	private final Optional<AEItemDefinition> quartzTorch;
+	private final Optional<AEItemDefinition> fluix;
+	private final Optional<AEItemDefinition> skyStone;
+	private final Optional<AEItemDefinition> skyChest;
+	private final Optional<AEItemDefinition> skyCompass;
+	private final Optional<AEItemDefinition> grindStone;
+	private final Optional<AEItemDefinition> crankHandle;
+	private final Optional<AEItemDefinition> inscriber;
+	private final Optional<AEItemDefinition> wireless;
+	private final Optional<AEItemDefinition> charger;
+	private final Optional<AEItemDefinition> tinyTNT;
+	private final Optional<AEItemDefinition> security;
+	private final Optional<AEItemDefinition> quantumRing;
+	private final Optional<AEItemDefinition> quantumLink;
+	private final Optional<AEItemDefinition> spatialPylon;
+	private final Optional<AEItemDefinition> spatialIOPort;
+	private final Optional<AEItemDefinition> multiPart;
+	private final Optional<AEItemDefinition> controller;
+	private final Optional<AEItemDefinition> drive;
+	private final Optional<AEItemDefinition> chest;
+	private final Optional<AEItemDefinition> iface;
+	private final Optional<AEItemDefinition> cellWorkbench;
+	private final Optional<AEItemDefinition> iOPort;
+	private final Optional<AEItemDefinition> condenser;
+	private final Optional<AEItemDefinition> energyAcceptor;
+	private final Optional<AEItemDefinition> vibrationChamber;
+	private final Optional<AEItemDefinition> quartzGrowthAccelerator;
+	private final Optional<AEItemDefinition> energyCell;
+	private final Optional<AEItemDefinition> energyCellDense;
+	private final Optional<AEItemDefinition> energyCellCreative;
+	private final Optional<AEItemDefinition> craftingUnit;
+	private final Optional<AEItemDefinition> craftingAccelerator;
+	private final Optional<AEItemDefinition> craftingStorage1k;
+	private final Optional<AEItemDefinition> craftingStorage4k;
+	private final Optional<AEItemDefinition> craftingStorage16k;
+	private final Optional<AEItemDefinition> craftingStorage64k;
+	private final Optional<AEItemDefinition> craftingMonitor;
+	private final Optional<AEItemDefinition> molecularAssembler;
+	private final Optional<AEItemDefinition> lightDetector;
+	private final Optional<AEItemDefinition> paint;
+	private final Optional<AEItemDefinition> skyStoneStair;
+	private final Optional<AEItemDefinition> skyStoneBlockStair;
+	private final Optional<AEItemDefinition> skyStoneBrickStair;
+	private final Optional<AEItemDefinition> skyStoneSmallBrickStair;
+	private final Optional<AEItemDefinition> fluixStair;
+	private final Optional<AEItemDefinition> quartzStair;
+	private final Optional<AEItemDefinition> chiseledQuartzStair;
+	private final Optional<AEItemDefinition> quartzPillarStair;
+
+	private final Optional<AEItemDefinition> itemGen;
+	private final Optional<AEItemDefinition> chunkLoader;
+	private final Optional<AEItemDefinition> phantomNode;
+	private final Optional<AEItemDefinition> cubeGenerator;
+
+	private final Set<IOrientableBlock> orientables;
+
+	public ApiBlocks( FeatureRegistry features, FeatureHandlerRegistry handlers )
+	{
+		this.features = features;
+		this.handlers = handlers;
+
+		final BlockLightDetector lightDetector = new BlockLightDetector();
+		final BlockQuartzPillar quartzPillar = new BlockQuartzPillar();
+		final BlockSkyStone skyStone = new BlockSkyStone();
+		final BlockQuartzGrowthAccelerator cga = new BlockQuartzGrowthAccelerator();
+		final BlockQuartzTorch quartzTorch = new BlockQuartzTorch();
+
+		this.orientables = ImmutableSet.<IOrientableBlock>of( lightDetector, quartzPillar, skyStone, cga, quartzTorch );
+
+		this.quartzOre = this.getMaybeDefinition( new OreQuartz() );
+		this.quartzOreCharged = this.getMaybeDefinition( new OreQuartzCharged() );
+		this.matrixFrame = this.getMaybeDefinition( new BlockMatrixFrame() );
+		this.quartz = this.getMaybeDefinition( new BlockQuartz() );
+		this.quartzPillar = this.getMaybeDefinition( quartzPillar );
+		this.quartzChiseled = this.getMaybeDefinition( new BlockQuartzChiseled() );
+		this.quartzGlass = this.getMaybeDefinition( new BlockQuartzGlass() );
+		this.quartzVibrantGlass = this.getMaybeDefinition( new BlockQuartzLamp() );
+		this.quartzTorch = this.getMaybeDefinition( quartzTorch );
+		this.fluix = this.getMaybeDefinition( new BlockFluix() );
+		this.skyStone = this.getMaybeDefinition( skyStone );
+		this.skyChest = this.getMaybeDefinition( new BlockSkyChest() );
+		this.skyCompass = this.getMaybeDefinition( new BlockSkyCompass() );
+		this.grindStone = this.getMaybeDefinition( new BlockGrinder() );
+		this.crankHandle = this.getMaybeDefinition( new BlockCrank() );
+		this.inscriber = this.getMaybeDefinition( new BlockInscriber() );
+		this.wireless = this.getMaybeDefinition( new BlockWireless() );
+		this.charger = this.getMaybeDefinition( new BlockCharger() );
+		this.tinyTNT = this.getMaybeDefinition( new BlockTinyTNT() );
+		this.security = this.getMaybeDefinition( new BlockSecurity() );
+		this.quantumRing = this.getMaybeDefinition( new BlockQuantumRing() );
+		this.quantumLink = this.getMaybeDefinition( new BlockQuantumLinkChamber() );
+		this.spatialPylon = this.getMaybeDefinition( new BlockSpatialPylon() );
+		this.spatialIOPort = this.getMaybeDefinition( new BlockSpatialIOPort() );
+		this.multiPart = this.getMaybeDefinition( new BlockCableBus() );
+		this.controller = this.getMaybeDefinition( new BlockController() );
+		this.drive = this.getMaybeDefinition( new BlockDrive() );
+		this.chest = this.getMaybeDefinition( new BlockChest() );
+		this.iface = this.getMaybeDefinition( new BlockInterface() );
+		this.cellWorkbench = this.getMaybeDefinition( new BlockCellWorkbench() );
+		this.iOPort = this.getMaybeDefinition( new BlockIOPort() );
+		this.condenser = this.getMaybeDefinition( new BlockCondenser() );
+		this.energyAcceptor = this.getMaybeDefinition( new BlockEnergyAcceptor() );
+		this.vibrationChamber = this.getMaybeDefinition( new BlockVibrationChamber() );
+		this.quartzGrowthAccelerator = this.getMaybeDefinition( cga );
+		this.energyCell = this.getMaybeDefinition( new BlockEnergyCell() );
+		this.energyCellDense = this.getMaybeDefinition( new BlockDenseEnergyCell() );
+		this.energyCellCreative = this.getMaybeDefinition( new BlockCreativeEnergyCell() );
+		this.craftingUnit = this.getMaybeDefinition( new BlockCraftingUnit() );
+		this.craftingAccelerator = this.craftingUnit.transform( new WrappedItemDamageDefinitionTransformation( 1 ) );
+		this.craftingStorage1k = this.getMaybeDefinition( new BlockCraftingStorage() );
+		this.craftingStorage4k = this.craftingStorage1k.transform( new WrappedItemDamageDefinitionTransformation( 1 ) );
+		this.craftingStorage16k = this.craftingStorage1k.transform( new WrappedItemDamageDefinitionTransformation( 2 ) );
+		this.craftingStorage64k = this.craftingStorage1k.transform( new WrappedItemDamageDefinitionTransformation( 3 ) );
+		this.craftingMonitor = this.getMaybeDefinition( new BlockCraftingMonitor() );
+		this.molecularAssembler = this.getMaybeDefinition( new BlockMolecularAssembler() );
+		this.lightDetector = this.getMaybeDefinition( lightDetector );
+		this.paint = this.getMaybeDefinition( new BlockPaint() );
+
+		if ( this.skyStone.isPresent() )
+		{
+			final AEItemDefinition definition = this.skyStone.get();
+			final Block blockID = definition.block();
+
+			this.skyStoneStair = this.getMaybeDefinition( new SkyStoneStairBlock( blockID, 0 ) );
+			this.skyStoneBlockStair = this.getMaybeDefinition( new SkyStoneBlockStairBlock( blockID, 1 ) );
+			this.skyStoneBrickStair = this.getMaybeDefinition( new SkyStoneBrickStairBlock( blockID, 2 ) );
+			this.skyStoneSmallBrickStair = this.getMaybeDefinition( new SkyStoneSmallBrickStairBlock( blockID, 3 ) );
+		}
+		else
+		{
+			this.skyStoneStair = Optional.absent();
+			this.skyStoneBlockStair = Optional.absent();
+			this.skyStoneBrickStair = Optional.absent();
+			this.skyStoneSmallBrickStair = Optional.absent();
+		}
+
+		if ( this.fluix.isPresent() )
+		{
+			final AEItemDefinition definition = this.fluix.get();
+			final Block blockID = definition.block();
+
+			this.fluixStair = this.getMaybeDefinition( new FluixStairBlock( blockID ) );
+		}
+		else
+		{
+			this.fluixStair = Optional.absent();
+		}
+
+		if ( this.quartz.isPresent() )
+		{
+			final AEItemDefinition definition = this.quartz.get();
+			final Block blockID = definition.block();
+
+			this.quartzStair = this.getMaybeDefinition( new QuartzStairBlock( blockID ) );
+		}
+		else
+		{
+			this.quartzStair = Optional.absent();
+		}
+
+		if ( this.quartzChiseled.isPresent() )
+		{
+			final AEItemDefinition definition = this.quartzChiseled.get();
+			final Block blockID = definition.block();
+
+			this.chiseledQuartzStair = this.getMaybeDefinition( new ChiseledQuartzStairBlock( blockID ) );
+		}
+		else
+		{
+			this.chiseledQuartzStair = Optional.absent();
+		}
+
+		if ( this.quartzPillar.isPresent() )
+		{
+			final AEItemDefinition definition = this.quartzPillar.get();
+			final Block blockID = definition.block();
+
+			this.quartzPillarStair = this.getMaybeDefinition( new QuartzPillarStairBlock( blockID ) );
+		}
+		else
+		{
+			this.quartzPillarStair = Optional.absent();
+		}
+
+		this.itemGen = this.getMaybeDefinition( new BlockItemGen() );
+		this.chunkLoader = this.getMaybeDefinition( new BlockChunkloader() );
+		this.phantomNode = this.getMaybeDefinition( new BlockPhantomNode() );
+		this.cubeGenerator = this.getMaybeDefinition( new BlockCubeGenerator() );
+	}
+
+	private Optional<AEItemDefinition> getMaybeDefinition( IAEFeature feature )
+	{
+		final IFeatureHandler handler = feature.handler();
+
+		if ( handler.isFeatureAvailable() )
+		{
+			this.handlers.addFeatureHandler( handler );
+			this.features.addFeature( feature );
+
+			return Optional.of( handler.getDefinition() );
+		}
+		else
+		{
+			return Optional.absent();
+		}
+	}
+
+	@Override
+	public Optional<AEItemDefinition> quartzOre()
+	{
+		return this.quartzOre;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> quartzOreCharged()
+	{
+		return this.quartzOreCharged;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> matrixFrame()
+	{
+		return this.matrixFrame;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> quartz()
+	{
+		return this.quartz;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> quartzPillar()
+	{
+		return this.quartzPillar;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> quartzChiseled()
+	{
+		return this.quartzChiseled;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> quartzGlass()
+	{
+		return this.quartzGlass;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> quartzVibrantGlass()
+	{
+		return this.quartzVibrantGlass;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> quartzTorch()
+	{
+		return this.quartzTorch;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> fluix()
+	{
+		return this.fluix;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> skyStone()
+	{
+		return this.skyStone;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> skyChest()
+	{
+		return this.skyChest;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> skyCompass()
+	{
+		return this.skyCompass;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> skyStoneStair()
+	{
+		return this.skyStoneStair;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> skyStoneBlockStair()
+	{
+		return this.skyStoneBlockStair;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> skyStoneBrickStair()
+	{
+		return this.skyStoneBrickStair;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> skyStoneSmallBrickStair()
+	{
+		return this.skyStoneSmallBrickStair;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> fluixStair()
+	{
+		return this.fluixStair;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> quartzStair()
+	{
+		return this.quartzStair;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> chiseledQuartzStair()
+	{
+		return this.chiseledQuartzStair;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> quartzPillarStair()
+	{
+		return this.quartzPillarStair;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> grindStone()
+	{
+		return this.grindStone;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> crankHandle()
+	{
+		return this.crankHandle;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> inscriber()
+	{
+		return this.inscriber;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> wireless()
+	{
+		return this.wireless;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> charger()
+	{
+		return this.charger;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> tinyTNT()
+	{
+		return this.tinyTNT;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> security()
+	{
+		return this.security;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> quantumRing()
+	{
+		return this.quantumRing;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> quantumLink()
+	{
+		return this.quantumLink;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> spatialPylon()
+	{
+		return this.spatialPylon;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> spatialIOPort()
+	{
+		return this.spatialIOPort;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> multiPart()
+	{
+		return this.multiPart;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> controller()
+	{
+		return this.controller;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> drive()
+	{
+		return this.drive;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> chest()
+	{
+		return this.chest;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> iface()
+	{
+		return this.iface;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> cellWorkbench()
+	{
+		return this.cellWorkbench;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> iOPort()
+	{
+		return this.iOPort;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> condenser()
+	{
+		return this.condenser;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> energyAcceptor()
+	{
+		return this.energyAcceptor;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> vibrationChamber()
+	{
+		return this.vibrationChamber;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> quartzGrowthAccelerator()
+	{
+		return this.quartzGrowthAccelerator;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> energyCell()
+	{
+		return this.energyCell;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> energyCellDense()
+	{
+		return this.energyCellDense;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> energyCellCreative()
+	{
+		return this.energyCellCreative;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> craftingUnit()
+	{
+		return this.craftingUnit;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> craftingAccelerator()
+	{
+		return this.craftingAccelerator;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> craftingStorage1k()
+	{
+		return this.craftingStorage1k;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> craftingStorage4k()
+	{
+		return this.craftingStorage4k;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> craftingStorage16k()
+	{
+		return this.craftingStorage16k;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> craftingStorage64k()
+	{
+		return this.craftingStorage64k;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> craftingMonitor()
+	{
+		return this.craftingMonitor;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> molecularAssembler()
+	{
+		return this.molecularAssembler;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> lightDetector()
+	{
+		return this.lightDetector;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> paint()
+	{
+		return this.paint;
+	}
+
+	public Optional<AEItemDefinition> chunkLoader()
+	{
+		return this.chunkLoader;
+	}
+
+	public Optional<AEItemDefinition> itemGen()
+	{
+		return this.itemGen;
+	}
+
+	public Optional<AEItemDefinition> phantomNode()
+	{
+		return this.phantomNode;
+	}
+
+	public Optional<AEItemDefinition> cubeGenerator()
+	{
+		return this.cubeGenerator;
+	}
+
+	public Set<IOrientableBlock> orientables()
+	{
+		return this.orientables;
+	}
+
+	private static class WrappedItemDamageDefinitionTransformation implements Function<AEItemDefinition, AEItemDefinition>
+	{
+		private final int itemDamage;
+
+		public WrappedItemDamageDefinitionTransformation( int itemDamage )
+		{
+			this.itemDamage = itemDamage;
+		}
+
+		@Nullable
+		@Override
+		public AEItemDefinition apply( AEItemDefinition input )
+		{
+			return new WrappedDamageItemDefinition( input, this.itemDamage );
+		}
+	}
+}

--- a/src/main/java/appeng/core/api/definitions/ApiItems.java
+++ b/src/main/java/appeng/core/api/definitions/ApiItems.java
@@ -1,0 +1,481 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.core.api.definitions;
+
+
+import javax.annotation.Nullable;
+
+import net.minecraft.item.Item;
+
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+
+import appeng.api.definitions.IItems;
+import appeng.api.util.AEColor;
+import appeng.api.util.AEColoredItemDefinition;
+import appeng.api.util.AEItemDefinition;
+import appeng.core.FeatureHandlerRegistry;
+import appeng.core.FeatureRegistry;
+import appeng.core.features.AEFeature;
+import appeng.core.features.ColoredItemDefinition;
+import appeng.core.features.IAEFeature;
+import appeng.core.features.IFeatureHandler;
+import appeng.core.features.ItemStackSrc;
+import appeng.debug.ToolDebugCard;
+import appeng.debug.ToolEraser;
+import appeng.debug.ToolMeteoritePlacer;
+import appeng.debug.ToolReplicatorCard;
+import appeng.items.materials.MaterialType;
+import appeng.items.misc.ItemCrystalSeed;
+import appeng.items.misc.ItemEncodedPattern;
+import appeng.items.misc.ItemPaintBall;
+import appeng.items.parts.ItemFacade;
+import appeng.items.storage.ItemBasicStorageCell;
+import appeng.items.storage.ItemCreativeStorageCell;
+import appeng.items.storage.ItemSpatialStorageCell;
+import appeng.items.storage.ItemViewCell;
+import appeng.items.tools.ToolBiometricCard;
+import appeng.items.tools.ToolMemoryCard;
+import appeng.items.tools.ToolNetworkTool;
+import appeng.items.tools.powered.ToolChargedStaff;
+import appeng.items.tools.powered.ToolColorApplicator;
+import appeng.items.tools.powered.ToolEntropyManipulator;
+import appeng.items.tools.powered.ToolMassCannon;
+import appeng.items.tools.powered.ToolPortableCell;
+import appeng.items.tools.powered.ToolWirelessTerminal;
+import appeng.items.tools.quartz.ToolQuartzAxe;
+import appeng.items.tools.quartz.ToolQuartzCuttingKnife;
+import appeng.items.tools.quartz.ToolQuartzHoe;
+import appeng.items.tools.quartz.ToolQuartzPickaxe;
+import appeng.items.tools.quartz.ToolQuartzSpade;
+import appeng.items.tools.quartz.ToolQuartzSword;
+import appeng.items.tools.quartz.ToolQuartzWrench;
+
+
+/**
+ * Internal implementation for the API items
+ */
+public final class ApiItems implements IItems
+{
+	private final FeatureRegistry features;
+	private final FeatureHandlerRegistry handlers;
+
+	private final Optional<AEItemDefinition> certusQuartzAxe;
+	private final Optional<AEItemDefinition> certusQuartzHoe;
+	private final Optional<AEItemDefinition> certusQuartzShovel;
+	private final Optional<AEItemDefinition> certusQuartzPick;
+	private final Optional<AEItemDefinition> certusQuartzSword;
+	private final Optional<AEItemDefinition> certusQuartzWrench;
+	private final Optional<AEItemDefinition> certusQuartzKnife;
+
+	private final Optional<AEItemDefinition> netherQuartzAxe;
+	private final Optional<AEItemDefinition> netherQuartzHoe;
+	private final Optional<AEItemDefinition> netherQuartzShovel;
+	private final Optional<AEItemDefinition> netherQuartzPick;
+	private final Optional<AEItemDefinition> netherQuartzSword;
+	private final Optional<AEItemDefinition> netherQuartzWrench;
+	private final Optional<AEItemDefinition> netherQuartzKnife;
+
+	private final Optional<AEItemDefinition> entropyManipulator;
+	private final Optional<AEItemDefinition> wirelessTerminal;
+	private final Optional<AEItemDefinition> biometricCard;
+	private final Optional<AEItemDefinition> chargedStaff;
+	private final Optional<AEItemDefinition> massCannon;
+	private final Optional<AEItemDefinition> memoryCard;
+	private final Optional<AEItemDefinition> networkTool;
+	private final Optional<AEItemDefinition> portableCell;
+
+	private final Optional<AEItemDefinition> cellCreative;
+	private final Optional<AEItemDefinition> viewCell;
+
+	private final Optional<AEItemDefinition> cell1k;
+	private final Optional<AEItemDefinition> cell4k;
+	private final Optional<AEItemDefinition> cell16k;
+	private final Optional<AEItemDefinition> cell64k;
+
+	private final Optional<AEItemDefinition> spatialCell2;
+	private final Optional<AEItemDefinition> spatialCell16;
+	private final Optional<AEItemDefinition> spatialCell128;
+
+	private final Optional<AEItemDefinition> facade;
+	private final Optional<AEItemDefinition> crystalSeed;
+
+	// rv1
+	private final Optional<AEItemDefinition> encodedPattern;
+	private final Optional<AEItemDefinition> colorApplicator;
+
+	private final Optional<AEItemDefinition> paintBall;
+	private final Optional<AEColoredItemDefinition> coloredPaintBall;
+	private final Optional<AEColoredItemDefinition> coloredLumenPaintBall;
+
+	// unsupported dev tools
+	private final Optional<AEItemDefinition> toolEraser;
+	private final Optional<AEItemDefinition> toolMeteoritePlacer;
+	private final Optional<AEItemDefinition> toolDebugCard;
+	private final Optional<AEItemDefinition> toolReplicatorCard;
+
+	public ApiItems( FeatureRegistry features, FeatureHandlerRegistry handlers )
+	{
+		this.features = features;
+		this.handlers = handlers;
+
+		this.certusQuartzAxe = this.getMaybeDefinition( new ToolQuartzAxe( AEFeature.CertusQuartzTools ) );
+		this.certusQuartzHoe = this.getMaybeDefinition( new ToolQuartzHoe( AEFeature.CertusQuartzTools ) );
+		this.certusQuartzShovel = this.getMaybeDefinition( new ToolQuartzSpade( AEFeature.CertusQuartzTools ) );
+		this.certusQuartzPick = this.getMaybeDefinition( new ToolQuartzPickaxe( AEFeature.CertusQuartzTools ) );
+		this.certusQuartzSword = this.getMaybeDefinition( new ToolQuartzSword( AEFeature.CertusQuartzTools ) );
+		this.certusQuartzWrench = this.getMaybeDefinition( new ToolQuartzWrench( AEFeature.CertusQuartzTools ) );
+		this.certusQuartzKnife = this.getMaybeDefinition( new ToolQuartzCuttingKnife( AEFeature.CertusQuartzTools ) );
+
+		this.netherQuartzAxe = this.getMaybeDefinition( new ToolQuartzAxe( AEFeature.NetherQuartzTools ) );
+		this.netherQuartzHoe = this.getMaybeDefinition( new ToolQuartzHoe( AEFeature.NetherQuartzTools ) );
+		this.netherQuartzShovel = this.getMaybeDefinition( new ToolQuartzSpade( AEFeature.NetherQuartzTools ) );
+		this.netherQuartzPick = this.getMaybeDefinition( new ToolQuartzPickaxe( AEFeature.NetherQuartzTools ) );
+		this.netherQuartzSword = this.getMaybeDefinition( new ToolQuartzSword( AEFeature.NetherQuartzTools ) );
+		this.netherQuartzWrench = this.getMaybeDefinition( new ToolQuartzWrench( AEFeature.NetherQuartzTools ) );
+		this.netherQuartzKnife = this.getMaybeDefinition( new ToolQuartzCuttingKnife( AEFeature.NetherQuartzTools ) );
+
+		this.entropyManipulator = this.getMaybeDefinition( new ToolEntropyManipulator() );
+		this.wirelessTerminal = this.getMaybeDefinition( new ToolWirelessTerminal() );
+		this.biometricCard = this.getMaybeDefinition( new ToolBiometricCard() );
+		this.chargedStaff = this.getMaybeDefinition( new ToolChargedStaff() );
+		this.massCannon = this.getMaybeDefinition( new ToolMassCannon() );
+		this.memoryCard = this.getMaybeDefinition( new ToolMemoryCard() );
+		this.networkTool = this.getMaybeDefinition( new ToolNetworkTool() );
+		this.portableCell = this.getMaybeDefinition( new ToolPortableCell() );
+
+		this.cellCreative = this.getMaybeDefinition( new ItemCreativeStorageCell() );
+		this.viewCell = this.getMaybeDefinition( new ItemViewCell() );
+
+		this.cell1k = this.getMaybeDefinition( new ItemBasicStorageCell( MaterialType.Cell1kPart, 1 ) );
+		this.cell4k = this.getMaybeDefinition( new ItemBasicStorageCell( MaterialType.Cell4kPart, 4 ) );
+		this.cell16k = this.getMaybeDefinition( new ItemBasicStorageCell( MaterialType.Cell16kPart, 16 ) );
+		this.cell64k = this.getMaybeDefinition( new ItemBasicStorageCell( MaterialType.Cell64kPart, 64 ) );
+
+		this.spatialCell2 = this.getMaybeDefinition( new ItemSpatialStorageCell( MaterialType.Cell2SpatialPart, 2 ) );
+		this.spatialCell16 = this.getMaybeDefinition( new ItemSpatialStorageCell( MaterialType.Cell2SpatialPart, 16 ) );
+		this.spatialCell128 = this.getMaybeDefinition( new ItemSpatialStorageCell( MaterialType.Cell2SpatialPart, 128 ) );
+
+		this.facade = this.getMaybeDefinition( new ItemFacade() );
+		this.crystalSeed = this.getMaybeDefinition( new ItemCrystalSeed() );
+
+		// rv1
+		this.encodedPattern = this.getMaybeDefinition( new ItemEncodedPattern() );
+		this.colorApplicator = this.getMaybeDefinition( new ToolColorApplicator() );
+
+		this.paintBall = this.getMaybeDefinition( new ItemPaintBall() );
+		this.coloredPaintBall = this.paintBall.transform( new ColoredTransformationFunction( new ColoredItemDefinition(), 0 ) );
+		this.coloredLumenPaintBall = this.paintBall.transform( new ColoredTransformationFunction( new ColoredItemDefinition(), 20 ) );
+
+		this.toolEraser = this.getMaybeDefinition( new ToolEraser() );
+		this.toolMeteoritePlacer = this.getMaybeDefinition( new ToolMeteoritePlacer() );
+		this.toolDebugCard = this.getMaybeDefinition( new ToolDebugCard() );
+		this.toolReplicatorCard = this.getMaybeDefinition( new ToolReplicatorCard() );
+	}
+
+	private Optional<AEItemDefinition> getMaybeDefinition( IAEFeature feature )
+	{
+		final IFeatureHandler handler = feature.handler();
+
+		if ( handler.isFeatureAvailable() )
+		{
+			this.handlers.addFeatureHandler( handler );
+			this.features.addFeature( feature );
+
+			return Optional.of( handler.getDefinition() );
+		}
+		else
+		{
+			return Optional.absent();
+		}
+	}
+
+	@Override
+	public Optional<AEItemDefinition> certusQuartzAxe()
+	{
+		return this.certusQuartzAxe;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> certusQuartzHoe()
+	{
+		return this.certusQuartzHoe;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> certusQuartzShovel()
+	{
+		return this.certusQuartzShovel;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> certusQuartzPick()
+	{
+		return this.certusQuartzPick;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> certusQuartzSword()
+	{
+		return this.certusQuartzSword;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> certusQuartzWrench()
+	{
+		return this.certusQuartzWrench;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> certusQuartzKnife()
+	{
+		return this.certusQuartzKnife;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> netherQuartzAxe()
+	{
+		return this.netherQuartzAxe;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> netherQuartzHoe()
+	{
+		return this.netherQuartzHoe;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> netherQuartzShovel()
+	{
+		return this.netherQuartzShovel;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> netherQuartzPick()
+	{
+		return this.netherQuartzPick;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> netherQuartzSword()
+	{
+		return this.netherQuartzSword;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> netherQuartzWrench()
+	{
+		return this.netherQuartzWrench;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> netherQuartzKnife()
+	{
+		return this.netherQuartzKnife;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> entropyManipulator()
+	{
+		return this.entropyManipulator;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> wirelessTerminal()
+	{
+		return this.wirelessTerminal;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> biometricCard()
+	{
+		return this.biometricCard;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> chargedStaff()
+	{
+		return this.memoryCard;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> massCannon()
+	{
+		return this.massCannon;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> memoryCard()
+	{
+		return this.memoryCard;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> networkTool()
+	{
+		return this.networkTool;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> portableCell()
+	{
+		return this.portableCell;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> cellCreative()
+	{
+		return this.cellCreative;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> viewCell()
+	{
+		return this.viewCell;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> cell1k()
+	{
+		return this.cell1k;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> cell4k()
+	{
+		return this.cell4k;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> cell16k()
+	{
+		return this.cell16k;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> cell64k()
+	{
+		return this.cell64k;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> spatialCell2()
+	{
+		return this.spatialCell2;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> spatialCell16()
+	{
+		return this.spatialCell16;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> spatialCell128()
+	{
+		return this.spatialCell128;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> facade()
+	{
+		return this.facade;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> crystalSeed()
+	{
+		return this.crystalSeed;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> encodedPattern()
+	{
+		return this.encodedPattern;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> colorApplicator()
+	{
+		return this.colorApplicator;
+	}
+
+	@Override
+	public Optional<AEColoredItemDefinition> coloredPaintBall()
+	{
+		return this.coloredPaintBall;
+	}
+
+	@Override
+	public Optional<AEColoredItemDefinition> coloredLumenPaintBall()
+	{
+		return this.coloredLumenPaintBall;
+	}
+
+	public Optional<AEItemDefinition> paintBall()
+	{
+		return this.paintBall;
+	}
+
+	public Optional<AEItemDefinition> toolEraser()
+	{
+		return this.toolEraser;
+	}
+
+	public Optional<AEItemDefinition> toolMeteoritePlacer()
+	{
+		return this.toolMeteoritePlacer;
+	}
+
+	public Optional<AEItemDefinition> toolDebugCard()
+	{
+		return this.toolDebugCard;
+	}
+
+	public Optional<AEItemDefinition> toolReplicatorCard()
+	{
+		return this.toolReplicatorCard;
+	}
+
+	private static final class ColoredTransformationFunction implements Function<AEItemDefinition, AEColoredItemDefinition>
+	{
+		private final ColoredItemDefinition colorDefinition;
+		private final int offset;
+
+		public ColoredTransformationFunction( ColoredItemDefinition colorDefinition, int offset )
+		{
+			this.colorDefinition = colorDefinition;
+			this.offset = offset;
+		}
+
+		@Nullable
+		@Override
+		public AEColoredItemDefinition apply( AEItemDefinition input )
+		{
+			final Item item = input.item();
+
+			for ( AEColor color : AEColor.VALID_COLORS )
+			{
+				this.colorDefinition.add( color, new ItemStackSrc( item, this.offset + color.ordinal() ) );
+			}
+
+			return this.colorDefinition;
+		}
+	}
+}

--- a/src/main/java/appeng/core/api/definitions/ApiMaterials.java
+++ b/src/main/java/appeng/core/api/definitions/ApiMaterials.java
@@ -1,0 +1,570 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.core.api.definitions;
+
+
+import javax.annotation.Nullable;
+
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+
+import appeng.api.definitions.IMaterials;
+import appeng.api.util.AEItemDefinition;
+import appeng.core.FeatureHandlerRegistry;
+import appeng.core.FeatureRegistry;
+import appeng.core.features.DamagedItemDefinition;
+import appeng.core.features.IAEFeature;
+import appeng.core.features.IFeatureHandler;
+import appeng.core.features.IStackSrc;
+import appeng.core.features.NullItemDefinition;
+import appeng.items.materials.ItemMultiMaterial;
+import appeng.items.materials.MaterialType;
+
+
+/**
+ * Internal implementation for the API materials
+ */
+public final class ApiMaterials implements IMaterials
+{
+	private final FeatureRegistry features;
+	private final FeatureHandlerRegistry handlers;
+
+	private final Optional<AEItemDefinition> cell2SpatialPart;
+	private final Optional<AEItemDefinition> cell16SpatialPart;
+	private final Optional<AEItemDefinition> cell128SpatialPart;
+
+	private final Optional<AEItemDefinition> silicon;
+	private final Optional<AEItemDefinition> skyDust;
+
+	private final Optional<AEItemDefinition> calcProcessorPress;
+	private final Optional<AEItemDefinition> engProcessorPress;
+	private final Optional<AEItemDefinition> logicProcessorPress;
+
+	private final Optional<AEItemDefinition> calcProcessorPrint;
+	private final Optional<AEItemDefinition> engProcessorPrint;
+	private final Optional<AEItemDefinition> logicProcessorPrint;
+
+	private final Optional<AEItemDefinition> siliconPress;
+	private final Optional<AEItemDefinition> siliconPrint;
+
+	private final Optional<AEItemDefinition> namePress;
+
+	private final Optional<AEItemDefinition> logicProcessor;
+	private final Optional<AEItemDefinition> calcProcessor;
+	private final Optional<AEItemDefinition> engProcessor;
+
+	private final Optional<AEItemDefinition> basicCard;
+	private final Optional<AEItemDefinition> advCard;
+
+	private final Optional<AEItemDefinition> purifiedCertusQuartzCrystal;
+	private final Optional<AEItemDefinition> purifiedNetherQuartzCrystal;
+	private final Optional<AEItemDefinition> purifiedFluixCrystal;
+
+	private final Optional<AEItemDefinition> cell1kPart;
+	private final Optional<AEItemDefinition> cell4kPart;
+	private final Optional<AEItemDefinition> cell16kPart;
+	private final Optional<AEItemDefinition> cell64kPart;
+	private final Optional<AEItemDefinition> emptyStorageCell;
+
+	private final Optional<AEItemDefinition> cardRedstone;
+	private final Optional<AEItemDefinition> cardSpeed;
+	private final Optional<AEItemDefinition> cardCapacity;
+	private final Optional<AEItemDefinition> cardFuzzy;
+	private final Optional<AEItemDefinition> cardInverter;
+	private final Optional<AEItemDefinition> cardCrafting;
+
+	private final Optional<AEItemDefinition> enderDust;
+	private final Optional<AEItemDefinition> flour;
+	private final Optional<AEItemDefinition> goldDust;
+	private final Optional<AEItemDefinition> ironDust;
+	private final Optional<AEItemDefinition> fluixDust;
+	private final Optional<AEItemDefinition> certusQuartzDust;
+	private final Optional<AEItemDefinition> netherQuartzDust;
+
+	private final Optional<AEItemDefinition> matterBall;
+	private final Optional<AEItemDefinition> ironNugget;
+
+	private final Optional<AEItemDefinition> certusQuartzCrystal;
+	private final Optional<AEItemDefinition> certusQuartzCrystalCharged;
+	private final Optional<AEItemDefinition> fluixCrystal;
+	private final Optional<AEItemDefinition> fluixPearl;
+
+	private final Optional<AEItemDefinition> woodenGear;
+
+	private final Optional<AEItemDefinition> wireless;
+	private final Optional<AEItemDefinition> wirelessBooster;
+
+	private final Optional<AEItemDefinition> annihilationCore;
+	private final Optional<AEItemDefinition> formationCore;
+
+	private final Optional<AEItemDefinition> singularity;
+	private final Optional<AEItemDefinition> qESingularity;
+	private final Optional<AEItemDefinition> blankPattern;
+
+	public ApiMaterials( FeatureRegistry features, FeatureHandlerRegistry handlers )
+	{
+		this.features = features;
+		this.handlers = handlers;
+
+		final ItemMultiMaterial itemMultiMaterial = new ItemMultiMaterial();
+		final Optional<AEItemDefinition> multiMaterial = this.getMaybeDefinition( itemMultiMaterial );
+
+		this.cell2SpatialPart = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.Cell2SpatialPart ) );
+		this.cell16SpatialPart = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.Cell16SpatialPart ) );
+		this.cell128SpatialPart = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.Cell128SpatialPart ) );
+
+		this.silicon = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.Silicon ) );
+		this.skyDust = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.SkyDust ) );
+
+		this.calcProcessorPress = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.CalcProcessorPress ) );
+		this.engProcessorPress = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.EngProcessorPress ) );
+		this.logicProcessorPress = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.LogicProcessorPress ) );
+
+		this.calcProcessorPrint = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.CalcProcessorPrint ) );
+		this.engProcessorPrint = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.EngProcessorPrint ) );
+		this.logicProcessorPrint = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.LogicProcessorPrint ) );
+
+		this.siliconPress = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.SiliconPress ) );
+		this.siliconPrint = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.SiliconPrint ) );
+
+		this.namePress = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.NamePress ) );
+
+		this.logicProcessor = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.LogicProcessor ) );
+		this.calcProcessor = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.CalcProcessor ) );
+		this.engProcessor = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.EngProcessor ) );
+
+		this.basicCard = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.BasicCard ) );
+		this.advCard = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.AdvCard ) );
+
+		this.purifiedCertusQuartzCrystal = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.PurifiedCertusQuartzCrystal ) );
+		this.purifiedNetherQuartzCrystal = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.PurifiedNetherQuartzCrystal ) );
+		this.purifiedFluixCrystal = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.PurifiedFluixCrystal ) );
+
+		this.cell1kPart = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.Cell1kPart ) );
+		this.cell4kPart = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.Cell4kPart ) );
+		this.cell16kPart = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.Cell16kPart ) );
+		this.cell64kPart = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.Cell64kPart ) );
+		this.emptyStorageCell = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.EmptyStorageCell ) );
+
+		this.cardRedstone = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.CardRedstone ) );
+		this.cardSpeed = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.CardSpeed ) );
+		this.cardCapacity = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.CardCapacity ) );
+		this.cardFuzzy = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.CardFuzzy ) );
+		this.cardInverter = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.CardInverter ) );
+		this.cardCrafting = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.CardCrafting ) );
+
+		this.enderDust = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.EnderDust ) );
+		this.flour = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.Flour ) );
+		this.goldDust = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.GoldDust ) );
+		this.ironDust = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.IronDust ) );
+		this.fluixDust = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.FluixDust ) );
+		this.certusQuartzDust = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.CertusQuartzDust ) );
+		this.netherQuartzDust = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.NetherQuartzDust ) );
+
+		this.matterBall = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.MatterBall ) );
+		this.ironNugget = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.IronNugget ) );
+
+		this.certusQuartzCrystal = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.CertusQuartzCrystal ) );
+		this.certusQuartzCrystalCharged = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.CertusQuartzCrystalCharged ) );
+		this.fluixCrystal = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.FluixCrystal ) );
+		this.fluixPearl = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.FluixPearl ) );
+
+		this.woodenGear = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.WoodenGear ) );
+
+		this.wireless = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.Wireless ) );
+		this.wirelessBooster = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.WirelessBooster ) );
+
+		this.annihilationCore = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.AnnihilationCore ) );
+		this.formationCore = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.FormationCore ) );
+
+		this.singularity = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.Singularity ) );
+		this.qESingularity = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.QESingularity ) );
+		this.blankPattern = multiMaterial.transform( new MaterialTransformationFunction( itemMultiMaterial, MaterialType.BlankPattern ) );
+	}
+
+	private Optional<AEItemDefinition> getMaybeDefinition( IAEFeature feature )
+	{
+		final IFeatureHandler handler = feature.handler();
+
+		if ( handler.isFeatureAvailable() )
+		{
+			this.handlers.addFeatureHandler( handler );
+			this.features.addFeature( feature );
+
+			return Optional.of( handler.getDefinition() );
+		}
+		else
+		{
+			return Optional.absent();
+		}
+	}
+
+	@Override
+	public Optional<AEItemDefinition> cell2SpatialPart()
+	{
+		return this.cell2SpatialPart;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> cell16SpatialPart()
+	{
+		return this.cell16SpatialPart;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> cell128SpatialPart()
+	{
+		return this.cell128SpatialPart;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> silicon()
+	{
+		return this.silicon;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> skyDust()
+	{
+		return this.skyDust;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> calcProcessorPress()
+	{
+		return this.calcProcessorPress;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> engProcessorPress()
+	{
+		return this.engProcessorPress;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> logicProcessorPress()
+	{
+		return this.logicProcessorPress;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> calcProcessorPrint()
+	{
+		return this.calcProcessorPrint;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> engProcessorPrint()
+	{
+		return this.engProcessorPrint;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> logicProcessorPrint()
+	{
+		return this.logicProcessorPrint;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> siliconPress()
+	{
+		return this.siliconPress;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> siliconPrint()
+	{
+		return this.siliconPrint;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> namePress()
+	{
+		return this.namePress;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> logicProcessor()
+	{
+		return this.logicProcessor;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> calcProcessor()
+	{
+		return this.calcProcessor;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> engProcessor()
+	{
+		return this.engProcessor;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> basicCard()
+	{
+		return this.basicCard;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> advCard()
+	{
+		return this.advCard;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> purifiedCertusQuartzCrystal()
+	{
+		return this.purifiedCertusQuartzCrystal;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> purifiedNetherQuartzCrystal()
+	{
+		return this.purifiedNetherQuartzCrystal;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> purifiedFluixCrystal()
+	{
+		return this.purifiedFluixCrystal;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> cell1kPart()
+	{
+		return this.cell1kPart;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> cell4kPart()
+	{
+		return this.cell4kPart;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> cell16kPart()
+	{
+		return this.cell16kPart;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> cell64kPart()
+	{
+		return this.cell64kPart;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> emptyStorageCell()
+	{
+		return this.emptyStorageCell;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> cardRedstone()
+	{
+		return this.cardRedstone;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> cardSpeed()
+	{
+		return this.cardSpeed;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> cardCapacity()
+	{
+		return this.cardCapacity;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> cardFuzzy()
+	{
+		return this.cardFuzzy;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> cardInverter()
+	{
+		return this.cardInverter;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> cardCrafting()
+	{
+		return this.cardCrafting;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> enderDust()
+	{
+		return this.enderDust;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> flour()
+	{
+		return this.flour;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> goldDust()
+	{
+		return this.goldDust;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> ironDust()
+	{
+		return this.ironDust;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> fluixDust()
+	{
+		return this.fluixDust;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> certusQuartzDust()
+	{
+		return this.certusQuartzDust;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> netherQuartzDust()
+	{
+		return this.netherQuartzDust;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> matterBall()
+	{
+		return this.matterBall;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> ironNugget()
+	{
+		return this.ironNugget;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> certusQuartzCrystal()
+	{
+		return this.certusQuartzCrystal;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> certusQuartzCrystalCharged()
+	{
+		return this.certusQuartzCrystalCharged;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> fluixCrystal()
+	{
+		return this.fluixCrystal;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> fluixPearl()
+	{
+		return this.fluixPearl;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> woodenGear()
+	{
+		return this.woodenGear;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> wireless()
+	{
+		return this.wireless;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> wirelessBooster()
+	{
+		return this.wirelessBooster;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> annihilationCore()
+	{
+		return this.annihilationCore;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> formationCore()
+	{
+		return this.formationCore;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> singularity()
+	{
+		return this.singularity;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> qESingularity()
+	{
+		return this.qESingularity;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> blankPattern()
+	{
+		return this.blankPattern;
+	}
+
+	private static final class MaterialTransformationFunction implements Function<AEItemDefinition, AEItemDefinition>
+	{
+		private final ItemMultiMaterial itemMultiMaterial;
+		private final MaterialType type;
+
+		public MaterialTransformationFunction( ItemMultiMaterial itemMultiMaterial, MaterialType type )
+		{
+			this.itemMultiMaterial = itemMultiMaterial;
+			this.type = type;
+		}
+
+		@Nullable
+		@Override
+		public AEItemDefinition apply( AEItemDefinition input )
+		{
+			final IStackSrc stackSource = this.itemMultiMaterial.createMaterial( this.type );
+			final Optional<IStackSrc> maybeSource = Optional.fromNullable( stackSource );
+
+			if ( maybeSource.isPresent() )
+			{
+				return new DamagedItemDefinition( stackSource );
+			}
+			else
+			{
+				return new NullItemDefinition();
+			}
+		}
+	}
+}

--- a/src/main/java/appeng/core/api/definitions/ApiParts.java
+++ b/src/main/java/appeng/core/api/definitions/ApiParts.java
@@ -1,0 +1,429 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.core.api.definitions;
+
+
+import javax.annotation.Nullable;
+
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+
+import appeng.api.definitions.IParts;
+import appeng.api.parts.IPartHelper;
+import appeng.api.util.AEColor;
+import appeng.api.util.AEColoredItemDefinition;
+import appeng.api.util.AEItemDefinition;
+import appeng.core.FeatureHandlerRegistry;
+import appeng.core.FeatureRegistry;
+import appeng.core.features.ColoredItemDefinition;
+import appeng.core.features.DamagedItemDefinition;
+import appeng.core.features.IAEFeature;
+import appeng.core.features.IFeatureHandler;
+import appeng.core.features.IStackSrc;
+import appeng.core.features.ItemStackSrc;
+import appeng.core.features.NullItemDefinition;
+import appeng.items.parts.ItemMultiPart;
+import appeng.items.parts.PartType;
+
+
+/**
+ * Internal implementation for the API parts
+ */
+public final class ApiParts implements IParts
+{
+	private final FeatureRegistry features;
+	private final FeatureHandlerRegistry handlers;
+
+	private final Optional<AEColoredItemDefinition> cableSmart;
+	private final Optional<AEColoredItemDefinition> cableCovered;
+	private final Optional<AEColoredItemDefinition> cableGlass;
+	private final Optional<AEColoredItemDefinition> cableDense;
+	private final Optional<AEColoredItemDefinition> lumenCableSmart;
+	private final Optional<AEColoredItemDefinition> lumenCableCovered;
+	private final Optional<AEColoredItemDefinition> lumenCableGlass;
+	private final Optional<AEColoredItemDefinition> lumenCableDense;
+	private final Optional<AEItemDefinition> quartzFiber;
+	private final Optional<AEItemDefinition> toggleBus;
+	private final Optional<AEItemDefinition> invertedToggleBus;
+	private final Optional<AEItemDefinition> storageBus;
+	private final Optional<AEItemDefinition> importBus;
+	private final Optional<AEItemDefinition> exportBus;
+	private final Optional<AEItemDefinition> iface;
+	private final Optional<AEItemDefinition> levelEmitter;
+	private final Optional<AEItemDefinition> annihilationPlane;
+	private final Optional<AEItemDefinition> formationPlane;
+	private final Optional<AEItemDefinition> p2PTunnelME;
+	private final Optional<AEItemDefinition> p2PTunnelRedstone;
+	private final Optional<AEItemDefinition> p2PTunnelItems;
+	private final Optional<AEItemDefinition> p2PTunnelLiquids;
+	private final Optional<AEItemDefinition> p2PTunnelMJ;
+	private final Optional<AEItemDefinition> p2PTunnelEU;
+	private final Optional<AEItemDefinition> p2PTunnelRF;
+	private final Optional<AEItemDefinition> p2PTunnelLight;
+	private final Optional<AEItemDefinition> cableAnchor;
+	private final Optional<AEItemDefinition> monitor;
+	private final Optional<AEItemDefinition> semiDarkMonitor;
+	private final Optional<AEItemDefinition> darkMonitor;
+	private final Optional<AEItemDefinition> interfaceTerminal;
+	private final Optional<AEItemDefinition> patternTerminal;
+	private final Optional<AEItemDefinition> craftingTerminal;
+	private final Optional<AEItemDefinition> terminal;
+	private final Optional<AEItemDefinition> storageMonitor;
+	private final Optional<AEItemDefinition> conversionMonitor;
+
+	public ApiParts( FeatureRegistry features, FeatureHandlerRegistry handlers, IPartHelper partHelper )
+	{
+		this.features = features;
+		this.handlers = handlers;
+
+		final ItemMultiPart itemMultiPart = new ItemMultiPart( partHelper );
+		final Optional<AEItemDefinition> multiPart = this.getMaybeDefinition( itemMultiPart );
+
+		this.cableSmart = multiPart.transform( new ColoredPartTransformationFunction( itemMultiPart, PartType.CableSmart ) );
+		this.cableCovered = multiPart.transform( new ColoredPartTransformationFunction( itemMultiPart, PartType.CableCovered ) );
+		this.cableGlass = multiPart.transform( new ColoredPartTransformationFunction( itemMultiPart, PartType.CableGlass ) );
+		this.cableDense = multiPart.transform( new ColoredPartTransformationFunction( itemMultiPart, PartType.CableDense ) );
+		this.lumenCableSmart = Optional.absent(); // has yet to be implemented, no PartType defined for it yet
+		this.lumenCableCovered = Optional.absent(); // has yet to be implemented, no PartType defined for it yet
+		this.lumenCableGlass = Optional.absent(); // has yet to be implemented, no PartType defined for it yet
+		this.lumenCableDense = Optional.absent(); // has yet to be implemented, no PartType defined for it yet
+		this.quartzFiber = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.QuartzFiber ) );
+		this.toggleBus = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.ToggleBus ) );
+		this.invertedToggleBus = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.InvertedToggleBus ) );
+		this.storageBus = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.StorageBus ) );
+		this.importBus = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.ImportBus ) );
+		this.exportBus = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.ExportBus ) );
+		this.iface = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.Interface ) );
+		this.levelEmitter = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.LevelEmitter ) );
+		this.annihilationPlane = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.AnnihilationPlane ) );
+		this.formationPlane = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.FormationPlane ) );
+		this.p2PTunnelME = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.P2PTunnelME ) );
+		this.p2PTunnelRedstone = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.P2PTunnelRedstone ) );
+		this.p2PTunnelItems = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.P2PTunnelItems ) );
+		this.p2PTunnelLiquids = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.P2PTunnelLiquids ) );
+		this.p2PTunnelMJ = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.P2PTunnelMJ ) );
+		this.p2PTunnelEU = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.P2PTunnelEU ) );
+		this.p2PTunnelRF = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.P2PTunnelRF ) );
+		this.p2PTunnelLight = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.P2PTunnelLight ) );
+		this.cableAnchor = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.CableAnchor ) );
+		this.monitor = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.Monitor ) );
+		this.semiDarkMonitor = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.SemiDarkMonitor ) );
+		this.darkMonitor = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.DarkMonitor ) );
+		this.interfaceTerminal = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.InterfaceTerminal ) );
+		this.patternTerminal = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.PatternTerminal ) );
+		this.craftingTerminal = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.CraftingTerminal ) );
+		this.terminal = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.Terminal ) );
+		this.storageMonitor = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.StorageMonitor ) );
+		this.conversionMonitor = multiPart.transform( new PartTransformationFunction( itemMultiPart, PartType.ConversionMonitor ) );
+	}
+
+	private Optional<AEItemDefinition> getMaybeDefinition( IAEFeature feature )
+	{
+		final IFeatureHandler handler = feature.handler();
+
+		if ( handler.isFeatureAvailable() )
+		{
+			this.handlers.addFeatureHandler( handler );
+			this.features.addFeature( feature );
+
+			return Optional.of( handler.getDefinition() );
+		}
+		else
+		{
+			return Optional.absent();
+		}
+	}
+
+	@Override
+	public Optional<AEColoredItemDefinition> cableSmart()
+	{
+		return this.cableSmart;
+	}
+
+	@Override
+	public Optional<AEColoredItemDefinition> cableCovered()
+	{
+		return this.cableCovered;
+	}
+
+	@Override
+	public Optional<AEColoredItemDefinition> cableGlass()
+	{
+		return this.cableGlass;
+	}
+
+	@Override
+	public Optional<AEColoredItemDefinition> cableDense()
+	{
+		return this.cableDense;
+	}
+
+	@Override
+	public Optional<AEColoredItemDefinition> lumenCableSmart()
+	{
+		return this.lumenCableSmart;
+	}
+
+	@Override
+	public Optional<AEColoredItemDefinition> lumenCableCovered()
+	{
+		return this.lumenCableCovered;
+	}
+
+	@Override
+	public Optional<AEColoredItemDefinition> lumenCableGlass()
+	{
+		return this.lumenCableGlass;
+	}
+
+	@Override
+	public Optional<AEColoredItemDefinition> lumenCableDense()
+	{
+		return this.lumenCableDense;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> quartzFiber()
+	{
+		return this.quartzFiber;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> toggleBus()
+	{
+		return this.toggleBus;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> invertedToggleBus()
+	{
+		return this.invertedToggleBus;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> storageBus()
+	{
+		return this.storageBus;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> importBus()
+	{
+		return this.importBus;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> exportBus()
+	{
+		return this.exportBus;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> iface()
+	{
+		return this.iface;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> levelEmitter()
+	{
+		return this.levelEmitter;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> annihilationPlane()
+	{
+		return this.annihilationPlane;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> formationPlane()
+	{
+		return this.formationPlane;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> p2PTunnelME()
+	{
+		return this.p2PTunnelME;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> p2PTunnelRedstone()
+	{
+		return this.p2PTunnelRedstone;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> p2PTunnelItems()
+	{
+		return this.p2PTunnelItems;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> p2PTunnelLiquids()
+	{
+		return this.p2PTunnelLiquids;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> p2PTunnelMJ()
+	{
+		return this.p2PTunnelMJ;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> p2PTunnelEU()
+	{
+		return this.p2PTunnelEU;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> p2PTunnelRF()
+	{
+		return this.p2PTunnelRF;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> p2PTunnelLight()
+	{
+		return this.p2PTunnelLight;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> cableAnchor()
+	{
+		return this.cableAnchor;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> monitor()
+	{
+		return this.monitor;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> semiDarkMonitor()
+	{
+		return this.semiDarkMonitor;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> darkMonitor()
+	{
+		return this.darkMonitor;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> interfaceTerminal()
+	{
+		return this.interfaceTerminal;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> patternTerminal()
+	{
+		return this.patternTerminal;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> craftingTerminal()
+	{
+		return this.craftingTerminal;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> terminal()
+	{
+		return this.terminal;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> storageMonitor()
+	{
+		return this.storageMonitor;
+	}
+
+	@Override
+	public Optional<AEItemDefinition> conversionMonitor()
+	{
+		return this.conversionMonitor;
+	}
+
+	private static final class ColoredPartTransformationFunction implements Function<AEItemDefinition, AEColoredItemDefinition>
+	{
+		private final ItemMultiPart multiPart;
+		private final PartType type;
+
+		public ColoredPartTransformationFunction( ItemMultiPart multiPart, PartType type )
+		{
+			this.multiPart = multiPart;
+			this.type = type;
+		}
+
+		@Nullable
+		@Override
+		public AEColoredItemDefinition apply( @Nullable AEItemDefinition input )
+		{
+			final ColoredItemDefinition coloredDefinition = new ColoredItemDefinition();
+			for ( AEColor color : this.type.getVariants() )
+			{
+				ItemStackSrc multiPartSource = this.multiPart.createPart( this.type, color );
+				final Optional<ItemStackSrc> maybeSource = Optional.fromNullable( multiPartSource );
+
+				if ( maybeSource.isPresent() )
+				{
+					coloredDefinition.add( color, multiPartSource );
+				}
+			}
+
+			return coloredDefinition;
+		}
+	}
+
+
+	private static final class PartTransformationFunction implements Function<AEItemDefinition, AEItemDefinition>
+	{
+		private final ItemMultiPart multiPart;
+		private final PartType type;
+
+		public PartTransformationFunction( ItemMultiPart multiPart, PartType type )
+		{
+			this.multiPart = multiPart;
+			this.type = type;
+		}
+
+		@Nullable
+		@Override
+		public AEItemDefinition apply( AEItemDefinition input )
+		{
+			final IStackSrc stackSource = this.multiPart.createPart( this.type, null );
+			final Optional<IStackSrc> maybeSource = Optional.fromNullable( stackSource );
+
+			if ( maybeSource.isPresent() )
+			{
+				return new DamagedItemDefinition( stackSource );
+			}
+			else
+			{
+				return new NullItemDefinition();
+			}
+		}
+	}
+}

--- a/src/main/java/appeng/core/features/AEBlockFeatureHandler.java
+++ b/src/main/java/appeng/core/features/AEBlockFeatureHandler.java
@@ -46,7 +46,7 @@ public class AEBlockFeatureHandler implements IFeatureHandler
 		this.features = features;
 		this.featured = featured;
 		this.extractor = new FeatureNameExtractor( featured.getClass(), subName );
-		this.enabled = new FeaturedActiveChecker( features ).get();
+		this.enabled = new FeaturedActiveChecker( features ).isFeatureActive();
 		this.definition = new AEBlockDefinition( featured, this.enabled );
 	}
 

--- a/src/main/java/appeng/core/features/AEFeatureHandler.java
+++ b/src/main/java/appeng/core/features/AEFeatureHandler.java
@@ -49,8 +49,8 @@ public class AEFeatureHandler implements AEItemDefinition
 	private final String subName;
 	private final IAEFeature feature;
 
-	private Item ItemData;
-	private Block BlockData;
+	private Item itemData;
+	private Block blockData;
 	private BlockStairs stairData;
 
 	public AEFeatureHandler( EnumSet<AEFeature> features, IAEFeature feature, String subName )
@@ -91,7 +91,7 @@ public class AEFeatureHandler implements AEItemDefinition
 
 	private void initItem( Item i )
 	{
-		this.ItemData = i;
+		this.itemData = i;
 
 		String name = getName( i.getClass(), this.subName );
 		i.setTextureName( "appliedenergistics2:" + name );
@@ -124,14 +124,14 @@ public class AEFeatureHandler implements AEItemDefinition
 
 	private void initBlock( Block b )
 	{
-		this.BlockData = b;
+		this.blockData = b;
 
 		String name = getName( b.getClass(), this.subName );
 		b.setCreativeTab( CreativeTab.instance );
 		b.setBlockName( /* "tile." */"appliedenergistics2." + name );
 		b.setBlockTextureName( "appliedenergistics2:" + name );
 
-		if ( Platform.isClient() && this.BlockData instanceof AEBaseBlock )
+		if ( Platform.isClient() && this.blockData instanceof AEBaseBlock )
 		{
 			AEBaseBlock bb = ( AEBaseBlock ) b;
 			CommonHelper.proxy.bindTileEntitySpecialRenderer( bb.getTileEntityClass(), bb );
@@ -179,19 +179,19 @@ public class AEFeatureHandler implements AEItemDefinition
 	@Override
 	public Block block()
 	{
-		return this.BlockData;
+		return this.blockData;
 	}
 
 	@Override
 	public Item item()
 	{
-		if ( this.ItemData != null )
+		if ( this.itemData != null )
 		{
-			return this.ItemData;
+			return this.itemData;
 		}
-		else if ( this.BlockData != null )
+		else if ( this.blockData != null )
 		{
-			return Item.getItemFromBlock( this.BlockData );
+			return Item.getItemFromBlock( this.blockData );
 		}
 		else if ( this.stairData != null )
 		{
@@ -204,9 +204,9 @@ public class AEFeatureHandler implements AEItemDefinition
 	@Override
 	public Class<? extends TileEntity> entity()
 	{
-		if ( this.BlockData instanceof AEBaseBlock )
+		if ( this.blockData instanceof AEBaseBlock )
 		{
-			AEBaseBlock bb = ( AEBaseBlock ) this.BlockData;
+			AEBaseBlock bb = ( AEBaseBlock ) this.blockData;
 			return bb.getTileEntityClass();
 		}
 
@@ -220,10 +220,10 @@ public class AEFeatureHandler implements AEItemDefinition
 		{
 			ItemStack rv;
 
-			if ( this.ItemData != null )
-				rv = new ItemStack( this.ItemData );
+			if ( this.itemData != null )
+				rv = new ItemStack( this.itemData );
 			else
-				rv = new ItemStack( this.BlockData );
+				rv = new ItemStack( this.blockData );
 
 			rv.stackSize = stackSize;
 			return rv;
@@ -255,7 +255,7 @@ public class AEFeatureHandler implements AEItemDefinition
 	@Override
 	public boolean sameAsBlock( IBlockAccess world, int x, int y, int z )
 	{
-		return this.isFeatureAvailable() && this.BlockData != null && world.getBlock( x, y, z ) == this.BlockData;
+		return this.isFeatureAvailable() && this.blockData != null && world.getBlock( x, y, z ) == this.blockData;
 	}
 
 }

--- a/src/main/java/appeng/core/features/FeaturedActiveChecker.java
+++ b/src/main/java/appeng/core/features/FeaturedActiveChecker.java
@@ -33,7 +33,7 @@ public class FeaturedActiveChecker
 		this.features = features;
 	}
 
-	public boolean get()
+	public boolean isFeatureActive()
 	{
 		for ( AEFeature f : this.features )
 		{

--- a/src/main/java/appeng/core/features/ItemFeatureHandler.java
+++ b/src/main/java/appeng/core/features/ItemFeatureHandler.java
@@ -46,7 +46,7 @@ public class ItemFeatureHandler implements IFeatureHandler
 		this.features = features;
 		this.item = item;
 		this.extractor = new FeatureNameExtractor( featured.getClass(), subName );
-		this.enabled = new FeaturedActiveChecker( features ).get();
+		this.enabled = new FeaturedActiveChecker( features ).isFeatureActive();
 		this.definition = new ItemDefinition( item, this.enabled );
 	}
 

--- a/src/main/java/appeng/core/features/StairBlockFeatureHandler.java
+++ b/src/main/java/appeng/core/features/StairBlockFeatureHandler.java
@@ -44,7 +44,7 @@ public class StairBlockFeatureHandler implements IFeatureHandler
 		this.features = features;
 		this.stairs = stairs;
 		this.extractor = new FeatureNameExtractor( stairs.getClass(), subName );
-		this.enabled = new FeaturedActiveChecker( features ).get();
+		this.enabled = new FeaturedActiveChecker( features ).isFeatureActive();
 		this.definition = new BlockDefinition( stairs, this.enabled );
 	}
 

--- a/src/main/java/appeng/core/features/registries/P2PTunnelRegistry.java
+++ b/src/main/java/appeng/core/features/registries/P2PTunnelRegistry.java
@@ -30,9 +30,14 @@ import cpw.mods.fml.common.registry.GameRegistry;
 
 import appeng.api.AEApi;
 import appeng.api.config.TunnelType;
+import appeng.api.definitions.IBlocks;
+import appeng.api.definitions.IDefinitions;
+import appeng.api.definitions.IParts;
 import appeng.api.definitions.Parts;
 import appeng.api.features.IP2PTunnelRegistry;
 import appeng.api.util.AEColor;
+import appeng.api.util.AEColoredItemDefinition;
+import appeng.api.util.AEItemDefinition;
 import appeng.util.Platform;
 
 public class P2PTunnelRegistry implements IP2PTunnelRegistry
@@ -78,14 +83,30 @@ public class P2PTunnelRegistry implements IP2PTunnelRegistry
 		/**
 		 * attune based on lots of random item related stuff
 		 */
-		appeng.api.definitions.Blocks AEBlocks = AEApi.instance().blocks();
-		Parts Parts = AEApi.instance().parts();
+		final IDefinitions definitions = AEApi.instance().definitions();
+		final IBlocks blocks = definitions.blocks();
+		final IParts parts = definitions.parts();
 
-		this.addNewAttunement( AEBlocks.blockInterface.stack( 1 ), TunnelType.ITEM );
-		this.addNewAttunement( Parts.partInterface.stack( 1 ), TunnelType.ITEM );
-		this.addNewAttunement( Parts.partStorageBus.stack( 1 ), TunnelType.ITEM );
-		this.addNewAttunement( Parts.partImportBus.stack( 1 ), TunnelType.ITEM );
-		this.addNewAttunement( Parts.partExportBus.stack( 1 ), TunnelType.ITEM );
+		for ( AEItemDefinition iface : blocks.iface().asSet() )
+		{
+			this.addNewAttunement( iface.stack( 1 ), TunnelType.ITEM );
+		}
+		for ( AEItemDefinition iface : parts.iface().asSet() )
+		{
+			this.addNewAttunement( iface.stack( 1 ), TunnelType.ITEM );
+		}
+		for ( AEItemDefinition storageBus : parts.storageBus().asSet() )
+		{
+			this.addNewAttunement( storageBus.stack( 1 ), TunnelType.ITEM );
+		}
+		for ( AEItemDefinition importBus : parts.importBus().asSet() )
+		{
+			this.addNewAttunement( importBus.stack( 1 ), TunnelType.ITEM );
+		}
+		for ( AEItemDefinition exportBus : parts.exportBus().asSet() )
+		{
+			this.addNewAttunement( exportBus.stack( 1 ), TunnelType.ITEM );
+		}
 		this.addNewAttunement( new ItemStack( Blocks.hopper ), TunnelType.ITEM );
 		this.addNewAttunement( new ItemStack( Blocks.chest ), TunnelType.ITEM );
 		this.addNewAttunement( new ItemStack( Blocks.trapped_chest ), TunnelType.ITEM );
@@ -108,10 +129,22 @@ public class P2PTunnelRegistry implements IP2PTunnelRegistry
 
 		for (AEColor c : AEColor.values())
 		{
-			this.addNewAttunement( Parts.partCableGlass.stack( c, 1 ), TunnelType.ME );
-			this.addNewAttunement( Parts.partCableCovered.stack( c, 1 ), TunnelType.ME );
-			this.addNewAttunement( Parts.partCableSmart.stack( c, 1 ), TunnelType.ME );
-			this.addNewAttunement( Parts.partCableDense.stack( c, 1 ), TunnelType.ME );
+			for ( AEColoredItemDefinition glass : parts.cableGlass().asSet() )
+			{
+				this.addNewAttunement( glass.stack( c, 1 ), TunnelType.ME );
+			}
+			for ( AEColoredItemDefinition covered : parts.cableCovered().asSet() )
+			{
+				this.addNewAttunement( covered.stack( c, 1 ), TunnelType.ME );
+			}
+			for ( AEColoredItemDefinition smart : parts.cableSmart().asSet() )
+			{
+				this.addNewAttunement( smart.stack( c, 1 ), TunnelType.ME );
+			}
+			for ( AEColoredItemDefinition dense : parts.cableDense().asSet() )
+			{
+				this.addNewAttunement( dense.stack( c, 1 ), TunnelType.ME );
+			}
 		}
 	}
 

--- a/src/main/java/appeng/core/stats/Achievements.java
+++ b/src/main/java/appeng/core/stats/Achievements.java
@@ -23,6 +23,8 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.stats.Achievement;
 
+import com.google.common.base.Optional;
+
 import appeng.api.AEApi;
 import appeng.api.util.AEColor;
 import appeng.api.util.AEColoredItemDefinition;
@@ -31,81 +33,80 @@ import appeng.api.util.AEItemDefinition;
 
 public enum Achievements
 {
+	// done
+	Compass( -2, -4, AEApi.instance().definitions().blocks().skyCompass().get(), AchievementType.Craft ),
 
 	// done
-	Compass( -2, -4, AEApi.instance().blocks().blockSkyCompass, AchievementType.Craft ),
+	Presses( -2, -2, AEApi.instance().definitions().materials().logicProcessorPress().get(), AchievementType.Custom ),
 
 	// done
-	Presses( -2, -2, AEApi.instance().materials().materialLogicProcessorPress, AchievementType.Custom ),
+	SpatialIO( -4, -4, AEApi.instance().definitions().blocks().spatialIOPort().get(), AchievementType.Craft ),
 
 	// done
-	SpatialIO( -4, -4, AEApi.instance().blocks().blockSpatialIOPort, AchievementType.Craft ),
+	SpatialIOExplorer( -4, -2, AEApi.instance().definitions().items().spatialCell128().get(), AchievementType.Custom ),
 
 	// done
-	SpatialIOExplorer( -4, -2, AEApi.instance().items().itemSpatialCell128, AchievementType.Custom ),
+	StorageCell( -6, -4, AEApi.instance().definitions().items().cell64k().get(), AchievementType.CraftItem ),
 
 	// done
-	StorageCell( -6, -4, AEApi.instance().items().itemCell64k, AchievementType.CraftItem ),
+	IOPort( -6, -2, AEApi.instance().definitions().blocks().iOPort().get(), AchievementType.Craft ),
 
 	// done
-	IOPort( -6, -2, AEApi.instance().blocks().blockIOPort, AchievementType.Craft ),
+	CraftingTerminal( -8, -4, AEApi.instance().definitions().parts().craftingTerminal().get(), AchievementType.Craft ),
 
 	// done
-	CraftingTerminal( -8, -4, AEApi.instance().parts().partCraftingTerminal, AchievementType.Craft ),
+	PatternTerminal( -8, -2, AEApi.instance().definitions().parts().patternTerminal().get(), AchievementType.Craft ),
 
 	// done
-	PatternTerminal( -8, -2, AEApi.instance().parts().partPatternTerminal, AchievementType.Craft ),
+	ChargedQuartz( 0, -4, AEApi.instance().definitions().materials().certusQuartzCrystalCharged().get(), AchievementType.Pickup ),
 
 	// done
-	ChargedQuartz( 0, -4, AEApi.instance().materials().materialCertusQuartzCrystalCharged, AchievementType.Pickup ),
+	Fluix( 0, -2, AEApi.instance().definitions().materials().fluixCrystal().get(), AchievementType.Pickup ),
 
 	// done
-	Fluix( 0, -2, AEApi.instance().materials().materialFluixCrystal, AchievementType.Pickup ),
+	Charger( 0, 0, AEApi.instance().definitions().blocks().charger().get(), AchievementType.Craft ),
 
 	// done
-	Charger( 0, 0, AEApi.instance().blocks().blockCharger, AchievementType.Craft ),
+	CrystalGrowthAccelerator( -2, 0, AEApi.instance().definitions().blocks().quartzGrowthAccelerator().get(), AchievementType.Craft ),
 
 	// done
-	CrystalGrowthAccelerator( -2, 0, AEApi.instance().blocks().blockQuartzGrowthAccelerator, AchievementType.Craft ),
+	GlassCable( 2, 0, AEApi.instance().definitions().parts().cableGlass().get(), AchievementType.Craft ),
 
 	// done
-	GlassCable( 2, 0, AEApi.instance().parts().partCableGlass, AchievementType.Craft ),
+	Networking1( 4, -6, AEApi.instance().definitions().parts().cableCovered().get(), AchievementType.Custom ),
 
 	// done
-	Networking1( 4, -6, AEApi.instance().parts().partCableCovered, AchievementType.Custom ),
+	Controller( 4, -4, AEApi.instance().definitions().blocks().controller().get(), AchievementType.Craft ),
 
 	// done
-	Controller( 4, -4, AEApi.instance().blocks().blockController, AchievementType.Craft ),
+	Networking2( 4, 0, AEApi.instance().definitions().parts().cableSmart().get(), AchievementType.Custom ),
 
 	// done
-	Networking2( 4, 0, AEApi.instance().parts().partCableSmart, AchievementType.Custom ),
+	Networking3( 4, 2, AEApi.instance().definitions().parts().cableDense().get(), AchievementType.Custom ),
 
 	// done
-	Networking3( 4, 2, AEApi.instance().parts().partCableDense, AchievementType.Custom ),
+	P2P( 2, -2, AEApi.instance().definitions().parts().p2PTunnelME().get(), AchievementType.Craft ),
 
 	// done
-	P2P( 2, -2, AEApi.instance().parts().partP2PTunnelME, AchievementType.Craft ),
+	Recursive( 6, -2, AEApi.instance().definitions().blocks().iface().get(), AchievementType.Craft ),
 
 	// done
-	Recursive( 6, -2, AEApi.instance().blocks().blockInterface, AchievementType.Craft ),
+	CraftingCPU( 6, 0, AEApi.instance().definitions().blocks().craftingStorage64k().get(), AchievementType.CraftItem ),
 
 	// done
-	CraftingCPU( 6, 0, AEApi.instance().blocks().blockCraftingStorage64k, AchievementType.CraftItem ),
+	Facade( 6, 2, AEApi.instance().definitions().items().facade().get(), AchievementType.CraftItem ),
 
 	// done
-	Facade( 6, 2, AEApi.instance().items().itemFacade, AchievementType.CraftItem ),
+	NetworkTool( 8, 0, AEApi.instance().definitions().items().networkTool().get(), AchievementType.Craft ),
 
 	// done
-	NetworkTool( 8, 0, AEApi.instance().items().itemNetworkTool, AchievementType.Craft ),
+	PortableCell( 8, 2, AEApi.instance().definitions().items().portableCell().get(), AchievementType.Craft ),
 
 	// done
-	PortableCell( 8, 2, AEApi.instance().items().itemPortableCell, AchievementType.Craft ),
+	StorageBus( 10, 0, AEApi.instance().definitions().parts().storageBus().get(), AchievementType.Craft ),
 
 	// done
-	StorageBus( 10, 0, AEApi.instance().parts().partStorageBus, AchievementType.Craft ),
-
-	// done
-	QNB( 10, 2, AEApi.instance().blocks().blockQuantumLink, AchievementType.Craft );
+	QNB( 10, 2, AEApi.instance().definitions().blocks().quantumLink().get(), AchievementType.Craft );
 
 	public final ItemStack stack;
 	public final AchievementType type;

--- a/src/main/java/appeng/core/sync/packets/PacketClick.java
+++ b/src/main/java/appeng/core/sync/packets/PacketClick.java
@@ -24,9 +24,13 @@ import io.netty.buffer.Unpooled;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 
+import com.google.common.base.Optional;
+
 import appeng.api.AEApi;
+import appeng.api.definitions.IItems;
 import appeng.api.implementations.items.IMemoryCard;
 import appeng.api.implementations.items.MemoryCardMessages;
+import appeng.api.util.AEItemDefinition;
 import appeng.core.sync.AppEngPacket;
 import appeng.core.sync.network.INetworkInfo;
 import appeng.items.tools.ToolNetworkTool;
@@ -58,21 +62,30 @@ public class PacketClick extends AppEngPacket
 	public void serverPacketData(INetworkInfo manager, AppEngPacket packet, EntityPlayer player)
 	{
 		ItemStack is = player.inventory.getCurrentItem();
-		if ( is != null && is.getItem() instanceof ToolNetworkTool )
+		final IItems items = AEApi.instance().definitions().items();
+		final Optional<AEItemDefinition> maybeMemoryCard = items.memoryCard();
+		final Optional<AEItemDefinition> maybeColorApplicator = items.colorApplicator();
+
+		if ( is != null )
 		{
-			ToolNetworkTool tnt = (ToolNetworkTool) is.getItem();
-			tnt.serverSideToolLogic( is, player, player.worldObj, this.x, this.y, this.z, this.side, this.hitX, this.hitY, this.hitZ );
-		}
-		else if ( is != null && AEApi.instance().items().itemMemoryCard.sameAsStack( is ) )
-		{
-			IMemoryCard mem = (IMemoryCard) is.getItem();
-			mem.notifyUser( player, MemoryCardMessages.SETTINGS_CLEARED );
-			is.setTagCompound( null );
-		}
-		else if ( is != null && AEApi.instance().items().itemColorApplicator.sameAsStack( is ) )
-		{
-			ToolColorApplicator mem = (ToolColorApplicator) is.getItem();
-			mem.cycleColors( is, mem.getColor( is ), 1 );
+			if ( is.getItem() instanceof ToolNetworkTool )
+			{
+				ToolNetworkTool tnt = (ToolNetworkTool) is.getItem();
+				tnt.serverSideToolLogic( is, player, player.worldObj, this.x, this.y, this.z, this.side, this.hitX, this.hitY, this.hitZ );
+			}
+
+			else if ( maybeMemoryCard.isPresent() && maybeMemoryCard.get().sameAsStack( is ) )
+			{
+				IMemoryCard mem = (IMemoryCard) is.getItem();
+				mem.notifyUser( player, MemoryCardMessages.SETTINGS_CLEARED );
+				is.setTagCompound( null );
+			}
+
+			else if ( maybeColorApplicator.isPresent() && maybeColorApplicator.get().sameAsStack( is ) )
+			{
+				ToolColorApplicator mem = (ToolColorApplicator) is.getItem();
+				mem.cycleColors( is, mem.getColor( is ), 1 );
+			}
 		}
 	}
 

--- a/src/main/java/appeng/entity/EntityChargedQuartz.java
+++ b/src/main/java/appeng/entity/EntityChargedQuartz.java
@@ -30,6 +30,8 @@ import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 
 import appeng.api.AEApi;
+import appeng.api.definitions.IMaterials;
+import appeng.api.util.AEItemDefinition;
 import appeng.client.EffectType;
 import appeng.core.AEConfig;
 import appeng.core.CommonHelper;
@@ -87,49 +89,57 @@ final public class EntityChargedQuartz extends AEBaseEntityItem
 	public boolean transform()
 	{
 		ItemStack item = this.getEntityItem();
-		if ( AEApi.instance().materials().materialCertusQuartzCrystalCharged.sameAsStack( item ) )
+		final IMaterials materials = AEApi.instance().definitions().materials();
+
+		for ( AEItemDefinition definition : materials.certusQuartzCrystalCharged().asSet() )
 		{
-			AxisAlignedBB region = AxisAlignedBB.getBoundingBox( this.posX - 1, this.posY - 1, this.posZ - 1, this.posX + 1, this.posY + 1, this.posZ + 1 );
-			List<Entity> l = this.getCheckedEntitiesWithinAABBExcludingEntity( region );
-
-			EntityItem redstone = null;
-			EntityItem netherQuartz = null;
-
-			for (Entity e : l)
+			if ( definition.sameAsStack( item ) )
 			{
-				if ( e instanceof EntityItem && !e.isDead )
-				{
-					ItemStack other = ((EntityItem) e).getEntityItem();
-					if ( other != null && other.stackSize > 0 )
-					{
-						if ( Platform.isSameItem( other, new ItemStack( Items.redstone ) ) )
-							redstone = (EntityItem) e;
+				AxisAlignedBB region = AxisAlignedBB.getBoundingBox( this.posX - 1, this.posY - 1, this.posZ - 1, this.posX + 1, this.posY + 1, this.posZ + 1 );
+				List<Entity> l = this.getCheckedEntitiesWithinAABBExcludingEntity( region );
 
-						if ( Platform.isSameItem( other, new ItemStack( Items.quartz ) ) )
-							netherQuartz = (EntityItem) e;
+				EntityItem redstone = null;
+				EntityItem netherQuartz = null;
+
+				for (Entity e : l)
+				{
+					if ( e instanceof EntityItem && !e.isDead )
+					{
+						ItemStack other = ((EntityItem) e).getEntityItem();
+						if ( other != null && other.stackSize > 0 )
+						{
+							if ( Platform.isSameItem( other, new ItemStack( Items.redstone ) ) )
+								redstone = (EntityItem) e;
+
+							if ( Platform.isSameItem( other, new ItemStack( Items.quartz ) ) )
+								netherQuartz = (EntityItem) e;
+						}
 					}
 				}
-			}
 
-			if ( redstone != null && netherQuartz != null )
-			{
-				this.getEntityItem().stackSize--;
-				redstone.getEntityItem().stackSize--;
-				netherQuartz.getEntityItem().stackSize--;
+				if ( redstone != null && netherQuartz != null )
+				{
+					this.getEntityItem().stackSize--;
+					redstone.getEntityItem().stackSize--;
+					netherQuartz.getEntityItem().stackSize--;
 
-				if ( this.getEntityItem().stackSize <= 0 )
-					this.setDead();
+					if ( this.getEntityItem().stackSize <= 0 )
+						this.setDead();
 
-				if ( redstone.getEntityItem().stackSize <= 0 )
-					redstone.setDead();
+					if ( redstone.getEntityItem().stackSize <= 0 )
+						redstone.setDead();
 
-				if ( netherQuartz.getEntityItem().stackSize <= 0 )
-					netherQuartz.setDead();
+					if ( netherQuartz.getEntityItem().stackSize <= 0 )
+						netherQuartz.setDead();
 
-				ItemStack Output = AEApi.instance().materials().materialFluixCrystal.stack( 2 );
-				this.worldObj.spawnEntityInWorld( new EntityItem( this.worldObj, this.posX, this.posY, this.posZ, Output ) );
+					for ( AEItemDefinition fluixCrystal : materials.fluixCrystal().asSet() )
+					{
+						ItemStack output = fluixCrystal.stack( 2 );
+						this.worldObj.spawnEntityInWorld( new EntityItem( this.worldObj, this.posX, this.posY, this.posZ, output ) );
+					}
 
-				return true;
+					return true;
+				}
 			}
 		}
 		return false;

--- a/src/main/java/appeng/entity/EntityTinyTNTPrimed.java
+++ b/src/main/java/appeng/entity/EntityTinyTNTPrimed.java
@@ -34,6 +34,7 @@ import net.minecraft.world.World;
 import cpw.mods.fml.common.registry.IEntityAdditionalSpawnData;
 
 import appeng.api.AEApi;
+import appeng.api.util.AEItemDefinition;
 import appeng.core.AEConfig;
 import appeng.core.CommonHelper;
 import appeng.core.features.AEFeature;
@@ -80,15 +81,18 @@ final public class EntityTinyTNTPrimed extends EntityTNTPrimed implements IEntit
 
 		if ( this.isInWater() && Platform.isServer() ) // put out the fuse.
 		{
-			EntityItem item = new EntityItem( this.worldObj, this.posX, this.posY, this.posZ, AEApi.instance().blocks().blockTinyTNT.stack( 1 ) );
-			item.motionX = this.motionX;
-			item.motionY = this.motionY;
-			item.motionZ = this.motionZ;
-			item.prevPosX = this.prevPosX;
-			item.prevPosY = this.prevPosY;
-			item.prevPosZ = this.prevPosZ;
-			this.worldObj.spawnEntityInWorld( item );
-			this.setDead();
+			for ( AEItemDefinition definition : AEApi.instance().definitions().blocks().tinyTNT().asSet() )
+			{
+				EntityItem item = new EntityItem( this.worldObj, this.posX, this.posY, this.posZ, definition.stack( 1 ) );
+				item.motionX = this.motionX;
+				item.motionY = this.motionY;
+				item.motionZ = this.motionZ;
+				item.prevPosX = this.prevPosX;
+				item.prevPosY = this.prevPosY;
+				item.prevPosZ = this.prevPosZ;
+				this.worldObj.spawnEntityInWorld( item );
+				this.setDead();
+			}
 		}
 
 		if ( this.fuse-- <= 0 )

--- a/src/main/java/appeng/facade/FacadeContainer.java
+++ b/src/main/java/appeng/facade/FacadeContainer.java
@@ -32,6 +32,7 @@ import appeng.api.AEApi;
 import appeng.api.parts.IFacadeContainer;
 import appeng.api.parts.IFacadePart;
 import appeng.api.parts.IPartHost;
+import appeng.api.util.AEItemDefinition;
 import appeng.core.AppEng;
 import appeng.integration.IntegrationType;
 import appeng.integration.abstraction.IBC;
@@ -99,12 +100,15 @@ public class FacadeContainer implements IFacadeContainer
 				}
 				else if ( !isBC )
 				{
-					ItemFacade ifa = (ItemFacade) AEApi.instance().items().itemFacade.item();
-					ItemStack facade = ifa.createFromIDs( ids );
-					if ( facade != null )
+					for ( AEItemDefinition definition : AEApi.instance().definitions().items().facade().asSet() )
 					{
-						changed = changed || this.storage.getFacade( x ) == null;
-						this.storage.setFacade( x, ifa.createPartFromItemStack( facade, side ) );
+						ItemFacade ifa = (ItemFacade) definition.item();
+						ItemStack facade = ifa.createFromIDs( ids );
+						if ( facade != null )
+						{
+							changed = changed || this.storage.getFacade( x ) == null;
+							this.storage.setFacade( x, ifa.createPartFromItemStack( facade, side ) );
+						}
 					}
 				}
 			}

--- a/src/main/java/appeng/fmp/PartRegistry.java
+++ b/src/main/java/appeng/fmp/PartRegistry.java
@@ -51,7 +51,7 @@ public enum PartRegistry
 		try
 		{
 			if ( this == CableBusPart )
-				return (TMultiPart) Api.INSTANCE.partHelper.getCombinedInstance( this.part.getName() ).newInstance();
+				return (TMultiPart) Api.INSTANCE.getPartHelper().getCombinedInstance( this.part.getName() ).newInstance();
 			else
 				return this.part.getConstructor( int.class ).newInstance( meta );
 		}

--- a/src/main/java/appeng/fmp/QuartzTorchPart.java
+++ b/src/main/java/appeng/fmp/QuartzTorchPart.java
@@ -31,6 +31,9 @@ import codechicken.multipart.minecraft.McBlockPart;
 import codechicken.multipart.minecraft.McSidedMetaPart;
 
 import appeng.api.AEApi;
+import appeng.api.exceptions.MissingDefinition;
+import appeng.api.util.AEItemDefinition;
+
 
 public class QuartzTorchPart extends McSidedMetaPart implements IRandomDisplayTick
 {
@@ -52,7 +55,12 @@ public class QuartzTorchPart extends McSidedMetaPart implements IRandomDisplayTi
 	@Override
 	public Block getBlock()
 	{
-		return AEApi.instance().blocks().blockQuartzTorch.block();
+		for ( AEItemDefinition definition : AEApi.instance().definitions().blocks().quartzTorch().asSet() )
+		{
+			return definition.block();
+		}
+
+		throw new MissingDefinition( "No quartz torch." );
 	}
 
 	@Override

--- a/src/main/java/appeng/helpers/MeteoritePlacer.java
+++ b/src/main/java/appeng/helpers/MeteoritePlacer.java
@@ -21,6 +21,7 @@ package appeng.helpers;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 
 import net.minecraft.block.Block;
 import net.minecraft.entity.Entity;
@@ -36,7 +37,12 @@ import net.minecraft.world.chunk.Chunk;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.oredict.OreDictionary;
 
+import com.google.common.base.Optional;
+
 import appeng.api.AEApi;
+import appeng.api.definitions.IBlocks;
+import appeng.api.definitions.IMaterials;
+import appeng.api.util.AEItemDefinition;
 import appeng.core.AEConfig;
 import appeng.core.WorldSettings;
 import appeng.core.features.AEFeature;
@@ -402,7 +408,8 @@ public class MeteoritePlacer
 
 	Fallout type = new Fallout();
 
-	final Block skystone = AEApi.instance().blocks().blockSkyStone.block();
+	private static final Optional<AEItemDefinition> MAYBE_SKY_STONE = AEApi.instance().definitions().blocks().skyStone();
+	final Block skystone = ( MAYBE_SKY_STONE.isPresent() ) ? MAYBE_SKY_STONE.get().block() : null;
 	final Block skychest;
 
 	double real_sizeOfMeteorite = (Math.random() * 6.0) + 2;
@@ -413,10 +420,24 @@ public class MeteoritePlacer
 
 	public MeteoritePlacer() {
 
-		if ( AEApi.instance().blocks().blockSkyChest.block() == null )
-			this.skychest = Blocks.chest;
+		final Optional<AEItemDefinition> maybeSkychest = AEApi.instance().definitions().blocks().skyChest();
+		if ( maybeSkychest.isPresent() )
+		{
+			final AEItemDefinition definition = maybeSkychest.get();
+
+			if ( definition.block() == null )
+			{
+				this.skychest = Blocks.chest;
+			}
+			else
+			{
+				this.skychest = definition.block();
+			}
+		}
 		else
-			this.skychest = AEApi.instance().blocks().blockSkyChest.block();
+		{
+			this.skychest = Blocks.chest;
+		}
 
 		this.validSpawn.add( Blocks.stone );
 		this.validSpawn.add( Blocks.cobblestone );
@@ -681,20 +702,33 @@ public class MeteoritePlacer
 							r = (int) (Math.random() * 1000);
 
 						ItemStack toAdd = null;
+						final IMaterials materials = AEApi.instance().definitions().materials();
 
 						switch (r % 4)
 						{
 						case 0:
-							toAdd = AEApi.instance().materials().materialCalcProcessorPress.stack( 1 );
+							for ( AEItemDefinition calc : materials.calcProcessorPress().asSet() )
+							{
+								toAdd = calc.stack( 1 );
+							}
 							break;
 						case 1:
-							toAdd = AEApi.instance().materials().materialEngProcessorPress.stack( 1 );
+							for ( AEItemDefinition calc : materials.engProcessorPress().asSet() )
+							{
+								toAdd = calc.stack( 1 );
+							}
 							break;
 						case 2:
-							toAdd = AEApi.instance().materials().materialLogicProcessorPress.stack( 1 );
+							for ( AEItemDefinition calc : materials.logicProcessorPress().asSet() )
+							{
+								toAdd = calc.stack( 1 );
+							}
 							break;
 						case 3:
-							toAdd = AEApi.instance().materials().materialSiliconPress.stack( 1 );
+							for ( AEItemDefinition calc : materials.siliconPress().asSet() )
+							{
+								toAdd = calc.stack( 1 );
+							}
 							break;
 						default:
 						}
@@ -710,13 +744,18 @@ public class MeteoritePlacer
 					while (duplicate);
 				}
 
+				final Set<AEItemDefinition> maybeSkystone = AEApi.instance().definitions().blocks().skyStone().asSet();
+
 				int secondary = Math.max( 1, (int) (Math.random() * 3) );
 				for (int zz = 0; zz < secondary; zz++)
 				{
 					switch ((int) (Math.random() * 1000) % 3)
 					{
 					case 0:
-						ap.addItems( AEApi.instance().blocks().blockSkyStone.stack( (int) (Math.random() * 12) + 1 ) );
+						for ( AEItemDefinition definition : maybeSkystone )
+						{
+							ap.addItems( definition.stack( (int) (Math.random() * 12) + 1 ) );
+						}
 						break;
 					case 1:
 						List<ItemStack> possibles = new LinkedList<ItemStack>();

--- a/src/main/java/appeng/hooks/AETrading.java
+++ b/src/main/java/appeng/hooks/AETrading.java
@@ -29,6 +29,9 @@ import net.minecraft.village.MerchantRecipeList;
 import cpw.mods.fml.common.registry.VillagerRegistry.IVillageTradeHandler;
 
 import appeng.api.AEApi;
+import appeng.api.definitions.IMaterials;
+import appeng.api.util.AEItemDefinition;
+
 
 public class AETrading implements IVillageTradeHandler
 {
@@ -96,12 +99,30 @@ public class AETrading implements IVillageTradeHandler
 	@Override
 	public void manipulateTradesForVillager(EntityVillager villager, MerchantRecipeList recipeList, Random random)
 	{
-		this.addMerchant( recipeList, AEApi.instance().materials().materialSilicon.stack( 1 ), 1, random, 2 );
-		this.addMerchant( recipeList, AEApi.instance().materials().materialCertusQuartzCrystal.stack( 1 ), 2, random, 4 );
-		this.addMerchant( recipeList, AEApi.instance().materials().materialCertusQuartzDust.stack( 1 ), 1, random, 3 );
+		final IMaterials materials = AEApi.instance().definitions().materials();
 
-		this.addTrade( recipeList, AEApi.instance().materials().materialCertusQuartzDust.stack( 1 ),
-				AEApi.instance().materials().materialCertusQuartzCrystal.stack( 1 ), random, 2 );
+		for ( AEItemDefinition definition : materials.silicon().asSet() )
+		{
+			this.addMerchant( recipeList, definition.stack( 1 ), 1, random, 2 );
+		}
+
+		for ( AEItemDefinition definition : materials.certusQuartzCrystal().asSet() )
+		{
+			this.addMerchant( recipeList, definition.stack( 1 ), 2, random, 4 );
+		}
+
+		for ( AEItemDefinition definition : materials.certusQuartzDust().asSet() )
+		{
+			this.addMerchant( recipeList, definition.stack( 1 ), 1, random, 3 );
+		}
+
+		for ( AEItemDefinition dustDefinition : materials.certusQuartzDust().asSet() )
+		{
+			for ( AEItemDefinition crystalDefinition : materials.certusQuartzCrystal().asSet() )
+			{
+				this.addTrade( recipeList, dustDefinition.stack( 1 ), crystalDefinition.stack( 1 ), random, 2 );
+			}
+		}
 	}
 
 }

--- a/src/main/java/appeng/hooks/QuartzWorldGen.java
+++ b/src/main/java/appeng/hooks/QuartzWorldGen.java
@@ -28,8 +28,12 @@ import net.minecraft.world.gen.feature.WorldGenMinable;
 
 import cpw.mods.fml.common.IWorldGenerator;
 
+import com.google.common.base.Optional;
+
 import appeng.api.AEApi;
+import appeng.api.definitions.IBlocks;
 import appeng.api.features.IWorldGen.WorldGenType;
+import appeng.api.util.AEItemDefinition;
 import appeng.core.AEConfig;
 import appeng.core.features.registries.WorldGenRegistry;
 
@@ -39,17 +43,25 @@ final public class QuartzWorldGen implements IWorldGenerator
 	final WorldGenMinable oreNormal;
 	final WorldGenMinable oreCharged;
 
-	public QuartzWorldGen() {
-		Block normal = AEApi.instance().blocks().blockQuartzOre.block();
-		Block charged = AEApi.instance().blocks().blockQuartzOreCharged.block();
+	public QuartzWorldGen()
+	{
+		final IBlocks blocks = AEApi.instance().definitions().blocks();
+		final Optional<AEItemDefinition> maybeOre = blocks.quartzOre();
+		final Optional<AEItemDefinition> maybeCharged = blocks.quartzOreCharged();
 
-		if ( normal != null && charged != null )
+		if ( maybeOre.isPresent() && maybeCharged.isPresent() )
 		{
-			this.oreNormal = new WorldGenMinable( normal, 0, AEConfig.instance.quartzOresPerCluster, Blocks.stone );
+			final Block ore = maybeOre.get().block();
+			final Block charged = maybeCharged.get().block();
+
+			this.oreNormal = new WorldGenMinable( ore, 0, AEConfig.instance.quartzOresPerCluster, Blocks.stone );
 			this.oreCharged = new WorldGenMinable( charged, 0, AEConfig.instance.quartzOresPerCluster, Blocks.stone );
 		}
 		else
-			this.oreNormal = this.oreCharged = null;
+		{
+			this.oreNormal = null;
+			this.oreCharged = null;
+		}
 	}
 
 	@Override

--- a/src/main/java/appeng/integration/modules/FMP.java
+++ b/src/main/java/appeng/integration/modules/FMP.java
@@ -18,7 +18,9 @@
 
 package appeng.integration.modules;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -36,10 +38,13 @@ import codechicken.multipart.MultiPartRegistry.IPartFactory;
 import codechicken.multipart.MultipartGenerator;
 import codechicken.multipart.TMultiPart;
 import codechicken.multipart.TileMultipart;
+import com.google.common.collect.Lists;
 
 import appeng.api.AEApi;
 import appeng.api.definitions.Blocks;
+import appeng.api.definitions.IBlocks;
 import appeng.api.parts.IPartHost;
+import appeng.api.util.AEItemDefinition;
 import appeng.core.AELog;
 import appeng.fmp.CableBusPart;
 import appeng.fmp.FMPEvent;
@@ -86,13 +91,36 @@ public class FMP implements IIntegrationModule, IPartFactory, IPartConverter, IF
 	@Override
 	public void init() throws Throwable
 	{
-		this.createAndRegister( AEApi.instance().blocks().blockQuartz.block(), 0 );
-		this.createAndRegister( AEApi.instance().blocks().blockQuartzPillar.block(), 0 );
-		this.createAndRegister( AEApi.instance().blocks().blockQuartzChiseled.block(), 0 );
-		this.createAndRegister( AEApi.instance().blocks().blockSkyStone.block(), 0 );
-		this.createAndRegister( AEApi.instance().blocks().blockSkyStone.block(), 1 );
-		this.createAndRegister( AEApi.instance().blocks().blockSkyStone.block(), 2 );
-		this.createAndRegister( AEApi.instance().blocks().blockSkyStone.block(), 3 );
+		final IBlocks blocks = AEApi.instance().definitions().blocks();
+
+		for ( AEItemDefinition definition : blocks.quartz().asSet() )
+		{
+			this.createAndRegister( definition.block(), 0 );
+		}
+		for ( AEItemDefinition definition : blocks.quartzPillar().asSet() )
+		{
+			this.createAndRegister( definition.block(), 0 );
+		}
+		for ( AEItemDefinition definition : blocks.quartzChiseled().asSet() )
+		{
+			this.createAndRegister( definition.block(), 0 );
+		}
+		for ( AEItemDefinition definition : blocks.skyStone().asSet() )
+		{
+			this.createAndRegister( definition.block(), 0 );
+		}
+		for ( AEItemDefinition definition : blocks.skyStone().asSet() )
+		{
+			this.createAndRegister( definition.block(), 1 );
+		}
+		for ( AEItemDefinition definition : blocks.skyStone().asSet() )
+		{
+			this.createAndRegister( definition.block(), 2 );
+		}
+		for ( AEItemDefinition definition : blocks.skyStone().asSet() )
+		{
+			this.createAndRegister( definition.block(), 3 );
+		}
 
 		PartRegistry[] reg = PartRegistry.values();
 
@@ -186,8 +214,20 @@ public class FMP implements IIntegrationModule, IPartFactory, IPartConverter, IF
 	@Override
 	public Iterable<Block> blockTypes()
 	{
-		Blocks def = AEApi.instance().blocks();
-		return Arrays.asList( def.blockMultiPart.block(), def.blockQuartzTorch.block() );
+		final IBlocks blocks = AEApi.instance().definitions().blocks();
+		final List<Block> blockTypes = Lists.newArrayListWithCapacity( 2 );
+
+		for ( AEItemDefinition definition : blocks.multiPart().asSet() )
+		{
+			blockTypes.add( definition.block() );
+		}
+
+		for ( AEItemDefinition definition : blocks.quartzTorch().asSet() )
+		{
+			blockTypes.add( definition.block() );
+		}
+
+		return blockTypes;
 	}
 
 }

--- a/src/main/java/appeng/integration/modules/ImmibisMicroblocks.java
+++ b/src/main/java/appeng/integration/modules/ImmibisMicroblocks.java
@@ -34,6 +34,7 @@ import mods.immibis.core.api.multipart.IPartContainer;
 import appeng.api.AEApi;
 import appeng.api.parts.IPartHost;
 import appeng.api.parts.IPartItem;
+import appeng.api.util.AEItemDefinition;
 import appeng.core.AELog;
 import appeng.integration.BaseModule;
 import appeng.integration.abstraction.IImmibisMicroblocks;
@@ -102,19 +103,22 @@ public class ImmibisMicroblocks extends BaseModule implements IImmibisMicroblock
 
 		if ( te instanceof IMultipartTile && this.canConvertTiles && isPartItem )
 		{
-			final Block blk = AEApi.instance().blocks().blockMultiPart.block();
-			final ItemStack what = AEApi.instance().blocks().blockMultiPart.stack( 1 );
+			for ( AEItemDefinition multiPart : AEApi.instance().definitions().blocks().multiPart().asSet() )
+			{
+				final Block blk = multiPart.block();
+				final ItemStack what = multiPart.stack( 1 );
 
-			try
-			{
-				// ItemStack.class, EntityPlayer.class, World.class,
-				// int.class, int.class, int.class, int.class, Block.class, int.class );
-				this.mergeIntoMicroblockContainer.invoke( null, what, player, w, x, y, z, side, blk, 0 );
-			}
-			catch ( Throwable e )
-			{
-				this.canConvertTiles = false;
-				return null;
+				try
+				{
+					// ItemStack.class, EntityPlayer.class, World.class,
+					// int.class, int.class, int.class, int.class, Block.class, int.class );
+					this.mergeIntoMicroblockContainer.invoke( null, what, player, w, x, y, z, side, blk, 0 );
+				}
+				catch ( Throwable e )
+				{
+					this.canConvertTiles = false;
+					return null;
+				}
 			}
 		}
 

--- a/src/main/java/appeng/integration/modules/NEIHelpers/NEIFacadeRecipeHandler.java
+++ b/src/main/java/appeng/integration/modules/NEIHelpers/NEIFacadeRecipeHandler.java
@@ -34,17 +34,29 @@ import codechicken.nei.api.IRecipeOverlayRenderer;
 import codechicken.nei.api.IStackPositioner;
 import codechicken.nei.recipe.RecipeInfo;
 import codechicken.nei.recipe.TemplateRecipeHandler;
+import com.google.common.base.Optional;
 
 import appeng.api.AEApi;
+import appeng.api.definitions.IDefinitions;
+import appeng.api.util.AEItemDefinition;
 import appeng.core.localization.GuiText;
 import appeng.items.parts.ItemFacade;
 
 public class NEIFacadeRecipeHandler extends TemplateRecipeHandler
 {
+	final ItemFacade facade;
+	final ItemStack anchor;
 
-	final ItemFacade ifa = (ItemFacade) AEApi.instance().items().itemFacade.item();
-	final ItemStack cable_anchor = AEApi.instance().parts().partCableAnchor.stack( 1 );
+	public NEIFacadeRecipeHandler()
+	{
+		final IDefinitions definitions = AEApi.instance().definitions();
+		final Optional<AEItemDefinition> facade = definitions.items().facade();
+		final Optional<AEItemDefinition> anchor = definitions.parts().cableAnchor();
 
+		this.facade = ( facade.isPresent() ) ? (ItemFacade) facade.get() : null;
+		this.anchor = ( anchor.isPresent() ) ? anchor.get().stack( 1 ) : null;
+	}
+	
 	@Override
 	public void loadTransferRects()
 	{
@@ -68,13 +80,16 @@ public class NEIFacadeRecipeHandler extends TemplateRecipeHandler
 	{
 		if ( (outputId.equals( "crafting" )) && (this.getClass() == NEIFacadeRecipeHandler.class) )
 		{
-			ItemFacade ifa = (ItemFacade) AEApi.instance().items().itemFacade.item();
-			List<ItemStack> facades = ifa.getFacades();
-			for (ItemStack is : facades)
+			for ( AEItemDefinition definition : AEApi.instance().definitions().items().facade().asSet() )
 			{
-				CachedShapedRecipe recipe = new CachedShapedRecipe( is );
-				recipe.computeVisuals();
-				this.arecipes.add( recipe );
+				ItemFacade ifa = (ItemFacade) definition.item();
+				List<ItemStack> facades = ifa.getFacades();
+				for (ItemStack is : facades)
+				{
+					CachedShapedRecipe recipe = new CachedShapedRecipe( is );
+					recipe.computeVisuals();
+					this.arecipes.add( recipe );
+				}
 			}
 		}
 		else
@@ -86,7 +101,7 @@ public class NEIFacadeRecipeHandler extends TemplateRecipeHandler
 	@Override
 	public void loadCraftingRecipes(ItemStack result)
 	{
-		if ( result.getItem() == this.ifa )
+		if ( result.getItem() == this.facade )
 		{
 			CachedShapedRecipe recipe = new CachedShapedRecipe( result );
 			recipe.computeVisuals();
@@ -97,7 +112,7 @@ public class NEIFacadeRecipeHandler extends TemplateRecipeHandler
 	@Override
 	public void loadUsageRecipes(ItemStack ingredient)
 	{
-		List<ItemStack> facades = this.ifa.getFacades();
+		List<ItemStack> facades = this.facade.getFacades();
 		for (ItemStack is : facades)
 		{
 			CachedShapedRecipe recipe = new CachedShapedRecipe( is );
@@ -176,8 +191,8 @@ public class NEIFacadeRecipeHandler extends TemplateRecipeHandler
 			output.stackSize = 4;
 			this.result = new PositionedStack( output, 119, 24 );
 			this.ingredients = new ArrayList<PositionedStack>();
-			ItemStack in = NEIFacadeRecipeHandler.this.ifa.getTextureItem( output );
-			this.setIngredients( 3, 3, new Object[] { null, NEIFacadeRecipeHandler.this.cable_anchor, null, NEIFacadeRecipeHandler.this.cable_anchor, in, NEIFacadeRecipeHandler.this.cable_anchor, null, NEIFacadeRecipeHandler.this.cable_anchor, null } );
+			ItemStack in = NEIFacadeRecipeHandler.this.facade.getTextureItem( output );
+			this.setIngredients( 3, 3, new Object[] { null, NEIFacadeRecipeHandler.this.anchor, null, NEIFacadeRecipeHandler.this.anchor, in, NEIFacadeRecipeHandler.this.anchor, null, NEIFacadeRecipeHandler.this.anchor, null } );
 		}
 
 		public void setIngredients(int width, int height, Object[] items)

--- a/src/main/java/appeng/integration/modules/NEIHelpers/NEIWorldCraftingHandler.java
+++ b/src/main/java/appeng/integration/modules/NEIHelpers/NEIWorldCraftingHandler.java
@@ -40,6 +40,8 @@ import codechicken.nei.recipe.ICraftingHandler;
 import codechicken.nei.recipe.IUsageHandler;
 
 import appeng.api.AEApi;
+import appeng.api.definitions.IDefinitions;
+import appeng.api.definitions.IMaterials;
 import appeng.api.util.AEItemDefinition;
 import appeng.core.AEConfig;
 import appeng.core.features.AEFeature;
@@ -66,31 +68,70 @@ public class NEIWorldCraftingHandler implements ICraftingHandler, IUsageHandler
 
 	private void addRecipes()
 	{
+		final IDefinitions definitions = AEApi.instance().definitions();
+		final IMaterials materials = definitions.materials();
 
-		if ( AEConfig.instance.isFeatureEnabled( AEFeature.CertusQuartzWorldGen ) )
-			this.addRecipe( AEApi.instance().materials().materialCertusQuartzCrystalCharged,
-					GuiText.ChargedQuartz.getLocal() + "\n\n" + GuiText.ChargedQuartzFind.getLocal() );
-		else
-			this.addRecipe( AEApi.instance().materials().materialCertusQuartzCrystalCharged, GuiText.ChargedQuartzFind.getLocal() );
+		for ( AEItemDefinition charged : materials.certusQuartzCrystalCharged().asSet() )
+		{
+			final String message;
+			if ( AEConfig.instance.isFeatureEnabled( AEFeature.CertusQuartzWorldGen ) )
+			{
+				message = GuiText.ChargedQuartz.getLocal() + "\n\n" + GuiText.ChargedQuartzFind.getLocal();
+			}
+			else
+			{
+				message = GuiText.ChargedQuartzFind.getLocal();
+			}
+
+			this.addRecipe( charged, message );
+		}
 
 		if ( AEConfig.instance.isFeatureEnabled( AEFeature.MeteoriteWorldGen ) )
 		{
-			this.addRecipe( AEApi.instance().materials().materialLogicProcessorPress, GuiText.inWorldCraftingPresses.getLocal() );
-			this.addRecipe( AEApi.instance().materials().materialCalcProcessorPress, GuiText.inWorldCraftingPresses.getLocal() );
-			this.addRecipe( AEApi.instance().materials().materialEngProcessorPress, GuiText.inWorldCraftingPresses.getLocal() );
+			for ( AEItemDefinition logic : materials.logicProcessorPress().asSet() )
+			{
+				this.addRecipe( logic, GuiText.inWorldCraftingPresses.getLocal() );
+			}
+			for ( AEItemDefinition calc : materials.calcProcessorPress().asSet() )
+			{
+				this.addRecipe( calc, GuiText.inWorldCraftingPresses.getLocal() );
+			}
+			for ( AEItemDefinition eng : materials.engProcessorPress().asSet() )
+			{
+				this.addRecipe( eng, GuiText.inWorldCraftingPresses.getLocal() );
+			}
 		}
 
 		if ( AEConfig.instance.isFeatureEnabled( AEFeature.inWorldFluix ) )
-			this.addRecipe( AEApi.instance().materials().materialFluixCrystal, GuiText.inWorldFluix.getLocal() );
+		{
+			for ( AEItemDefinition fluix : materials.fluixCrystal().asSet() )
+			{
+				this.addRecipe( fluix, GuiText.inWorldFluix.getLocal() );
+			}
+		}
 
 		if ( AEConfig.instance.isFeatureEnabled( AEFeature.inWorldSingularity ) )
-			this.addRecipe( AEApi.instance().materials().materialQESingularity, GuiText.inWorldSingularity.getLocal() );
+		{
+			for ( AEItemDefinition qes : materials.qESingularity().asSet() )
+			{
+				this.addRecipe( qes, GuiText.inWorldSingularity.getLocal() );
+			}
+		}
 
 		if ( AEConfig.instance.isFeatureEnabled( AEFeature.inWorldPurification ) )
 		{
-			this.addRecipe( AEApi.instance().materials().materialPurifiedCertusQuartzCrystal, GuiText.inWorldPurificationCertus.getLocal() );
-			this.addRecipe( AEApi.instance().materials().materialPurifiedNetherQuartzCrystal, GuiText.inWorldPurificationNether.getLocal() );
-			this.addRecipe( AEApi.instance().materials().materialPurifiedFluixCrystal, GuiText.inWorldPurificationFluix.getLocal() );
+			for ( AEItemDefinition pureCert : materials.purifiedCertusQuartzCrystal().asSet() )
+			{
+				this.addRecipe( pureCert, GuiText.inWorldPurificationCertus.getLocal() );
+			}
+			for ( AEItemDefinition pureNether : materials.purifiedNetherQuartzCrystal().asSet() )
+			{
+				this.addRecipe( pureNether, GuiText.inWorldPurificationNether.getLocal() );
+			}
+			for ( AEItemDefinition pureFluix : materials.purifiedFluixCrystal().asSet() )
+			{
+				this.addRecipe( pureFluix, GuiText.inWorldPurificationFluix.getLocal() );
+			}
 		}
 	}
 

--- a/src/main/java/appeng/items/misc/ItemCrystalSeed.java
+++ b/src/main/java/appeng/items/misc/ItemCrystalSeed.java
@@ -38,8 +38,10 @@ import net.minecraft.world.World;
 import cpw.mods.fml.common.registry.EntityRegistry;
 
 import appeng.api.AEApi;
+import appeng.api.definitions.IMaterials;
 import appeng.api.implementations.items.IGrowableCrystal;
 import appeng.api.recipes.ResolverResult;
+import appeng.api.util.AEItemDefinition;
 import appeng.core.AppEng;
 import appeng.core.features.AEFeature;
 import appeng.core.localization.ButtonToolTips;
@@ -122,13 +124,30 @@ public class ItemCrystalSeed extends AEBaseItem implements IGrowableCrystal
 	public ItemStack triggerGrowth(ItemStack is)
 	{
 		int newDamage = this.getProgress( is ) + 1;
+		final IMaterials materials = AEApi.instance().definitions().materials();
+		final int size = is.stackSize;
 
 		if ( newDamage == Certus + SINGLE_OFFSET )
-			return AEApi.instance().materials().materialPurifiedCertusQuartzCrystal.stack( is.stackSize );
+		{
+			for ( AEItemDefinition pureCert : materials.purifiedCertusQuartzCrystal().asSet() )
+			{
+				return pureCert.stack( size );
+			}
+		}
 		if ( newDamage == Nether + SINGLE_OFFSET )
-			return AEApi.instance().materials().materialPurifiedNetherQuartzCrystal.stack( is.stackSize );
+		{
+			for ( AEItemDefinition pureNether : materials.purifiedNetherQuartzCrystal().asSet() )
+			{
+				return pureNether.stack( size );
+			}
+		}
 		if ( newDamage == Fluix + SINGLE_OFFSET )
-			return AEApi.instance().materials().materialPurifiedFluixCrystal.stack( is.stackSize );
+		{
+			for ( AEItemDefinition pureFluix : materials.purifiedFluixCrystal().asSet() )
+			{
+				return pureFluix.stack( size );
+			}
+		}
 		if ( newDamage > END )
 			return null;
 
@@ -275,10 +294,17 @@ public class ItemCrystalSeed extends AEBaseItem implements IGrowableCrystal
 
 	public static ResolverResult getResolver(int certus2)
 	{
-		ItemStack is = AEApi.instance().items().itemCrystalSeed.stack( 1 );
-		is.setItemDamage( certus2 );
-		is = newStyle( is );
-		return new ResolverResult( "ItemCrystalSeed", is.getItemDamage(), is.getTagCompound() );
+		ResolverResult resolver = null;
+
+		for ( AEItemDefinition definition : AEApi.instance().definitions().items().crystalSeed().asSet() )
+		{
+			ItemStack is = definition.stack( 1 );
+			is.setItemDamage( certus2 );
+			is = newStyle( is );
+			resolver = new ResolverResult( "ItemCrystalSeed", is.getItemDamage(), is.getTagCompound() );
+		}
+
+		return resolver;
 	}
 
 }

--- a/src/main/java/appeng/items/misc/ItemEncodedPattern.java
+++ b/src/main/java/appeng/items/misc/ItemEncodedPattern.java
@@ -34,6 +34,7 @@ import appeng.api.AEApi;
 import appeng.api.implementations.ICraftingPatternItem;
 import appeng.api.networking.crafting.ICraftingPatternDetails;
 import appeng.api.storage.data.IAEItemStack;
+import appeng.api.util.AEItemDefinition;
 import appeng.client.render.items.ItemEncodedPatternRenderer;
 import appeng.core.CommonHelper;
 import appeng.core.features.AEFeature;
@@ -66,7 +67,11 @@ public class ItemEncodedPattern extends AEBaseItem implements ICraftingPatternIt
 			{
 				if ( inv.getStackInSlot( s ) == stack )
 				{
-					inv.setInventorySlotContents( s, AEApi.instance().materials().materialBlankPattern.stack( stack.stackSize ) );
+					for ( AEItemDefinition blankPattern : AEApi.instance().definitions().materials().blankPattern().asSet() )
+					{
+						inv.setInventorySlotContents( s, blankPattern.stack( stack.stackSize ) );
+					}
+
 					return true;
 				}
 			}

--- a/src/main/java/appeng/items/parts/ItemFacade.java
+++ b/src/main/java/appeng/items/parts/ItemFacade.java
@@ -41,8 +41,11 @@ import cpw.mods.fml.common.registry.GameRegistry.UniqueIdentifier;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
+import com.sun.corba.se.impl.oa.NullServantImpl;
+
 import appeng.api.AEApi;
 import appeng.api.parts.IAlphaPassItem;
+import appeng.api.util.AEItemDefinition;
 import appeng.block.solids.OreQuartz;
 import appeng.client.render.BusRenderer;
 import appeng.core.FacadeConfig;
@@ -110,11 +113,17 @@ public class ItemFacade extends AEBaseItem implements IFacadeItem, IAlphaPassIte
 
 	public ItemStack createFromIDs(int[] ids)
 	{
-		ItemStack is = new ItemStack( AEApi.instance().items().itemFacade.item() );
-		NBTTagCompound data = new NBTTagCompound();
-		data.setIntArray( "x", ids.clone() );
-		is.setTagCompound( data );
-		return is;
+		ItemStack facade = null;
+
+		for ( AEItemDefinition definition : AEApi.instance().definitions().items().facade().asSet() )
+		{
+			facade = new ItemStack( definition.item() );
+			NBTTagCompound data = new NBTTagCompound();
+			data.setIntArray( "x", ids.clone() );
+			facade.setTagCompound( data );
+		}
+
+		return facade;
 	}
 
 	@Override

--- a/src/main/java/appeng/items/parts/ItemMultiPart.java
+++ b/src/main/java/appeng/items/parts/ItemMultiPart.java
@@ -41,7 +41,9 @@ import cpw.mods.fml.relauncher.SideOnly;
 import appeng.api.AEApi;
 import appeng.api.implementations.items.IItemGroup;
 import appeng.api.parts.IPart;
+import appeng.api.parts.IPartHelper;
 import appeng.api.parts.IPartItem;
+import appeng.api.util.AEColor;
 import appeng.core.AEConfig;
 import appeng.core.AELog;
 import appeng.core.features.AEFeature;
@@ -67,10 +69,10 @@ public class ItemMultiPart extends AEBaseItem implements IPartItem, IItemGroup
 
 	public static ItemMultiPart instance;
 
-	public ItemMultiPart() {
+	public ItemMultiPart( IPartHelper partHelper ) {
 		super( ItemMultiPart.class );
 		this.setFeature( EnumSet.of( AEFeature.Core ) );
-		AEApi.instance().partHelper().setItemBusRenderer( this );
+		partHelper.setItemBusRenderer( this );
 		this.setHasSubtypes( true );
 		instance = this;
 	}
@@ -176,7 +178,7 @@ public class ItemMultiPart extends AEBaseItem implements IPartItem, IItemGroup
 		if ( pt == null )
 			return "Unnamed";
 
-		Enum[] variants = pt.getVariants();
+		AEColor[] variants = pt.getVariants();
 
 		if ( variants != null )
 			return super.getItemStackDisplayName( is ) + " - " + variants[this.dmgToPart.get( is.getItemDamage() ).variant].toString();

--- a/src/main/java/appeng/items/parts/PartType.java
+++ b/src/main/java/appeng/items/parts/PartType.java
@@ -144,7 +144,7 @@ public enum PartType
 		this.baseDamage = baseMetaValue;
 	}
 
-	public Enum<AEColor>[] getVariants()
+	public AEColor[] getVariants()
 	{
 		if ( this == CableSmart || this == CableCovered || this == CableGlass || this == CableDense )
 			return AEColor.values();

--- a/src/main/java/appeng/items/storage/ItemBasicStorageCell.java
+++ b/src/main/java/appeng/items/storage/ItemBasicStorageCell.java
@@ -35,6 +35,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 import appeng.api.AEApi;
 import appeng.api.config.FuzzyMode;
 import appeng.api.config.IncludeExclude;
+import appeng.api.exceptions.MissingDefinition;
 import appeng.api.implementations.items.IItemGroup;
 import appeng.api.implementations.items.IStorageCell;
 import appeng.api.storage.ICellInventory;
@@ -43,6 +44,7 @@ import appeng.api.storage.IMEInventoryHandler;
 import appeng.api.storage.StorageChannel;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.api.storage.data.IItemList;
+import appeng.api.util.AEItemDefinition;
 import appeng.core.AEConfig;
 import appeng.core.features.AEFeature;
 import appeng.core.localization.GuiText;
@@ -240,12 +242,16 @@ public class ItemBasicStorageCell extends AEBaseItem implements IStorageCell, II
 					playerInventory.setInventorySlotContents( playerInventory.currentItem, null );
 
 					ItemStack extraB = ia.addItems( this.component.stack( 1 ) );
-					ItemStack extraA = ia.addItems( AEApi.instance().materials().materialEmptyStorageCell.stack( 1 ) );
-
-					if ( extraA != null )
-						player.dropPlayerItemWithRandomChoice( extraA, false );
 					if ( extraB != null )
 						player.dropPlayerItemWithRandomChoice( extraB, false );
+
+					for ( AEItemDefinition emptyStorageCell : AEApi.instance().definitions().materials().emptyStorageCell().asSet() )
+					{
+						ItemStack extraA = ia.addItems( emptyStorageCell.stack( 1 ) );
+						if ( extraA != null )
+							player.dropPlayerItemWithRandomChoice( extraA, false );
+					}
+
 
 					if ( player.inventoryContainer != null )
 						player.inventoryContainer.detectAndSendChanges();
@@ -266,7 +272,12 @@ public class ItemBasicStorageCell extends AEBaseItem implements IStorageCell, II
 	@Override
 	public ItemStack getContainerItem( ItemStack itemStack )
 	{
-		return AEApi.instance().materials().materialEmptyStorageCell.stack( 1 );
+		for ( AEItemDefinition emptyStorageCell : AEApi.instance().definitions().materials().emptyStorageCell().asSet() )
+		{
+			return emptyStorageCell.stack( 1 );
+		}
+
+		throw new MissingDefinition( "No empty storage cell." );
 	}
 
 	@Override

--- a/src/main/java/appeng/items/tools/powered/ToolMassCannon.java
+++ b/src/main/java/appeng/items/tools/powered/ToolMassCannon.java
@@ -57,6 +57,7 @@ import appeng.api.storage.data.IAEItemStack;
 import appeng.api.storage.data.IAEStack;
 import appeng.api.storage.data.IItemList;
 import appeng.api.util.AEColor;
+import appeng.api.util.AEItemDefinition;
 import appeng.api.util.DimensionalCoord;
 import appeng.core.AEConfig;
 import appeng.core.AELog;
@@ -297,7 +298,10 @@ public class ToolMassCannon extends AEBasePoweredItem implements IStorageCell
 				Block whatsThere = w.getBlock( x, y, z );
 				if ( whatsThere.isReplaceable( w, x, y, z ) && w.isAirBlock( x, y, z ) )
 				{
-					w.setBlock( x, y, z, AEApi.instance().blocks().blockPaint.block(), 0, 3 );
+					for ( AEItemDefinition paint : AEApi.instance().definitions().blocks().paint().asSet() )
+					{
+						w.setBlock( x, y, z, paint.block(), 0, 3 );
+					}
 				}
 
 				TileEntity te = w.getTileEntity( x, y, z );

--- a/src/main/java/appeng/items/tools/powered/ToolWirelessTerminal.java
+++ b/src/main/java/appeng/items/tools/powered/ToolWirelessTerminal.java
@@ -39,6 +39,7 @@ import appeng.api.config.SortDir;
 import appeng.api.config.SortOrder;
 import appeng.api.config.ViewItems;
 import appeng.api.features.IWirelessTermHandler;
+import appeng.api.util.AEItemDefinition;
 import appeng.api.util.IConfigManager;
 import appeng.core.AEConfig;
 import appeng.core.features.AEFeature;
@@ -98,7 +99,9 @@ public class ToolWirelessTerminal extends AEBasePoweredItem implements IWireless
 	@Override
 	public boolean canHandle( ItemStack is )
 	{
-		return AEApi.instance().items().itemWirelessTerminal.sameAsStack( is );
+		final Optional<AEItemDefinition> maybe = AEApi.instance().definitions().items().wirelessTerminal();
+
+		return maybe.isPresent() && maybe.get().sameAsStack( is );
 	}
 
 	@Override

--- a/src/main/java/appeng/items/tools/quartz/ToolQuartzCuttingKnife.java
+++ b/src/main/java/appeng/items/tools/quartz/ToolQuartzCuttingKnife.java
@@ -42,11 +42,11 @@ public class ToolQuartzCuttingKnife extends AEBaseItem implements IGuiItem
 
 	final AEFeature type;
 
-	public ToolQuartzCuttingKnife( AEFeature Type )
+	public ToolQuartzCuttingKnife( AEFeature type )
 	{
-		super( ToolQuartzCuttingKnife.class, Optional.of( Type.name() ) );
+		super( ToolQuartzCuttingKnife.class, Optional.of( type.name() ) );
 
-		this.setFeature( EnumSet.of( this.type = Type, AEFeature.QuartzKnife ) );
+		this.setFeature( EnumSet.of( this.type = type, AEFeature.QuartzKnife ) );
 		this.setMaxDamage( 50 );
 		this.setMaxStackSize( 1 );
 	}

--- a/src/main/java/appeng/me/cluster/implementations/QuantumCalculator.java
+++ b/src/main/java/appeng/me/cluster/implementations/QuantumCalculator.java
@@ -22,7 +22,10 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 
 import appeng.api.AEApi;
+import appeng.api.definitions.IBlocks;
+import appeng.api.util.AEItemDefinition;
 import appeng.api.util.WorldCoord;
+import appeng.block.misc.BlockCondenser;
 import appeng.me.cluster.IAECluster;
 import appeng.me.cluster.IAEMultiBlock;
 import appeng.me.cluster.MBCalculator;
@@ -129,17 +132,23 @@ public class QuantumCalculator extends MBCalculator
 						return false;
 
 					num++;
+					final IBlocks blocks = AEApi.instance().definitions().blocks();
 					if ( num == 5 )
 					{
-						if ( !Platform.blockAtLocationIs( w, x, y, z, AEApi.instance().blocks().blockQuantumLink ) )
-							return false;
+						for ( AEItemDefinition quantumLink : blocks.quantumLink().asSet() )
+						{
+							if ( !Platform.blockAtLocationIs( w, x, y, z, quantumLink ) )
+								return false;
+						}
 					}
 					else
 					{
-						if ( !Platform.blockAtLocationIs( w, x, y, z, AEApi.instance().blocks().blockQuantumRing ) )
-							return false;
+						for ( AEItemDefinition quantumRing : blocks.quantumRing().asSet() )
+						{
+							if ( !Platform.blockAtLocationIs( w, x, y, z, quantumRing ) )
+								return false;
+						}
 					}
-
 				}
 			}
 		}

--- a/src/main/java/appeng/me/storage/SecurityInventory.java
+++ b/src/main/java/appeng/me/storage/SecurityInventory.java
@@ -31,6 +31,7 @@ import appeng.api.storage.IMEInventoryHandler;
 import appeng.api.storage.StorageChannel;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.api.storage.data.IItemList;
+import appeng.api.util.AEItemDefinition;
 import appeng.me.GridAccessException;
 import appeng.tile.misc.TileSecurity;
 
@@ -63,16 +64,22 @@ public class SecurityInventory implements IMEInventoryHandler<IAEItemStack>
 	@Override
 	public IAEItemStack injectItems(IAEItemStack input, Actionable type, BaseActionSource src)
 	{
-		if ( this.hasPermission( src ) && AEApi.instance().items().itemBiometricCard.sameAsStack( input.getItemStack() ) )
+		if ( this.hasPermission( src ) )
 		{
-			if ( this.canAccept( input ) )
+			for ( AEItemDefinition definition : AEApi.instance().definitions().items().biometricCard().asSet() )
 			{
-				if ( type == Actionable.SIMULATE )
-					return null;
+				if ( definition.sameAsStack( input.getItemStack() ) )
+				{
+					if ( this.canAccept( input ) )
+					{
+						if ( type == Actionable.SIMULATE )
+							return null;
 
-				this.storedItems.add( input );
-				this.securityTile.inventoryChanged();
-				return null;
+						this.storedItems.add( input );
+						this.securityTile.inventoryChanged();
+						return null;
+					}
+				}
 			}
 		}
 		return input;

--- a/src/main/java/appeng/parts/AEBasePart.java
+++ b/src/main/java/appeng/parts/AEBasePart.java
@@ -45,6 +45,7 @@ import cpw.mods.fml.relauncher.SideOnly;
 
 import appeng.api.AEApi;
 import appeng.api.config.Upgrades;
+import appeng.api.definitions.IDefinitions;
 import appeng.api.implementations.IUpgradeableHost;
 import appeng.api.implementations.items.IMemoryCard;
 import appeng.api.implementations.items.MemoryCardMessages;
@@ -59,6 +60,7 @@ import appeng.api.parts.ISimplifiedBundle;
 import appeng.api.parts.PartItemStack;
 import appeng.api.util.AECableType;
 import appeng.api.util.AEColor;
+import appeng.api.util.AEItemDefinition;
 import appeng.api.util.DimensionalCoord;
 import appeng.api.util.IConfigManager;
 import appeng.helpers.ICustomNameObject;
@@ -386,8 +388,17 @@ public class AEBasePart implements IPart, IGridProxyable, IActionHost, IUpgradea
 			ItemStack is = this.getItemStack( PartItemStack.Network );
 
 			// Blocks and parts share the same soul!
-			if ( AEApi.instance().parts().partInterface.sameAsStack( is ) )
-				is = AEApi.instance().blocks().blockInterface.stack( 1 );
+			final IDefinitions definitions = AEApi.instance().definitions();
+			for ( AEItemDefinition ifacePart : definitions.parts().iface().asSet() )
+			{
+				if ( ifacePart.sameAsStack( is ) )
+				{
+					for ( AEItemDefinition ifaceBlock : definitions.blocks().iface().asSet() )
+					{
+						is = ifaceBlock.stack( 1 );
+					}
+				}
+			}
 
 			String name = is.getUnlocalizedName();
 

--- a/src/main/java/appeng/parts/networking/PartCable.java
+++ b/src/main/java/appeng/parts/networking/PartCable.java
@@ -40,6 +40,8 @@ import cpw.mods.fml.relauncher.SideOnly;
 
 import appeng.api.AEApi;
 import appeng.api.config.SecurityPermissions;
+import appeng.api.definitions.IParts;
+import appeng.api.exceptions.MissingDefinition;
 import appeng.api.implementations.parts.IPartCable;
 import appeng.api.networking.GridFlags;
 import appeng.api.networking.IGridConnection;
@@ -52,6 +54,7 @@ import appeng.api.parts.IPartHost;
 import appeng.api.parts.IPartRenderHelper;
 import appeng.api.util.AECableType;
 import appeng.api.util.AEColor;
+import appeng.api.util.AEColoredItemDefinition;
 import appeng.api.util.IReadOnlyCollection;
 import appeng.block.AEBaseBlock;
 import appeng.client.texture.CableBusTextures;
@@ -130,8 +133,13 @@ public class PartCable extends AEBasePart implements IPartCable
 				return CableBusTextures.MECable_Yellow.getIcon();
 			default:
 		}
-		return AEApi.instance().parts().partCableGlass.item( AEColor.Transparent ).getIconIndex(
-				AEApi.instance().parts().partCableGlass.stack( AEColor.Transparent, 1 ) );
+
+		for ( AEColoredItemDefinition glass : AEApi.instance().definitions().parts().cableGlass().asSet() )
+		{
+			return glass.item( AEColor.Transparent ).getIconIndex( glass.stack( AEColor.Transparent, 1 ) );
+		}
+
+		throw new MissingDefinition( "No cable glass" );
 	}
 
 	public IIcon getTexture( AEColor c )
@@ -177,8 +185,13 @@ public class PartCable extends AEBasePart implements IPartCable
 				return CableBusTextures.MECovered_Yellow.getIcon();
 			default:
 		}
-		return AEApi.instance().parts().partCableCovered.item( AEColor.Transparent ).getIconIndex(
-				AEApi.instance().parts().partCableCovered.stack( AEColor.Transparent, 1 ) );
+
+		for ( AEColoredItemDefinition covered : AEApi.instance().definitions().parts().cableCovered().asSet() )
+		{
+			return covered.item( AEColor.Transparent ).getIconIndex( covered.stack( AEColor.Transparent, 1 ) );
+		}
+
+		throw new MissingDefinition( "No covered cable" );
 	}
 
 	public IIcon getSmartTexture( AEColor c )
@@ -219,8 +232,19 @@ public class PartCable extends AEBasePart implements IPartCable
 				return CableBusTextures.MESmart_Yellow.getIcon();
 			default:
 		}
-		return AEApi.instance().parts().partCableCovered.item( AEColor.Transparent ).getIconIndex(
-				AEApi.instance().parts().partCableSmart.stack( AEColor.Transparent, 1 ) );
+
+		final IParts parts = AEApi.instance().definitions().parts();
+		for ( AEColoredItemDefinition covered : parts.cableCovered().asSet() )
+		{
+			for ( AEColoredItemDefinition smart : parts.cableSmart().asSet() )
+			{
+				return covered.item( AEColor.Transparent ).getIconIndex( smart.stack( AEColor.Transparent, 1 ) );
+			}
+
+			throw new MissingDefinition( "No smart cable" );
+		}
+
+		throw new MissingDefinition( "No covered glass" );
 	}
 
 	@Override
@@ -1009,21 +1033,35 @@ public class PartCable extends AEBasePart implements IPartCable
 		{
 			ItemStack newPart = null;
 
+			final IParts parts = AEApi.instance().definitions().parts();
+
 			if ( this.getCableConnectionType() == AECableType.GLASS )
 			{
-				newPart = AEApi.instance().parts().partCableGlass.stack( newColor, 1 );
+				for ( AEColoredItemDefinition glass : parts.cableGlass().asSet() )
+				{
+					newPart = glass.stack( newColor, 1 );
+				}
 			}
 			else if ( this.getCableConnectionType() == AECableType.COVERED )
 			{
-				newPart = AEApi.instance().parts().partCableCovered.stack( newColor, 1 );
+				for ( AEColoredItemDefinition covered : parts.cableCovered().asSet() )
+				{
+					newPart = covered.stack( newColor, 1 );
+				}
 			}
 			else if ( this.getCableConnectionType() == AECableType.SMART )
 			{
-				newPart = AEApi.instance().parts().partCableSmart.stack( newColor, 1 );
+				for ( AEColoredItemDefinition smart : parts.cableSmart().asSet() )
+				{
+					newPart = smart.stack( newColor, 1 );
+				}
 			}
 			else if ( this.getCableConnectionType() == AECableType.DENSE )
 			{
-				newPart = AEApi.instance().parts().partCableDense.stack( newColor, 1 );
+				for ( AEColoredItemDefinition dense : parts.cableDense().asSet() )
+				{
+					newPart = dense.stack( newColor, 1 );
+				}
 			}
 
 			boolean hasPermission = true;

--- a/src/main/java/appeng/parts/networking/PartDenseCable.java
+++ b/src/main/java/appeng/parts/networking/PartDenseCable.java
@@ -45,6 +45,7 @@ import appeng.api.parts.IPartHost;
 import appeng.api.parts.IPartRenderHelper;
 import appeng.api.util.AECableType;
 import appeng.api.util.AEColor;
+import appeng.api.util.AEColoredItemDefinition;
 import appeng.block.AEBaseBlock;
 import appeng.client.texture.CableBusTextures;
 import appeng.client.texture.FlippableIcon;
@@ -92,7 +93,12 @@ public class PartDenseCable extends PartCable
 	public IIcon getTexture(AEColor c)
 	{
 		if ( c == AEColor.Transparent )
-			return AEApi.instance().parts().partCableSmart.stack( AEColor.Transparent, 1 ).getIconIndex();
+		{
+			for ( AEColoredItemDefinition smart : AEApi.instance().definitions().parts().cableSmart().asSet() )
+			{
+				return smart.stack( AEColor.Transparent, 1 ).getIconIndex();
+			}
+		}
 
 		return this.getSmartTexture( c );
 	}

--- a/src/main/java/appeng/parts/p2p/PartP2PTunnel.java
+++ b/src/main/java/appeng/parts/p2p/PartP2PTunnel.java
@@ -32,11 +32,15 @@ import net.minecraftforge.common.util.ForgeDirection;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
+import com.google.common.base.Optional;
+
 import appeng.api.AEApi;
 import appeng.api.config.Actionable;
 import appeng.api.config.PowerMultiplier;
 import appeng.api.config.PowerUnits;
 import appeng.api.config.TunnelType;
+import appeng.api.definitions.IParts;
+import appeng.api.exceptions.MissingDefinition;
 import appeng.api.implementations.items.IMemoryCard;
 import appeng.api.implementations.items.MemoryCardMessages;
 import appeng.api.parts.IPart;
@@ -44,6 +48,7 @@ import appeng.api.parts.IPartCollisionHelper;
 import appeng.api.parts.IPartItem;
 import appeng.api.parts.IPartRenderHelper;
 import appeng.api.parts.PartItemStack;
+import appeng.api.util.AEItemDefinition;
 import appeng.client.texture.CableBusTextures;
 import appeng.core.AEConfig;
 import appeng.me.GridAccessException;
@@ -144,42 +149,68 @@ public class PartP2PTunnel<T extends PartP2PTunnel> extends PartBasicState
 		{
 			ItemStack newType = null;
 
+			final IParts parts = AEApi.instance().definitions().parts();
+
 			switch (tt)
 			{
-			case LIGHT:
-				newType = AEApi.instance().parts().partP2PTunnelLight.stack( 1 );
-				break;
+				case LIGHT:
+					for ( AEItemDefinition light : parts.p2PTunnelLight().asSet() )
+					{
+						newType = light.stack( 1 );
+					}
+					break;
 
-			case RF_POWER:
-				newType = AEApi.instance().parts().partP2PTunnelRF.stack( 1 );
-				break;
+				case RF_POWER:
+					for ( AEItemDefinition rf : parts.p2PTunnelRF().asSet() )
+					{
+						newType = rf.stack( 1 );
+					}
+					break;
 
-			case BC_POWER:
-				newType = AEApi.instance().parts().partP2PTunnelMJ.stack( 1 );
-				break;
+				case BC_POWER:
+					for ( AEItemDefinition mj : parts.p2PTunnelMJ().asSet() )
+					{
+						newType = mj.stack( 1 );
+					}
+					break;
 
-			case FLUID:
-				newType = AEApi.instance().parts().partP2PTunnelLiquids.stack( 1 );
-				break;
+				case FLUID:
+					for ( AEItemDefinition liquids : parts.p2PTunnelLiquids().asSet() )
+					{
+						newType = liquids.stack( 1 );
+					}
+					break;
 
-			case IC2_POWER:
-				newType = AEApi.instance().parts().partP2PTunnelEU.stack( 1 );
-				break;
+				case IC2_POWER:
+					for ( AEItemDefinition eu : parts.p2PTunnelEU().asSet() )
+					{
+						newType = eu.stack( 1 );
+					}
+					break;
 
-			case ITEM:
-				newType = AEApi.instance().parts().partP2PTunnelItems.stack( 1 );
-				break;
+				case ITEM:
+					for ( AEItemDefinition items : parts.p2PTunnelItems().asSet() )
+					{
+						newType = items.stack( 1 );
+					}
+					break;
 
-			case ME:
-				newType = AEApi.instance().parts().partP2PTunnelME.stack( 1 );
-				break;
+				case ME:
+					for ( AEItemDefinition me : parts.p2PTunnelME().asSet() )
+					{
+						newType = me.stack( 1 );
+					}
+					break;
 
-			case REDSTONE:
-				newType = AEApi.instance().parts().partP2PTunnelRedstone.stack( 1 );
-				break;
+				case REDSTONE:
+					for ( AEItemDefinition redstone : parts.p2PTunnelRedstone().asSet() )
+					{
+						newType = redstone.stack( 1 );
+					}
+					break;
 
-			default:
-				break;
+				default:
+					break;
 
 			}
 
@@ -272,7 +303,12 @@ public class PartP2PTunnel<T extends PartP2PTunnel> extends PartBasicState
 		if ( type == PartItemStack.World || type == PartItemStack.Network || type == PartItemStack.Wrench || type == PartItemStack.Pick )
 			return super.getItemStack( type );
 
-		return AEApi.instance().parts().partP2PTunnelME.stack( 1 );
+		for ( AEItemDefinition me : AEApi.instance().definitions().parts().p2PTunnelME().asSet() )
+		{
+			return me.stack( 1 );
+		}
+
+		throw new MissingDefinition( "No me tunnel" );
 	}
 
 	public TunnelCollection<T> getCollection(Collection<PartP2PTunnel> collection, Class<? extends PartP2PTunnel> c)
@@ -335,7 +371,16 @@ public class PartP2PTunnel<T extends PartP2PTunnel> extends PartBasicState
 
 	protected IIcon getTypeTexture()
 	{
-		return AEApi.instance().blocks().blockQuartz.block().getIcon( 0, 0 );
+		final Optional<AEItemDefinition> maybeQuartz = AEApi.instance().definitions().blocks().quartz();
+
+		if ( maybeQuartz.isPresent() )
+		{
+			return maybeQuartz.get().block().getIcon( 0, 0 );
+		}
+		else
+		{
+			return null;
+		}
 	}
 
 	@Override

--- a/src/main/java/appeng/recipes/AEItemResolver.java
+++ b/src/main/java/appeng/recipes/AEItemResolver.java
@@ -22,6 +22,9 @@ package appeng.recipes;
 import net.minecraft.item.ItemStack;
 
 import appeng.api.AEApi;
+import appeng.api.definitions.IDefinitions;
+import appeng.api.definitions.IItems;
+import appeng.api.definitions.IParts;
 import appeng.api.recipes.ISubItemResolver;
 import appeng.api.recipes.ResolverResult;
 import appeng.api.recipes.ResolverResultSet;
@@ -43,54 +46,88 @@ public class AEItemResolver implements ISubItemResolver
 
 		if ( nameSpace.equals( AppEng.MOD_ID ) )
 		{
+			final IDefinitions definitions = AEApi.instance().definitions();
+			final IItems items = definitions.items();
+			final IParts parts = definitions.parts();
+
 			if ( itemName.startsWith( "PaintBall." ) )
 			{
-				return this.paintBall( AEApi.instance().items().itemPaintBall, itemName.substring( itemName.indexOf( "." ) + 1 ), false );
+				for ( AEColoredItemDefinition definition : items.coloredPaintBall().asSet() )
+				{
+					return this.paintBall( definition, itemName.substring( itemName.indexOf( '.' ) + 1 ), false  );
+				}
 			}
 
 			if ( itemName.startsWith( "LumenPaintBall." ) )
 			{
-				return this.paintBall( AEApi.instance().items().itemPaintBall, itemName.substring( itemName.indexOf( "." ) + 1 ), true );
+				for ( AEColoredItemDefinition definition : items.coloredLumenPaintBall().asSet() )
+				{
+					return this.paintBall( definition, itemName.substring( itemName.indexOf( '.' ) + 1 ), true  );
+				}
 			}
 
 			if ( itemName.equals( "CableGlass" ) )
 			{
-				return new ResolverResultSet( "CableGlass", AEApi.instance().parts().partCableGlass.allStacks( 1 ) );
+				for ( AEColoredItemDefinition definition : parts.cableGlass().asSet() )
+				{
+					return new ResolverResultSet( "CableGlass", definition.allStacks( 1 ) );
+				}
 			}
 
 			if ( itemName.startsWith( "CableGlass." ) )
 			{
-				return this.cableItem( AEApi.instance().parts().partCableGlass, itemName.substring( itemName.indexOf( "." ) + 1 ) );
+				for ( AEColoredItemDefinition definition : parts.cableGlass().asSet() )
+				{
+					return this.cableItem( definition, itemName.substring( itemName.indexOf( '.' ) + 1 ) );
+				}
 			}
 
 			if ( itemName.equals( "CableCovered" ) )
 			{
-				return new ResolverResultSet( "CableCovered", AEApi.instance().parts().partCableCovered.allStacks( 1 ) );
+				for ( AEColoredItemDefinition definition : parts.cableCovered().asSet() )
+				{
+					return new ResolverResultSet( "CableCovered", definition.allStacks( 1 ) );
+				}
 			}
 
 			if ( itemName.startsWith( "CableCovered." ) )
 			{
-				return this.cableItem( AEApi.instance().parts().partCableCovered, itemName.substring( itemName.indexOf( "." ) + 1 ) );
+				for ( AEColoredItemDefinition definition : parts.cableCovered().asSet() )
+				{
+					return this.cableItem( definition, itemName.substring( itemName.indexOf( '.' ) + 1 ) );
+				}
 			}
 
 			if ( itemName.equals( "CableSmart" ) )
 			{
-				return new ResolverResultSet( "CableSmart", AEApi.instance().parts().partCableSmart.allStacks( 1 ) );
+				for ( AEColoredItemDefinition definition : parts.cableSmart().asSet() )
+				{
+					return new ResolverResultSet( "CableSmart", definition.allStacks( 1 ) );
+				}
 			}
 
 			if ( itemName.startsWith( "CableSmart." ) )
 			{
-				return this.cableItem( AEApi.instance().parts().partCableSmart, itemName.substring( itemName.indexOf( "." ) + 1 ) );
+				for ( AEColoredItemDefinition definition : parts.cableSmart().asSet() )
+				{
+					return this.cableItem( definition, itemName.substring( itemName.indexOf( '.' ) + 1 ) );
+				}
 			}
 
 			if ( itemName.equals( "CableDense" ) )
 			{
-				return new ResolverResultSet( "CableDense", AEApi.instance().parts().partCableDense.allStacks( 1 ) );
+				for ( AEColoredItemDefinition definition : parts.cableDense().asSet() )
+				{
+					return new ResolverResultSet( "CableDense", definition.allStacks( 1 ) );
+				}
 			}
 
 			if ( itemName.startsWith( "CableDense." ) )
 			{
-				return this.cableItem( AEApi.instance().parts().partCableDense, itemName.substring( itemName.indexOf( "." ) + 1 ) );
+				for ( AEColoredItemDefinition definition : parts.cableDense().asSet() )
+				{
+					return this.cableItem( definition, itemName.substring( itemName.indexOf( '.' ) + 1 ) );
+				}
 			}
 
 			if ( itemName.startsWith( "ItemCrystalSeed." ) )
@@ -107,7 +144,7 @@ public class AEItemResolver implements ISubItemResolver
 
 			if ( itemName.startsWith( "ItemMaterial." ) )
 			{
-				String materialName = itemName.substring( itemName.indexOf( "." ) + 1 );
+				String materialName = itemName.substring( itemName.indexOf( '.' ) + 1 );
 				MaterialType mt = MaterialType.valueOf( materialName );
 				// itemName = itemName.substring( 0, itemName.indexOf( "." ) );
 				if ( mt.itemInstance == ItemMultiMaterial.instance && mt.damageValue >= 0 && mt.isRegistered() )
@@ -116,7 +153,7 @@ public class AEItemResolver implements ISubItemResolver
 
 			if ( itemName.startsWith( "ItemPart." ) )
 			{
-				String partName = itemName.substring( itemName.indexOf( "." ) + 1 );
+				String partName = itemName.substring( itemName.indexOf( '.' ) + 1 );
 				PartType pt = PartType.valueOf( partName );
 				// itemName = itemName.substring( 0, itemName.indexOf( "." ) );
 				int dVal = ItemMultiPart.instance.getDamageByType( pt );
@@ -130,7 +167,7 @@ public class AEItemResolver implements ISubItemResolver
 
 	private Object paintBall(AEColoredItemDefinition partType, String substring, boolean lumen)
 	{
-		AEColor col = AEColor.Transparent;
+		AEColor col;
 
 		try
 		{
@@ -150,7 +187,7 @@ public class AEItemResolver implements ISubItemResolver
 
 	private Object cableItem(AEColoredItemDefinition partType, String substring)
 	{
-		AEColor col = AEColor.Transparent;
+		AEColor col;
 
 		try
 		{

--- a/src/main/java/appeng/recipes/RecipeHandler.java
+++ b/src/main/java/appeng/recipes/RecipeHandler.java
@@ -39,6 +39,9 @@ import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.common.registry.GameRegistry.UniqueIdentifier;
 
 import appeng.api.AEApi;
+import appeng.api.definitions.IBlocks;
+import appeng.api.definitions.IDefinitions;
+import appeng.api.definitions.IItems;
 import appeng.api.exceptions.MissingIngredientError;
 import appeng.api.exceptions.RecipeError;
 import appeng.api.exceptions.RegistrationError;
@@ -47,6 +50,7 @@ import appeng.api.recipes.ICraftHandler;
 import appeng.api.recipes.IIngredient;
 import appeng.api.recipes.IRecipeHandler;
 import appeng.api.recipes.IRecipeLoader;
+import appeng.api.util.AEItemDefinition;
 import appeng.core.AEConfig;
 import appeng.core.AELog;
 import appeng.core.AppEng;
@@ -258,7 +262,11 @@ public class RecipeHandler implements IRecipeHandler
 		if ( !id.modId.equals( AppEng.MOD_ID ) && !id.modId.equals( "minecraft" ) )
 			throw new RecipeError( "Not applicable for website" );
 
-		if ( is.getItem() == AEApi.instance().items().itemCrystalSeed.item() )
+		final IDefinitions definitions = AEApi.instance().definitions();
+		final IItems items = definitions.items();
+		final IBlocks blocks = definitions.blocks();
+
+		if ( items.crystalSeed().isPresent() && is.getItem() == items.crystalSeed().get().item() )
 		{
 			int dmg = is.getItemDamage();
 			if ( dmg < ItemCrystalSeed.Nether )
@@ -268,7 +276,7 @@ public class RecipeHandler implements IRecipeHandler
 			else if ( dmg < ItemCrystalSeed.END )
 				realName += ".Fluix";
 		}
-		else if ( is.getItem() == AEApi.instance().blocks().blockSkyStone.item() )
+		else if ( blocks.skyStone().isPresent() && is.getItem() == blocks.skyStone().get().item() )
 		{
 			switch (is.getItemDamage())
 			{
@@ -284,7 +292,7 @@ public class RecipeHandler implements IRecipeHandler
 			default:
 			}
 		}
-		else if ( is.getItem() == AEApi.instance().blocks().blockCraftingStorage1k.item() )
+		else if ( blocks.craftingStorage1k().isPresent() && is.getItem() == blocks.craftingStorage1k().get().item() )
 		{
 			switch (is.getItemDamage())
 			{
@@ -300,7 +308,7 @@ public class RecipeHandler implements IRecipeHandler
 			default:
 			}
 		}
-		else if ( is.getItem() == AEApi.instance().blocks().blockCraftingUnit.item() )
+		else if ( blocks.craftingUnit().isPresent() && is.getItem() == blocks.craftingUnit().get().item() )
 		{
 			switch (is.getItemDamage())
 			{
@@ -310,7 +318,7 @@ public class RecipeHandler implements IRecipeHandler
 			default:
 			}
 		}
-		else if ( is.getItem() == AEApi.instance().blocks().blockSkyChest.item() )
+		else if ( blocks.skyChest().isPresent() && is.getItem() == blocks.skyChest().get().item() )
 		{
 			switch (is.getItemDamage())
 			{

--- a/src/main/java/appeng/recipes/game/DisassembleRecipe.java
+++ b/src/main/java/appeng/recipes/game/DisassembleRecipe.java
@@ -25,19 +25,24 @@ import net.minecraft.world.World;
 
 import appeng.api.AEApi;
 import appeng.api.definitions.Blocks;
+import appeng.api.definitions.IBlocks;
+import appeng.api.definitions.IItems;
+import appeng.api.definitions.IMaterials;
 import appeng.api.definitions.Items;
 import appeng.api.definitions.Materials;
 import appeng.api.storage.IMEInventory;
 import appeng.api.storage.StorageChannel;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.api.storage.data.IItemList;
+import appeng.api.util.AEItemDefinition;
+
 
 public class DisassembleRecipe implements IRecipe
 {
 
-	private final Materials mats = AEApi.instance().materials();
-	private final Items items = AEApi.instance().items();
-	private final Blocks blocks = AEApi.instance().blocks();
+	private final IMaterials mats = AEApi.instance().definitions().materials();
+	private final IItems items = AEApi.instance().definitions().items();
+	private final IBlocks blocks = AEApi.instance().definitions().blocks();
 
 	private ItemStack getOutput(InventoryCrafting inv, boolean createFacade)
 	{
@@ -51,17 +56,49 @@ public class DisassembleRecipe implements IRecipe
 				if ( hasCell != null )
 					return null;
 
-				if ( this.items.itemCell1k.sameAsStack( is ) )
-					hasCell = this.mats.materialCell1kPart.stack( 1 );
+				for ( AEItemDefinition definition : this.items.cell1k().asSet() )
+				{
+					if ( definition.sameAsStack( is ) )
+					{
+						for ( AEItemDefinition partDefinition : this.mats.cell1kPart().asSet() )
+						{
+							hasCell = partDefinition.stack( 1 );
+						}
+					}
+				}
 
-				if ( this.items.itemCell4k.sameAsStack( is ) )
-					hasCell = this.mats.materialCell4kPart.stack( 1 );
+				for ( AEItemDefinition definition : this.items.cell4k().asSet() )
+				{
+					if ( definition.sameAsStack( is ) )
+					{
+						for ( AEItemDefinition partDefinition : this.mats.cell4kPart().asSet() )
+						{
+							hasCell = partDefinition.stack( 1 );
+						}
+					}
+				}
 
-				if ( this.items.itemCell16k.sameAsStack( is ) )
-					hasCell = this.mats.materialCell16kPart.stack( 1 );
+				for ( AEItemDefinition definition : this.items.cell16k().asSet() )
+				{
+					if ( definition.sameAsStack( is ) )
+					{
+						for ( AEItemDefinition partDefinition : this.mats.cell16kPart().asSet() )
+						{
+							hasCell = partDefinition.stack( 1 );
+						}
+					}
+				}
 
-				if ( this.items.itemCell64k.sameAsStack( is ) )
-					hasCell = this.mats.materialCell64kPart.stack( 1 );
+				for ( AEItemDefinition definition : this.items.cell64k().asSet() )
+				{
+					if ( definition.sameAsStack( is ) )
+					{
+						for ( AEItemDefinition partDefinition : this.mats.cell64kPart().asSet() )
+						{
+							hasCell = partDefinition.stack( 1 );
+						}
+					}
+				}
 
 				// make sure the storage cell is empty...
 				if ( hasCell != null )
@@ -75,20 +112,60 @@ public class DisassembleRecipe implements IRecipe
 					}
 				}
 
-				if ( this.items.itemEncodedPattern.sameAsStack( is ) )
-					hasCell = this.mats.materialBlankPattern.stack( 1 );
+				for ( AEItemDefinition definition : this.items.encodedPattern().asSet() )
+				{
+					if ( definition.sameAsStack( is ) )
+					{
+						for ( AEItemDefinition partDefinition : this.mats.blankPattern().asSet() )
+						{
+							hasCell = partDefinition.stack( 1 );
+						}
+					}
+				}
 
-				if ( this.blocks.blockCraftingStorage1k.sameAsStack( is ) )
-					hasCell = this.mats.materialCell1kPart.stack( 1 );
+				for ( AEItemDefinition definition : this.blocks.craftingStorage1k().asSet() )
+				{
+					if ( definition.sameAsStack( is ) )
+					{
+						for ( AEItemDefinition partDefinition : this.mats.cell1kPart().asSet() )
+						{
+							hasCell = partDefinition.stack( 1 );
+						}
+					}
+				}
 
-				if ( this.blocks.blockCraftingStorage4k.sameAsStack( is ) )
-					hasCell = this.mats.materialCell4kPart.stack( 1 );
+				for ( AEItemDefinition definition : this.blocks.craftingStorage4k().asSet() )
+				{
+					if ( definition.sameAsStack( is ) )
+					{
+						for ( AEItemDefinition partDefinition : this.mats.cell4kPart().asSet() )
+						{
+							hasCell = partDefinition.stack( 1 );
+						}
+					}
+				}
 
-				if ( this.blocks.blockCraftingStorage16k.sameAsStack( is ) )
-					hasCell = this.mats.materialCell16kPart.stack( 1 );
+				for ( AEItemDefinition definition : this.blocks.craftingStorage16k().asSet() )
+				{
+					if ( definition.sameAsStack( is ) )
+					{
+						for ( AEItemDefinition partDefinition : this.mats.cell16kPart().asSet() )
+						{
+							hasCell = partDefinition.stack( 1 );
+						}
+					}
+				}
 
-				if ( this.blocks.blockCraftingStorage64k.sameAsStack( is ) )
-					hasCell = this.mats.materialCell64kPart.stack( 1 );
+				for ( AEItemDefinition definition : this.blocks.craftingStorage64k().asSet() )
+				{
+					if ( definition.sameAsStack( is ) )
+					{
+						for ( AEItemDefinition partDefinition : this.mats.cell64kPart().asSet() )
+						{
+							hasCell = partDefinition.stack( 1 );
+						}
+					}
+				}
 
 				if ( hasCell == null )
 					return null;

--- a/src/main/java/appeng/recipes/game/FacadeRecipe.java
+++ b/src/main/java/appeng/recipes/game/FacadeRecipe.java
@@ -29,6 +29,7 @@ import net.minecraft.world.World;
 import com.google.common.base.Optional;
 
 import appeng.api.AEApi;
+import appeng.api.definitions.IDefinitions;
 import appeng.api.util.AEItemDefinition;
 import appeng.items.parts.ItemFacade;
 
@@ -41,8 +42,10 @@ public class FacadeRecipe implements IRecipe
 
 	public FacadeRecipe()
 	{
-		this.maybeFacade = Optional.fromNullable( AEApi.instance().items().itemFacade );
-		this.maybeAnchor = Optional.fromNullable( AEApi.instance().parts().partCableAnchor );
+		final IDefinitions definitions = AEApi.instance().definitions();
+
+		this.maybeFacade = definitions.items().facade();
+		this.maybeAnchor = definitions.parts().cableAnchor();
 	}
 
 	@Override

--- a/src/main/java/appeng/server/AECommand.java
+++ b/src/main/java/appeng/server/AECommand.java
@@ -69,10 +69,12 @@ public class AECommand extends CommandBase
 					throw new WrongUsageException( c.command.getHelp( this.srv ) );
 				}
 			}
+			catch ( WrongUsageException wrong )
+			{
+				throw wrong;
+			}
 			catch (Throwable er)
 			{
-				if ( er instanceof WrongUsageException )
-					throw (WrongUsageException) er;
 				throw new WrongUsageException( "commands.ae2.usage" );
 			}
 		}
@@ -90,10 +92,12 @@ public class AECommand extends CommandBase
 				else
 					throw new WrongUsageException( "commands.ae2.permissions" );
 			}
+			catch ( WrongUsageException wrong )
+			{
+				throw wrong;
+			}
 			catch (Throwable er)
 			{
-				if ( er instanceof WrongUsageException )
-					throw (WrongUsageException) er;
 				throw new WrongUsageException( "commands.ae2.usage" );
 			}
 		}

--- a/src/main/java/appeng/spatial/CachedPlane.java
+++ b/src/main/java/appeng/spatial/CachedPlane.java
@@ -32,9 +32,12 @@ import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.storage.ExtendedBlockStorage;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import com.google.common.base.Optional;
+
 import appeng.api.AEApi;
 import appeng.api.movable.IMovableHandler;
 import appeng.api.movable.IMovableRegistry;
+import appeng.api.util.AEItemDefinition;
 import appeng.api.util.WorldCoord;
 import appeng.core.AELog;
 import appeng.core.WorldSettings;
@@ -130,7 +133,8 @@ public class CachedPlane
 	final LinkedList<NextTickListEntry> ticks = new LinkedList<NextTickListEntry>();
 
 	final World world;
-	final Block matrixFrame = AEApi.instance().blocks().blockMatrixFrame.block();
+	private static final Optional<AEItemDefinition> MAYBE_MATRIX_FRAME = AEApi.instance().definitions().blocks().matrixFrame();
+	private final Block matrixFrame = ( MAYBE_MATRIX_FRAME.isPresent()) ? MAYBE_MATRIX_FRAME.get().block() : null;
 	final IMovableRegistry reg = AEApi.instance().registries().movable();
 
 	final LinkedList<WorldCoord> updates = new LinkedList<WorldCoord>();

--- a/src/main/java/appeng/spatial/StorageChunkProvider.java
+++ b/src/main/java/appeng/spatial/StorageChunkProvider.java
@@ -29,6 +29,7 @@ import net.minecraft.world.chunk.IChunkProvider;
 import net.minecraft.world.gen.ChunkProviderGenerate;
 
 import appeng.api.AEApi;
+import appeng.api.util.AEItemDefinition;
 import appeng.core.AEConfig;
 
 public class StorageChunkProvider extends ChunkProviderGenerate
@@ -40,10 +41,13 @@ public class StorageChunkProvider extends ChunkProviderGenerate
 
 		BLOCKS = new Block[255 * 256];
 
-		Block matrixFrame = AEApi.instance().blocks().blockMatrixFrame.block();
-		for (int x = 0; x < BLOCKS.length; x++)
-			BLOCKS[x] = matrixFrame;
-
+		for ( AEItemDefinition matrixFrame : AEApi.instance().definitions().blocks().matrixFrame().asSet() )
+		{
+			for (int x = 0; x < BLOCKS.length; x++)
+			{
+				BLOCKS[x] = matrixFrame.block();
+			}
+		}
 	}
 
 	final World w;

--- a/src/main/java/appeng/spatial/StorageHelper.java
+++ b/src/main/java/appeng/spatial/StorageHelper.java
@@ -33,6 +33,7 @@ import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
 
 import appeng.api.AEApi;
+import appeng.api.util.AEItemDefinition;
 import appeng.api.util.WorldCoord;
 import appeng.block.spatial.BlockMatrixFrame;
 import appeng.core.stats.Achievements;
@@ -289,9 +290,10 @@ public class StorageHelper
 	, World dst /** storage cell **/
 	, int x, int y, int z, int i, int j, int k, int scaleX, int scaleY, int scaleZ)
 	{
-		BlockMatrixFrame blkMF = (BlockMatrixFrame) AEApi.instance().blocks().blockMatrixFrame.block();
-
-		this.transverseEdges( i - 1, j - 1, k - 1, i + scaleX + 1, j + scaleY + 1, k + scaleZ + 1, new WrapInMatrixFrame( blkMF, 0, dst ) );
+		for ( AEItemDefinition matrixFrame : AEApi.instance().definitions().blocks().matrixFrame().asSet() )
+		{
+			this.transverseEdges( i - 1, j - 1, k - 1, i + scaleX + 1, j + scaleY + 1, k + scaleZ + 1, new WrapInMatrixFrame( matrixFrame.block(), 0, dst ) );
+		}
 
 		AxisAlignedBB srcBox = AxisAlignedBB.getBoundingBox( x, y, z, x + scaleX + 1, y + scaleY + 1, z + scaleZ + 1 );
 

--- a/src/main/java/appeng/tile/crafting/TileCraftingStorageTile.java
+++ b/src/main/java/appeng/tile/crafting/TileCraftingStorageTile.java
@@ -21,13 +21,15 @@ package appeng.tile.crafting;
 import net.minecraft.item.ItemStack;
 
 import appeng.api.AEApi;
+import appeng.api.definitions.IBlocks;
+
 
 public class TileCraftingStorageTile extends TileCraftingTile
 {
-
-	static final ItemStack STACK_4K_STORAGE = AEApi.instance().blocks().blockCraftingStorage4k.stack( 1 );
-	static final ItemStack STACK_16K_STORAGE = AEApi.instance().blocks().blockCraftingStorage16k.stack( 1 );
-	static final ItemStack STACK_64K_STORAGE = AEApi.instance().blocks().blockCraftingStorage64k.stack( 1 );
+	private static final IBlocks BLOCKS = AEApi.instance().definitions().blocks();
+	static final ItemStack STACK_4K_STORAGE = ( BLOCKS.craftingStorage4k().isPresent() ) ? BLOCKS.craftingStorage4k().get().stack( 1 ) : null;
+	static final ItemStack STACK_16K_STORAGE = ( BLOCKS.craftingStorage16k().isPresent() ) ? BLOCKS.craftingStorage16k().get().stack( 1 ) : null;
+	static final ItemStack STACK_64K_STORAGE = ( BLOCKS.craftingStorage64k().isPresent() ) ? BLOCKS.craftingStorage64k().get().stack( 1 ) : null;
 
 	@Override
 	protected ItemStack getItemFromTile(Object obj)

--- a/src/main/java/appeng/tile/crafting/TileCraftingTile.java
+++ b/src/main/java/appeng/tile/crafting/TileCraftingTile.java
@@ -29,6 +29,8 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import com.google.common.base.Optional;
+
 import appeng.api.AEApi;
 import appeng.api.config.Actionable;
 import appeng.api.implementations.IPowerChannelState;
@@ -40,6 +42,7 @@ import appeng.api.networking.events.MENetworkPowerStatusChange;
 import appeng.api.parts.ISimplifiedBundle;
 import appeng.api.storage.IMEInventory;
 import appeng.api.storage.data.IAEItemStack;
+import appeng.api.util.AEItemDefinition;
 import appeng.api.util.WorldCoord;
 import appeng.me.cluster.IAECluster;
 import appeng.me.cluster.IAEMultiBlock;
@@ -63,7 +66,8 @@ public class TileCraftingTile extends AENetworkTile implements IAEMultiBlock, IP
 	public NBTTagCompound previousState = null;
 	public boolean isCoreBlock = false;
 
-	static final ItemStack STACK_CO_PROCESSOR = AEApi.instance().blocks().blockCraftingAccelerator.stack( 1 );
+	private static final Optional<AEItemDefinition> MAYBE_ACCELERATOR = AEApi.instance().definitions().blocks().craftingAccelerator();
+	static final ItemStack STACK_CO_PROCESSOR = ( MAYBE_ACCELERATOR.isPresent() ) ? MAYBE_ACCELERATOR.get().stack( 1 ) : null;
 
 	@Override
 	protected AENetworkProxy createProxy()

--- a/src/main/java/appeng/tile/crafting/TileMolecularAssembler.java
+++ b/src/main/java/appeng/tile/crafting/TileMolecularAssembler.java
@@ -35,6 +35,8 @@ import net.minecraftforge.common.util.ForgeDirection;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.network.NetworkRegistry.TargetPoint;
 
+import com.google.common.base.Optional;
+
 import appeng.api.AEApi;
 import appeng.api.config.Actionable;
 import appeng.api.config.PowerMultiplier;
@@ -54,6 +56,7 @@ import appeng.api.networking.ticking.TickingRequest;
 import appeng.api.parts.ISimplifiedBundle;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.api.util.AECableType;
+import appeng.api.util.AEItemDefinition;
 import appeng.api.util.DimensionalCoord;
 import appeng.api.util.IConfigManager;
 import appeng.container.ContainerNull;
@@ -78,7 +81,8 @@ public class TileMolecularAssembler extends AENetworkInvTile implements IUpgrade
 {
 
 	private static final int[] SIDES = new int[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
-	private static final ItemStack STACK_ASSEMBLER = AEApi.instance().blocks().blockMolecularAssembler.stack( 1 );
+	private static final Optional<AEItemDefinition> MAYBE_ASSEMBLER = AEApi.instance().definitions().blocks().molecularAssembler();
+	private static final ItemStack STACK_ASSEMBLER = ( MAYBE_ASSEMBLER.isPresent() ) ? MAYBE_ASSEMBLER.get().stack( 1 ) : null;
 
 	private final InventoryCrafting craftingInv = new InventoryCrafting( new ContainerNull(), 3, 3 );
 	private final AppEngInternalInventory inv = new AppEngInternalInventory( this, 9 + 2 );

--- a/src/main/java/appeng/tile/misc/TileCondenser.java
+++ b/src/main/java/appeng/tile/misc/TileCondenser.java
@@ -30,7 +30,9 @@ import net.minecraftforge.fluids.IFluidHandler;
 import appeng.api.AEApi;
 import appeng.api.config.CondenserOutput;
 import appeng.api.config.Settings;
+import appeng.api.definitions.IMaterials;
 import appeng.api.implementations.items.IStorageComponent;
+import appeng.api.util.AEItemDefinition;
 import appeng.api.util.IConfigManager;
 import appeng.api.util.IConfigurableObject;
 import appeng.tile.AEBaseInvTile;
@@ -130,14 +132,26 @@ public class TileCondenser extends AEBaseInvTile implements IFluidHandler, IConf
 
 	private ItemStack getOutput()
 	{
+		final IMaterials materials = AEApi.instance().definitions().materials();
+
 		switch ((CondenserOutput) this.cm.getSetting( Settings.CONDENSER_OUTPUT ))
 		{
-		case MATTER_BALLS:
-			return AEApi.instance().materials().materialMatterBall.stack( 1 );
-		case SINGULARITY:
-			return AEApi.instance().materials().materialSingularity.stack( 1 );
-		case TRASH:
-		default:
+			case MATTER_BALLS:
+				for ( AEItemDefinition matterBall : materials.matterBall().asSet() )
+				{
+					return matterBall.stack( 1 );
+				}
+				break;
+
+			case SINGULARITY:
+				for ( AEItemDefinition singularity : materials.singularity().asSet() )
+				{
+					return singularity.stack( 1 );
+				}
+				break;
+
+			case TRASH:
+			default:
 		}
 		return null;
 	}

--- a/src/main/java/appeng/tile/networking/TileWireless.java
+++ b/src/main/java/appeng/tile/networking/TileWireless.java
@@ -37,6 +37,7 @@ import appeng.api.networking.events.MENetworkChannelsChanged;
 import appeng.api.networking.events.MENetworkEventSubscribe;
 import appeng.api.networking.events.MENetworkPowerStatusChange;
 import appeng.api.util.AECableType;
+import appeng.api.util.AEItemDefinition;
 import appeng.api.util.DimensionalCoord;
 import appeng.core.AEConfig;
 import appeng.me.GridAccessException;
@@ -193,7 +194,12 @@ public class TileWireless extends AENetworkInvTile implements IWirelessAccessPoi
 	@Override
 	public boolean isItemValidForSlot( int i, ItemStack itemstack )
 	{
-		return AEApi.instance().materials().materialWirelessBooster.sameAsStack( itemstack );
+		for ( AEItemDefinition booster : AEApi.instance().definitions().materials().wirelessBooster().asSet() )
+		{
+			return booster.sameAsStack( itemstack );
+		}
+
+		return false;
 	}
 
 	@Override

--- a/src/main/java/appeng/tile/qnb/TileQuantumBridge.java
+++ b/src/main/java/appeng/tile/qnb/TileQuantumBridge.java
@@ -28,11 +28,14 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import com.google.common.base.Optional;
+
 import appeng.api.AEApi;
 import appeng.api.networking.GridFlags;
 import appeng.api.networking.events.MENetworkEventSubscribe;
 import appeng.api.networking.events.MENetworkPowerStatusChange;
 import appeng.api.util.AECableType;
+import appeng.api.util.AEItemDefinition;
 import appeng.api.util.DimensionalCoord;
 import appeng.me.GridAccessException;
 import appeng.me.cluster.IAECluster;
@@ -48,8 +51,8 @@ import appeng.util.Platform;
 
 public class TileQuantumBridge extends AENetworkInvTile implements IAEMultiBlock
 {
-
-	final private static ItemStack RING_STACK = ( AEApi.instance().blocks().blockQuantumRing != null ) ? AEApi.instance().blocks().blockQuantumRing.stack( 1 ) : null;
+	private static final Optional<AEItemDefinition> QUANTUM_RING = AEApi.instance().definitions().blocks().quantumRing();
+	private static final ItemStack RING_STACK = ( QUANTUM_RING.isPresent() ) ? QUANTUM_RING.get().stack( 1 ) : null;
 
 	final int[] sidesRing = new int[] { };
 	final int[] sidesLink = new int[] { 0 };
@@ -170,8 +173,14 @@ public class TileQuantumBridge extends AENetworkInvTile implements IAEMultiBlock
 	public void onReady()
 	{
 		super.onReady();
-		if ( this.worldObj.getBlock( this.xCoord, this.yCoord, this.zCoord ) == AEApi.instance().blocks().blockQuantumRing.block() )
-			this.gridProxy.setVisualRepresentation( RING_STACK );
+
+		for ( AEItemDefinition definition : AEApi.instance().definitions().blocks().quantumRing().asSet() )
+		{
+			if ( this.worldObj.getBlock( this.xCoord, this.yCoord, this.zCoord ) == definition.block() )
+			{
+				this.gridProxy.setVisualRepresentation( RING_STACK );
+			}
+		}
 	}
 
 	@Override
@@ -223,7 +232,12 @@ public class TileQuantumBridge extends AENetworkInvTile implements IAEMultiBlock
 
 	public boolean isCenter()
 	{
-		return this.getBlockType() == AEApi.instance().blocks().blockQuantumLink.block();
+		for ( AEItemDefinition definition : AEApi.instance().definitions().blocks().quantumLink().asSet() )
+		{
+			return this.getBlockType() == definition.block();
+		}
+
+		return false;
 	}
 
 	public boolean isCorner()

--- a/src/main/java/appeng/util/Platform.java
+++ b/src/main/java/appeng/util/Platform.java
@@ -85,6 +85,7 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
 import buildcraft.api.tools.IToolWrench;
+import com.google.common.base.Optional;
 
 import appeng.api.AEApi;
 import appeng.api.config.AccessRestriction;
@@ -95,6 +96,8 @@ import appeng.api.config.PowerUnits;
 import appeng.api.config.SearchBoxMode;
 import appeng.api.config.SecurityPermissions;
 import appeng.api.config.SortOrder;
+import appeng.api.definitions.IMaterials;
+import appeng.api.definitions.IParts;
 import appeng.api.implementations.items.IAEItemPowerStorage;
 import appeng.api.implementations.items.IAEWrench;
 import appeng.api.implementations.tiles.ITileStorageMonitorable;
@@ -118,6 +121,7 @@ import appeng.api.storage.data.IAEStack;
 import appeng.api.storage.data.IAETagCompound;
 import appeng.api.storage.data.IItemList;
 import appeng.api.util.AEColor;
+import appeng.api.util.AEColoredItemDefinition;
 import appeng.api.util.AEItemDefinition;
 import appeng.api.util.DimensionalCoord;
 import appeng.core.AEConfig;
@@ -1755,7 +1759,11 @@ public class Platform
 			return false;
 
 		if ( type == AEFeature.CertusQuartzTools )
-			return AEApi.instance().materials().materialCertusQuartzCrystal.sameAsStack( b );
+		{
+			final Optional<AEItemDefinition> maybeCertus = AEApi.instance().definitions().materials().certusQuartzCrystal();
+
+			return maybeCertus.isPresent() && maybeCertus.get().sameAsStack( b );
+		}
 
 		if ( type == AEFeature.NetherQuartzTools )
 			return Items.quartz == b.getItem();
@@ -1765,19 +1773,41 @@ public class Platform
 
 	public static Object findPreferred(ItemStack[] is)
 	{
+		final IParts parts = AEApi.instance().definitions().parts();
+
 		for (ItemStack stack : is)
 		{
-			if ( AEApi.instance().parts().partCableGlass.sameAs( AEColor.Transparent, stack ) )
-				return stack;
+			for ( AEColoredItemDefinition glass : parts.cableGlass().asSet() )
+			{
+				if ( glass.sameAs( AEColor.Transparent, stack ) )
+				{
+					return stack;
+				}
+			}
 
-			if ( AEApi.instance().parts().partCableCovered.sameAs( AEColor.Transparent, stack ) )
-				return stack;
+			for ( AEColoredItemDefinition covered : parts.cableCovered().asSet() )
+			{
+				if ( covered.sameAs( AEColor.Transparent, stack ) )
+				{
+					return stack;
+				}
+			}
 
-			if ( AEApi.instance().parts().partCableSmart.sameAs( AEColor.Transparent, stack ) )
-				return stack;
+			for ( AEColoredItemDefinition smart : parts.cableSmart().asSet() )
+			{
+				if ( smart.sameAs( AEColor.Transparent, stack ) )
+				{
+					return stack;
+				}
+			}
 
-			if ( AEApi.instance().parts().partCableDense.sameAs( AEColor.Transparent, stack ) )
-				return stack;
+			for ( AEColoredItemDefinition dense : parts.cableDense().asSet() )
+			{
+				if ( dense.sameAs( AEColor.Transparent, stack ) )
+				{
+					return stack;
+				}
+			}
 		}
 
 		return is;
@@ -1865,8 +1895,23 @@ public class Platform
 
 	public static boolean isRecipePrioritized(ItemStack what)
 	{
-		return AEApi.instance().materials().materialPurifiedCertusQuartzCrystal.sameAsStack( what )
-				|| AEApi.instance().materials().materialPurifiedFluixCrystal.sameAsStack( what )
-				|| AEApi.instance().materials().materialPurifiedNetherQuartzCrystal.sameAsStack( what );
+		final IMaterials materials = AEApi.instance().definitions().materials();
+
+		for ( AEItemDefinition pureCert : materials.purifiedCertusQuartzCrystal().asSet() )
+		{
+			return pureCert.sameAsStack( what );
+		}
+
+		for ( AEItemDefinition pureFluix : materials.purifiedFluixCrystal().asSet() )
+		{
+			return pureFluix.sameAsStack( what );
+		}
+
+		for ( AEItemDefinition pureNether : materials.purifiedNetherQuartzCrystal().asSet() )
+		{
+			return pureNether.sameAsStack( what );
+		}
+
+		return false;
 	}
 }


### PR DESCRIPTION
**Changes**
Deprecates the old usage of the `AEItemDefinitions` via the direct method access of.

* `blocks()`
* `parts()`
* `items()`
* `materials()`

and thus use the new re-direct via `definitions()`.
Also fields are marked as `@Nullable` to give direct IDE support, if somebody should ever use them by accident again

**Intention**
The whole change is just a temporary major fix to the nagging of the missing definitions
due to the possibility that they being null if being deactivated by config.

For future reference, it would be better to initialize the block and item definitions,
but intercept the registration, so the user cant access it, but the processing,
will not fail, because the definitions will still be valid. This could be an API change introduced in Minecraft 1.8+

**Old Way**
    `AEItemDefinition AEApi.instance().blocksQuartzOre`

**New Way**
    `Optional<AEItemDefinition> AEApi.instancen().blocks().quartzOre()`

It uses the Guava Optional Class, which is feature-wise more than the Java 8 version. It enables transformations and iterations

**Notice**
Many of the commit changes are due to a reformat of the API files

**Edit**
Format