### PR TITLE
Removes creating a ItemStack with a full NBT copy

### DIFF
--- a/src/main/java/appeng/me/storage/CellInventory.java
+++ b/src/main/java/appeng/me/storage/CellInventory.java
@@ -481,8 +481,7 @@ public class CellInventory implements ICellInventory
 		if ( request == null )
 			return null;
 
-		ItemStack sharedItem = request.getItemStack();
-		int size = sharedItem.stackSize;
+		long size = Math.min( Integer.MAX_VALUE, request.getStackSize() );
 
 		IAEItemStack Results = null;
 


### PR DESCRIPTION
There is no need to create a full copy just to fetch the already available
stacksize. It still respects the maximum stacksize of Integer.MAX_VALUE as they copy is doing.

Fixes #982