### PR TITLE
Improved AEItemStack.compareTo performance.

### DIFF
--- a/src/main/java/appeng/util/item/AEItemDef.java
+++ b/src/main/java/appeng/util/item/AEItemDef.java
@@ -37,7 +37,7 @@ public class AEItemDef
 
 	public int def;
 
-	private final int itemID;
+	public final int itemID;
 	public final Item item;
 	public int damageValue;
 
@@ -62,7 +62,7 @@ public class AEItemDef
 
 	public AEItemDef(Item it) {
 		this.item = it;
-		this.itemID = System.identityHashCode( this.item );
+		this.itemID = Item.getIdFromItem( it );
 	}
 
 	public AEItemDef copy()

--- a/src/main/java/appeng/util/item/AEItemStack.java
+++ b/src/main/java/appeng/util/item/AEItemStack.java
@@ -261,11 +261,19 @@ public final class AEItemStack extends AEStack<IAEItemStack> implements IAEItemS
 	@Override
 	public int compareTo(AEItemStack b)
 	{
-		int id = this.compare( this.def.item.hashCode(), b.def.item.hashCode() );
-		int damageValue = this.compare( this.def.damageValue, b.def.damageValue );
-		int displayDamage = this.compare( this.def.displayDamage, b.def.displayDamage );
-		// AELog.info( "NBT: " + nbt );
-		return id == 0 ? (damageValue == 0 ? (displayDamage == 0 ? this.compareNBT( b.def ) : displayDamage) : damageValue) : id;
+		int id = this.def.itemID - b.def.itemID;
+		if (id != 0)
+			return id;
+
+		int damageValue = this.def.damageValue - b.def.damageValue ;
+		if (damageValue != 0)
+			return damageValue;
+
+		int displayDamage = this.def.displayDamage - b.def.displayDamage;
+		if (displayDamage != 0)
+			return displayDamage;
+
+		return (this.def.tagCompound == b.def.tagCompound) ? 0 : this.compareNBT( b.def );
 	}
 
 	private int compareNBT(AEItemDef b)
@@ -276,7 +284,7 @@ public final class AEItemStack extends AEStack<IAEItemStack> implements IAEItemS
 		return nbt;
 	}
 
-	private int compare(int l, long m)
+	private int compare(int l, int m)
 	{
 		return l < m ? -1 : (l > m ? 1 : 0);
 	}


### PR DESCRIPTION
Changed `AEItemDef.itemID` to public, mostly for caching the value. `Item.getIdFromItem()` is already backed by an `IdentityHashMap` and using `System.identityHashCode()`.
Also directly dealing with the internal id guarantees no overflows caused by using `a - b` to compare two integers.

`AEItemStack.compareTo()` will now return as soon as possible. For example there is no need to compare metadata, damage value and NBT data, if we already know that these are two item ids.
Whereever it is possible it also uses `a - b` to compare both values (No overflows).
Furthermore it now does an identity compare between the `NBTTagCompound` before actually comparing them. This results in not calling `compareNBT`, if both are null or the same object.
As we already use a shared `NBTTagCompound` (`AESharedNBT`) it also removes uneccessary calls to `compareNBT`.

These are two Snapshots using the old and new `compareTo`.
https://www.dropbox.com/s/mafdwiiviq82dc2/ae2-aeitemstack-compareto-old.nps?dl=0
https://www.dropbox.com/s/dhz3qhyyngbgxoq/ae2-aeitemstack-compareto-new.nps?dl=0

Both are using the same map with a noticeable impact with shift clicking massive amounts.
The Snapshots are done by filling the whole player inventory with the same crafting operation.

The important call is `ConcurrentSkipListMap.findPredecessor`, which is heavily using `compareTo`.
The reduction of over 50% should of course be taken with a grain of salt. But it is also clearly noticeable ingame.
