### PR TITLE
Improved MEInventoryHandler.getAccess()

### DIFF
--- a/src/main/java/appeng/me/storage/CellInventoryHandler.java
+++ b/src/main/java/appeng/me/storage/CellInventoryHandler.java
@@ -101,14 +101,14 @@ public class CellInventoryHandler extends MEInventoryHandler<IAEItemStack> imple
 					priorityList.add( AEItemStack.create( is ) );
 			}
 
-			this.myWhitelist = hasInverter ? IncludeExclude.BLACKLIST : IncludeExclude.WHITELIST;
+			this.setWhitelist( hasInverter ? IncludeExclude.BLACKLIST : IncludeExclude.WHITELIST );
 
 			if ( !priorityList.isEmpty() )
 			{
 				if ( hasFuzzy )
-					this.myPartitionList = new FuzzyPriorityList<IAEItemStack>( priorityList, fzMode );
+					this.setPartitionList( new FuzzyPriorityList<IAEItemStack>( priorityList, fzMode ) );
 				else
-					this.myPartitionList = new PrecisePriorityList<IAEItemStack>( priorityList );
+					this.setPartitionList( new PrecisePriorityList<IAEItemStack>( priorityList ) );
 			}
 		}
 	}
@@ -116,19 +116,19 @@ public class CellInventoryHandler extends MEInventoryHandler<IAEItemStack> imple
 	@Override
 	public boolean isPreformatted()
 	{
-		return ! this.myPartitionList.isEmpty();
+		return ! this.getPartitionList().isEmpty();
 	}
 
 	@Override
 	public boolean isFuzzy()
 	{
-		return this.myPartitionList instanceof FuzzyPriorityList;
+		return this.getPartitionList() instanceof FuzzyPriorityList;
 	}
 
 	@Override
 	public IncludeExclude getIncludeExcludeMode()
 	{
-		return this.myWhitelist;
+		return this.getWhitelist();
 	}
 
 	public int getStatusForCell()

--- a/src/main/java/appeng/me/storage/NetworkInventoryHandler.java
+++ b/src/main/java/appeng/me/storage/NetworkInventoryHandler.java
@@ -24,6 +24,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.NavigableMap;
+import java.util.TreeMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 
 import appeng.api.config.AccessRestriction;
@@ -64,7 +65,7 @@ public class NetworkInventoryHandler<T extends IAEStack<T>> implements IMEInvent
 	public NetworkInventoryHandler(StorageChannel chan, SecurityCache security) {
 		this.myChannel = chan;
 		this.security = security;
-		this.priorityInventory = new ConcurrentSkipListMap<Integer, List<IMEInventoryHandler<T>>>( PRIORITY_SORTER ); // TreeMultimap.create( prioritySorter, hashSorter );
+		this.priorityInventory = new TreeMap<Integer, List<IMEInventoryHandler<T>>>( PRIORITY_SORTER ); // TreeMultimap.create( prioritySorter, hashSorter );
 	}
 
 	public void addNewStorage(IMEInventoryHandler<T> h)

--- a/src/main/java/appeng/parts/automation/PartFormationPlane.java
+++ b/src/main/java/appeng/parts/automation/PartFormationPlane.java
@@ -313,9 +313,10 @@ public class PartFormationPlane extends PartUpgradeable implements ICellContaine
 
 	private void updateHandler()
 	{
-		this.myHandler.myAccess = AccessRestriction.WRITE;
-		this.myHandler.myWhitelist = this.getInstalledUpgrades( Upgrades.INVERTER ) > 0 ? IncludeExclude.BLACKLIST : IncludeExclude.WHITELIST;
-		this.myHandler.myPriority = this.priority;
+		this.myHandler.setBaseAccess( AccessRestriction.WRITE );
+		;
+		this.myHandler.setWhitelist( this.getInstalledUpgrades( Upgrades.INVERTER ) > 0 ? IncludeExclude.BLACKLIST : IncludeExclude.WHITELIST );
+		this.myHandler.setPriority( this.priority );
 
 		IItemList<IAEItemStack> priorityList = AEApi.instance().storage().createItemList();
 
@@ -328,9 +329,9 @@ public class PartFormationPlane extends PartUpgradeable implements ICellContaine
 		}
 
 		if ( this.getInstalledUpgrades( Upgrades.FUZZY ) > 0 )
-			this.myHandler.myPartitionList = new FuzzyPriorityList( priorityList, ( FuzzyMode ) this.getConfigManager().getSetting( Settings.FUZZY_MODE ) );
+			this.myHandler.setPartitionList( new FuzzyPriorityList( priorityList, ( FuzzyMode ) this.getConfigManager().getSetting( Settings.FUZZY_MODE ) ) );
 		else
-			this.myHandler.myPartitionList = new PrecisePriorityList( priorityList );
+			this.myHandler.setPartitionList( new PrecisePriorityList( priorityList ) );
 
 		try
 		{

--- a/src/main/java/appeng/parts/misc/PartStorageBus.java
+++ b/src/main/java/appeng/parts/misc/PartStorageBus.java
@@ -319,9 +319,9 @@ public class PartStorageBus
 
 					this.handler = new MEInventoryHandler( inv, StorageChannel.ITEMS );
 
-					this.handler.myAccess = ( AccessRestriction ) this.getConfigManager().getSetting( Settings.ACCESS );
-					this.handler.myWhitelist = this.getInstalledUpgrades( Upgrades.INVERTER ) > 0 ? IncludeExclude.BLACKLIST : IncludeExclude.WHITELIST;
-					this.handler.myPriority = this.priority;
+					this.handler.setBaseAccess( ( AccessRestriction ) this.getConfigManager().getSetting( Settings.ACCESS ) );;
+					this.handler.setWhitelist( this.getInstalledUpgrades( Upgrades.INVERTER ) > 0 ? IncludeExclude.BLACKLIST : IncludeExclude.WHITELIST );
+					this.handler.setPriority( this.priority );
 
 					IItemList<IAEItemStack> priorityList = AEApi.instance().storage().createItemList();
 
@@ -334,9 +334,9 @@ public class PartStorageBus
 					}
 
 					if ( this.getInstalledUpgrades( Upgrades.FUZZY ) > 0 )
-						this.handler.myPartitionList = new FuzzyPriorityList( priorityList, ( FuzzyMode ) this.getConfigManager().getSetting( Settings.FUZZY_MODE ) );
+						this.handler.setPartitionList( new FuzzyPriorityList( priorityList, ( FuzzyMode ) this.getConfigManager().getSetting( Settings.FUZZY_MODE ) ) );
 					else
-						this.handler.myPartitionList = new PrecisePriorityList( priorityList );
+						this.handler.setPartitionList ( new PrecisePriorityList( priorityList ));
 
 					if ( inv instanceof IMEMonitor )
 						( ( IMEMonitor ) inv ).addListener( this, this.handler );

--- a/src/main/java/appeng/tile/storage/TileChest.java
+++ b/src/main/java/appeng/tile/storage/TileChest.java
@@ -427,7 +427,7 @@ public class TileChest extends AENetworkPowerTile implements IMEChest, IFluidHan
 			return null;
 
 		MEInventoryHandler ih = new MEInventoryHandler( h, h.getChannel() );
-		ih.myPriority = this.priority;
+		ih.setPriority( this.priority );
 
 		MEMonitorHandler<StackType> g = new ChestMonitorHandler<StackType>( ih );
 		g.addListener( new ChestNetNotifier( h.getChannel() ), g );

--- a/src/main/java/appeng/tile/storage/TileDrive.java
+++ b/src/main/java/appeng/tile/storage/TileDrive.java
@@ -245,7 +245,7 @@ public class TileDrive extends AENetworkInvTile implements IChestOrDrive, IPrior
 							power += this.handlersBySlot[x].cellIdleDrain( is, cell );
 
 							DriveWatcher<IAEItemStack> ih = new DriveWatcher( cell, is, this.handlersBySlot[x], this );
-							ih.myPriority = this.priority;
+							ih.setPriority( this.priority );
 							this.invBySlot[x] = ih;
 							this.items.add( ih );
 						}
@@ -258,7 +258,7 @@ public class TileDrive extends AENetworkInvTile implements IChestOrDrive, IPrior
 								power += this.handlersBySlot[x].cellIdleDrain( is, cell );
 
 								DriveWatcher<IAEItemStack> ih = new DriveWatcher( cell, is, this.handlersBySlot[x], this );
-								ih.myPriority = this.priority;
+								ih.setPriority( this.priority );
 								this.invBySlot[x] = ih;
 								this.fluids.add( ih );
 							}


### PR DESCRIPTION
Changed the public fields in `MEInventoryHandler` to private and added setters and getters for them. I kept the my prefix to prevent them from clashing with the already existing `IMEInventoryHandler.getAccess()`.

The actual access rights are now only calculated once for every change as well as an additional booleans for read and write access.
Previously there were calculated multiple times with every access to the inventory (`extractItems/injectItems/getAvailableItems`).
`MEInventoryHandler.getAccess()` alone could contribute half of the total cpu time consumed by AE2. The actual calculation for the read/write access were part of other methods, so they are not showing up in the normal profiling, but I suspect they also contributed a good part to the actual cpu time.

It is quite similar to the `compareTo`, the actual methods are pretty fast. But the amount of invokes just add up.

I also changed the `CSLM` used in `NetworkInventoryHandler` back to a `TreeMap`. The only (currently) required use for a `CSLM` is the `ItemList`, only caused be the `MeaningfulIterator`.
The `TreeMap` is a bit faster and every bit helps. (As long as it will not start throwing `CMEs` like the `ItemList`)