### PR TITLE
Add coords to duplicate connection GridException.

### DIFF
--- a/src/main/java/appeng/me/GridConnection.java
+++ b/src/main/java/appeng/me/GridConnection.java
@@ -77,8 +77,12 @@ public class GridConnection implements IGridConnection, IPathItem
 			throw new GridException( "Connection Forged Between null entities." );
 
 		if ( a.hasConnection( b ) || b.hasConnection( a ) )
-			throw new GridException( "Connection already exists." );
+		{
+			final String aCoords = a.getGridBlock().getLocation().toString();
+			final String bCoords = b.getGridBlock().getLocation().toString();
 
+			throw new GridException( String.format( "Connection already exists between node at [%s] and node at [%s].", aCoords, bCoords ) );
+		}
 		this.sideA = a;
 		this.fromAtoB = fromAtoB;
 		this.sideB = b;


### PR DESCRIPTION
We've had quite a few of these causing crash loops (see thraaawn/CompactMachines#79 for an example). I think it is caused mainly from mods that haven't been updated yet to the latest version of the AE2 API, but I'm not certain. 

Without the block coordinates there is no easy way to find out where the issue is and mcedit it out. This alleviates that issue and makes finding the offending blocks much easier. 