### PR TITLE
Fixes NEI recipe handler

### DIFF
--- a/src/main/java/appeng/integration/modules/NEIHelpers/NEIFacadeRecipeHandler.java
+++ b/src/main/java/appeng/integration/modules/NEIHelpers/NEIFacadeRecipeHandler.java
@@ -53,7 +53,7 @@ public class NEIFacadeRecipeHandler extends TemplateRecipeHandler
 	{
 		final IDefinitions definitions = AEApi.instance().definitions();
 
-		this.facade = (ItemFacade) definitions.items().facade();
+		this.facade = (ItemFacade) definitions.items().facade().maybeItem().get();
 		this.anchorDefinition = definitions.parts().cableAnchor();
 	}
 


### PR DESCRIPTION
.get() is used as it is safe to assert facades are present at this point.
If not there should be an exception being thrown.