### PR TITLE
Fixes api refactoring causing items to be null.

### DIFF
--- a/src/main/java/appeng/core/features/AEBlockFeatureHandler.java
+++ b/src/main/java/appeng/core/features/AEBlockFeatureHandler.java
@@ -21,13 +21,12 @@ package appeng.core.features;
 
 import java.util.EnumSet;
 
-import cpw.mods.fml.common.registry.GameRegistry;
-
 import com.google.common.base.Optional;
+
+import cpw.mods.fml.common.registry.GameRegistry;
 
 import appeng.api.definitions.ITileDefinition;
 import appeng.block.AEBaseBlock;
-import appeng.block.AEBaseItemBlock;
 import appeng.core.CommonHelper;
 import appeng.core.CreativeTab;
 import appeng.util.Platform;
@@ -77,9 +76,13 @@ public final class AEBlockFeatureHandler implements IFeatureHandler
 				CommonHelper.proxy.bindTileEntitySpecialRenderer( this.featured.getTileEntityClass(), this.featured );
 			}
 
-			Class<? extends AEBaseItemBlock> itemBlockClass = this.featured.getItemBlockClass();
+			// Class<? extends AEBaseItemBlock> itemBlockClass = this.featured.getItemBlockClass();
 
-			GameRegistry.registerBlock( this.featured, itemBlockClass, "tile." + name );
+			final String registryName = "tile." + name;
+
+			// Bypass the forge magic with null to register our own itemblock later.
+			GameRegistry.registerBlock( this.featured, null, registryName );
+			GameRegistry.registerItem( this.definition.maybeItem().get(), registryName );
 		}
 	}
 }

--- a/src/main/java/appeng/core/features/ItemDefinition.java
+++ b/src/main/java/appeng/core/features/ItemDefinition.java
@@ -36,6 +36,8 @@ public class ItemDefinition implements IItemDefinition
 
 	public ItemDefinition( Item item, ActivityState state )
 	{
+		assert item != null;
+
 		this.item = item;
 		this.enabled = state == ActivityState.Enabled;
 	}

--- a/src/main/java/appeng/core/features/TileDefinition.java
+++ b/src/main/java/appeng/core/features/TileDefinition.java
@@ -34,6 +34,7 @@ public final class TileDefinition extends BlockDefinition implements ITileDefini
 	public TileDefinition( AEBaseBlock block, ActivityState state )
 	{
 		super( block, state );
+		assert !block.hasBlockTileEntity() || block.getTileEntityClass() != null;
 
 		this.block = block;
 	}


### PR DESCRIPTION
This happens as nothing is registered with minecraft at this point, so it
will always return null for the ItemBlock.

Currently we are relying on the magic performed by forge to create and register an `ItemBlock` during the registration of a `Block`.
We will now force forge to not register them anymore and instead register an instance of ItemBlock on our own. This allows us to preconstruct anything we need to later register and and not dynamically resolved them.

I also added some asserts to the Definitions in the cases where null is not allowed.

Currently there can still be an issue with the `TileDefinition` as the actually `TileEntity` can still be null at the time the feature is created and the Definition will be missing this and return null.
The assert here is pretty useless as it will actually be always true. But there is currently no option to distinguish between a block with or without a tileentity.