### PR TITLE
Moved AEBaseBlock.setFeature() to the end of any constructor.

### DIFF
--- a/src/main/java/appeng/block/crafting/BlockMolecularAssembler.java
+++ b/src/main/java/appeng/block/crafting/BlockMolecularAssembler.java
@@ -46,10 +46,10 @@ public class BlockMolecularAssembler extends AEBaseBlock
 	public BlockMolecularAssembler()
 	{
 		super( BlockMolecularAssembler.class, Material.iron );
-		this.setFeature( EnumSet.of( AEFeature.MolecularAssembler ) );
 		this.setTileEntity( TileMolecularAssembler.class );
 		this.isOpaque = false;
 		this.lightOpacity = 1;
+		this.setFeature( EnumSet.of( AEFeature.MolecularAssembler ) );
 	}
 
 	@Override

--- a/src/main/java/appeng/block/grindstone/BlockCrank.java
+++ b/src/main/java/appeng/block/grindstone/BlockCrank.java
@@ -47,11 +47,11 @@ public class BlockCrank extends AEBaseBlock
 	public BlockCrank()
 	{
 		super( BlockCrank.class, Material.wood );
-		this.setFeature( EnumSet.of( AEFeature.GrindStone ) );
 		this.setTileEntity( TileCrank.class );
 		this.setLightOpacity( 0 );
 		this.setHarvestLevel( "axe", 0 );
 		this.isFullSize = this.isOpaque = false;
+		this.setFeature( EnumSet.of( AEFeature.GrindStone ) );
 	}
 
 	@Override

--- a/src/main/java/appeng/block/grindstone/BlockGrinder.java
+++ b/src/main/java/appeng/block/grindstone/BlockGrinder.java
@@ -39,9 +39,9 @@ public class BlockGrinder extends AEBaseBlock
 	public BlockGrinder()
 	{
 		super( BlockGrinder.class, Material.rock );
-		this.setFeature( EnumSet.of( AEFeature.GrindStone ) );
 		this.setTileEntity( TileGrinder.class );
 		this.setHardness( 3.2F );
+		this.setFeature( EnumSet.of( AEFeature.GrindStone ) );
 	}
 
 	@Override

--- a/src/main/java/appeng/block/misc/BlockCellWorkbench.java
+++ b/src/main/java/appeng/block/misc/BlockCellWorkbench.java
@@ -39,8 +39,8 @@ public class BlockCellWorkbench extends AEBaseBlock
 	public BlockCellWorkbench()
 	{
 		super( BlockCellWorkbench.class, Material.iron );
-		this.setFeature( EnumSet.of( AEFeature.StorageCells ) );
 		this.setTileEntity( TileCellWorkbench.class );
+		this.setFeature( EnumSet.of( AEFeature.StorageCells ) );
 	}
 
 	@Override

--- a/src/main/java/appeng/block/misc/BlockCharger.java
+++ b/src/main/java/appeng/block/misc/BlockCharger.java
@@ -55,10 +55,10 @@ public class BlockCharger extends AEBaseBlock implements ICustomCollision
 	public BlockCharger()
 	{
 		super( BlockCharger.class, Material.iron );
-		this.setFeature( EnumSet.of( AEFeature.Core ) );
 		this.setTileEntity( TileCharger.class );
 		this.setLightOpacity( 2 );
 		this.isFullSize = this.isOpaque = false;
+		this.setFeature( EnumSet.of( AEFeature.Core ) );
 	}
 
 	@Override

--- a/src/main/java/appeng/block/misc/BlockCondenser.java
+++ b/src/main/java/appeng/block/misc/BlockCondenser.java
@@ -39,8 +39,8 @@ public class BlockCondenser extends AEBaseBlock
 	public BlockCondenser()
 	{
 		super( BlockCondenser.class, Material.iron );
-		this.setFeature( EnumSet.of( AEFeature.Core ) );
 		this.setTileEntity( TileCondenser.class );
+		this.setFeature( EnumSet.of( AEFeature.Core ) );
 	}
 
 	@Override

--- a/src/main/java/appeng/block/misc/BlockInscriber.java
+++ b/src/main/java/appeng/block/misc/BlockInscriber.java
@@ -41,10 +41,10 @@ public class BlockInscriber extends AEBaseBlock
 	public BlockInscriber()
 	{
 		super( BlockInscriber.class, Material.iron );
-		this.setFeature( EnumSet.of( AEFeature.Inscriber ) );
 		this.setTileEntity( TileInscriber.class );
 		this.setLightOpacity( 2 );
 		this.isFullSize = this.isOpaque = false;
+		this.setFeature( EnumSet.of( AEFeature.Inscriber ) );
 	}
 
 	@Override

--- a/src/main/java/appeng/block/misc/BlockInterface.java
+++ b/src/main/java/appeng/block/misc/BlockInterface.java
@@ -42,8 +42,8 @@ public class BlockInterface extends AEBaseBlock
 	public BlockInterface()
 	{
 		super( BlockInterface.class, Material.iron );
-		this.setFeature( EnumSet.of( AEFeature.Core ) );
 		this.setTileEntity( TileInterface.class );
+		this.setFeature( EnumSet.of( AEFeature.Core ) );
 	}
 
 	@Override

--- a/src/main/java/appeng/block/misc/BlockLightDetector.java
+++ b/src/main/java/appeng/block/misc/BlockLightDetector.java
@@ -38,8 +38,8 @@ public class BlockLightDetector extends BlockQuartzTorch
 	public BlockLightDetector()
 	{
 		super( BlockLightDetector.class );
-		this.setFeature( EnumSet.of( AEFeature.LightDetector ) );
 		this.setTileEntity( TileLightDetector.class );
+		this.setFeature( EnumSet.of( AEFeature.LightDetector ) );
 	}
 
 	@Override

--- a/src/main/java/appeng/block/misc/BlockPaint.java
+++ b/src/main/java/appeng/block/misc/BlockPaint.java
@@ -50,11 +50,11 @@ public class BlockPaint extends AEBaseBlock
 	public BlockPaint()
 	{
 		super( BlockPaint.class, new MaterialLiquid( MapColor.airColor ) );
-		this.setFeature( EnumSet.of( AEFeature.PaintBalls ) );
 		this.setTileEntity( TilePaint.class );
 		this.setLightOpacity( 0 );
 		this.isFullSize = false;
 		this.isOpaque = false;
+		this.setFeature( EnumSet.of( AEFeature.PaintBalls ) );
 	}
 
 	@Override

--- a/src/main/java/appeng/block/misc/BlockQuartzGrowthAccelerator.java
+++ b/src/main/java/appeng/block/misc/BlockQuartzGrowthAccelerator.java
@@ -53,8 +53,8 @@ public class BlockQuartzGrowthAccelerator extends AEBaseBlock implements IOrient
 	{
 		super( BlockQuartzGrowthAccelerator.class, Material.rock );
 		this.setStepSound( Block.soundTypeMetal );
-		this.setFeature( EnumSet.of( AEFeature.Core ) );
 		this.setTileEntity( TileQuartzGrowthAccelerator.class );
+		this.setFeature( EnumSet.of( AEFeature.Core ) );
 	}
 
 	@Override

--- a/src/main/java/appeng/block/misc/BlockQuartzTorch.java
+++ b/src/main/java/appeng/block/misc/BlockQuartzTorch.java
@@ -55,8 +55,8 @@ public class BlockQuartzTorch extends AEBaseBlock implements IOrientableBlock, I
 	public BlockQuartzTorch()
 	{
 		this( BlockQuartzTorch.class );
-		this.setFeature( EnumSet.of( AEFeature.DecorativeLights ) );
 		this.setLightLevel( 0.9375F );
+		this.setFeature( EnumSet.of( AEFeature.DecorativeLights ) );
 	}
 
 	protected BlockQuartzTorch( Class which )

--- a/src/main/java/appeng/block/misc/BlockSecurity.java
+++ b/src/main/java/appeng/block/misc/BlockSecurity.java
@@ -41,8 +41,8 @@ public class BlockSecurity extends AEBaseBlock
 	public BlockSecurity()
 	{
 		super( BlockSecurity.class, Material.iron );
-		this.setFeature( EnumSet.of( AEFeature.Security ) );
 		this.setTileEntity( TileSecurity.class );
+		this.setFeature( EnumSet.of( AEFeature.Security ) );
 	}
 
 	@Override

--- a/src/main/java/appeng/block/misc/BlockSkyCompass.java
+++ b/src/main/java/appeng/block/misc/BlockSkyCompass.java
@@ -50,10 +50,10 @@ public class BlockSkyCompass extends AEBaseBlock implements ICustomCollision
 	public BlockSkyCompass()
 	{
 		super( BlockSkyCompass.class, Material.iron );
-		this.setFeature( EnumSet.of( AEFeature.MeteoriteCompass ) );
 		this.setTileEntity( TileSkyCompass.class );
 		this.isOpaque = this.isFullSize = false;
 		this.lightOpacity = 0;
+		this.setFeature( EnumSet.of( AEFeature.MeteoriteCompass ) );
 	}
 
 	@Override

--- a/src/main/java/appeng/block/misc/BlockTinyTNT.java
+++ b/src/main/java/appeng/block/misc/BlockTinyTNT.java
@@ -59,12 +59,12 @@ public class BlockTinyTNT extends AEBaseBlock implements ICustomCollision
 	public BlockTinyTNT()
 	{
 		super( BlockTinyTNT.class, Material.tnt );
-		this.setFeature( EnumSet.of( AEFeature.TinyTNT ) );
 		this.setLightOpacity( 1 );
 		this.setBlockBounds( 0.25f, 0.0f, 0.25f, 0.75f, 0.5f, 0.75f );
 		this.isFullSize = this.isOpaque = false;
 		this.setStepSound( soundTypeGrass );
 		this.setHardness( 0F );
+		this.setFeature( EnumSet.of( AEFeature.TinyTNT ) );
 
 		EntityRegistry.registerModEntity( EntityTinyTNTPrimed.class, "EntityTinyTNTPrimed", EntityIds.TINY_TNT, AppEng.instance, 16, 4, true );
 	}

--- a/src/main/java/appeng/block/misc/BlockVibrationChamber.java
+++ b/src/main/java/appeng/block/misc/BlockVibrationChamber.java
@@ -45,9 +45,9 @@ public class BlockVibrationChamber extends AEBaseBlock
 	public BlockVibrationChamber()
 	{
 		super( BlockVibrationChamber.class, Material.iron );
-		this.setFeature( EnumSet.of( AEFeature.PowerGen ) );
 		this.setTileEntity( TileVibrationChamber.class );
 		this.setHardness( 4.2F );
+		this.setFeature( EnumSet.of( AEFeature.PowerGen ) );
 	}
 
 	@Override

--- a/src/main/java/appeng/block/networking/BlockCableBus.java
+++ b/src/main/java/appeng/block/networking/BlockCableBus.java
@@ -92,9 +92,9 @@ public class BlockCableBus extends AEBaseBlock implements IRedNetConnection
 	public BlockCableBus()
 	{
 		super( BlockCableBus.class, AEGlassMaterial.INSTANCE );
-		this.setFeature( EnumSet.of( AEFeature.Core ) );
 		this.setLightOpacity( 0 );
 		this.isFullSize = this.isOpaque = false;
+		this.setFeature( EnumSet.of( AEFeature.Core ) );
 	}
 
 	@Override

--- a/src/main/java/appeng/block/networking/BlockController.java
+++ b/src/main/java/appeng/block/networking/BlockController.java
@@ -38,9 +38,9 @@ public class BlockController extends AEBaseBlock
 	public BlockController()
 	{
 		super( BlockController.class, Material.iron );
-		this.setFeature( EnumSet.of( AEFeature.Channels ) );
 		this.setTileEntity( TileController.class );
 		this.setHardness( 6 );
+		this.setFeature( EnumSet.of( AEFeature.Channels ) );
 	}
 
 	@Override

--- a/src/main/java/appeng/block/networking/BlockCreativeEnergyCell.java
+++ b/src/main/java/appeng/block/networking/BlockCreativeEnergyCell.java
@@ -33,7 +33,7 @@ public class BlockCreativeEnergyCell extends AEBaseBlock
 	public BlockCreativeEnergyCell()
 	{
 		super( BlockCreativeEnergyCell.class, AEGlassMaterial.INSTANCE );
-		this.setFeature( EnumSet.of( AEFeature.Creative ) );
 		this.setTileEntity( TileCreativeEnergyCell.class );
+		this.setFeature( EnumSet.of( AEFeature.Creative ) );
 	}
 }

--- a/src/main/java/appeng/block/networking/BlockDenseEnergyCell.java
+++ b/src/main/java/appeng/block/networking/BlockDenseEnergyCell.java
@@ -34,8 +34,8 @@ public class BlockDenseEnergyCell extends BlockEnergyCell
 	public BlockDenseEnergyCell()
 	{
 		super( BlockDenseEnergyCell.class );
-		this.setFeature( EnumSet.of( AEFeature.DenseEnergyCells ) );
 		this.setTileEntity( TileDenseEnergyCell.class );
+		this.setFeature( EnumSet.of( AEFeature.DenseEnergyCells ) );
 	}
 
 	@Override

--- a/src/main/java/appeng/block/networking/BlockEnergyAcceptor.java
+++ b/src/main/java/appeng/block/networking/BlockEnergyAcceptor.java
@@ -34,7 +34,7 @@ public class BlockEnergyAcceptor extends AEBaseBlock
 	public BlockEnergyAcceptor()
 	{
 		super( BlockEnergyAcceptor.class, Material.iron );
-		this.setFeature( EnumSet.of( AEFeature.Core ) );
 		this.setTileEntity( TileEnergyAcceptor.class );
+		this.setFeature( EnumSet.of( AEFeature.Core ) );
 	}
 }

--- a/src/main/java/appeng/block/networking/BlockEnergyCell.java
+++ b/src/main/java/appeng/block/networking/BlockEnergyCell.java
@@ -49,8 +49,8 @@ public class BlockEnergyCell extends AEBaseBlock
 	public BlockEnergyCell()
 	{
 		this( BlockEnergyCell.class );
-		this.setFeature( EnumSet.of( AEFeature.Core ) );
 		this.setTileEntity( TileEnergyCell.class );
+		this.setFeature( EnumSet.of( AEFeature.Core ) );
 	}
 
 	public BlockEnergyCell( Class c )

--- a/src/main/java/appeng/block/networking/BlockWireless.java
+++ b/src/main/java/appeng/block/networking/BlockWireless.java
@@ -46,11 +46,11 @@ public class BlockWireless extends AEBaseBlock implements ICustomCollision
 	public BlockWireless()
 	{
 		super( BlockWireless.class, AEGlassMaterial.INSTANCE );
-		this.setFeature( EnumSet.of( AEFeature.Core, AEFeature.WirelessAccessTerminal ) );
 		this.setTileEntity( TileWireless.class );
 		this.setLightOpacity( 0 );
 		this.isFullSize = false;
 		this.isOpaque = false;
+		this.setFeature( EnumSet.of( AEFeature.Core, AEFeature.WirelessAccessTerminal ) );
 	}
 
 	@Override

--- a/src/main/java/appeng/block/qnb/BlockQuantumLinkChamber.java
+++ b/src/main/java/appeng/block/qnb/BlockQuantumLinkChamber.java
@@ -53,12 +53,12 @@ public class BlockQuantumLinkChamber extends AEBaseBlock implements ICustomColli
 	public BlockQuantumLinkChamber()
 	{
 		super( BlockQuantumLinkChamber.class, AEGlassMaterial.INSTANCE );
-		this.setFeature( EnumSet.of( AEFeature.QuantumNetworkBridge ) );
 		this.setTileEntity( TileQuantumBridge.class );
 		float shave = 2.0f / 16.0f;
 		this.setBlockBounds( shave, shave, shave, 1.0f - shave, 1.0f - shave, 1.0f - shave );
 		this.setLightOpacity( 0 );
 		this.isFullSize = this.isOpaque = false;
+		this.setFeature( EnumSet.of( AEFeature.QuantumNetworkBridge ) );
 	}
 
 	@Override

--- a/src/main/java/appeng/block/qnb/BlockQuantumRing.java
+++ b/src/main/java/appeng/block/qnb/BlockQuantumRing.java
@@ -43,12 +43,12 @@ public class BlockQuantumRing extends AEBaseBlock implements ICustomCollision
 	public BlockQuantumRing()
 	{
 		super( BlockQuantumRing.class, Material.iron );
-		this.setFeature( EnumSet.of( AEFeature.QuantumNetworkBridge ) );
 		this.setTileEntity( TileQuantumBridge.class );
 		float shave = 2.0f / 16.0f;
 		this.setBlockBounds( shave, shave, shave, 1.0f - shave, 1.0f - shave, 1.0f - shave );
 		this.setLightOpacity( 1 );
 		this.isFullSize = this.isOpaque = false;
+		this.setFeature( EnumSet.of( AEFeature.QuantumNetworkBridge ) );
 	}
 
 	@Override

--- a/src/main/java/appeng/block/solids/BlockQuartzGlass.java
+++ b/src/main/java/appeng/block/solids/BlockQuartzGlass.java
@@ -45,9 +45,9 @@ public class BlockQuartzGlass extends AEBaseBlock
 	public BlockQuartzGlass( Class c )
 	{
 		super( c, Material.glass );
-		this.setFeature( EnumSet.of( AEFeature.DecorativeQuartzBlocks ) );
 		this.setLightOpacity( 0 );
 		this.isOpaque = false;
+		this.setFeature( EnumSet.of( AEFeature.DecorativeQuartzBlocks ) );
 	}
 
 	@Override

--- a/src/main/java/appeng/block/solids/BlockQuartzLamp.java
+++ b/src/main/java/appeng/block/solids/BlockQuartzLamp.java
@@ -40,9 +40,9 @@ public class BlockQuartzLamp extends BlockQuartzGlass
 	public BlockQuartzLamp()
 	{
 		super( BlockQuartzLamp.class );
-		this.setFeature( EnumSet.of( AEFeature.DecorativeQuartzBlocks, AEFeature.DecorativeLights ) );
 		this.setLightLevel( 1.0f );
 		this.setBlockTextureName( "BlockQuartzGlass" );
+		this.setFeature( EnumSet.of( AEFeature.DecorativeQuartzBlocks, AEFeature.DecorativeLights ) );
 	}
 
 	@Override

--- a/src/main/java/appeng/block/solids/BlockSkyStone.java
+++ b/src/main/java/appeng/block/solids/BlockSkyStone.java
@@ -72,11 +72,12 @@ public class BlockSkyStone extends AEBaseBlock implements IOrientableBlock
 	public BlockSkyStone()
 	{
 		super( BlockSkyStone.class, Material.rock );
-		this.setFeature( EnumSet.of( AEFeature.Core ) );
 		this.setHardness( 50 );
 		this.hasSubtypes = true;
 		this.blockResistance = 150.0f;
 		this.setHarvestLevel( "pickaxe", 3, 0 );
+		this.setFeature( EnumSet.of( AEFeature.Core ) );
+
 		MinecraftForge.EVENT_BUS.register( this );
 	}
 

--- a/src/main/java/appeng/block/solids/OreQuartz.java
+++ b/src/main/java/appeng/block/solids/OreQuartz.java
@@ -53,12 +53,12 @@ public class OreQuartz extends AEBaseBlock
 	public OreQuartz( Class<? extends OreQuartz> self )
 	{
 		super( self, Material.rock );
-		this.setFeature( EnumSet.of( AEFeature.Core ) );
 		this.setHardness( 3.0F );
 		this.setResistance( 5.0F );
 		this.boostBrightnessLow = 0;
 		this.boostBrightnessHigh = 1;
 		this.enhanceBrightness = false;
+		this.setFeature( EnumSet.of( AEFeature.Core ) );
 	}
 
 	@Override

--- a/src/main/java/appeng/block/spatial/BlockMatrixFrame.java
+++ b/src/main/java/appeng/block/spatial/BlockMatrixFrame.java
@@ -50,11 +50,11 @@ public class BlockMatrixFrame extends AEBaseBlock implements ICustomCollision
 	public BlockMatrixFrame()
 	{
 		super( BlockMatrixFrame.class, Material.anvil );
-		this.setFeature( EnumSet.of( AEFeature.SpatialIO ) );
 		this.setResistance( 6000000.0F );
 		this.setBlockUnbreakable();
 		this.setLightOpacity( 0 );
 		this.isOpaque = false;
+		this.setFeature( EnumSet.of( AEFeature.SpatialIO ) );
 	}
 
 	@Override

--- a/src/main/java/appeng/block/spatial/BlockSpatialIOPort.java
+++ b/src/main/java/appeng/block/spatial/BlockSpatialIOPort.java
@@ -40,8 +40,8 @@ public class BlockSpatialIOPort extends AEBaseBlock
 	public BlockSpatialIOPort()
 	{
 		super( BlockSpatialIOPort.class, Material.iron );
-		this.setFeature( EnumSet.of( AEFeature.SpatialIO ) );
 		this.setTileEntity( TileSpatialIOPort.class );
+		this.setFeature( EnumSet.of( AEFeature.SpatialIO ) );
 	}
 
 	@Override

--- a/src/main/java/appeng/block/spatial/BlockSpatialPylon.java
+++ b/src/main/java/appeng/block/spatial/BlockSpatialPylon.java
@@ -39,8 +39,8 @@ public class BlockSpatialPylon extends AEBaseBlock
 	public BlockSpatialPylon()
 	{
 		super( BlockSpatialPylon.class, AEGlassMaterial.INSTANCE );
-		this.setFeature( EnumSet.of( AEFeature.SpatialIO ) );
 		this.setTileEntity( TileSpatialPylon.class );
+		this.setFeature( EnumSet.of( AEFeature.SpatialIO ) );
 	}
 
 	@Override

--- a/src/main/java/appeng/block/storage/BlockChest.java
+++ b/src/main/java/appeng/block/storage/BlockChest.java
@@ -45,8 +45,8 @@ public class BlockChest extends AEBaseBlock
 	public BlockChest()
 	{
 		super( BlockChest.class, Material.iron );
-		this.setFeature( EnumSet.of( AEFeature.StorageCells, AEFeature.MEChest ) );
 		this.setTileEntity( TileChest.class );
+		this.setFeature( EnumSet.of( AEFeature.StorageCells, AEFeature.MEChest ) );
 	}
 
 	@Override

--- a/src/main/java/appeng/block/storage/BlockDrive.java
+++ b/src/main/java/appeng/block/storage/BlockDrive.java
@@ -41,8 +41,8 @@ public class BlockDrive extends AEBaseBlock
 	public BlockDrive()
 	{
 		super( BlockDrive.class, Material.iron );
-		this.setFeature( EnumSet.of( AEFeature.StorageCells, AEFeature.MEDrive ) );
 		this.setTileEntity( TileDrive.class );
+		this.setFeature( EnumSet.of( AEFeature.StorageCells, AEFeature.MEDrive ) );
 	}
 
 	@Override

--- a/src/main/java/appeng/block/storage/BlockIOPort.java
+++ b/src/main/java/appeng/block/storage/BlockIOPort.java
@@ -40,8 +40,8 @@ public class BlockIOPort extends AEBaseBlock
 	public BlockIOPort()
 	{
 		super( BlockIOPort.class, Material.iron );
-		this.setFeature( EnumSet.of( AEFeature.StorageCells, AEFeature.IOPort ) );
 		this.setTileEntity( TileIOPort.class );
+		this.setFeature( EnumSet.of( AEFeature.StorageCells, AEFeature.IOPort ) );
 	}
 
 	@Override

--- a/src/main/java/appeng/block/storage/BlockSkyChest.java
+++ b/src/main/java/appeng/block/storage/BlockSkyChest.java
@@ -58,13 +58,13 @@ public class BlockSkyChest extends AEBaseBlock implements ICustomCollision
 	public BlockSkyChest()
 	{
 		super( BlockSkyChest.class, Material.rock );
-		this.setFeature( EnumSet.of( AEFeature.Core, AEFeature.SkyStoneChests ) );
 		this.setTileEntity( TileSkyChest.class );
 		this.isOpaque = this.isFullSize = false;
 		this.lightOpacity = 0;
 		this.hasSubtypes = true;
 		this.setHardness( 50 );
 		this.blockResistance = 150.0f;
+		this.setFeature( EnumSet.of( AEFeature.Core, AEFeature.SkyStoneChests ) );
 	}
 
 	@Override

--- a/src/main/java/appeng/debug/BlockChunkloader.java
+++ b/src/main/java/appeng/debug/BlockChunkloader.java
@@ -40,9 +40,9 @@ public class BlockChunkloader extends AEBaseBlock implements LoadingCallback
 	public BlockChunkloader()
 	{
 		super( BlockChunkloader.class, Material.iron );
-		this.setFeature( EnumSet.of( AEFeature.UnsupportedDeveloperTools, AEFeature.Creative ) );
 		this.setTileEntity( TileChunkLoader.class );
 		ForgeChunkManager.setForcedChunkLoadingCallback( AppEng.instance, this );
+		this.setFeature( EnumSet.of( AEFeature.UnsupportedDeveloperTools, AEFeature.Creative ) );
 	}
 
 	@Override

--- a/src/main/java/appeng/debug/BlockCubeGenerator.java
+++ b/src/main/java/appeng/debug/BlockCubeGenerator.java
@@ -36,8 +36,8 @@ public class BlockCubeGenerator extends AEBaseBlock
 	public BlockCubeGenerator()
 	{
 		super( BlockCubeGenerator.class, Material.iron );
-		this.setFeature( EnumSet.of( AEFeature.UnsupportedDeveloperTools, AEFeature.Creative ) );
 		this.setTileEntity( TileCubeGenerator.class );
+		this.setFeature( EnumSet.of( AEFeature.UnsupportedDeveloperTools, AEFeature.Creative ) );
 	}
 
 	@Override

--- a/src/main/java/appeng/debug/BlockItemGen.java
+++ b/src/main/java/appeng/debug/BlockItemGen.java
@@ -34,8 +34,8 @@ public class BlockItemGen extends AEBaseBlock
 	public BlockItemGen()
 	{
 		super( BlockItemGen.class, Material.iron );
-		this.setFeature( EnumSet.of( AEFeature.UnsupportedDeveloperTools, AEFeature.Creative ) );
 		this.setTileEntity( TileItemGen.class );
+		this.setFeature( EnumSet.of( AEFeature.UnsupportedDeveloperTools, AEFeature.Creative ) );
 	}
 
 	@Override

--- a/src/main/java/appeng/debug/BlockPhantomNode.java
+++ b/src/main/java/appeng/debug/BlockPhantomNode.java
@@ -36,8 +36,8 @@ public class BlockPhantomNode extends AEBaseBlock
 	public BlockPhantomNode()
 	{
 		super( BlockPhantomNode.class, Material.iron );
-		this.setFeature( EnumSet.of( AEFeature.UnsupportedDeveloperTools, AEFeature.Creative ) );
 		this.setTileEntity( TilePhantomNode.class );
+		this.setFeature( EnumSet.of( AEFeature.UnsupportedDeveloperTools, AEFeature.Creative ) );
 	}
 
 	@Override


### PR DESCRIPTION
Otherwise it can cause a registration of incomplete blocks, like missing subtypes.

Fixes #1191