### PR TITLE
Stops AEBaseItemBlock from modifying the metadata before placing.

### DIFF
--- a/src/main/java/appeng/block/AEBaseItemBlock.java
+++ b/src/main/java/appeng/block/AEBaseItemBlock.java
@@ -162,8 +162,6 @@ public class AEBaseItemBlock extends ItemBlock
 			forward = ForgeDirection.SOUTH;
 			if( up.offsetY == 0 )
 				forward = ForgeDirection.UP;
-
-			ori.setOrientation( forward, up );
 		}
 
 		if( !this.blockType.isValidOrientation( w, x, y, z, forward, up ) )


### PR DESCRIPTION
Fixes #1068