### PR TITLE
Fixes integration bug for Resources between Gradle and IntelliJ, does not affect Eclipse

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,6 +103,9 @@ sourceSets {
                     "assets/appliedenergistics2/textures/models/*",
                     "assets/appliedenergistics2/textures/items/*"
         }
+
+        // IntelliJ and Gradle interaction bug
+        output.resourcesDir = output.classesDir
     }
 }
 


### PR DESCRIPTION
Else I have to keep copying resources manually from A to B