### PR TITLE
Fixes #1186: Storage Cells drop upgrades upon disassembling

### DIFF
--- a/src/api/java/appeng/api/implementations/items/IStorageCell.java
+++ b/src/api/java/appeng/api/implementations/items/IStorageCell.java
@@ -59,8 +59,20 @@ public interface IStorageCell extends ICellWorkbenchItem
 	 * @param cellItem item
 	 *
 	 * @return number of bytes
+	 *
+	 * @deprecated use {@link IStorageCell#getBytesPerType(ItemStack)}
 	 */
+	@Deprecated
 	int BytePerType( ItemStack cellItem );
+
+	/**
+	 * Determines the number of bytes used for any type included on the cell.
+	 *
+	 * @param cellItem item
+	 *
+	 * @return number of bytes
+	 */
+	int getBytesPerType( ItemStack cellItem );
 
 	/**
 	 * Must be between 1 and 63, indicates how many types you want to store on

--- a/src/main/java/appeng/container/implementations/ContainerCellWorkbench.java
+++ b/src/main/java/appeng/container/implementations/ContainerCellWorkbench.java
@@ -49,15 +49,13 @@ import appeng.util.iterators.NullIterator;
 
 public class ContainerCellWorkbench extends ContainerUpgradeable
 {
-
-	final TileCellWorkbench workBench;
-	final AppEngNullInventory ni = new AppEngNullInventory();
+	private final TileCellWorkbench workBench;
+	private final AppEngNullInventory nullInventory = new AppEngNullInventory();
 	@GuiSync( 2 )
 	public CopyMode copyMode = CopyMode.CLEAR_ON_REMOVE;
-	IInventory UpgradeInventoryWrapper;
-	ItemStack prevStack = null;
-	int lastUpgrades = 0;
-	ItemStack LastCell;
+	private ItemStack prevStack = null;
+	private int lastUpgrades = 0;
+	private ItemStack LastCell;
 
 	public ContainerCellWorkbench( InventoryPlayer ip, TileCellWorkbench te )
 	{
@@ -99,7 +97,7 @@ public class ContainerCellWorkbench extends ContainerUpgradeable
 		this.addSlotToContainer( new SlotRestrictedInput( SlotRestrictedInput.PlacableItemType.WORKBENCH_CELL, cell, 0, 152, 8, this.invPlayer ) );
 
 		IInventory inv = this.upgradeable.getInventoryByName( "config" );
-		this.UpgradeInventoryWrapper = new Upgrades();// Platform.isServer() ? new Upgrades() : new AppEngInternalInventory(
+		IInventory upgradeInventory = new Upgrades();
 		// null, 3 * 8 );
 
 		for( int w = 0; w < 7; w++ )
@@ -113,7 +111,7 @@ public class ContainerCellWorkbench extends ContainerUpgradeable
 			for( int z = 0; z < 8; z++ )
 			{
 				int iSLot = zz * 8 + z;
-				this.addSlotToContainer( new OptionalSlotRestrictedInput( SlotRestrictedInput.PlacableItemType.UPGRADES, this.UpgradeInventoryWrapper, this, iSLot, 187 + zz * 18, 8 + 18 * z, iSLot, this.invPlayer ) );
+				this.addSlotToContainer( new OptionalSlotRestrictedInput( SlotRestrictedInput.PlacableItemType.UPGRADES, upgradeInventory, this, iSLot, 187 + zz * 18, 8 + 18 * z, iSLot, this.invPlayer ) );
 			}
 		/*
 		 * if ( supportCapacity() ) { for (int w = 0; w < 2; w++) for (int z = 0; z < 9; z++) addSlotToContainer( new
@@ -134,7 +132,7 @@ public class ContainerCellWorkbench extends ContainerUpgradeable
 		if( this.prevStack != is )
 		{
 			this.prevStack = is;
-			return this.lastUpgrades = this.getCellUpgradeInventory().getSizeInventory();
+			this.lastUpgrades = this.getCellUpgradeInventory().getSizeInventory();
 		}
 		return this.lastUpgrades;
 	}
@@ -180,8 +178,9 @@ public class ContainerCellWorkbench extends ContainerUpgradeable
 
 	public IInventory getCellUpgradeInventory()
 	{
-		IInventory ri = this.workBench.getCellUpgradeInventory();
-		return ri == null ? this.ni : ri;
+		final IInventory upgradeInventory = this.workBench.getCellUpgradeInventory();
+
+		return upgradeInventory == null ? this.nullInventory : upgradeInventory;
 	}
 
 	@Override
@@ -237,7 +236,7 @@ public class ContainerCellWorkbench extends ContainerUpgradeable
 		this.detectAndSendChanges();
 	}
 
-	class Upgrades implements IInventory
+	private class Upgrades implements IInventory
 	{
 
 		@Override

--- a/src/main/java/appeng/items/AEBaseItem.java
+++ b/src/main/java/appeng/items/AEBaseItem.java
@@ -78,9 +78,9 @@ public abstract class AEBaseItem extends Item implements IAEFeature
 
 	@Override
 	@SuppressWarnings( "unchecked" )
-	public final void addInformation( ItemStack stack, EntityPlayer player, List lines, boolean displayAdditionalInformation )
+	public final void addInformation( ItemStack stack, EntityPlayer player, List lines, boolean displayMoreInfo )
 	{
-		this.addCheckedInformation( stack, player, lines, displayAdditionalInformation );
+		this.addCheckedInformation( stack, player, lines, displayMoreInfo );
 	}
 
 	@Override
@@ -89,8 +89,8 @@ public abstract class AEBaseItem extends Item implements IAEFeature
 		return false;
 	}
 
-	public void addCheckedInformation( ItemStack stack, EntityPlayer player, List<String> lines, boolean displayAdditionalInformation )
+	public void addCheckedInformation( ItemStack stack, EntityPlayer player, List<String> lines, boolean displayMoreInfo )
 	{
-		super.addInformation( stack, player, lines, displayAdditionalInformation );
+		super.addInformation( stack, player, lines, displayMoreInfo );
 	}
 }

--- a/src/main/java/appeng/items/materials/ItemMultiMaterial.java
+++ b/src/main/java/appeng/items/materials/ItemMultiMaterial.java
@@ -85,9 +85,9 @@ public class ItemMultiMaterial extends AEBaseItem implements IStorageComponent, 
 	}
 
 	@Override
-	public void addCheckedInformation( ItemStack stack, EntityPlayer player, List<String> lines, boolean displayAdditionalInformation )
+	public void addCheckedInformation( ItemStack stack, EntityPlayer player, List<String> lines, boolean displayMoreInfo )
 	{
-		super.addCheckedInformation( stack, player, lines, displayAdditionalInformation );
+		super.addCheckedInformation( stack, player, lines, displayMoreInfo );
 
 		MaterialType mt = this.getTypeByStack( stack );
 		if( mt == null )

--- a/src/main/java/appeng/items/misc/ItemCrystalSeed.java
+++ b/src/main/java/appeng/items/misc/ItemCrystalSeed.java
@@ -162,13 +162,13 @@ public class ItemCrystalSeed extends AEBaseItem implements IGrowableCrystal
 	}
 
 	@Override
-	public void addCheckedInformation( ItemStack stack, EntityPlayer player, List<String> lines, boolean displayAdditionalInformation )
+	public void addCheckedInformation( ItemStack stack, EntityPlayer player, List<String> lines, boolean displayMoreInfo )
 	{
 		lines.add( ButtonToolTips.DoesntDespawn.getLocal() );
 		int progress = this.getProgress( stack ) % SINGLE_OFFSET;
 		lines.add( Math.floor( (float) progress / (float) ( SINGLE_OFFSET / 100 ) ) + "%" );
 
-		super.addCheckedInformation( stack, player, lines, displayAdditionalInformation );
+		super.addCheckedInformation( stack, player, lines, displayMoreInfo );
 	}
 
 	@Override

--- a/src/main/java/appeng/items/misc/ItemEncodedPattern.java
+++ b/src/main/java/appeng/items/misc/ItemEncodedPattern.java
@@ -98,7 +98,7 @@ public class ItemEncodedPattern extends AEBaseItem implements ICraftingPatternIt
 	}
 
 	@Override
-	public void addCheckedInformation( ItemStack stack, EntityPlayer player, List<String> lines, boolean displayAdditionalInformation )
+	public void addCheckedInformation( ItemStack stack, EntityPlayer player, List<String> lines, boolean displayMoreInfo )
 	{
 		ICraftingPatternDetails details = this.getPatternForItem( stack, player.worldObj );
 

--- a/src/main/java/appeng/items/storage/ItemSpatialStorageCell.java
+++ b/src/main/java/appeng/items/storage/ItemSpatialStorageCell.java
@@ -55,7 +55,7 @@ public class ItemSpatialStorageCell extends AEBaseItem implements ISpatialStorag
 	}
 
 	@Override
-	public void addCheckedInformation( ItemStack stack, EntityPlayer player, List<String> lines, boolean displayAdditionalInformation )
+	public void addCheckedInformation( ItemStack stack, EntityPlayer player, List<String> lines, boolean displayMoreInfo )
 	{
 		WorldCoord wc = this.getStoredSize( stack );
 		if( wc.x > 0 )

--- a/src/main/java/appeng/items/tools/ToolBiometricCard.java
+++ b/src/main/java/appeng/items/tools/ToolBiometricCard.java
@@ -166,7 +166,7 @@ public class ToolBiometricCard extends AEBaseItem implements IBiometricCard
 	}
 
 	@Override
-	public void addCheckedInformation( ItemStack stack, EntityPlayer player, List<String> lines, boolean displayAdditionalInformation )
+	public void addCheckedInformation( ItemStack stack, EntityPlayer player, List<String> lines, boolean displayMoreInfo )
 	{
 		EnumSet<SecurityPermissions> perms = this.getPermissions( stack );
 		if( perms.isEmpty() )

--- a/src/main/java/appeng/items/tools/ToolMemoryCard.java
+++ b/src/main/java/appeng/items/tools/ToolMemoryCard.java
@@ -46,7 +46,7 @@ public class ToolMemoryCard extends AEBaseItem implements IMemoryCard
 	}
 
 	@Override
-	public void addCheckedInformation( ItemStack stack, EntityPlayer player, List<String> lines, boolean displayAdditionalInformation )
+	public void addCheckedInformation( ItemStack stack, EntityPlayer player, List<String> lines, boolean displayMoreInfo )
 	{
 		lines.add( this.getLocalizedName( this.getSettingsName( stack ) + ".name", this.getSettingsName( stack ) ) );
 

--- a/src/main/java/appeng/items/tools/powered/ToolColorApplicator.java
+++ b/src/main/java/appeng/items/tools/powered/ToolColorApplicator.java
@@ -388,9 +388,9 @@ public class ToolColorApplicator extends AEBasePoweredItem implements IStorageCe
 	}
 
 	@Override
-	public void addCheckedInformation( ItemStack stack, EntityPlayer player, List<String> lines, boolean displayAdditionalInformation )
+	public void addCheckedInformation( ItemStack stack, EntityPlayer player, List<String> lines, boolean displayMoreInfo )
 	{
-		super.addCheckedInformation( stack, player, lines, displayAdditionalInformation );
+		super.addCheckedInformation( stack, player, lines, displayMoreInfo );
 
 		IMEInventory<IAEItemStack> cdi = AEApi.instance().registries().cell().getCellInventory( stack, null, StorageChannel.ITEMS );
 
@@ -413,6 +413,12 @@ public class ToolColorApplicator extends AEBasePoweredItem implements IStorageCe
 
 	@Override
 	public int BytePerType( ItemStack cell )
+	{
+		return 8;
+	}
+
+	@Override
+	public int getBytesPerType( ItemStack cellItem )
 	{
 		return 8;
 	}

--- a/src/main/java/appeng/items/tools/powered/ToolMassCannon.java
+++ b/src/main/java/appeng/items/tools/powered/ToolMassCannon.java
@@ -95,9 +95,9 @@ public class ToolMassCannon extends AEBasePoweredItem implements IStorageCell
 	}
 
 	@Override
-	public void addCheckedInformation( ItemStack stack, EntityPlayer player, List<String> lines, boolean displayAdditionalInformation )
+	public void addCheckedInformation( ItemStack stack, EntityPlayer player, List<String> lines, boolean displayMoreInfo )
 	{
-		super.addCheckedInformation( stack, player, lines, displayAdditionalInformation );
+		super.addCheckedInformation( stack, player, lines, displayMoreInfo );
 
 		IMEInventory<IAEItemStack> cdi = AEApi.instance().registries().cell().getCellInventory( stack, null, StorageChannel.ITEMS );
 
@@ -477,6 +477,12 @@ public class ToolMassCannon extends AEBasePoweredItem implements IStorageCell
 
 	@Override
 	public int BytePerType( ItemStack cell )
+	{
+		return 8;
+	}
+
+	@Override
+	public int getBytesPerType( ItemStack cellItem )
 	{
 		return 8;
 	}

--- a/src/main/java/appeng/items/tools/powered/ToolPortableCell.java
+++ b/src/main/java/appeng/items/tools/powered/ToolPortableCell.java
@@ -80,9 +80,9 @@ public class ToolPortableCell extends AEBasePoweredItem implements IStorageCell,
 	}
 
 	@Override
-	public void addCheckedInformation( ItemStack stack, EntityPlayer player, List<String> lines, boolean displayAdditionalInformation )
+	public void addCheckedInformation( ItemStack stack, EntityPlayer player, List<String> lines, boolean displayMoreInfo )
 	{
-		super.addCheckedInformation( stack, player, lines, displayAdditionalInformation );
+		super.addCheckedInformation( stack, player, lines, displayMoreInfo );
 
 		IMEInventory<IAEItemStack> cdi = AEApi.instance().registries().cell().getCellInventory( stack, null, StorageChannel.ITEMS );
 
@@ -105,6 +105,12 @@ public class ToolPortableCell extends AEBasePoweredItem implements IStorageCell,
 
 	@Override
 	public int BytePerType( ItemStack cell )
+	{
+		return 8;
+	}
+
+	@Override
+	public int getBytesPerType( ItemStack cellItem )
 	{
 		return 8;
 	}

--- a/src/main/java/appeng/items/tools/powered/ToolWirelessTerminal.java
+++ b/src/main/java/appeng/items/tools/powered/ToolWirelessTerminal.java
@@ -73,9 +73,9 @@ public class ToolWirelessTerminal extends AEBasePoweredItem implements IWireless
 	}
 
 	@Override
-	public void addCheckedInformation( ItemStack stack, EntityPlayer player, List<String> lines, boolean displayAdditionalInformation )
+	public void addCheckedInformation( ItemStack stack, EntityPlayer player, List<String> lines, boolean displayMoreInfo )
 	{
-		super.addCheckedInformation( stack, player, lines, displayAdditionalInformation );
+		super.addCheckedInformation( stack, player, lines, displayMoreInfo );
 
 		if( stack.hasTagCompound() )
 		{

--- a/src/main/java/appeng/items/tools/powered/powersink/AERootPoweredItem.java
+++ b/src/main/java/appeng/items/tools/powered/powersink/AERootPoweredItem.java
@@ -54,7 +54,7 @@ public abstract class AERootPoweredItem extends AEBaseItem implements IAEItemPow
 	}
 
 	@Override
-	public void addCheckedInformation( ItemStack stack, EntityPlayer player, List<String> lines, boolean displayAdditionalInformation )
+	public void addCheckedInformation( ItemStack stack, EntityPlayer player, List<String> lines, boolean displayMoreInfo )
 	{
 		NBTTagCompound tag = stack.getTagCompound();
 		double internalCurrentPower = 0;

--- a/src/main/java/appeng/tile/misc/TileCellWorkbench.java
+++ b/src/main/java/appeng/tile/misc/TileCellWorkbench.java
@@ -48,7 +48,7 @@ public class TileCellWorkbench extends AEBaseTile implements IUpgradeableHost, I
 
 	final AppEngInternalInventory cell = new AppEngInternalInventory( this, 1 );
 	final AppEngInternalAEInventory config = new AppEngInternalAEInventory( this, 63 );
-	final ConfigManager cm = new ConfigManager( this );
+	final ConfigManager manager = new ConfigManager( this );
 
 	IInventory cacheUpgrades = null;
 	IInventory cacheConfig = null;
@@ -56,7 +56,7 @@ public class TileCellWorkbench extends AEBaseTile implements IUpgradeableHost, I
 
 	public TileCellWorkbench()
 	{
-		this.cm.registerSetting( Settings.COPY_MODE, CopyMode.CLEAR_ON_REMOVE );
+		this.manager.registerSetting( Settings.COPY_MODE, CopyMode.CLEAR_ON_REMOVE );
 		this.cell.enableClientEvents = true;
 	}
 
@@ -97,7 +97,7 @@ public class TileCellWorkbench extends AEBaseTile implements IUpgradeableHost, I
 	{
 		this.cell.writeToNBT( data, "cell" );
 		this.config.writeToNBT( data, "config" );
-		this.cm.writeToNBT( data );
+		this.manager.writeToNBT( data );
 	}
 
 	@TileEvent( TileEventType.WORLD_NBT_READ )
@@ -105,7 +105,7 @@ public class TileCellWorkbench extends AEBaseTile implements IUpgradeableHost, I
 	{
 		this.cell.readFromNBT( data, "cell" );
 		this.config.readFromNBT( data, "config" );
-		this.cm.readFromNBT( data );
+		this.manager.readFromNBT( data );
 	}
 
 	@Override
@@ -136,13 +136,13 @@ public class TileCellWorkbench extends AEBaseTile implements IUpgradeableHost, I
 			this.cacheUpgrades = null;
 			this.cacheConfig = null;
 
-			IInventory c = this.getCellConfigInventory();
-			if( c != null )
+			IInventory configInventory = this.getCellConfigInventory();
+			if( configInventory != null )
 			{
 				boolean cellHasConfig = false;
-				for( int x = 0; x < c.getSizeInventory(); x++ )
+				for( int x = 0; x < configInventory.getSizeInventory(); x++ )
 				{
-					if( c.getStackInSlot( x ) != null )
+					if( configInventory.getStackInSlot( x ) != null )
 					{
 						cellHasConfig = true;
 						break;
@@ -152,17 +152,17 @@ public class TileCellWorkbench extends AEBaseTile implements IUpgradeableHost, I
 				if( cellHasConfig )
 				{
 					for( int x = 0; x < this.config.getSizeInventory(); x++ )
-						this.config.setInventorySlotContents( x, c.getStackInSlot( x ) );
+						this.config.setInventorySlotContents( x, configInventory.getStackInSlot( x ) );
 				}
 				else
 				{
 					for( int x = 0; x < this.config.getSizeInventory(); x++ )
-						c.setInventorySlotContents( x, this.config.getStackInSlot( x ) );
+						configInventory.setInventorySlotContents( x, this.config.getStackInSlot( x ) );
 
-					c.markDirty();
+					configInventory.markDirty();
 				}
 			}
-			else if( this.cm.getSetting( Settings.COPY_MODE ) == CopyMode.CLEAR_ON_REMOVE )
+			else if( this.manager.getSetting( Settings.COPY_MODE ) == CopyMode.CLEAR_ON_REMOVE )
 			{
 				for( int x = 0; x < this.config.getSizeInventory(); x++ )
 					this.config.setInventorySlotContents( x, null );
@@ -185,7 +185,7 @@ public class TileCellWorkbench extends AEBaseTile implements IUpgradeableHost, I
 		}
 	}
 
-	public IInventory getCellConfigInventory()
+	private IInventory getCellConfigInventory()
 	{
 		if( this.cacheConfig == null )
 		{
@@ -201,7 +201,7 @@ public class TileCellWorkbench extends AEBaseTile implements IUpgradeableHost, I
 			if( inv == null )
 				return null;
 
-			return this.cacheConfig = inv;
+			this.cacheConfig = inv;
 		}
 		return this.cacheConfig;
 	}
@@ -218,7 +218,7 @@ public class TileCellWorkbench extends AEBaseTile implements IUpgradeableHost, I
 	@Override
 	public IConfigManager getConfigManager()
 	{
-		return this.cm;
+		return this.manager;
 	}
 
 	@Override


### PR DESCRIPTION
only `ItemBasicStorageCell.java` contains the relevant code, rest was noise to detect the required code to fix the bug