### PR TITLE
Removes the unneeded information about the current class in all blocks

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat May 02 19:28:20 CEST 2015
+#Sun May 03 18:51:13 CEST 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.3-all.zip

--- a/src/main/java/appeng/block/AEBaseBlock.java
+++ b/src/main/java/appeng/block/AEBaseBlock.java
@@ -49,7 +49,6 @@ import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.ReflectionHelper;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -102,9 +101,9 @@ public class AEBaseBlock extends BlockContainer implements IAEFeature
 	@Nullable
 	private Class<? extends TileEntity> tileEntityType = null;
 
-	protected AEBaseBlock( Class<? extends AEBaseBlock> c, Material mat )
+	protected AEBaseBlock( Material mat )
 	{
-		this( c, mat, Optional.<String>absent() );
+		this( mat, Optional.<String>absent() );
 		this.setLightOpacity( 255 );
 		this.setLightLevel( 0 );
 		this.setHardness( 2.2F );
@@ -112,7 +111,7 @@ public class AEBaseBlock extends BlockContainer implements IAEFeature
 		this.setHarvestLevel( "pickaxe", 0 );
 	}
 
-	protected AEBaseBlock( Class<?> c, Material mat, Optional<String> subName )
+	protected AEBaseBlock( Material mat, Optional<String> subName )
 	{
 		super( mat );
 
@@ -133,7 +132,7 @@ public class AEBaseBlock extends BlockContainer implements IAEFeature
 			this.setStepSound( Block.soundTypeMetal );
 		}
 
-		this.featureFullName = new FeatureNameExtractor( c, subName ).get();
+		this.featureFullName = new FeatureNameExtractor( this.getClass(), subName ).get();
 		this.featureSubName = subName;
 	}
 
@@ -197,7 +196,6 @@ public class AEBaseBlock extends BlockContainer implements IAEFeature
 		this.tileEntityType = c;
 
 		AEBaseTile.registerTileItem( c, new ItemStackSrc( this, 0 ) );
-		GameRegistry.registerTileEntity( this.tileEntityType, this.featureFullName );
 		this.isInventory = IInventory.class.isAssignableFrom( c );
 		this.setTileProvider( this.hasBlockTileEntity() );
 	}

--- a/src/main/java/appeng/block/AEDecorativeBlock.java
+++ b/src/main/java/appeng/block/AEDecorativeBlock.java
@@ -26,9 +26,9 @@ import net.minecraft.world.IBlockAccess;
 
 public class AEDecorativeBlock extends AEBaseBlock
 {
-	public AEDecorativeBlock( Class<? extends AEBaseBlock> c, Material mat )
+	public AEDecorativeBlock( Material mat )
 	{
-		super( c, mat );
+		super( mat );
 	}
 
 	@Override

--- a/src/main/java/appeng/block/crafting/BlockCraftingMonitor.java
+++ b/src/main/java/appeng/block/crafting/BlockCraftingMonitor.java
@@ -40,11 +40,8 @@ import appeng.tile.crafting.TileCraftingMonitorTile;
 
 public class BlockCraftingMonitor extends BlockCraftingUnit
 {
-
 	public BlockCraftingMonitor()
 	{
-		super( BlockCraftingMonitor.class );
-
 		this.setTileEntity( TileCraftingMonitorTile.class );
 	}
 

--- a/src/main/java/appeng/block/crafting/BlockCraftingStorage.java
+++ b/src/main/java/appeng/block/crafting/BlockCraftingStorage.java
@@ -37,8 +37,6 @@ public class BlockCraftingStorage extends BlockCraftingUnit
 {
 	public BlockCraftingStorage()
 	{
-		super( BlockCraftingStorage.class );
-
 		this.setTileEntity( TileCraftingStorageTile.class );
 	}
 

--- a/src/main/java/appeng/block/crafting/BlockCraftingUnit.java
+++ b/src/main/java/appeng/block/crafting/BlockCraftingUnit.java
@@ -51,16 +51,10 @@ public class BlockCraftingUnit extends AEBaseBlock
 
 	public BlockCraftingUnit()
 	{
-		this( BlockCraftingUnit.class );
-
-		this.setTileEntity( TileCraftingTile.class );
-	}
-
-	public BlockCraftingUnit( Class<? extends BlockCraftingUnit> childClass )
-	{
-		super( childClass, Material.iron );
+		super( Material.iron );
 
 		this.hasSubtypes = true;
+		this.setTileEntity( TileCraftingTile.class );
 		this.setFeature( EnumSet.of( AEFeature.CraftingCPU ) );
 	}
 

--- a/src/main/java/appeng/block/crafting/BlockMolecularAssembler.java
+++ b/src/main/java/appeng/block/crafting/BlockMolecularAssembler.java
@@ -45,7 +45,8 @@ public class BlockMolecularAssembler extends AEBaseBlock
 
 	public BlockMolecularAssembler()
 	{
-		super( BlockMolecularAssembler.class, Material.iron );
+		super( Material.iron );
+	
 		this.setTileEntity( TileMolecularAssembler.class );
 		this.isOpaque = false;
 		this.lightOpacity = 1;

--- a/src/main/java/appeng/block/grindstone/BlockCrank.java
+++ b/src/main/java/appeng/block/grindstone/BlockCrank.java
@@ -46,7 +46,8 @@ public class BlockCrank extends AEBaseBlock
 
 	public BlockCrank()
 	{
-		super( BlockCrank.class, Material.wood );
+		super( Material.wood );
+
 		this.setTileEntity( TileCrank.class );
 		this.setLightOpacity( 0 );
 		this.setHarvestLevel( "axe", 0 );

--- a/src/main/java/appeng/block/grindstone/BlockGrinder.java
+++ b/src/main/java/appeng/block/grindstone/BlockGrinder.java
@@ -38,7 +38,8 @@ public class BlockGrinder extends AEBaseBlock
 
 	public BlockGrinder()
 	{
-		super( BlockGrinder.class, Material.rock );
+		super( Material.rock );
+
 		this.setTileEntity( TileGrinder.class );
 		this.setHardness( 3.2F );
 		this.setFeature( EnumSet.of( AEFeature.GrindStone ) );

--- a/src/main/java/appeng/block/misc/BlockCellWorkbench.java
+++ b/src/main/java/appeng/block/misc/BlockCellWorkbench.java
@@ -38,7 +38,8 @@ public class BlockCellWorkbench extends AEBaseBlock
 
 	public BlockCellWorkbench()
 	{
-		super( BlockCellWorkbench.class, Material.iron );
+		super( Material.iron );
+
 		this.setTileEntity( TileCellWorkbench.class );
 		this.setFeature( EnumSet.of( AEFeature.StorageCells ) );
 	}

--- a/src/main/java/appeng/block/misc/BlockCharger.java
+++ b/src/main/java/appeng/block/misc/BlockCharger.java
@@ -54,7 +54,8 @@ public class BlockCharger extends AEBaseBlock implements ICustomCollision
 
 	public BlockCharger()
 	{
-		super( BlockCharger.class, Material.iron );
+		super( Material.iron );
+
 		this.setTileEntity( TileCharger.class );
 		this.setLightOpacity( 2 );
 		this.isFullSize = this.isOpaque = false;

--- a/src/main/java/appeng/block/misc/BlockCondenser.java
+++ b/src/main/java/appeng/block/misc/BlockCondenser.java
@@ -38,7 +38,8 @@ public class BlockCondenser extends AEBaseBlock
 
 	public BlockCondenser()
 	{
-		super( BlockCondenser.class, Material.iron );
+		super( Material.iron );
+
 		this.setTileEntity( TileCondenser.class );
 		this.setFeature( EnumSet.of( AEFeature.Core ) );
 	}

--- a/src/main/java/appeng/block/misc/BlockInscriber.java
+++ b/src/main/java/appeng/block/misc/BlockInscriber.java
@@ -40,7 +40,8 @@ public class BlockInscriber extends AEBaseBlock
 
 	public BlockInscriber()
 	{
-		super( BlockInscriber.class, Material.iron );
+		super( Material.iron );
+
 		this.setTileEntity( TileInscriber.class );
 		this.setLightOpacity( 2 );
 		this.isFullSize = this.isOpaque = false;

--- a/src/main/java/appeng/block/misc/BlockInterface.java
+++ b/src/main/java/appeng/block/misc/BlockInterface.java
@@ -41,7 +41,8 @@ public class BlockInterface extends AEBaseBlock
 
 	public BlockInterface()
 	{
-		super( BlockInterface.class, Material.iron );
+		super( Material.iron );
+		
 		this.setTileEntity( TileInterface.class );
 		this.setFeature( EnumSet.of( AEFeature.Core ) );
 	}

--- a/src/main/java/appeng/block/misc/BlockLightDetector.java
+++ b/src/main/java/appeng/block/misc/BlockLightDetector.java
@@ -37,7 +37,6 @@ public class BlockLightDetector extends BlockQuartzTorch
 
 	public BlockLightDetector()
 	{
-		super( BlockLightDetector.class );
 		this.setTileEntity( TileLightDetector.class );
 		this.setFeature( EnumSet.of( AEFeature.LightDetector ) );
 	}

--- a/src/main/java/appeng/block/misc/BlockPaint.java
+++ b/src/main/java/appeng/block/misc/BlockPaint.java
@@ -49,7 +49,8 @@ public class BlockPaint extends AEBaseBlock
 
 	public BlockPaint()
 	{
-		super( BlockPaint.class, new MaterialLiquid( MapColor.airColor ) );
+		super( new MaterialLiquid( MapColor.airColor ) );
+	
 		this.setTileEntity( TilePaint.class );
 		this.setLightOpacity( 0 );
 		this.isFullSize = false;

--- a/src/main/java/appeng/block/misc/BlockQuartzGrowthAccelerator.java
+++ b/src/main/java/appeng/block/misc/BlockQuartzGrowthAccelerator.java
@@ -51,7 +51,7 @@ public class BlockQuartzGrowthAccelerator extends AEBaseBlock implements IOrient
 
 	public BlockQuartzGrowthAccelerator()
 	{
-		super( BlockQuartzGrowthAccelerator.class, Material.rock );
+		super( Material.rock );
 		this.setStepSound( Block.soundTypeMetal );
 		this.setTileEntity( TileQuartzGrowthAccelerator.class );
 		this.setFeature( EnumSet.of( AEFeature.Core ) );

--- a/src/main/java/appeng/block/misc/BlockQuartzTorch.java
+++ b/src/main/java/appeng/block/misc/BlockQuartzTorch.java
@@ -51,19 +51,15 @@ import appeng.helpers.MetaRotation;
 
 public class BlockQuartzTorch extends AEBaseBlock implements IOrientableBlock, ICustomCollision
 {
-
 	public BlockQuartzTorch()
 	{
-		this( BlockQuartzTorch.class );
-		this.setLightLevel( 0.9375F );
-		this.setFeature( EnumSet.of( AEFeature.DecorativeLights ) );
-	}
+		super( Material.circuits );
 
-	protected BlockQuartzTorch( Class which )
-	{
-		super( which, Material.circuits );
+		this.setFeature( EnumSet.of( AEFeature.DecorativeLights ) );
+		this.setLightLevel( 0.9375F );
 		this.setLightOpacity( 0 );
-		this.isFullSize = this.isOpaque = false;
+		this.isFullSize = false;
+		this.isOpaque = false;
 	}
 
 	@Override

--- a/src/main/java/appeng/block/misc/BlockSecurity.java
+++ b/src/main/java/appeng/block/misc/BlockSecurity.java
@@ -40,7 +40,8 @@ public class BlockSecurity extends AEBaseBlock
 
 	public BlockSecurity()
 	{
-		super( BlockSecurity.class, Material.iron );
+		super( Material.iron );
+	
 		this.setTileEntity( TileSecurity.class );
 		this.setFeature( EnumSet.of( AEFeature.Security ) );
 	}

--- a/src/main/java/appeng/block/misc/BlockSkyCompass.java
+++ b/src/main/java/appeng/block/misc/BlockSkyCompass.java
@@ -49,7 +49,7 @@ public class BlockSkyCompass extends AEBaseBlock implements ICustomCollision
 
 	public BlockSkyCompass()
 	{
-		super( BlockSkyCompass.class, Material.iron );
+		super( Material.iron );
 		this.setTileEntity( TileSkyCompass.class );
 		this.isOpaque = this.isFullSize = false;
 		this.lightOpacity = 0;

--- a/src/main/java/appeng/block/misc/BlockTinyTNT.java
+++ b/src/main/java/appeng/block/misc/BlockTinyTNT.java
@@ -58,7 +58,7 @@ public class BlockTinyTNT extends AEBaseBlock implements ICustomCollision
 
 	public BlockTinyTNT()
 	{
-		super( BlockTinyTNT.class, Material.tnt );
+		super( Material.tnt );
 		this.setLightOpacity( 1 );
 		this.setBlockBounds( 0.25f, 0.0f, 0.25f, 0.75f, 0.5f, 0.75f );
 		this.isFullSize = this.isOpaque = false;

--- a/src/main/java/appeng/block/misc/BlockVibrationChamber.java
+++ b/src/main/java/appeng/block/misc/BlockVibrationChamber.java
@@ -44,7 +44,7 @@ public final class BlockVibrationChamber extends AEBaseBlock
 
 	public BlockVibrationChamber()
 	{
-		super( BlockVibrationChamber.class, Material.iron );
+		super( Material.iron );
 		this.setTileEntity( TileVibrationChamber.class );
 		this.setHardness( 4.2F );
 		this.setFeature( EnumSet.of( AEFeature.PowerGen ) );

--- a/src/main/java/appeng/block/networking/BlockCableBus.java
+++ b/src/main/java/appeng/block/networking/BlockCableBus.java
@@ -91,7 +91,7 @@ public class BlockCableBus extends AEBaseBlock implements IRedNetConnection
 
 	public BlockCableBus()
 	{
-		super( BlockCableBus.class, AEGlassMaterial.INSTANCE );
+		super( AEGlassMaterial.INSTANCE );
 		this.setLightOpacity( 0 );
 		this.isFullSize = this.isOpaque = false;
 		this.setFeature( EnumSet.of( AEFeature.Core ) );
@@ -483,7 +483,9 @@ public class BlockCableBus extends AEBaseBlock implements IRedNetConnection
 
 	public void setupTile()
 	{
-		this.setTileEntity( noTesrTile = Api.INSTANCE.partHelper().getCombinedInstance( TileCableBus.class.getName() ) );
+		noTesrTile = Api.INSTANCE.partHelper().getCombinedInstance( TileCableBus.class.getName() );
+		this.setTileEntity( noTesrTile );
+		GameRegistry.registerTileEntity( noTesrTile, "BlockCableBus" );
 		if( Platform.isClient() )
 		{
 			tesrTile = Api.INSTANCE.partHelper().getCombinedInstance( TileCableBusTESR.class.getName() );

--- a/src/main/java/appeng/block/networking/BlockController.java
+++ b/src/main/java/appeng/block/networking/BlockController.java
@@ -37,7 +37,7 @@ public class BlockController extends AEBaseBlock
 
 	public BlockController()
 	{
-		super( BlockController.class, Material.iron );
+		super( Material.iron );
 		this.setTileEntity( TileController.class );
 		this.setHardness( 6 );
 		this.setFeature( EnumSet.of( AEFeature.Channels ) );

--- a/src/main/java/appeng/block/networking/BlockCreativeEnergyCell.java
+++ b/src/main/java/appeng/block/networking/BlockCreativeEnergyCell.java
@@ -32,7 +32,7 @@ public class BlockCreativeEnergyCell extends AEBaseBlock
 
 	public BlockCreativeEnergyCell()
 	{
-		super( BlockCreativeEnergyCell.class, AEGlassMaterial.INSTANCE );
+		super( AEGlassMaterial.INSTANCE );
 		this.setTileEntity( TileCreativeEnergyCell.class );
 		this.setFeature( EnumSet.of( AEFeature.Creative ) );
 	}

--- a/src/main/java/appeng/block/networking/BlockDenseEnergyCell.java
+++ b/src/main/java/appeng/block/networking/BlockDenseEnergyCell.java
@@ -33,7 +33,6 @@ public class BlockDenseEnergyCell extends BlockEnergyCell
 
 	public BlockDenseEnergyCell()
 	{
-		super( BlockDenseEnergyCell.class );
 		this.setTileEntity( TileDenseEnergyCell.class );
 		this.setFeature( EnumSet.of( AEFeature.DenseEnergyCells ) );
 	}

--- a/src/main/java/appeng/block/networking/BlockEnergyAcceptor.java
+++ b/src/main/java/appeng/block/networking/BlockEnergyAcceptor.java
@@ -33,7 +33,7 @@ public class BlockEnergyAcceptor extends AEBaseBlock
 
 	public BlockEnergyAcceptor()
 	{
-		super( BlockEnergyAcceptor.class, Material.iron );
+		super( Material.iron );
 		this.setTileEntity( TileEnergyAcceptor.class );
 		this.setFeature( EnumSet.of( AEFeature.Core ) );
 	}

--- a/src/main/java/appeng/block/networking/BlockEnergyCell.java
+++ b/src/main/java/appeng/block/networking/BlockEnergyCell.java
@@ -48,14 +48,10 @@ public class BlockEnergyCell extends AEBaseBlock
 
 	public BlockEnergyCell()
 	{
-		this( BlockEnergyCell.class );
+		super( AEGlassMaterial.INSTANCE );
+
 		this.setTileEntity( TileEnergyCell.class );
 		this.setFeature( EnumSet.of( AEFeature.Core ) );
-	}
-
-	public BlockEnergyCell( Class c )
-	{
-		super( c, AEGlassMaterial.INSTANCE );
 	}
 
 	@Override

--- a/src/main/java/appeng/block/networking/BlockWireless.java
+++ b/src/main/java/appeng/block/networking/BlockWireless.java
@@ -45,7 +45,7 @@ public class BlockWireless extends AEBaseBlock implements ICustomCollision
 
 	public BlockWireless()
 	{
-		super( BlockWireless.class, AEGlassMaterial.INSTANCE );
+		super( AEGlassMaterial.INSTANCE );
 		this.setTileEntity( TileWireless.class );
 		this.setLightOpacity( 0 );
 		this.isFullSize = false;

--- a/src/main/java/appeng/block/qnb/BlockQuantumLinkChamber.java
+++ b/src/main/java/appeng/block/qnb/BlockQuantumLinkChamber.java
@@ -52,7 +52,7 @@ public class BlockQuantumLinkChamber extends AEBaseBlock implements ICustomColli
 
 	public BlockQuantumLinkChamber()
 	{
-		super( BlockQuantumLinkChamber.class, AEGlassMaterial.INSTANCE );
+		super( AEGlassMaterial.INSTANCE );
 		this.setTileEntity( TileQuantumBridge.class );
 		float shave = 2.0f / 16.0f;
 		this.setBlockBounds( shave, shave, shave, 1.0f - shave, 1.0f - shave, 1.0f - shave );

--- a/src/main/java/appeng/block/qnb/BlockQuantumRing.java
+++ b/src/main/java/appeng/block/qnb/BlockQuantumRing.java
@@ -42,7 +42,7 @@ public class BlockQuantumRing extends AEBaseBlock implements ICustomCollision
 
 	public BlockQuantumRing()
 	{
-		super( BlockQuantumRing.class, Material.iron );
+		super( Material.iron );
 		this.setTileEntity( TileQuantumBridge.class );
 		float shave = 2.0f / 16.0f;
 		this.setBlockBounds( shave, shave, shave, 1.0f - shave, 1.0f - shave, 1.0f - shave );

--- a/src/main/java/appeng/block/solids/BlockFluix.java
+++ b/src/main/java/appeng/block/solids/BlockFluix.java
@@ -31,7 +31,7 @@ public class BlockFluix extends AEDecorativeBlock
 {
 	public BlockFluix()
 	{
-		super( BlockFluix.class, Material.rock );
+		super( Material.rock );
 		this.setFeature( EnumSet.of( AEFeature.DecorativeQuartzBlocks ) );
 	}
 }

--- a/src/main/java/appeng/block/solids/BlockQuartz.java
+++ b/src/main/java/appeng/block/solids/BlockQuartz.java
@@ -32,7 +32,7 @@ public class BlockQuartz extends AEDecorativeBlock
 
 	public BlockQuartz()
 	{
-		super( BlockQuartz.class, Material.rock );
+		super( Material.rock );
 		this.setFeature( EnumSet.of( AEFeature.DecorativeQuartzBlocks ) );
 	}
 }

--- a/src/main/java/appeng/block/solids/BlockQuartzChiseled.java
+++ b/src/main/java/appeng/block/solids/BlockQuartzChiseled.java
@@ -32,7 +32,7 @@ public class BlockQuartzChiseled extends AEDecorativeBlock
 
 	public BlockQuartzChiseled()
 	{
-		super( BlockQuartzChiseled.class, Material.rock );
+		super( Material.rock );
 		this.setFeature( EnumSet.of( AEFeature.DecorativeQuartzBlocks ) );
 	}
 }

--- a/src/main/java/appeng/block/solids/BlockQuartzGlass.java
+++ b/src/main/java/appeng/block/solids/BlockQuartzGlass.java
@@ -36,15 +36,9 @@ import appeng.helpers.AEGlassMaterial;
 
 public class BlockQuartzGlass extends AEBaseBlock
 {
-
 	public BlockQuartzGlass()
 	{
-		this( BlockQuartzGlass.class );
-	}
-
-	public BlockQuartzGlass( Class c )
-	{
-		super( c, Material.glass );
+		super( Material.glass );
 		this.setLightOpacity( 0 );
 		this.isOpaque = false;
 		this.setFeature( EnumSet.of( AEFeature.DecorativeQuartzBlocks ) );

--- a/src/main/java/appeng/block/solids/BlockQuartzLamp.java
+++ b/src/main/java/appeng/block/solids/BlockQuartzLamp.java
@@ -39,7 +39,6 @@ public class BlockQuartzLamp extends BlockQuartzGlass
 
 	public BlockQuartzLamp()
 	{
-		super( BlockQuartzLamp.class );
 		this.setLightLevel( 1.0f );
 		this.setBlockTextureName( "BlockQuartzGlass" );
 		this.setFeature( EnumSet.of( AEFeature.DecorativeQuartzBlocks, AEFeature.DecorativeLights ) );

--- a/src/main/java/appeng/block/solids/BlockQuartzPillar.java
+++ b/src/main/java/appeng/block/solids/BlockQuartzPillar.java
@@ -36,7 +36,7 @@ public class BlockQuartzPillar extends AEBaseBlock implements IOrientableBlock
 
 	public BlockQuartzPillar()
 	{
-		super( BlockQuartzPillar.class, Material.rock );
+		super( Material.rock );
 		this.setFeature( EnumSet.of( AEFeature.DecorativeQuartzBlocks ) );
 	}
 

--- a/src/main/java/appeng/block/solids/BlockSkyStone.java
+++ b/src/main/java/appeng/block/solids/BlockSkyStone.java
@@ -71,7 +71,7 @@ public class BlockSkyStone extends AEBaseBlock implements IOrientableBlock
 
 	public BlockSkyStone()
 	{
-		super( BlockSkyStone.class, Material.rock );
+		super( Material.rock );
 		this.setHardness( 50 );
 		this.hasSubtypes = true;
 		this.blockResistance = 150.0f;

--- a/src/main/java/appeng/block/solids/OreQuartz.java
+++ b/src/main/java/appeng/block/solids/OreQuartz.java
@@ -47,12 +47,7 @@ public class OreQuartz extends AEBaseBlock
 
 	public OreQuartz()
 	{
-		this( OreQuartz.class );
-	}
-
-	public OreQuartz( Class<? extends OreQuartz> self )
-	{
-		super( self, Material.rock );
+		super( Material.rock );
 		this.setHardness( 3.0F );
 		this.setResistance( 5.0F );
 		this.boostBrightnessLow = 0;

--- a/src/main/java/appeng/block/solids/OreQuartzCharged.java
+++ b/src/main/java/appeng/block/solids/OreQuartzCharged.java
@@ -42,7 +42,6 @@ public class OreQuartzCharged extends OreQuartz
 
 	public OreQuartzCharged()
 	{
-		super( OreQuartzCharged.class );
 		this.setBoostBrightnessLow( 2 );
 		this.setBoostBrightnessHigh( 5 );
 	}

--- a/src/main/java/appeng/block/spatial/BlockMatrixFrame.java
+++ b/src/main/java/appeng/block/spatial/BlockMatrixFrame.java
@@ -49,7 +49,7 @@ public class BlockMatrixFrame extends AEBaseBlock implements ICustomCollision
 
 	public BlockMatrixFrame()
 	{
-		super( BlockMatrixFrame.class, Material.anvil );
+		super( Material.anvil );
 		this.setResistance( 6000000.0F );
 		this.setBlockUnbreakable();
 		this.setLightOpacity( 0 );

--- a/src/main/java/appeng/block/spatial/BlockSpatialIOPort.java
+++ b/src/main/java/appeng/block/spatial/BlockSpatialIOPort.java
@@ -39,7 +39,7 @@ public class BlockSpatialIOPort extends AEBaseBlock
 
 	public BlockSpatialIOPort()
 	{
-		super( BlockSpatialIOPort.class, Material.iron );
+		super( Material.iron );
 		this.setTileEntity( TileSpatialIOPort.class );
 		this.setFeature( EnumSet.of( AEFeature.SpatialIO ) );
 	}

--- a/src/main/java/appeng/block/spatial/BlockSpatialPylon.java
+++ b/src/main/java/appeng/block/spatial/BlockSpatialPylon.java
@@ -38,7 +38,7 @@ public class BlockSpatialPylon extends AEBaseBlock
 
 	public BlockSpatialPylon()
 	{
-		super( BlockSpatialPylon.class, AEGlassMaterial.INSTANCE );
+		super( AEGlassMaterial.INSTANCE );
 		this.setTileEntity( TileSpatialPylon.class );
 		this.setFeature( EnumSet.of( AEFeature.SpatialIO ) );
 	}

--- a/src/main/java/appeng/block/storage/BlockChest.java
+++ b/src/main/java/appeng/block/storage/BlockChest.java
@@ -44,7 +44,7 @@ public class BlockChest extends AEBaseBlock
 
 	public BlockChest()
 	{
-		super( BlockChest.class, Material.iron );
+		super( Material.iron );
 		this.setTileEntity( TileChest.class );
 		this.setFeature( EnumSet.of( AEFeature.StorageCells, AEFeature.MEChest ) );
 	}

--- a/src/main/java/appeng/block/storage/BlockDrive.java
+++ b/src/main/java/appeng/block/storage/BlockDrive.java
@@ -40,7 +40,7 @@ public class BlockDrive extends AEBaseBlock
 
 	public BlockDrive()
 	{
-		super( BlockDrive.class, Material.iron );
+		super( Material.iron );
 		this.setTileEntity( TileDrive.class );
 		this.setFeature( EnumSet.of( AEFeature.StorageCells, AEFeature.MEDrive ) );
 	}

--- a/src/main/java/appeng/block/storage/BlockIOPort.java
+++ b/src/main/java/appeng/block/storage/BlockIOPort.java
@@ -39,7 +39,7 @@ public class BlockIOPort extends AEBaseBlock
 
 	public BlockIOPort()
 	{
-		super( BlockIOPort.class, Material.iron );
+		super( Material.iron );
 		this.setTileEntity( TileIOPort.class );
 		this.setFeature( EnumSet.of( AEFeature.StorageCells, AEFeature.IOPort ) );
 	}

--- a/src/main/java/appeng/block/storage/BlockSkyChest.java
+++ b/src/main/java/appeng/block/storage/BlockSkyChest.java
@@ -57,7 +57,7 @@ public class BlockSkyChest extends AEBaseBlock implements ICustomCollision
 
 	public BlockSkyChest()
 	{
-		super( BlockSkyChest.class, Material.rock );
+		super( Material.rock );
 		this.setTileEntity( TileSkyChest.class );
 		this.isOpaque = this.isFullSize = false;
 		this.lightOpacity = 0;

--- a/src/main/java/appeng/core/features/AEBlockFeatureHandler.java
+++ b/src/main/java/appeng/core/features/AEBlockFeatureHandler.java
@@ -21,9 +21,9 @@ package appeng.core.features;
 
 import java.util.EnumSet;
 
-import com.google.common.base.Optional;
-
 import cpw.mods.fml.common.registry.GameRegistry;
+
+import com.google.common.base.Optional;
 
 import appeng.api.definitions.ITileDefinition;
 import appeng.block.AEBaseBlock;
@@ -83,6 +83,11 @@ public final class AEBlockFeatureHandler implements IFeatureHandler
 			// Bypass the forge magic with null to register our own itemblock later.
 			GameRegistry.registerBlock( this.featured, null, registryName );
 			GameRegistry.registerItem( this.definition.maybeItem().get(), registryName );
+
+			if( !this.featured.toString().equals( "BlockCableBus" ) )
+			{
+				GameRegistry.registerTileEntity( this.featured.getTileEntityClass(), this.featured.toString() );
+			}
 		}
 	}
 }

--- a/src/main/java/appeng/debug/BlockChunkloader.java
+++ b/src/main/java/appeng/debug/BlockChunkloader.java
@@ -39,7 +39,7 @@ public class BlockChunkloader extends AEBaseBlock implements LoadingCallback
 
 	public BlockChunkloader()
 	{
-		super( BlockChunkloader.class, Material.iron );
+		super( Material.iron );
 		this.setTileEntity( TileChunkLoader.class );
 		ForgeChunkManager.setForcedChunkLoadingCallback( AppEng.instance, this );
 		this.setFeature( EnumSet.of( AEFeature.UnsupportedDeveloperTools, AEFeature.Creative ) );

--- a/src/main/java/appeng/debug/BlockCubeGenerator.java
+++ b/src/main/java/appeng/debug/BlockCubeGenerator.java
@@ -35,7 +35,7 @@ public class BlockCubeGenerator extends AEBaseBlock
 
 	public BlockCubeGenerator()
 	{
-		super( BlockCubeGenerator.class, Material.iron );
+		super( Material.iron );
 		this.setTileEntity( TileCubeGenerator.class );
 		this.setFeature( EnumSet.of( AEFeature.UnsupportedDeveloperTools, AEFeature.Creative ) );
 	}
@@ -43,7 +43,6 @@ public class BlockCubeGenerator extends AEBaseBlock
 	@Override
 	public boolean onActivated( World w, int x, int y, int z, EntityPlayer player, int side, float hitX, float hitY, float hitZ )
 	{
-
 		TileCubeGenerator tcg = this.getTileEntity( w, x, y, z );
 		if( tcg != null )
 		{

--- a/src/main/java/appeng/debug/BlockItemGen.java
+++ b/src/main/java/appeng/debug/BlockItemGen.java
@@ -33,7 +33,7 @@ public class BlockItemGen extends AEBaseBlock
 
 	public BlockItemGen()
 	{
-		super( BlockItemGen.class, Material.iron );
+		super( Material.iron );
 		this.setTileEntity( TileItemGen.class );
 		this.setFeature( EnumSet.of( AEFeature.UnsupportedDeveloperTools, AEFeature.Creative ) );
 	}

--- a/src/main/java/appeng/debug/BlockPhantomNode.java
+++ b/src/main/java/appeng/debug/BlockPhantomNode.java
@@ -35,7 +35,7 @@ public class BlockPhantomNode extends AEBaseBlock
 
 	public BlockPhantomNode()
 	{
-		super( BlockPhantomNode.class, Material.iron );
+		super( Material.iron );
 		this.setTileEntity( TilePhantomNode.class );
 		this.setFeature( EnumSet.of( AEFeature.UnsupportedDeveloperTools, AEFeature.Creative ) );
 	}

--- a/src/main/java/appeng/fmp/PartRegistry.java
+++ b/src/main/java/appeng/fmp/PartRegistry.java
@@ -19,6 +19,8 @@
 package appeng.fmp;
 
 
+import javax.annotation.Nullable;
+
 import net.minecraft.block.Block;
 
 import codechicken.multipart.TMultiPart;
@@ -31,7 +33,8 @@ import appeng.core.Api;
 
 public enum PartRegistry
 {
-	QuartzTorchPart( "ae2_torch", BlockQuartzTorch.class, QuartzTorchPart.class ), CableBusPart( "ae2_cablebus", BlockCableBus.class, CableBusPart.class );
+	QuartzTorchPart( "ae2_torch", BlockQuartzTorch.class, QuartzTorchPart.class ),
+	CableBusPart( "ae2_cablebus", BlockCableBus.class, CableBusPart.class );
 
 	private final String name;
 	private final Class<? extends AEBaseBlock> blk;
@@ -44,20 +47,7 @@ public enum PartRegistry
 		this.part = part;
 	}
 
-	public static String getPartName( TMultiPart part )
-	{
-		Class c = part.getClass();
-		for( PartRegistry pr : values() )
-		{
-			if( pr.equals( c ) )
-			{
-				return pr.name;
-			}
-		}
-
-		throw new IllegalStateException( "Invalid PartName" );
-	}
-
+	@Nullable
 	public static TMultiPart getPartByBlock( Block block, int meta )
 	{
 		for( PartRegistry pr : values() )
@@ -87,18 +77,6 @@ public enum PartRegistry
 		{
 			throw new IllegalStateException( t );
 		}
-	}
-
-	public static boolean isPart( Block block )
-	{
-		for( PartRegistry pr : values() )
-		{
-			if( pr.blk.isInstance( block ) )
-			{
-				return true;
-			}
-		}
-		return false;
 	}
 
 	public String getName()

--- a/src/main/java/appeng/util/item/AESharedNBT.java
+++ b/src/main/java/appeng/util/item/AESharedNBT.java
@@ -50,14 +50,12 @@ public class AESharedNBT extends NBTTagCompound implements IAETagCompound
 
 	private AESharedNBT( Item itemID, int damageValue )
 	{
-		super();
 		this.item = itemID;
 		this.meta = damageValue;
 	}
 
 	public AESharedNBT( int fakeValue )
 	{
-		super();
 		this.item = null;
 		this.meta = 0;
 		this.hash = fakeValue;


### PR DESCRIPTION
Every Block had a call to its super, passing its own class.
This can easily be simulated by calling `this.getClass()` in the super class.
Also this was basically only used as using a name.
In the future it might be advisable to not use such methods,
since they are prone to refactoring.