### PR TITLE
Do not use the slurper anymore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 !gradlew
 !gradlew.bat
 !build.gradle
-!build.properties
+!gradle.properties
 
 # include markdowns
 !README.md

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,6 @@
 
 apply plugin: 'forge'
 
-apply from: 'gradle/scripts/propertyloader.gradle'
 apply from: 'gradle/scripts/dependencies.gradle'
 apply from: 'gradle/scripts/artifacts.gradle'
 apply from: 'gradle/scripts/autoinstallruntime.gradle'
@@ -51,9 +50,9 @@ configurations.all {
 sourceCompatibility = JavaVersion.VERSION_1_6
 targetCompatibility = JavaVersion.VERSION_1_6
 
-version = config.version + "-" + config.aechannel + "-" + config.build
-group = config.group
-archivesBaseName = config.archivesBaseName
+version = aeversion + "-" + aechannel + "-" + aebuild
+group = aegroup
+archivesBaseName = aebasename
 
 // If TeamCity is running this build, lets set the version info
 if (hasProperty("teamcity")) {
@@ -78,11 +77,11 @@ jar {
 }
 
 minecraft {
-    version = config.minecraft_version + "-" + config.forge_version
+    version = minecraft_version + "-" + forge_version
 
     replaceIn "AEConfig.java"
     replace "@version@", project.version
-    replace "@aechannel@", config.aechannel
+    replace "@aechannel@", aechannel
 
     // used when launching minecraft in dev env
     runDir = "run"
@@ -111,7 +110,7 @@ processResources {
     // replace stuff in mcmod.info, nothing else
     from(sourceSets.main.resources.srcDirs) {
         include 'mcmod.info'
-        expand 'version': project.version, 'mcversion': config.minecraft_version
+        expand 'version': project.version, 'mcversion': minecraft_version
         include 'pack.mcmeta'
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
-version=rv2
+aeversion=rv2
 aechannel=beta
-build=0
-group=appeng
-archivesBaseName=appliedenergistics2
+aebuild=0
+aegroup=appeng
+aebasename=appliedenergistics2
 
 #########################################################
 # Versions                                              #
@@ -13,7 +13,6 @@ forge_version=10.13.2.1291
 #########################################################
 # APIs used for development                             #
 #########################################################
-cb_minecraft_version=1.7.10
 fmp_version=1.1.1.324
 code_chicken_lib_version=1.1.3.127
 code_chicken_core_version=1.0.4.35

--- a/gradle/scripts/dependencies.gradle
+++ b/gradle/scripts/dependencies.gradle
@@ -38,27 +38,27 @@ repositories {
 
 dependencies {
 
-    compile "codechicken:ForgeMultipart:${config.cb_minecraft_version}-${config.fmp_version}:dev"
-    compile "codechicken:CodeChickenLib:${config.cb_minecraft_version}-${config.code_chicken_lib_version}:dev"
-    compile "codechicken:CodeChickenCore:${config.cb_minecraft_version}-${config.code_chicken_core_version}:dev"
-    compile "codechicken:NotEnoughItems:${config.cb_minecraft_version}-${config.nei_version}:dev"
+    compile "codechicken:ForgeMultipart:${minecraft_version}-${fmp_version}:dev"
+    compile "codechicken:CodeChickenLib:${minecraft_version}-${code_chicken_lib_version}:dev"
+    compile "codechicken:CodeChickenCore:${minecraft_version}-${code_chicken_core_version}:dev"
+    compile "codechicken:NotEnoughItems:${minecraft_version}-${nei_version}:dev"
 
-    compile "com.mod-buildcraft:buildcraft:${config.bc_version}:dev"
+    compile "com.mod-buildcraft:buildcraft:${bc_version}:dev"
 
     // self compiled APIs
-    compile(group: 'api', name: 'betterstorage', version: "${config.api_betterstorage_version}")
-    compile(group: 'api', name: 'coloredlightscore', version: "${config.api_coloredlightscore_version}")
-    compile(group: 'api', name: 'craftguide', version: "${config.api_craftguide_version}")
-    compile(group: 'api', name: 'ic2', version: "${config.api_ic2_version}")
-    compile(group: 'api', name: 'immibis', version: "${config.api_immibis_version}")
-    compile(group: 'api', name: 'invtweaks', version: "${config.api_invtweaks_version}")
-    compile(group: 'api', name: 'mfr', version: "${config.api_mfr_version}")
-    compile(group: 'api', name: 'railcraft', version: "${config.api_railcraft_version}")
-    compile(group: 'api', name: 'rblocks', version: "${config.api_rblocks_version}")
-    compile(group: 'api', name: 'rf', version: "${config.api_rf_version}")
-    compile "appeng:Waila:${config.api_waila_version}:api"
-    compile "appeng:RotaryCraft:${config.api_rotarycraft_version}:api"
-    compile "appeng:mekanism:${config.api_mekansim_version}:api"
+    compile(group: 'api', name: 'betterstorage', version: "${api_betterstorage_version}")
+    compile(group: 'api', name: 'coloredlightscore', version: "${api_coloredlightscore_version}")
+    compile(group: 'api', name: 'craftguide', version: "${api_craftguide_version}")
+    compile(group: 'api', name: 'ic2', version: "${api_ic2_version}")
+    compile(group: 'api', name: 'immibis', version: "${api_immibis_version}")
+    compile(group: 'api', name: 'invtweaks', version: "${api_invtweaks_version}")
+    compile(group: 'api', name: 'mfr', version: "${api_mfr_version}")
+    compile(group: 'api', name: 'railcraft', version: "${api_railcraft_version}")
+    compile(group: 'api', name: 'rblocks', version: "${api_rblocks_version}")
+    compile(group: 'api', name: 'rf', version: "${api_rf_version}")
+    compile "appeng:Waila:${api_waila_version}:api"
+    compile "appeng:RotaryCraft:${api_rotarycraft_version}:api"
+    compile "appeng:mekanism:${api_mekansim_version}:api"
 
     testCompile "junit:junit:4.11"
 }

--- a/gradle/scripts/propertyloader.gradle
+++ b/gradle/scripts/propertyloader.gradle
@@ -1,9 +1,0 @@
-// define the properties file
-ext.configFile = file "build.properties"
-
-configFile.withReader {
-    // read config.  it shall from now on be referenced as simply config or as project.config
-    def prop = new Properties()
-    prop.load(it)
-    project.ext.config = new ConfigSlurper().parse prop
-}


### PR DESCRIPTION
The proper way to use gradle is to actually use the gradle.properties. It will be automatically read without using a self defined config slurper.

The gradle.properties adds additional convenient options e.g. regarding the VM options and parallel calculation or daemons if needed