### PR TITLE
 Generate a Forge Server side only PlayerInteractEvent before accepting PacketClick or PacketPartPlacement.

### DIFF
--- a/src/main/java/appeng/core/sync/packets/PacketClick.java
+++ b/src/main/java/appeng/core/sync/packets/PacketClick.java
@@ -81,7 +81,6 @@ public class PacketClick extends AppEngPacket
 	@Override
 	public void serverPacketData( INetworkInfo manager, AppEngPacket packet, EntityPlayer player )
 	{
-<<<<<<< HEAD
 		ItemStack is = player.inventory.getCurrentItem();
 		final IItems items = AEApi.instance().definitions().items();
 		final IComparableDefinition maybeMemoryCard = items.memoryCard();
@@ -90,17 +89,6 @@ public class PacketClick extends AppEngPacket
 		if( is != null )
 		{
 			if( is.getItem() instanceof ToolNetworkTool )
-=======
-		PlayerInteractEvent event = ForgeEventFactory.onPlayerInteract( player, Action.RIGHT_CLICK_BLOCK, this.x, this.y, this.z, this.side, player.worldObj );
-		if ( !event.isCanceled() )
-		{
-			ItemStack is = player.inventory.getCurrentItem();
-			final IItems items = AEApi.instance().definitions().items();
-			final IComparableDefinition maybeMemoryCard = items.memoryCard();
-			final IComparableDefinition maybeColorApplicator = items.colorApplicator();
-	
-			if( is != null )
->>>>>>> branch 'master' of https://github.com/krwminer/Applied-Energistics-2.git
 			{
 				PlayerInteractEvent event = ForgeEventFactory.onPlayerInteract( player, Action.RIGHT_CLICK_BLOCK, this.x, this.y, this.z, this.side, player.worldObj );
 				if ( !event.isCanceled() )
@@ -109,7 +97,6 @@ public class PacketClick extends AppEngPacket
 					tnt.serverSideToolLogic( is, player, player.worldObj, this.x, this.y, this.z, this.side, this.hitX, this.hitY, this.hitZ );
 				}
 			}
-<<<<<<< HEAD
 
 			else if( maybeMemoryCard.isSameAs( is ) )
 			{
@@ -123,8 +110,6 @@ public class PacketClick extends AppEngPacket
 				ToolColorApplicator mem = (ToolColorApplicator) is.getItem();
 				mem.cycleColors( is, mem.getColor( is ), 1 );
 			}
-=======
->>>>>>> branch 'master' of https://github.com/krwminer/Applied-Energistics-2.git
 		}
 	}
 }

--- a/src/main/java/appeng/core/sync/packets/PacketClick.java
+++ b/src/main/java/appeng/core/sync/packets/PacketClick.java
@@ -81,9 +81,9 @@ public class PacketClick extends AppEngPacket
 	@Override
 	public void serverPacketData( INetworkInfo manager, AppEngPacket packet, EntityPlayer player )
 	{
-        PlayerInteractEvent event = ForgeEventFactory.onPlayerInteract(player, Action.RIGHT_CLICK_BLOCK, this.x, this.y, this.z, this.side, player.worldObj);
-        if (!event.isCanceled())
-        {
+		PlayerInteractEvent event = ForgeEventFactory.onPlayerInteract( player, Action.RIGHT_CLICK_BLOCK, this.x, this.y, this.z, this.side, player.worldObj );
+		if ( !event.isCanceled() )
+		{
 			ItemStack is = player.inventory.getCurrentItem();
 			final IItems items = AEApi.instance().definitions().items();
 			final IComparableDefinition maybeMemoryCard = items.memoryCard();
@@ -110,6 +110,6 @@ public class PacketClick extends AppEngPacket
 					mem.cycleColors( is, mem.getColor( is ), 1 );
 				}
 			}
-        }
+        	}
 	}
 }

--- a/src/main/java/appeng/core/sync/packets/PacketClick.java
+++ b/src/main/java/appeng/core/sync/packets/PacketClick.java
@@ -110,6 +110,6 @@ public class PacketClick extends AppEngPacket
 					mem.cycleColors( is, mem.getColor( is ), 1 );
 				}
 			}
-        	}
+		}
 	}
 }

--- a/src/main/java/appeng/core/sync/packets/PacketClick.java
+++ b/src/main/java/appeng/core/sync/packets/PacketClick.java
@@ -81,6 +81,16 @@ public class PacketClick extends AppEngPacket
 	@Override
 	public void serverPacketData( INetworkInfo manager, AppEngPacket packet, EntityPlayer player )
 	{
+<<<<<<< HEAD
+		ItemStack is = player.inventory.getCurrentItem();
+		final IItems items = AEApi.instance().definitions().items();
+		final IComparableDefinition maybeMemoryCard = items.memoryCard();
+		final IComparableDefinition maybeColorApplicator = items.colorApplicator();
+
+		if( is != null )
+		{
+			if( is.getItem() instanceof ToolNetworkTool )
+=======
 		PlayerInteractEvent event = ForgeEventFactory.onPlayerInteract( player, Action.RIGHT_CLICK_BLOCK, this.x, this.y, this.z, this.side, player.worldObj );
 		if ( !event.isCanceled() )
 		{
@@ -90,26 +100,31 @@ public class PacketClick extends AppEngPacket
 			final IComparableDefinition maybeColorApplicator = items.colorApplicator();
 	
 			if( is != null )
+>>>>>>> branch 'master' of https://github.com/krwminer/Applied-Energistics-2.git
 			{
-				if( is.getItem() instanceof ToolNetworkTool )
+				PlayerInteractEvent event = ForgeEventFactory.onPlayerInteract( player, Action.RIGHT_CLICK_BLOCK, this.x, this.y, this.z, this.side, player.worldObj );
+				if ( !event.isCanceled() )
 				{
 					ToolNetworkTool tnt = (ToolNetworkTool) is.getItem();
 					tnt.serverSideToolLogic( is, player, player.worldObj, this.x, this.y, this.z, this.side, this.hitX, this.hitY, this.hitZ );
 				}
-	
-				else if( maybeMemoryCard.isSameAs( is ) )
-				{
-					IMemoryCard mem = (IMemoryCard) is.getItem();
-					mem.notifyUser( player, MemoryCardMessages.SETTINGS_CLEARED );
-					is.setTagCompound( null );
-				}
-	
-				else if( maybeColorApplicator.isSameAs( is ) )
-				{
-					ToolColorApplicator mem = (ToolColorApplicator) is.getItem();
-					mem.cycleColors( is, mem.getColor( is ), 1 );
-				}
 			}
+<<<<<<< HEAD
+
+			else if( maybeMemoryCard.isSameAs( is ) )
+			{
+				IMemoryCard mem = (IMemoryCard) is.getItem();
+				mem.notifyUser( player, MemoryCardMessages.SETTINGS_CLEARED );
+				is.setTagCompound( null );
+			}
+
+			else if( maybeColorApplicator.isSameAs( is ) )
+			{
+				ToolColorApplicator mem = (ToolColorApplicator) is.getItem();
+				mem.cycleColors( is, mem.getColor( is ), 1 );
+			}
+=======
+>>>>>>> branch 'master' of https://github.com/krwminer/Applied-Energistics-2.git
 		}
 	}
 }

--- a/src/main/java/appeng/core/sync/packets/PacketPartPlacement.java
+++ b/src/main/java/appeng/core/sync/packets/PacketPartPlacement.java
@@ -71,14 +71,14 @@ public class PacketPartPlacement extends AppEngPacket
 	@Override
 	public void serverPacketData( INetworkInfo manager, AppEngPacket packet, EntityPlayer player )
 	{
-        PlayerInteractEvent event = ForgeEventFactory.onPlayerInteract(player, Action.RIGHT_CLICK_BLOCK, this.x, this.y, this.z, this.face, player.worldObj);
-        if (!event.isCanceled())
-        {
-    		EntityPlayerMP sender = (EntityPlayerMP) player;
-    		CommonHelper.proxy.updateRenderMode( sender );
-    		PartPlacement.eyeHeight = this.eyeHeight;
-    		PartPlacement.place( sender.getHeldItem(), this.x, this.y, this.z, this.face, sender, sender.worldObj, PartPlacement.PlaceType.INTERACT_FIRST_PASS, 0 );
-    		CommonHelper.proxy.updateRenderMode( null );
-        }
+		PlayerInteractEvent event = ForgeEventFactory.onPlayerInteract( player, Action.RIGHT_CLICK_BLOCK, this.x, this.y, this.z, this.face, player.worldObj );
+		if ( !event.isCanceled() )
+		{
+			EntityPlayerMP sender = (EntityPlayerMP) player;
+			CommonHelper.proxy.updateRenderMode( sender );
+			PartPlacement.eyeHeight = this.eyeHeight;
+			PartPlacement.place( sender.getHeldItem(), this.x, this.y, this.z, this.face, sender, sender.worldObj, PartPlacement.PlaceType.INTERACT_FIRST_PASS, 0 );
+			CommonHelper.proxy.updateRenderMode( null );
+		}
 	}
 }

--- a/src/main/java/appeng/core/sync/packets/PacketPartPlacement.java
+++ b/src/main/java/appeng/core/sync/packets/PacketPartPlacement.java
@@ -21,10 +21,13 @@ package appeng.core.sync.packets;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-
+import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
-
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.ForgeEventFactory;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent.Action;
 import appeng.core.CommonHelper;
 import appeng.core.sync.AppEngPacket;
 import appeng.core.sync.network.INetworkInfo;
@@ -68,10 +71,14 @@ public class PacketPartPlacement extends AppEngPacket
 	@Override
 	public void serverPacketData( INetworkInfo manager, AppEngPacket packet, EntityPlayer player )
 	{
-		EntityPlayerMP sender = (EntityPlayerMP) player;
-		CommonHelper.proxy.updateRenderMode( sender );
-		PartPlacement.eyeHeight = this.eyeHeight;
-		PartPlacement.place( sender.getHeldItem(), this.x, this.y, this.z, this.face, sender, sender.worldObj, PartPlacement.PlaceType.INTERACT_FIRST_PASS, 0 );
-		CommonHelper.proxy.updateRenderMode( null );
+        PlayerInteractEvent event = ForgeEventFactory.onPlayerInteract(player, Action.RIGHT_CLICK_BLOCK, this.x, this.y, this.z, this.face, player.worldObj);
+        if (!event.isCanceled())
+        {
+    		EntityPlayerMP sender = (EntityPlayerMP) player;
+    		CommonHelper.proxy.updateRenderMode( sender );
+    		PartPlacement.eyeHeight = this.eyeHeight;
+    		PartPlacement.place( sender.getHeldItem(), this.x, this.y, this.z, this.face, sender, sender.worldObj, PartPlacement.PlaceType.INTERACT_FIRST_PASS, 0 );
+    		CommonHelper.proxy.updateRenderMode( null );
+        }
 	}
 }

--- a/src/main/java/appeng/util/Platform.java
+++ b/src/main/java/appeng/util/Platform.java
@@ -77,6 +77,8 @@ import net.minecraft.world.chunk.Chunk;
 import net.minecraftforge.common.util.FakePlayerFactory;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.oredict.OreDictionary;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.world.BlockEvent;
 
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Loader;
@@ -387,7 +389,20 @@ public class Platform
 
 	public static boolean hasPermissions( DimensionalCoord dc, EntityPlayer player )
 	{
-		return dc.getWorld().canMineBlock( player, dc.x, dc.y, dc.z );
+		World world = dc.getWorld();
+
+		if ( !world.canMineBlock( player, dc.x, dc.y, dc.z ) )
+		{
+			return false;
+		}
+
+		Block block = world.getBlock( dc.x, dc.y, dc.z );
+		int meta = world.getBlockMetadata( dc.x, dc.y, dc.z );
+
+		BlockEvent.BreakEvent breakEvent = new BlockEvent.BreakEvent( dc.x, dc.y, dc.z, world, block, meta,	player );
+		MinecraftForge.EVENT_BUS.post(breakEvent);
+		
+		return !breakEvent.isCanceled();
 	}
 
 	/*

--- a/src/main/java/appeng/util/Platform.java
+++ b/src/main/java/appeng/util/Platform.java
@@ -77,8 +77,6 @@ import net.minecraft.world.chunk.Chunk;
 import net.minecraftforge.common.util.FakePlayerFactory;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.oredict.OreDictionary;
-import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.event.world.BlockEvent;
 
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Loader;

--- a/src/main/java/appeng/util/Platform.java
+++ b/src/main/java/appeng/util/Platform.java
@@ -389,20 +389,7 @@ public class Platform
 
 	public static boolean hasPermissions( DimensionalCoord dc, EntityPlayer player )
 	{
-		World world = dc.getWorld();
-
-		if ( !world.canMineBlock( player, dc.x, dc.y, dc.z ) )
-		{
-			return false;
-		}
-
-		Block block = world.getBlock( dc.x, dc.y, dc.z );
-		int meta = world.getBlockMetadata( dc.x, dc.y, dc.z );
-
-		BlockEvent.BreakEvent breakEvent = new BlockEvent.BreakEvent( dc.x, dc.y, dc.z, world, block, meta,	player );
-		MinecraftForge.EVENT_BUS.post(breakEvent);
-		
-		return !breakEvent.isCanceled();
+		return dc.getWorld().canMineBlock( player, dc.x, dc.y, dc.z );
 	}
 
 	/*


### PR DESCRIPTION
Since AE2 bypasses the normal server side playerInteract() Event that
can be used by Forge protection mods like MyTown2, this surfaces a Forge
protection event where AE2 is aleady doing a permission check.