### PR TITLE
Splits AEBaseBlock into AEBaseBlock + AEBaseTileBlock

### DIFF
--- a/src/api/java/appeng/api/definitions/IBlocks.java
+++ b/src/api/java/appeng/api/definitions/IBlocks.java
@@ -106,7 +106,7 @@ public interface IBlocks
 
 	ITileDefinition charger();
 
-	ITileDefinition tinyTNT();
+	IBlockDefinition tinyTNT();
 
 	ITileDefinition security();
 

--- a/src/main/java/appeng/block/AEBaseBlock.java
+++ b/src/main/java/appeng/block/AEBaseBlock.java
@@ -22,27 +22,19 @@ package appeng.block;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
-import javax.annotation.Nullable;
 
 import com.google.common.base.Optional;
-import com.google.common.collect.Lists;
 
 import net.minecraft.block.Block;
-import net.minecraft.block.BlockContainer;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.client.resources.IResource;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.Entity;
-import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.inventory.Container;
-import net.minecraft.inventory.IInventory;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.MovingObjectPosition;
@@ -52,17 +44,11 @@ import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import cpw.mods.fml.relauncher.ReflectionHelper;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
-import appeng.api.implementations.items.IMemoryCard;
-import appeng.api.implementations.items.MemoryCardMessages;
-import appeng.api.implementations.tiles.IColorableTile;
-import appeng.api.util.AEColor;
 import appeng.api.util.IOrientable;
 import appeng.api.util.IOrientableBlock;
-import appeng.block.networking.BlockCableBus;
 import appeng.client.render.BaseBlockRender;
 import appeng.client.render.BlockRenderInfo;
 import appeng.client.render.WorldRender;
@@ -73,33 +59,23 @@ import appeng.core.features.AEFeature;
 import appeng.core.features.FeatureNameExtractor;
 import appeng.core.features.IAEFeature;
 import appeng.core.features.IFeatureHandler;
-import appeng.core.features.ItemStackSrc;
 import appeng.helpers.AEGlassMaterial;
 import appeng.helpers.ICustomCollision;
-import appeng.tile.AEBaseTile;
-import appeng.tile.networking.TileCableBus;
-import appeng.tile.storage.TileSkyChest;
 import appeng.util.LookDirection;
 import appeng.util.Platform;
-import appeng.util.SettingsFrom;
 
 
-public class AEBaseBlock extends BlockContainer implements IAEFeature
+public abstract class AEBaseBlock extends Block implements IAEFeature
 {
 	private final String featureFullName;
-	private final Optional<String> featureSubName;
-	@SideOnly( Side.CLIENT )
-	public IIcon renderIcon;
+	protected final Optional<String> featureSubName;
 	protected boolean isOpaque = true;
 	protected boolean isFullSize = true;
 	protected boolean hasSubtypes = false;
 	protected boolean isInventory = false;
+	private IFeatureHandler handler;
 	@SideOnly( Side.CLIENT )
 	BlockRenderInfo renderInfo;
-	private IFeatureHandler handler;
-
-	@Nullable
-	private Class<? extends TileEntity> tileEntityType = null;
 
 	protected AEBaseBlock( Material mat )
 	{
@@ -107,7 +83,6 @@ public class AEBaseBlock extends BlockContainer implements IAEFeature
 		this.setLightOpacity( 255 );
 		this.setLightLevel( 0 );
 		this.setHardness( 2.2F );
-		this.setTileProvider( false );
 		this.setHarvestLevel( "pickaxe", 0 );
 	}
 
@@ -136,12 +111,6 @@ public class AEBaseBlock extends BlockContainer implements IAEFeature
 		this.featureSubName = subName;
 	}
 
-	// update Block value.
-	private void setTileProvider( boolean b )
-	{
-		ReflectionHelper.setPrivateValue( Block.class, this, b, "isTileProvider" );
-	}
-
 	@Override
 	public String toString()
 	{
@@ -150,8 +119,8 @@ public class AEBaseBlock extends BlockContainer implements IAEFeature
 
 	public void registerNoIcons()
 	{
-		BlockRenderInfo info = this.getRendererInstance();
-		FlippableIcon i = new FlippableIcon( new MissingIcon( this ) );
+		final BlockRenderInfo info = this.getRendererInstance();
+		final FlippableIcon i = new FlippableIcon( new MissingIcon( this ) );
 		info.updateIcons( i, i, i, i, i, i );
 	}
 
@@ -170,7 +139,7 @@ public class AEBaseBlock extends BlockContainer implements IAEFeature
 
 			return this.renderInfo;
 		}
-		catch ( InstantiationException e )
+		catch( InstantiationException e )
 		{
 			throw new IllegalStateException( "Failed to create a new instance of an illegal class " + this.getRenderer(), e );
 		}
@@ -191,29 +160,21 @@ public class AEBaseBlock extends BlockContainer implements IAEFeature
 		return super.getIcon( w, x, y, z, s );
 	}
 
-	protected void setTileEntity( Class<? extends TileEntity> c )
-	{
-		this.tileEntityType = c;
-
-		AEBaseTile.registerTileItem( c, new ItemStackSrc( this, 0 ) );
-		this.isInventory = IInventory.class.isAssignableFrom( c );
-		this.setTileProvider( this.hasBlockTileEntity() );
-	}
-
-	public boolean hasBlockTileEntity()
-	{
-		return this.tileEntityType != null;
-	}
-
 	protected void setFeature( EnumSet<AEFeature> f )
 	{
-		this.handler = new AEBlockFeatureHandler( f, this, this.featureSubName );
+		final AEBlockFeatureHandler featureHandler = new AEBlockFeatureHandler( f, this, this.featureSubName );
+		this.setHandler( featureHandler );
 	}
 
 	@Override
 	public final IFeatureHandler handler()
 	{
 		return this.handler;
+	}
+
+	protected final void setHandler( IFeatureHandler handler )
+	{
+		this.handler = handler;
 	}
 
 	@Override
@@ -250,12 +211,16 @@ public class AEBaseBlock extends BlockContainer implements IAEFeature
 	@SideOnly( Side.CLIENT )
 	public IIcon getIcon( int direction, int metadata )
 	{
-		if( this.renderIcon != null )
-		{
-			return this.renderIcon;
-		}
-
 		return this.getRendererInstance().getTexture( ForgeDirection.getOrientation( direction ) );
+	}
+
+	protected ICustomCollision getCustomCollision( World w, int x, int y, int z )
+	{
+		if( this instanceof ICustomCollision )
+		{
+			return (ICustomCollision) this;
+		}
+		return null;
 	}
 
 	@Override
@@ -263,20 +228,7 @@ public class AEBaseBlock extends BlockContainer implements IAEFeature
 	// NOTE: WAS FINAL, changed for Immibis
 	public void addCollisionBoxesToList( World w, int x, int y, int z, AxisAlignedBB bb, List out, Entity e )
 	{
-		ICustomCollision collisionHandler = null;
-
-		if( this instanceof ICustomCollision )
-		{
-			collisionHandler = (ICustomCollision) this;
-		}
-		else
-		{
-			AEBaseTile te = this.getTileEntity( w, x, y, z );
-			if( te instanceof ICustomCollision )
-			{
-				collisionHandler = (ICustomCollision) te;
-			}
-		}
+		final ICustomCollision collisionHandler = this.getCustomCollision( w, x, y, z );
 
 		if( collisionHandler != null && bb != null )
 		{
@@ -306,30 +258,16 @@ public class AEBaseBlock extends BlockContainer implements IAEFeature
 	@SideOnly( Side.CLIENT )
 	public final AxisAlignedBB getSelectedBoundingBoxFromPool( World w, int x, int y, int z )
 	{
-		ICustomCollision collisionHandler = null;
-		AxisAlignedBB b = null;
-
-		if( this instanceof ICustomCollision )
-		{
-			collisionHandler = (ICustomCollision) this;
-		}
-		else
-		{
-			AEBaseTile te = this.getTileEntity( w, x, y, z );
-			if( te instanceof ICustomCollision )
-			{
-				collisionHandler = (ICustomCollision) te;
-			}
-		}
+		final ICustomCollision collisionHandler = this.getCustomCollision( w, x, y, z );
 
 		if( collisionHandler != null )
 		{
 			if( Platform.isClient() )
 			{
-				EntityPlayer player = Minecraft.getMinecraft().thePlayer;
-				LookDirection ld = Platform.getPlayerRay( player, Platform.getEyeOffset( player ) );
+				final EntityPlayer player = Minecraft.getMinecraft().thePlayer;
+				final LookDirection ld = Platform.getPlayerRay( player, Platform.getEyeOffset( player ) );
 
-				Iterable<AxisAlignedBB> bbs = collisionHandler.getSelectedBoundingBoxesFromPool( w, x, y, z, Minecraft.getMinecraft().thePlayer, true );
+				final Iterable<AxisAlignedBB> bbs = collisionHandler.getSelectedBoundingBoxesFromPool( w, x, y, z, Minecraft.getMinecraft().thePlayer, true );
 				AxisAlignedBB br = null;
 
 				double lastDist = 0;
@@ -344,11 +282,12 @@ public class AEBaseBlock extends BlockContainer implements IAEFeature
 
 					if( r != null )
 					{
-						double xLen = ( ld.a.xCoord - r.hitVec.xCoord );
-						double yLen = ( ld.a.yCoord - r.hitVec.yCoord );
-						double zLen = ( ld.a.zCoord - r.hitVec.zCoord );
+						final double xLen = ( ld.a.xCoord - r.hitVec.xCoord );
+						final double yLen = ( ld.a.yCoord - r.hitVec.yCoord );
+						final double zLen = ( ld.a.zCoord - r.hitVec.zCoord );
 
-						double thisDist = xLen * xLen + yLen * yLen + zLen * zLen;
+						final double thisDist = xLen * xLen + yLen * yLen + zLen * zLen;
+
 						if( br == null || lastDist > thisDist )
 						{
 							lastDist = thisDist;
@@ -364,32 +303,26 @@ public class AEBaseBlock extends BlockContainer implements IAEFeature
 				}
 			}
 
+			final AxisAlignedBB b = AxisAlignedBB.getBoundingBox( 16d, 16d, 16d, 0d, 0d, 0d );
+
 			for( AxisAlignedBB bx : collisionHandler.getSelectedBoundingBoxesFromPool( w, x, y, z, null, false ) )
 			{
-				if( b == null )
-				{
-					b = bx;
-				}
-				else
-				{
-					double minX = Math.min( b.minX, bx.minX );
-					double minY = Math.min( b.minY, bx.minY );
-					double minZ = Math.min( b.minZ, bx.minZ );
-					double maxX = Math.max( b.maxX, bx.maxX );
-					double maxY = Math.max( b.maxY, bx.maxY );
-					double maxZ = Math.max( b.maxZ, bx.maxZ );
-					b.setBounds( minX, minY, minZ, maxX, maxY, maxZ );
-				}
+				final double minX = Math.min( b.minX, bx.minX );
+				final double minY = Math.min( b.minY, bx.minY );
+				final double minZ = Math.min( b.minZ, bx.minZ );
+				final double maxX = Math.max( b.maxX, bx.maxX );
+				final double maxY = Math.max( b.maxY, bx.maxY );
+				final double maxZ = Math.max( b.maxZ, bx.maxZ );
+
+				b.setBounds( minX, minY, minZ, maxX, maxY, maxZ );
 			}
 
 			b.setBounds( b.minX + x, b.minY + y, b.minZ + z, b.maxX + x, b.maxY + y, b.maxZ + z );
-		}
-		else
-		{
-			b = super.getSelectedBoundingBoxFromPool( w, x, y, z );
+
+			return b;
 		}
 
-		return b;
+		return super.getSelectedBoundingBoxFromPool( w, x, y, z );
 	}
 
 	@Override
@@ -401,24 +334,11 @@ public class AEBaseBlock extends BlockContainer implements IAEFeature
 	@Override
 	public MovingObjectPosition collisionRayTrace( World w, int x, int y, int z, Vec3 a, Vec3 b )
 	{
-		ICustomCollision collisionHandler = null;
-
-		if( this instanceof ICustomCollision )
-		{
-			collisionHandler = (ICustomCollision) this;
-		}
-		else
-		{
-			AEBaseTile te = this.getTileEntity( w, x, y, z );
-			if( te instanceof ICustomCollision )
-			{
-				collisionHandler = (ICustomCollision) te;
-			}
-		}
+		final ICustomCollision collisionHandler = this.getCustomCollision( w, x, y, z );
 
 		if( collisionHandler != null )
 		{
-			Iterable<AxisAlignedBB> bbs = collisionHandler.getSelectedBoundingBoxesFromPool( w, x, y, z, null, true );
+			final Iterable<AxisAlignedBB> bbs = collisionHandler.getSelectedBoundingBoxesFromPool( w, x, y, z, null, true );
 			MovingObjectPosition br = null;
 
 			double lastDist = 0;
@@ -450,6 +370,7 @@ public class AEBaseBlock extends BlockContainer implements IAEFeature
 			{
 				return br;
 			}
+
 			return null;
 		}
 
@@ -457,112 +378,9 @@ public class AEBaseBlock extends BlockContainer implements IAEFeature
 		return super.collisionRayTrace( w, x, y, z, a, b );
 	}
 
-	@Override
-	public final boolean onBlockActivated( World w, int x, int y, int z, EntityPlayer player, int side, float hitX, float hitY, float hitZ )
-	{
-		if( player != null )
-		{
-			ItemStack is = player.inventory.getCurrentItem();
-			if( is != null )
-			{
-				if( Platform.isWrench( player, is, x, y, z ) && player.isSneaking() )
-				{
-					Block id = w.getBlock( x, y, z );
-					if( id != null )
-					{
-						AEBaseTile tile = this.getTileEntity( w, x, y, z );
-						ItemStack[] drops = Platform.getBlockDrops( w, x, y, z );
-
-						if( tile == null )
-						{
-							return false;
-						}
-
-						if( tile instanceof TileCableBus || tile instanceof TileSkyChest )
-						{
-							return false;
-						}
-
-						ItemStack op = new ItemStack( this );
-						for( ItemStack ol : drops )
-						{
-							if( Platform.isSameItemType( ol, op ) )
-							{
-								NBTTagCompound tag = tile.downloadSettings( SettingsFrom.DISMANTLE_ITEM );
-								if( tag != null )
-								{
-									ol.setTagCompound( tag );
-								}
-							}
-						}
-
-						if( id.removedByPlayer( w, player, x, y, z, false ) )
-						{
-							List<ItemStack> l = Lists.newArrayList( drops );
-							Platform.spawnDrops( w, x, y, z, l );
-							w.setBlockToAir( x, y, z );
-						}
-					}
-					return false;
-				}
-
-				if( is.getItem() instanceof IMemoryCard && !( this instanceof BlockCableBus ) )
-				{
-					IMemoryCard memoryCard = (IMemoryCard) is.getItem();
-					if( player.isSneaking() )
-					{
-						AEBaseTile t = this.getTileEntity( w, x, y, z );
-						if( t != null )
-						{
-							String name = this.getUnlocalizedName();
-							NBTTagCompound data = t.downloadSettings( SettingsFrom.MEMORY_CARD );
-							if( data != null )
-							{
-								memoryCard.setMemoryCardContents( is, name, data );
-								memoryCard.notifyUser( player, MemoryCardMessages.SETTINGS_SAVED );
-								return true;
-							}
-						}
-					}
-					else
-					{
-						String name = memoryCard.getSettingsName( is );
-						NBTTagCompound data = memoryCard.getData( is );
-						if( this.getUnlocalizedName().equals( name ) )
-						{
-							AEBaseTile t = this.getTileEntity( w, x, y, z );
-							t.uploadSettings( SettingsFrom.MEMORY_CARD, data );
-							memoryCard.notifyUser( player, MemoryCardMessages.SETTINGS_LOADED );
-						}
-						else
-						{
-							memoryCard.notifyUser( player, MemoryCardMessages.INVALID_MACHINE );
-						}
-						return false;
-					}
-				}
-			}
-		}
-
-		return this.onActivated( w, x, y, z, player, side, hitX, hitY, hitZ );
-	}
-
 	public boolean onActivated( World w, int x, int y, int z, EntityPlayer player, int side, float hitX, float hitY, float hitZ )
 	{
 		return false;
-	}
-
-	@Override
-	public void onBlockPlacedBy( World w, int x, int y, int z, EntityLivingBase player, ItemStack is )
-	{
-		if( is.hasDisplayName() )
-		{
-			TileEntity te = this.getTileEntity( w, x, y, z );
-			if( te instanceof AEBaseTile )
-			{
-				( (AEBaseTile) w.getTileEntity( x, y, z ) ).setName( is.getDisplayName() );
-			}
-		}
 	}
 
 	@Override
@@ -582,11 +400,6 @@ public class AEBaseBlock extends BlockContainer implements IAEFeature
 	@Override
 	public int getComparatorInputOverride( World w, int x, int y, int z, int s )
 	{
-		TileEntity te = this.getTileEntity( w, x, y, z );
-		if( te instanceof IInventory )
-		{
-			return Container.calcRedstoneFromInventory( (IInventory) te );
-		}
 		return 0;
 	}
 
@@ -594,14 +407,14 @@ public class AEBaseBlock extends BlockContainer implements IAEFeature
 	@SideOnly( Side.CLIENT )
 	public void registerBlockIcons( IIconRegister iconRegistry )
 	{
-		BlockRenderInfo info = this.getRendererInstance();
-		FlippableIcon topIcon;
-		FlippableIcon bottomIcon;
-		FlippableIcon sideIcon;
-		FlippableIcon eastIcon;
-		FlippableIcon westIcon;
-		FlippableIcon southIcon;
-		FlippableIcon northIcon;
+		final BlockRenderInfo info = this.getRendererInstance();
+		final FlippableIcon topIcon;
+		final FlippableIcon bottomIcon;
+		final FlippableIcon sideIcon;
+		final FlippableIcon eastIcon;
+		final FlippableIcon westIcon;
+		final FlippableIcon southIcon;
+		final FlippableIcon northIcon;
 
 		this.blockIcon = topIcon = this.optionalIcon( iconRegistry, this.getTextureName(), null );
 		bottomIcon = this.optionalIcon( iconRegistry, this.getTextureName() + "Bottom", topIcon );
@@ -620,19 +433,19 @@ public class AEBaseBlock extends BlockContainer implements IAEFeature
 		return this.isFullSize;
 	}
 
+	public IOrientable getOrientable( IBlockAccess w, int x, int y, int z )
+	{
+		if( this instanceof IOrientableBlock )
+		{
+			return ( (IOrientableBlock) this ).getOrientable( w, x, y, z );
+		}
+		return null;
+	}
+
 	@Override
 	public final boolean rotateBlock( World w, int x, int y, int z, ForgeDirection axis )
 	{
-		IOrientable rotatable = null;
-
-		if( this.hasBlockTileEntity() )
-		{
-			rotatable = (IOrientable) this.getTileEntity( w, x, y, z );
-		}
-		else if( this instanceof IOrientableBlock )
-		{
-			rotatable = ( (IOrientableBlock) this ).getOrientable( w, x, y, z );
-		}
+		final IOrientable rotatable = this.getOrientable( w, x, y, z );
 
 		if( rotatable != null && rotatable.canBeRotated() )
 		{
@@ -679,40 +492,9 @@ public class AEBaseBlock extends BlockContainer implements IAEFeature
 	}
 
 	@Override
-	public final ForgeDirection[] getValidRotations( World w, int x, int y, int z )
+	public ForgeDirection[] getValidRotations( World w, int x, int y, int z )
 	{
-		if( this.hasBlockTileEntity() )
-		{
-			AEBaseTile obj = this.getTileEntity( w, x, y, z );
-			if( obj != null && obj.canBeRotated() )
-			{
-				return ForgeDirection.VALID_DIRECTIONS;
-			}
-		}
-
 		return new ForgeDirection[0];
-	}
-
-	@Override
-	public boolean recolourBlock( World world, int x, int y, int z, ForgeDirection side, int colour )
-	{
-		TileEntity te = this.getTileEntity( world, x, y, z );
-
-		if( te instanceof IColorableTile )
-		{
-			IColorableTile ct = (IColorableTile) te;
-			AEColor c = ct.getColor();
-			AEColor newColor = AEColor.values()[colour];
-
-			if( c != newColor )
-			{
-				ct.recolourBlock( side, newColor, null );
-				return true;
-			}
-			return false;
-		}
-
-		return super.recolourBlock( world, x, y, z, side, colour );
 	}
 
 	@SideOnly( Side.CLIENT )
@@ -754,16 +536,7 @@ public class AEBaseBlock extends BlockContainer implements IAEFeature
 
 	int mapRotation( IBlockAccess w, int x, int y, int z, int s )
 	{
-		IOrientable ori = null;
-
-		if( this.hasBlockTileEntity() )
-		{
-			ori = (IOrientable) this.getTileEntity( w, x, y, z );
-		}
-		else if( this instanceof IOrientableBlock )
-		{
-			ori = ( (IOrientableBlock) this ).getOrientable( w, x, y, z );
-		}
+		final IOrientable ori = this.getOrientable( w, x, y, z );
 
 		if( ori != null && ori.canBeRotated() )
 		{
@@ -771,23 +544,6 @@ public class AEBaseBlock extends BlockContainer implements IAEFeature
 		}
 
 		return s;
-	}
-
-	@Nullable
-	public <T extends TileEntity> T getTileEntity( IBlockAccess w, int x, int y, int z )
-	{
-		if( !this.hasBlockTileEntity() )
-		{
-			return null;
-		}
-
-		TileEntity te = w.getTileEntity( x, y, z );
-		if( this.tileEntityType.isInstance( te ) )
-		{
-			return (T) te;
-		}
-
-		return null;
 	}
 
 	public ForgeDirection mapRotation( IOrientable ori, ForgeDirection dir )
@@ -799,8 +555,8 @@ public class AEBaseBlock extends BlockContainer implements IAEFeature
 		// case WEST: return sideIcon;
 		// case EAST: return sideIcon;
 
-		ForgeDirection forward = ori.getForward();
-		ForgeDirection up = ori.getUp();
+		final ForgeDirection forward = ori.getForward();
+		final ForgeDirection up = ori.getUp();
 		ForgeDirection west = ForgeDirection.UNKNOWN;
 
 		if( forward == null || up == null )
@@ -850,64 +606,10 @@ public class AEBaseBlock extends BlockContainer implements IAEFeature
 		return ForgeDirection.UNKNOWN;
 	}
 
-	public Class<? extends TileEntity> getTileEntityClass()
-	{
-		return this.tileEntityType;
-	}
-
 	@SideOnly( Side.CLIENT )
 	public void setRenderStateByMeta( int itemDamage )
 	{
 
-	}
-
-	@Override
-	public final TileEntity createNewTileEntity( World var1, int var2 )
-	{
-		if( this.hasBlockTileEntity() )
-		{
-			try
-			{
-				return this.tileEntityType.newInstance();
-			}
-			catch( InstantiationException e )
-			{
-				throw new IllegalStateException( "Failed to create a new instance of an illegal class " + this.tileEntityType , e );
-			}
-			catch( IllegalAccessException e )
-			{
-				throw new IllegalStateException( "Failed to create a new instance of " + this.tileEntityType + ", because lack of permissions", e );
-			}
-		}
-
-		return null;
-	}
-
-	@Override
-	public void breakBlock( World w, int x, int y, int z, Block a, int b )
-	{
-		AEBaseTile te = this.getTileEntity( w, x, y, z );
-		if( te != null )
-		{
-			ArrayList<ItemStack> drops = new ArrayList<ItemStack>();
-			if( te.dropItems() )
-			{
-				te.getDrops( w, x, y, z, drops );
-			}
-			else
-			{
-				te.getNoDrops( w, x, y, z, drops );
-			}
-
-			// Cry ;_; ...
-			Platform.spawnDrops( w, x, y, z, drops );
-		}
-
-		super.breakBlock( w, x, y, z, a, b );
-		if( te != null )
-		{
-			w.setTileEntity( x, y, z, null );
-		}
 	}
 
 	public String getUnlocalizedName( ItemStack is )
@@ -929,4 +631,5 @@ public class AEBaseBlock extends BlockContainer implements IAEFeature
 	{
 		return this.hasSubtypes;
 	}
+
 }

--- a/src/main/java/appeng/block/AEBaseItemBlock.java
+++ b/src/main/java/appeng/block/AEBaseItemBlock.java
@@ -47,7 +47,7 @@ import appeng.util.Platform;
 public class AEBaseItemBlock extends ItemBlock
 {
 
-	final AEBaseBlock blockType;
+	private final AEBaseBlock blockType;
 
 	public AEBaseItemBlock( Block id )
 	{
@@ -105,7 +105,7 @@ public class AEBaseItemBlock extends ItemBlock
 
 		IOrientable ori = null;
 
-		if( this.blockType.hasBlockTileEntity() )
+		if( this.blockType instanceof AEBaseTileBlock )
 		{
 			if( this.blockType instanceof BlockLightDetector )
 			{
@@ -185,9 +185,9 @@ public class AEBaseItemBlock extends ItemBlock
 
 		if( super.placeBlockAt( stack, player, w, x, y, z, side, hitX, hitY, hitZ, metadata ) )
 		{
-			if( this.blockType.hasBlockTileEntity() && !( this.blockType instanceof BlockLightDetector ) )
+			if( this.blockType instanceof AEBaseTileBlock && !( this.blockType instanceof BlockLightDetector ) )
 			{
-				AEBaseTile tile = this.blockType.getTileEntity( w, x, y, z );
+				AEBaseTile tile = ( (AEBaseTileBlock) this.blockType ).getTileEntity( w, x, y, z );
 				ori = tile;
 
 				if( tile == null )
@@ -198,7 +198,7 @@ public class AEBaseItemBlock extends ItemBlock
 				if( ori.canBeRotated() && !this.blockType.hasCustomRotation() )
 				{
 					if( ori.getForward() == null || ori.getUp() == null || // null
-							tile.getForward() == ForgeDirection.UNKNOWN || ori.getUp() == ForgeDirection.UNKNOWN )
+					tile.getForward() == ForgeDirection.UNKNOWN || ori.getUp() == ForgeDirection.UNKNOWN )
 					{
 						ori.setOrientation( forward, up );
 					}

--- a/src/main/java/appeng/block/AEBaseItemBlockChargeable.java
+++ b/src/main/java/appeng/block/AEBaseItemBlockChargeable.java
@@ -51,7 +51,7 @@ public class AEBaseItemBlockChargeable extends AEBaseItemBlock implements IAEIte
 	@SideOnly( Side.CLIENT )
 	public void addCheckedInformation( ItemStack itemStack, EntityPlayer player, List<String> toolTip, boolean advancedTooltips )
 	{
-		NBTTagCompound tag = itemStack.getTagCompound();
+		final NBTTagCompound tag = itemStack.getTagCompound();
 		double internalCurrentPower = 0;
 		double internalMaxPower = this.getMaxEnergyCapacity();
 
@@ -60,14 +60,14 @@ public class AEBaseItemBlockChargeable extends AEBaseItemBlock implements IAEIte
 			internalCurrentPower = tag.getDouble( "internalCurrentPower" );
 		}
 
-		double percent = internalCurrentPower / internalMaxPower;
+		final double percent = internalCurrentPower / internalMaxPower;
 
 		toolTip.add( GuiText.StoredEnergy.getLocal() + ':' + MessageFormat.format( " {0,number,#} ", internalCurrentPower ) + Platform.gui_localize( PowerUnits.AE.unlocalizedName ) + " - " + MessageFormat.format( " {0,number,#.##%} ", percent ) );
 	}
 
 	private double getMaxEnergyCapacity()
 	{
-		Block blockID = Block.getBlockFromItem( this );
+		final Block blockID = Block.getBlockFromItem( this );
 		final IBlockDefinition energyCell = Api.INSTANCE.definitions().blocks().energyCell();
 		for( Block block : energyCell.maybeBlock().asSet() )
 		{
@@ -104,13 +104,13 @@ public class AEBaseItemBlockChargeable extends AEBaseItemBlock implements IAEIte
 
 	private double getInternal( ItemStack is )
 	{
-		NBTTagCompound nbt = Platform.openNbtData( is );
+		final NBTTagCompound nbt = Platform.openNbtData( is );
 		return nbt.getDouble( "internalCurrentPower" );
 	}
 
 	private void setInternal( ItemStack is, double amt )
 	{
-		NBTTagCompound nbt = Platform.openNbtData( is );
+		final NBTTagCompound nbt = Platform.openNbtData( is );
 		nbt.setDouble( "internalCurrentPower", amt );
 	}
 

--- a/src/main/java/appeng/block/AEBaseTileBlock.java
+++ b/src/main/java/appeng/block/AEBaseTileBlock.java
@@ -1,0 +1,350 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.block;
+
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.ITileEntityProvider;
+import net.minecraft.block.material.Material;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.Container;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.IBlockAccess;
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
+
+import cpw.mods.fml.relauncher.ReflectionHelper;
+
+import appeng.api.implementations.items.IMemoryCard;
+import appeng.api.implementations.items.MemoryCardMessages;
+import appeng.api.implementations.tiles.IColorableTile;
+import appeng.api.util.AEColor;
+import appeng.api.util.IOrientable;
+import appeng.core.features.AEFeature;
+import appeng.core.features.AETileBlockFeatureHandler;
+import appeng.core.features.IAEFeature;
+import appeng.core.features.ItemStackSrc;
+import appeng.helpers.ICustomCollision;
+import appeng.tile.AEBaseTile;
+import appeng.tile.networking.TileCableBus;
+import appeng.tile.storage.TileSkyChest;
+import appeng.util.Platform;
+import appeng.util.SettingsFrom;
+
+
+public abstract class AEBaseTileBlock extends AEBaseBlock implements IAEFeature, ITileEntityProvider
+{
+
+	@Nonnull
+	private Class<? extends TileEntity> tileEntityType;
+
+	public AEBaseTileBlock( Material mat )
+	{
+		super( mat );
+	}
+
+	protected AEBaseTileBlock( Material mat, Optional<String> subName )
+	{
+		super( mat, subName );
+	}
+
+	@Override
+	protected void setFeature( EnumSet<AEFeature> f )
+	{
+		final AETileBlockFeatureHandler featureHandler = new AETileBlockFeatureHandler( f, this, this.featureSubName );
+		this.setHandler( featureHandler );
+	}
+
+	protected void setTileEntity( Class<? extends TileEntity> c )
+	{
+		this.tileEntityType = c;
+
+		AEBaseTile.registerTileItem( c, new ItemStackSrc( this, 0 ) );
+		this.isInventory = IInventory.class.isAssignableFrom( c );
+		this.setTileProvider( this.hasBlockTileEntity() );
+	}
+
+	// update Block value.
+	private void setTileProvider( boolean b )
+	{
+		ReflectionHelper.setPrivateValue( Block.class, this, b, "isTileProvider" );
+	}
+
+	public boolean hasBlockTileEntity()
+	{
+		return this.tileEntityType != null;
+	}
+
+	public Class<? extends TileEntity> getTileEntityClass()
+	{
+		return this.tileEntityType;
+	}
+
+	@Nullable
+	public <T extends AEBaseTile> T getTileEntity( IBlockAccess w, int x, int y, int z )
+	{
+		if( !this.hasBlockTileEntity() )
+		{
+			return null;
+		}
+
+		final TileEntity te = w.getTileEntity( x, y, z );
+		if( this.tileEntityType.isInstance( te ) )
+		{
+			return (T) te;
+		}
+
+		return null;
+	}
+
+	@Override
+	public final TileEntity createNewTileEntity( World var1, int var2 )
+	{
+		if( this.hasBlockTileEntity() )
+		{
+			try
+			{
+				return this.tileEntityType.newInstance();
+			}
+			catch( InstantiationException e )
+			{
+				throw new IllegalStateException( "Failed to create a new instance of an illegal class " + this.tileEntityType, e );
+			}
+			catch( IllegalAccessException e )
+			{
+				throw new IllegalStateException( "Failed to create a new instance of " + this.tileEntityType + ", because lack of permissions", e );
+			}
+		}
+
+		return null;
+	}
+
+	@Override
+	public void breakBlock( World w, int x, int y, int z, Block a, int b )
+	{
+		final AEBaseTile te = this.getTileEntity( w, x, y, z );
+		if( te != null )
+		{
+			final ArrayList<ItemStack> drops = new ArrayList<ItemStack>();
+			if( te.dropItems() )
+			{
+				te.getDrops( w, x, y, z, drops );
+			}
+			else
+			{
+				te.getNoDrops( w, x, y, z, drops );
+			}
+
+			// Cry ;_; ...
+			Platform.spawnDrops( w, x, y, z, drops );
+		}
+
+		// super will remove the TE, as it is not an instance of BlockContainer
+		super.breakBlock( w, x, y, z, a, b );
+	}
+
+	@Override
+	public final ForgeDirection[] getValidRotations( World w, int x, int y, int z )
+	{
+		final AEBaseTile obj = this.getTileEntity( w, x, y, z );
+		if( obj != null && obj.canBeRotated() )
+		{
+			return ForgeDirection.VALID_DIRECTIONS;
+		}
+
+		return super.getValidRotations( w, x, y, z );
+	}
+
+	@Override
+	public boolean recolourBlock( World world, int x, int y, int z, ForgeDirection side, int colour )
+	{
+		final TileEntity te = this.getTileEntity( world, x, y, z );
+
+		if( te instanceof IColorableTile )
+		{
+			final IColorableTile ct = (IColorableTile) te;
+			final AEColor c = ct.getColor();
+			final AEColor newColor = AEColor.values()[colour];
+
+			if( c != newColor )
+			{
+				ct.recolourBlock( side, newColor, null );
+				return true;
+			}
+			return false;
+		}
+
+		return super.recolourBlock( world, x, y, z, side, colour );
+	}
+
+	@Override
+	public int getComparatorInputOverride( World w, int x, int y, int z, int s )
+	{
+		final TileEntity te = this.getTileEntity( w, x, y, z );
+		if( te instanceof IInventory )
+		{
+			return Container.calcRedstoneFromInventory( (IInventory) te );
+		}
+		return 0;
+	}
+
+	@Override
+	public boolean onBlockEventReceived( World p_149696_1_, int p_149696_2_, int p_149696_3_, int p_149696_4_, int p_149696_5_, int p_149696_6_ )
+	{
+		super.onBlockEventReceived( p_149696_1_, p_149696_2_, p_149696_3_, p_149696_4_, p_149696_5_, p_149696_6_ );
+		final TileEntity tileentity = p_149696_1_.getTileEntity( p_149696_2_, p_149696_3_, p_149696_4_ );
+		return tileentity != null ? tileentity.receiveClientEvent( p_149696_5_, p_149696_6_ ) : false;
+	}
+
+	@Override
+	public void onBlockPlacedBy( World w, int x, int y, int z, EntityLivingBase player, ItemStack is )
+	{
+		if( is.hasDisplayName() )
+		{
+			final TileEntity te = this.getTileEntity( w, x, y, z );
+			if( te instanceof AEBaseTile )
+			{
+				( (AEBaseTile) w.getTileEntity( x, y, z ) ).setName( is.getDisplayName() );
+			}
+		}
+	}
+
+	@Override
+	public final boolean onBlockActivated( World w, int x, int y, int z, EntityPlayer player, int side, float hitX, float hitY, float hitZ )
+	{
+		if( player != null )
+		{
+			final ItemStack is = player.inventory.getCurrentItem();
+			if( is != null )
+			{
+				if( Platform.isWrench( player, is, x, y, z ) && player.isSneaking() )
+				{
+					final Block id = w.getBlock( x, y, z );
+					if( id != null )
+					{
+						final AEBaseTile tile = this.getTileEntity( w, x, y, z );
+						final ItemStack[] drops = Platform.getBlockDrops( w, x, y, z );
+
+						if( tile == null )
+						{
+							return false;
+						}
+
+						if( tile instanceof TileCableBus || tile instanceof TileSkyChest )
+						{
+							return false;
+						}
+
+						final ItemStack op = new ItemStack( this );
+						for( ItemStack ol : drops )
+						{
+							if( Platform.isSameItemType( ol, op ) )
+							{
+								final NBTTagCompound tag = tile.downloadSettings( SettingsFrom.DISMANTLE_ITEM );
+								if( tag != null )
+								{
+									ol.setTagCompound( tag );
+								}
+							}
+						}
+
+						if( id.removedByPlayer( w, player, x, y, z, false ) )
+						{
+							final List<ItemStack> l = Lists.newArrayList( drops );
+							Platform.spawnDrops( w, x, y, z, l );
+							w.setBlockToAir( x, y, z );
+						}
+					}
+					return false;
+				}
+
+				if( is.getItem() instanceof IMemoryCard )
+				{
+					final IMemoryCard memoryCard = (IMemoryCard) is.getItem();
+					if( player.isSneaking() )
+					{
+						final AEBaseTile t = this.getTileEntity( w, x, y, z );
+						if( t != null )
+						{
+							final String name = this.getUnlocalizedName();
+							final NBTTagCompound data = t.downloadSettings( SettingsFrom.MEMORY_CARD );
+							if( data != null )
+							{
+								memoryCard.setMemoryCardContents( is, name, data );
+								memoryCard.notifyUser( player, MemoryCardMessages.SETTINGS_SAVED );
+								return true;
+							}
+						}
+					}
+					else
+					{
+						final String name = memoryCard.getSettingsName( is );
+						final NBTTagCompound data = memoryCard.getData( is );
+						if( this.getUnlocalizedName().equals( name ) )
+						{
+							final AEBaseTile t = this.getTileEntity( w, x, y, z );
+							t.uploadSettings( SettingsFrom.MEMORY_CARD, data );
+							memoryCard.notifyUser( player, MemoryCardMessages.SETTINGS_LOADED );
+						}
+						else
+						{
+							memoryCard.notifyUser( player, MemoryCardMessages.INVALID_MACHINE );
+						}
+						return false;
+					}
+				}
+			}
+		}
+
+		return this.onActivated( w, x, y, z, player, side, hitX, hitY, hitZ );
+	}
+
+	@Override
+	public IOrientable getOrientable( IBlockAccess w, int x, int y, int z )
+	{
+		return this.getTileEntity( w, x, y, z );
+	}
+
+	@Override
+	public ICustomCollision getCustomCollision( World w, int x, int y, int z )
+	{
+		final AEBaseTile te = this.getTileEntity( w, x, y, z );
+		if( te instanceof ICustomCollision )
+		{
+			return (ICustomCollision) te;
+		}
+
+		return super.getCustomCollision( w, x, y, z );
+	}
+
+}

--- a/src/main/java/appeng/block/crafting/BlockCraftingUnit.java
+++ b/src/main/java/appeng/block/crafting/BlockCraftingUnit.java
@@ -35,7 +35,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
-import appeng.block.AEBaseBlock;
+import appeng.block.AEBaseTileBlock;
 import appeng.client.render.BaseBlockRender;
 import appeng.client.render.blocks.RenderBlockCraftingCPU;
 import appeng.client.texture.ExtraBlockTextures;
@@ -45,7 +45,7 @@ import appeng.tile.crafting.TileCraftingTile;
 import appeng.util.Platform;
 
 
-public class BlockCraftingUnit extends AEBaseBlock
+public class BlockCraftingUnit extends AEBaseTileBlock
 {
 	public static final int FLAG_FORMED = 8;
 

--- a/src/main/java/appeng/block/crafting/BlockMolecularAssembler.java
+++ b/src/main/java/appeng/block/crafting/BlockMolecularAssembler.java
@@ -29,7 +29,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
-import appeng.block.AEBaseBlock;
+import appeng.block.AEBaseTileBlock;
 import appeng.client.render.BaseBlockRender;
 import appeng.client.render.blocks.RenderBlockAssembler;
 import appeng.core.features.AEFeature;
@@ -38,7 +38,7 @@ import appeng.tile.crafting.TileMolecularAssembler;
 import appeng.util.Platform;
 
 
-public class BlockMolecularAssembler extends AEBaseBlock
+public class BlockMolecularAssembler extends AEBaseTileBlock
 {
 
 	public static boolean booleanAlphaPass = false;
@@ -46,7 +46,7 @@ public class BlockMolecularAssembler extends AEBaseBlock
 	public BlockMolecularAssembler()
 	{
 		super( Material.iron );
-	
+
 		this.setTileEntity( TileMolecularAssembler.class );
 		this.isOpaque = false;
 		this.lightOpacity = 1;

--- a/src/main/java/appeng/block/grindstone/BlockCrank.java
+++ b/src/main/java/appeng/block/grindstone/BlockCrank.java
@@ -32,7 +32,7 @@ import net.minecraftforge.common.util.FakePlayer;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import appeng.api.implementations.tiles.ICrankable;
-import appeng.block.AEBaseBlock;
+import appeng.block.AEBaseTileBlock;
 import appeng.client.render.BaseBlockRender;
 import appeng.client.render.blocks.RenderBlockCrank;
 import appeng.core.features.AEFeature;
@@ -41,7 +41,7 @@ import appeng.tile.AEBaseTile;
 import appeng.tile.grindstone.TileCrank;
 
 
-public class BlockCrank extends AEBaseBlock
+public class BlockCrank extends AEBaseTileBlock
 {
 
 	public BlockCrank()

--- a/src/main/java/appeng/block/grindstone/BlockGrinder.java
+++ b/src/main/java/appeng/block/grindstone/BlockGrinder.java
@@ -26,14 +26,14 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import appeng.block.AEBaseBlock;
+import appeng.block.AEBaseTileBlock;
 import appeng.core.features.AEFeature;
 import appeng.core.sync.GuiBridge;
 import appeng.tile.grindstone.TileGrinder;
 import appeng.util.Platform;
 
 
-public class BlockGrinder extends AEBaseBlock
+public class BlockGrinder extends AEBaseTileBlock
 {
 
 	public BlockGrinder()

--- a/src/main/java/appeng/block/misc/BlockCellWorkbench.java
+++ b/src/main/java/appeng/block/misc/BlockCellWorkbench.java
@@ -26,14 +26,14 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import appeng.block.AEBaseBlock;
+import appeng.block.AEBaseTileBlock;
 import appeng.core.features.AEFeature;
 import appeng.core.sync.GuiBridge;
 import appeng.tile.misc.TileCellWorkbench;
 import appeng.util.Platform;
 
 
-public class BlockCellWorkbench extends AEBaseBlock
+public class BlockCellWorkbench extends AEBaseTileBlock
 {
 
 	public BlockCellWorkbench()

--- a/src/main/java/appeng/block/misc/BlockCharger.java
+++ b/src/main/java/appeng/block/misc/BlockCharger.java
@@ -36,7 +36,7 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
 import appeng.api.AEApi;
-import appeng.block.AEBaseBlock;
+import appeng.block.AEBaseTileBlock;
 import appeng.client.render.BaseBlockRender;
 import appeng.client.render.blocks.RenderBlockCharger;
 import appeng.client.render.effects.LightningFX;
@@ -49,7 +49,7 @@ import appeng.tile.misc.TileCharger;
 import appeng.util.Platform;
 
 
-public class BlockCharger extends AEBaseBlock implements ICustomCollision
+public class BlockCharger extends AEBaseTileBlock implements ICustomCollision
 {
 
 	public BlockCharger()

--- a/src/main/java/appeng/block/misc/BlockCondenser.java
+++ b/src/main/java/appeng/block/misc/BlockCondenser.java
@@ -26,14 +26,14 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import appeng.block.AEBaseBlock;
+import appeng.block.AEBaseTileBlock;
 import appeng.core.features.AEFeature;
 import appeng.core.sync.GuiBridge;
 import appeng.tile.misc.TileCondenser;
 import appeng.util.Platform;
 
 
-public class BlockCondenser extends AEBaseBlock
+public class BlockCondenser extends AEBaseTileBlock
 {
 
 	public BlockCondenser()

--- a/src/main/java/appeng/block/misc/BlockInscriber.java
+++ b/src/main/java/appeng/block/misc/BlockInscriber.java
@@ -26,7 +26,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import appeng.block.AEBaseBlock;
+import appeng.block.AEBaseTileBlock;
 import appeng.client.render.BaseBlockRender;
 import appeng.client.render.blocks.RenderBlockInscriber;
 import appeng.core.features.AEFeature;
@@ -35,7 +35,7 @@ import appeng.tile.misc.TileInscriber;
 import appeng.util.Platform;
 
 
-public class BlockInscriber extends AEBaseBlock
+public class BlockInscriber extends AEBaseTileBlock
 {
 
 	public BlockInscriber()

--- a/src/main/java/appeng/block/misc/BlockInterface.java
+++ b/src/main/java/appeng/block/misc/BlockInterface.java
@@ -27,7 +27,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import appeng.api.util.IOrientable;
-import appeng.block.AEBaseBlock;
+import appeng.block.AEBaseTileBlock;
 import appeng.client.render.BaseBlockRender;
 import appeng.client.render.blocks.RenderBlockInterface;
 import appeng.core.features.AEFeature;
@@ -36,13 +36,13 @@ import appeng.tile.misc.TileInterface;
 import appeng.util.Platform;
 
 
-public class BlockInterface extends AEBaseBlock
+public class BlockInterface extends AEBaseTileBlock
 {
 
 	public BlockInterface()
 	{
 		super( Material.iron );
-		
+
 		this.setTileEntity( TileInterface.class );
 		this.setFeature( EnumSet.of( AEFeature.Core ) );
 	}

--- a/src/main/java/appeng/block/misc/BlockLightDetector.java
+++ b/src/main/java/appeng/block/misc/BlockLightDetector.java
@@ -19,24 +19,45 @@
 package appeng.block.misc;
 
 
+import java.util.Collections;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Random;
 
+import net.minecraft.block.Block;
+import net.minecraft.block.material.Material;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
+import appeng.api.util.IOrientable;
+import appeng.api.util.IOrientableBlock;
+import appeng.block.AEBaseTileBlock;
+import appeng.client.render.BaseBlockRender;
+import appeng.client.render.blocks.RenderQuartzTorch;
 import appeng.core.features.AEFeature;
+import appeng.helpers.ICustomCollision;
+import appeng.helpers.MetaRotation;
 import appeng.tile.misc.TileLightDetector;
 
 
-public class BlockLightDetector extends BlockQuartzTorch
+public class BlockLightDetector extends AEBaseTileBlock implements IOrientableBlock, ICustomCollision
 {
 
 	public BlockLightDetector()
 	{
+		super( Material.circuits );
+
+		this.setLightLevel( 0.9375F );
+		this.setLightOpacity( 0 );
+		this.isFullSize = false;
+		this.isOpaque = false;
+
 		this.setTileEntity( TileLightDetector.class );
 		this.setFeature( EnumSet.of( AEFeature.LightDetector ) );
 	}
@@ -69,5 +90,83 @@ public class BlockLightDetector extends BlockQuartzTorch
 	public void randomDisplayTick( World w, int x, int y, int z, Random r )
 	{
 		// cancel out lightning
+	}
+
+	@Override
+	protected Class<? extends RenderQuartzTorch> getRenderer()
+	{
+		return RenderQuartzTorch.class;
+	}
+
+	@Override
+	public boolean isValidOrientation( World w, int x, int y, int z, ForgeDirection forward, ForgeDirection up )
+	{
+		return this.canPlaceAt( w, x, y, z, up.getOpposite() );
+	}
+
+	private boolean canPlaceAt( World w, int x, int y, int z, ForgeDirection dir )
+	{
+		return w.isSideSolid( x + dir.offsetX, y + dir.offsetY, z + dir.offsetZ, dir.getOpposite(), false );
+	}
+
+	@Override
+	public Iterable<AxisAlignedBB> getSelectedBoundingBoxesFromPool( World w, int x, int y, int z, Entity e, boolean isVisual )
+	{
+		ForgeDirection up = this.getOrientable( w, x, y, z ).getUp();
+		double xOff = -0.3 * up.offsetX;
+		double yOff = -0.3 * up.offsetY;
+		double zOff = -0.3 * up.offsetZ;
+		return Collections.singletonList( AxisAlignedBB.getBoundingBox( xOff + 0.3, yOff + 0.3, zOff + 0.3, xOff + 0.7, yOff + 0.7, zOff + 0.7 ) );
+	}
+
+	@Override
+	public void addCollidingBlockToList( World w, int x, int y, int z, AxisAlignedBB bb, List out, Entity e )
+	{/*
+	 * double xOff = -0.15 * getUp().offsetX; double yOff = -0.15 * getUp().offsetY; double zOff = -0.15 *
+	 * getUp().offsetZ; out.add( AxisAlignedBB.getBoundingBox( xOff + (double) x + 0.15, yOff + (double) y + 0.15, zOff
+	 * + (double) z + 0.15,// ahh xOff + (double) x + 0.85, yOff + (double) y + 0.85, zOff + (double) z + 0.85 ) );
+	 */
+	}
+
+	@Override
+	public void onNeighborBlockChange( World w, int x, int y, int z, Block id )
+	{
+		ForgeDirection up = this.getOrientable( w, x, y, z ).getUp();
+		if( !this.canPlaceAt( w, x, y, z, up.getOpposite() ) )
+		{
+			this.dropTorch( w, x, y, z );
+		}
+	}
+
+	private void dropTorch( World w, int x, int y, int z )
+	{
+		w.func_147480_a( x, y, z, true );
+		// w.destroyBlock( x, y, z, true );
+		w.markBlockForUpdate( x, y, z );
+	}
+
+	@Override
+	public boolean canPlaceBlockAt( World w, int x, int y, int z )
+	{
+		for( ForgeDirection dir : ForgeDirection.VALID_DIRECTIONS )
+		{
+			if( this.canPlaceAt( w, x, y, z, dir ) )
+			{
+				return true;
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public boolean usesMetadata()
+	{
+		return true;
+	}
+
+	@Override
+	public IOrientable getOrientable( final IBlockAccess w, final int x, final int y, final int z )
+	{
+		return new MetaRotation( w, x, y, z );
 	}
 }

--- a/src/main/java/appeng/block/misc/BlockPaint.java
+++ b/src/main/java/appeng/block/misc/BlockPaint.java
@@ -36,7 +36,7 @@ import net.minecraft.world.World;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
-import appeng.block.AEBaseBlock;
+import appeng.block.AEBaseTileBlock;
 import appeng.client.render.BaseBlockRender;
 import appeng.client.render.blocks.RenderBlockPaint;
 import appeng.core.features.AEFeature;
@@ -44,13 +44,13 @@ import appeng.tile.misc.TilePaint;
 import appeng.util.Platform;
 
 
-public class BlockPaint extends AEBaseBlock
+public class BlockPaint extends AEBaseTileBlock
 {
 
 	public BlockPaint()
 	{
 		super( new MaterialLiquid( MapColor.airColor ) );
-	
+
 		this.setTileEntity( TilePaint.class );
 		this.setLightOpacity( 0 );
 		this.isFullSize = false;

--- a/src/main/java/appeng/block/misc/BlockQuartzGrowthAccelerator.java
+++ b/src/main/java/appeng/block/misc/BlockQuartzGrowthAccelerator.java
@@ -34,7 +34,7 @@ import cpw.mods.fml.relauncher.SideOnly;
 
 import appeng.api.util.IOrientable;
 import appeng.api.util.IOrientableBlock;
-import appeng.block.AEBaseBlock;
+import appeng.block.AEBaseTileBlock;
 import appeng.client.render.BaseBlockRender;
 import appeng.client.render.blocks.RenderBlockQuartzAccelerator;
 import appeng.client.render.effects.LightningFX;
@@ -46,7 +46,7 @@ import appeng.tile.misc.TileQuartzGrowthAccelerator;
 import appeng.util.Platform;
 
 
-public class BlockQuartzGrowthAccelerator extends AEBaseBlock implements IOrientableBlock
+public class BlockQuartzGrowthAccelerator extends AEBaseTileBlock implements IOrientableBlock
 {
 
 	public BlockQuartzGrowthAccelerator()

--- a/src/main/java/appeng/block/misc/BlockSecurity.java
+++ b/src/main/java/appeng/block/misc/BlockSecurity.java
@@ -26,7 +26,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import appeng.block.AEBaseBlock;
+import appeng.block.AEBaseTileBlock;
 import appeng.client.render.BaseBlockRender;
 import appeng.client.render.blocks.RendererSecurity;
 import appeng.core.features.AEFeature;
@@ -35,13 +35,13 @@ import appeng.tile.misc.TileSecurity;
 import appeng.util.Platform;
 
 
-public class BlockSecurity extends AEBaseBlock
+public class BlockSecurity extends AEBaseTileBlock
 {
 
 	public BlockSecurity()
 	{
 		super( Material.iron );
-	
+
 		this.setTileEntity( TileSecurity.class );
 		this.setFeature( EnumSet.of( AEFeature.Security ) );
 	}

--- a/src/main/java/appeng/block/misc/BlockSkyCompass.java
+++ b/src/main/java/appeng/block/misc/BlockSkyCompass.java
@@ -36,7 +36,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
-import appeng.block.AEBaseBlock;
+import appeng.block.AEBaseTileBlock;
 import appeng.client.render.BaseBlockRender;
 import appeng.client.render.blocks.RenderBlockSkyCompass;
 import appeng.core.features.AEFeature;
@@ -44,7 +44,7 @@ import appeng.helpers.ICustomCollision;
 import appeng.tile.misc.TileSkyCompass;
 
 
-public class BlockSkyCompass extends AEBaseBlock implements ICustomCollision
+public class BlockSkyCompass extends AEBaseTileBlock implements ICustomCollision
 {
 
 	public BlockSkyCompass()

--- a/src/main/java/appeng/block/misc/BlockVibrationChamber.java
+++ b/src/main/java/appeng/block/misc/BlockVibrationChamber.java
@@ -29,7 +29,7 @@ import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import appeng.block.AEBaseBlock;
+import appeng.block.AEBaseTileBlock;
 import appeng.client.texture.ExtraBlockTextures;
 import appeng.core.AEConfig;
 import appeng.core.features.AEFeature;
@@ -39,7 +39,7 @@ import appeng.tile.misc.TileVibrationChamber;
 import appeng.util.Platform;
 
 
-public final class BlockVibrationChamber extends AEBaseBlock
+public final class BlockVibrationChamber extends AEBaseTileBlock
 {
 
 	public BlockVibrationChamber()

--- a/src/main/java/appeng/block/networking/BlockCableBus.java
+++ b/src/main/java/appeng/block/networking/BlockCableBus.java
@@ -53,7 +53,7 @@ import appeng.api.parts.IPartHost;
 import appeng.api.parts.PartItemStack;
 import appeng.api.parts.SelectedPart;
 import appeng.api.util.AEColor;
-import appeng.block.AEBaseBlock;
+import appeng.block.AEBaseTileBlock;
 import appeng.client.render.BaseBlockRender;
 import appeng.client.render.BusRenderHelper;
 import appeng.client.render.blocks.RendererCableBus;
@@ -61,6 +61,7 @@ import appeng.client.texture.ExtraBlockTextures;
 import appeng.core.AEConfig;
 import appeng.core.Api;
 import appeng.core.CommonHelper;
+import appeng.core.features.AECableBusFeatureHandler;
 import appeng.core.features.AEFeature;
 import appeng.helpers.AEGlassMaterial;
 import appeng.integration.IntegrationRegistry;
@@ -77,7 +78,7 @@ import appeng.util.Platform;
 
 
 @Interface( iface = "powercrystals.minefactoryreloaded.api.rednet.connectivity.IRedNetConnection", iname = "MFR" )
-public class BlockCableBus extends AEBaseBlock implements IRedNetConnection
+public class BlockCableBus extends AEBaseTileBlock implements IRedNetConnection
 {
 
 	private static final ICableBusContainer NULL_CABLE_BUS = new NullCableBusContainer();
@@ -94,6 +95,9 @@ public class BlockCableBus extends AEBaseBlock implements IRedNetConnection
 		super( AEGlassMaterial.INSTANCE );
 		this.setLightOpacity( 0 );
 		this.isFullSize = this.isOpaque = false;
+
+		// this will actually be overwritten later through setupTile and the combined layers
+		this.setTileEntity( TileCableBus.class );
 		this.setFeature( EnumSet.of( AEFeature.Core ) );
 	}
 
@@ -451,8 +455,7 @@ public class BlockCableBus extends AEBaseBlock implements IRedNetConnection
 			return this.cb( world, x, y, z ).recolourBlock( side, AEColor.values()[colour], who );
 		}
 		catch( Throwable ignored )
-		{
-		}
+		{}
 		return false;
 	}
 
@@ -464,7 +467,7 @@ public class BlockCableBus extends AEBaseBlock implements IRedNetConnection
 	}
 
 	@Override
-	public <T extends TileEntity> T getTileEntity( IBlockAccess w, int x, int y, int z )
+	public <T extends AEBaseTile> T getTileEntity( IBlockAccess w, int x, int y, int z )
 	{
 		TileEntity te = w.getTileEntity( x, y, z );
 
@@ -479,6 +482,13 @@ public class BlockCableBus extends AEBaseBlock implements IRedNetConnection
 		}
 
 		return null;
+	}
+
+	@Override
+	protected void setFeature( EnumSet<AEFeature> f )
+	{
+		final AECableBusFeatureHandler featureHandler = new AECableBusFeatureHandler( f, this, this.featureSubName );
+		this.setHandler( featureHandler );
 	}
 
 	public void setupTile()

--- a/src/main/java/appeng/block/networking/BlockController.java
+++ b/src/main/java/appeng/block/networking/BlockController.java
@@ -25,14 +25,14 @@ import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.world.World;
 
-import appeng.block.AEBaseBlock;
+import appeng.block.AEBaseTileBlock;
 import appeng.client.render.BaseBlockRender;
 import appeng.client.render.blocks.RenderBlockController;
 import appeng.core.features.AEFeature;
 import appeng.tile.networking.TileController;
 
 
-public class BlockController extends AEBaseBlock
+public class BlockController extends AEBaseTileBlock
 {
 
 	public BlockController()

--- a/src/main/java/appeng/block/networking/BlockCreativeEnergyCell.java
+++ b/src/main/java/appeng/block/networking/BlockCreativeEnergyCell.java
@@ -21,13 +21,13 @@ package appeng.block.networking;
 
 import java.util.EnumSet;
 
-import appeng.block.AEBaseBlock;
+import appeng.block.AEBaseTileBlock;
 import appeng.core.features.AEFeature;
 import appeng.helpers.AEGlassMaterial;
 import appeng.tile.networking.TileCreativeEnergyCell;
 
 
-public class BlockCreativeEnergyCell extends AEBaseBlock
+public class BlockCreativeEnergyCell extends AEBaseTileBlock
 {
 
 	public BlockCreativeEnergyCell()

--- a/src/main/java/appeng/block/networking/BlockEnergyAcceptor.java
+++ b/src/main/java/appeng/block/networking/BlockEnergyAcceptor.java
@@ -23,12 +23,12 @@ import java.util.EnumSet;
 
 import net.minecraft.block.material.Material;
 
-import appeng.block.AEBaseBlock;
+import appeng.block.AEBaseTileBlock;
 import appeng.core.features.AEFeature;
 import appeng.tile.networking.TileEnergyAcceptor;
 
 
-public class BlockEnergyAcceptor extends AEBaseBlock
+public class BlockEnergyAcceptor extends AEBaseTileBlock
 {
 
 	public BlockEnergyAcceptor()

--- a/src/main/java/appeng/block/networking/BlockEnergyCell.java
+++ b/src/main/java/appeng/block/networking/BlockEnergyCell.java
@@ -31,9 +31,9 @@ import net.minecraft.util.IIcon;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
-import appeng.block.AEBaseBlock;
 import appeng.block.AEBaseItemBlock;
 import appeng.block.AEBaseItemBlockChargeable;
+import appeng.block.AEBaseTileBlock;
 import appeng.client.render.BaseBlockRender;
 import appeng.client.render.blocks.RenderBlockEnergyCube;
 import appeng.client.texture.ExtraBlockTextures;
@@ -43,7 +43,7 @@ import appeng.tile.networking.TileEnergyCell;
 import appeng.util.Platform;
 
 
-public class BlockEnergyCell extends AEBaseBlock
+public class BlockEnergyCell extends AEBaseTileBlock
 {
 
 	public BlockEnergyCell()

--- a/src/main/java/appeng/block/networking/BlockWireless.java
+++ b/src/main/java/appeng/block/networking/BlockWireless.java
@@ -29,7 +29,7 @@ import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import appeng.block.AEBaseBlock;
+import appeng.block.AEBaseTileBlock;
 import appeng.client.render.BaseBlockRender;
 import appeng.client.render.blocks.RenderBlockWireless;
 import appeng.core.features.AEFeature;
@@ -40,7 +40,7 @@ import appeng.tile.networking.TileWireless;
 import appeng.util.Platform;
 
 
-public class BlockWireless extends AEBaseBlock implements ICustomCollision
+public class BlockWireless extends AEBaseTileBlock implements ICustomCollision
 {
 
 	public BlockWireless()

--- a/src/main/java/appeng/block/qnb/BlockQuantumBase.java
+++ b/src/main/java/appeng/block/qnb/BlockQuantumBase.java
@@ -1,0 +1,78 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.block.qnb;
+
+
+import java.util.EnumSet;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.material.Material;
+import net.minecraft.world.World;
+
+import appeng.block.AEBaseTileBlock;
+import appeng.client.render.BaseBlockRender;
+import appeng.client.render.blocks.RenderQNB;
+import appeng.core.features.AEFeature;
+import appeng.helpers.ICustomCollision;
+import appeng.tile.qnb.TileQuantumBridge;
+
+
+public abstract class BlockQuantumBase extends AEBaseTileBlock implements ICustomCollision
+{
+
+	public BlockQuantumBase( Material mat )
+	{
+		super( mat );
+		this.setTileEntity( TileQuantumBridge.class );
+		float shave = 2.0f / 16.0f;
+		this.setBlockBounds( shave, shave, shave, 1.0f - shave, 1.0f - shave, 1.0f - shave );
+		this.setLightOpacity( 0 );
+		this.isFullSize = this.isOpaque = false;
+		this.setFeature( EnumSet.of( AEFeature.QuantumNetworkBridge ) );
+	}
+
+	@Override
+	public void onNeighborBlockChange( World w, int x, int y, int z, Block pointlessNumber )
+	{
+		TileQuantumBridge bridge = this.getTileEntity( w, x, y, z );
+		if( bridge != null )
+		{
+			bridge.neighborUpdate();
+		}
+	}
+
+	@Override
+	public void breakBlock( World w, int x, int y, int z, Block a, int b )
+	{
+		TileQuantumBridge bridge = this.getTileEntity( w, x, y, z );
+		if( bridge != null )
+		{
+			bridge.breakCluster();
+		}
+
+		super.breakBlock( w, x, y, z, a, b );
+	}
+
+	@Override
+	protected Class<? extends RenderQNB> getRenderer()
+	{
+		return RenderQNB.class;
+	}
+
+}

--- a/src/main/java/appeng/block/qnb/BlockQuantumLinkChamber.java
+++ b/src/main/java/appeng/block/qnb/BlockQuantumLinkChamber.java
@@ -20,11 +20,9 @@ package appeng.block.qnb;
 
 
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.Random;
 
-import net.minecraft.block.Block;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.AxisAlignedBB;
@@ -34,31 +32,20 @@ import net.minecraftforge.common.util.ForgeDirection;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
-import appeng.block.AEBaseBlock;
 import appeng.client.EffectType;
-import appeng.client.render.BaseBlockRender;
-import appeng.client.render.blocks.RenderQNB;
 import appeng.core.CommonHelper;
-import appeng.core.features.AEFeature;
 import appeng.core.sync.GuiBridge;
 import appeng.helpers.AEGlassMaterial;
-import appeng.helpers.ICustomCollision;
 import appeng.tile.qnb.TileQuantumBridge;
 import appeng.util.Platform;
 
 
-public class BlockQuantumLinkChamber extends AEBaseBlock implements ICustomCollision
+public class BlockQuantumLinkChamber extends BlockQuantumBase
 {
 
 	public BlockQuantumLinkChamber()
 	{
 		super( AEGlassMaterial.INSTANCE );
-		this.setTileEntity( TileQuantumBridge.class );
-		float shave = 2.0f / 16.0f;
-		this.setBlockBounds( shave, shave, shave, 1.0f - shave, 1.0f - shave, 1.0f - shave );
-		this.setLightOpacity( 0 );
-		this.isFullSize = this.isOpaque = false;
-		this.setFeature( EnumSet.of( AEFeature.QuantumNetworkBridge ) );
 	}
 
 	@Override
@@ -79,22 +66,6 @@ public class BlockQuantumLinkChamber extends AEBaseBlock implements ICustomColli
 	}
 
 	@Override
-	public void onNeighborBlockChange( World w, int x, int y, int z, Block pointlessNumber )
-	{
-		TileQuantumBridge bridge = this.getTileEntity( w, x, y, z );
-		if( bridge != null )
-		{
-			bridge.neighborUpdate();
-		}
-	}
-
-	@Override
-	protected Class<? extends BaseBlockRender> getRenderer()
-	{
-		return RenderQNB.class;
-	}
-
-	@Override
 	public boolean onActivated( World w, int x, int y, int z, EntityPlayer p, int side, float hitX, float hitY, float hitZ )
 	{
 		if( p.isSneaking() )
@@ -112,18 +83,6 @@ public class BlockQuantumLinkChamber extends AEBaseBlock implements ICustomColli
 			return true;
 		}
 		return false;
-	}
-
-	@Override
-	public void breakBlock( World w, int x, int y, int z, Block a, int b )
-	{
-		TileQuantumBridge bridge = this.getTileEntity( w, x, y, z );
-		if( bridge != null )
-		{
-			bridge.breakCluster();
-		}
-
-		super.breakBlock( w, x, y, z, a, b );
 	}
 
 	@Override

--- a/src/main/java/appeng/block/qnb/BlockQuantumRing.java
+++ b/src/main/java/appeng/block/qnb/BlockQuantumRing.java
@@ -23,60 +23,21 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 
-import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.world.World;
 
-import appeng.block.AEBaseBlock;
-import appeng.client.render.BaseBlockRender;
-import appeng.client.render.blocks.RenderQNB;
 import appeng.core.features.AEFeature;
-import appeng.helpers.ICustomCollision;
 import appeng.tile.qnb.TileQuantumBridge;
 
 
-public class BlockQuantumRing extends AEBaseBlock implements ICustomCollision
+public class BlockQuantumRing extends BlockQuantumBase
 {
 
 	public BlockQuantumRing()
 	{
 		super( Material.iron );
-		this.setTileEntity( TileQuantumBridge.class );
-		float shave = 2.0f / 16.0f;
-		this.setBlockBounds( shave, shave, shave, 1.0f - shave, 1.0f - shave, 1.0f - shave );
-		this.setLightOpacity( 1 );
-		this.isFullSize = this.isOpaque = false;
-		this.setFeature( EnumSet.of( AEFeature.QuantumNetworkBridge ) );
-	}
-
-	@Override
-	public void onNeighborBlockChange( World w, int x, int y, int z, Block pointlessNumber )
-	{
-		TileQuantumBridge bridge = this.getTileEntity( w, x, y, z );
-		if( bridge != null )
-		{
-			bridge.neighborUpdate();
-		}
-	}
-
-	@Override
-	protected Class<? extends BaseBlockRender> getRenderer()
-	{
-		return RenderQNB.class;
-	}
-
-	@Override
-	public void breakBlock( World w, int x, int y, int z, Block a, int b )
-	{
-		TileQuantumBridge bridge = this.getTileEntity( w, x, y, z );
-		if( bridge != null )
-		{
-			bridge.breakCluster();
-		}
-
-		super.breakBlock( w, x, y, z, a, b );
 	}
 
 	@Override

--- a/src/main/java/appeng/block/spatial/BlockSpatialIOPort.java
+++ b/src/main/java/appeng/block/spatial/BlockSpatialIOPort.java
@@ -27,14 +27,14 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import appeng.block.AEBaseBlock;
+import appeng.block.AEBaseTileBlock;
 import appeng.core.features.AEFeature;
 import appeng.core.sync.GuiBridge;
 import appeng.tile.spatial.TileSpatialIOPort;
 import appeng.util.Platform;
 
 
-public class BlockSpatialIOPort extends AEBaseBlock
+public class BlockSpatialIOPort extends AEBaseTileBlock
 {
 
 	public BlockSpatialIOPort()

--- a/src/main/java/appeng/block/spatial/BlockSpatialPylon.java
+++ b/src/main/java/appeng/block/spatial/BlockSpatialPylon.java
@@ -25,7 +25,7 @@ import net.minecraft.block.Block;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
-import appeng.block.AEBaseBlock;
+import appeng.block.AEBaseTileBlock;
 import appeng.client.render.BaseBlockRender;
 import appeng.client.render.blocks.RenderSpatialPylon;
 import appeng.core.features.AEFeature;
@@ -33,7 +33,7 @@ import appeng.helpers.AEGlassMaterial;
 import appeng.tile.spatial.TileSpatialPylon;
 
 
-public class BlockSpatialPylon extends AEBaseBlock
+public class BlockSpatialPylon extends AEBaseTileBlock
 {
 
 	public BlockSpatialPylon()

--- a/src/main/java/appeng/block/storage/BlockChest.java
+++ b/src/main/java/appeng/block/storage/BlockChest.java
@@ -29,7 +29,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 
 import appeng.api.AEApi;
 import appeng.api.storage.ICellHandler;
-import appeng.block.AEBaseBlock;
+import appeng.block.AEBaseTileBlock;
 import appeng.client.render.BaseBlockRender;
 import appeng.client.render.blocks.RenderMEChest;
 import appeng.core.features.AEFeature;
@@ -39,7 +39,7 @@ import appeng.tile.storage.TileChest;
 import appeng.util.Platform;
 
 
-public class BlockChest extends AEBaseBlock
+public class BlockChest extends AEBaseTileBlock
 {
 
 	public BlockChest()

--- a/src/main/java/appeng/block/storage/BlockDrive.java
+++ b/src/main/java/appeng/block/storage/BlockDrive.java
@@ -26,7 +26,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import appeng.block.AEBaseBlock;
+import appeng.block.AEBaseTileBlock;
 import appeng.client.render.BaseBlockRender;
 import appeng.client.render.blocks.RenderDrive;
 import appeng.core.features.AEFeature;
@@ -35,7 +35,7 @@ import appeng.tile.storage.TileDrive;
 import appeng.util.Platform;
 
 
-public class BlockDrive extends AEBaseBlock
+public class BlockDrive extends AEBaseTileBlock
 {
 
 	public BlockDrive()

--- a/src/main/java/appeng/block/storage/BlockIOPort.java
+++ b/src/main/java/appeng/block/storage/BlockIOPort.java
@@ -27,14 +27,14 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import appeng.block.AEBaseBlock;
+import appeng.block.AEBaseTileBlock;
 import appeng.core.features.AEFeature;
 import appeng.core.sync.GuiBridge;
 import appeng.tile.storage.TileIOPort;
 import appeng.util.Platform;
 
 
-public class BlockIOPort extends AEBaseBlock
+public class BlockIOPort extends AEBaseTileBlock
 {
 
 	public BlockIOPort()

--- a/src/main/java/appeng/block/storage/BlockSkyChest.java
+++ b/src/main/java/appeng/block/storage/BlockSkyChest.java
@@ -42,7 +42,7 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
 import appeng.api.AEApi;
-import appeng.block.AEBaseBlock;
+import appeng.block.AEBaseTileBlock;
 import appeng.client.render.BaseBlockRender;
 import appeng.client.render.blocks.RenderBlockSkyChest;
 import appeng.core.features.AEFeature;
@@ -52,7 +52,7 @@ import appeng.tile.storage.TileSkyChest;
 import appeng.util.Platform;
 
 
-public class BlockSkyChest extends AEBaseBlock implements ICustomCollision
+public class BlockSkyChest extends AEBaseTileBlock implements ICustomCollision
 {
 
 	public BlockSkyChest()

--- a/src/main/java/appeng/client/render/BaseBlockRender.java
+++ b/src/main/java/appeng/client/render/BaseBlockRender.java
@@ -27,7 +27,6 @@ import javax.annotation.Nullable;
 import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.GL11;
 
-import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.RenderHelper;
@@ -47,7 +46,6 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
 import appeng.api.util.IOrientable;
-import appeng.api.util.IOrientableBlock;
 import appeng.block.AEBaseBlock;
 import appeng.client.texture.ExtraBlockTextures;
 import appeng.tile.AEBaseTile;
@@ -55,7 +53,7 @@ import appeng.util.Platform;
 
 
 @SideOnly( Side.CLIENT )
-public class BaseBlockRender
+public class BaseBlockRender<B extends AEBaseBlock, T extends AEBaseTile>
 {
 	private static final int ORIENTATION_BITS = 7;
 	private static final int FLIP_H_BIT = 8;
@@ -282,7 +280,7 @@ public class BaseBlockRender
 		return this.renderDistance;
 	}
 
-	public void renderInventory( AEBaseBlock block, ItemStack item, RenderBlocks renderer, ItemRenderType type, Object[] data )
+	public void renderInventory( B block, ItemStack item, RenderBlocks renderer, ItemRenderType type, Object[] data )
 	{
 		Tessellator tess = Tessellator.instance;
 
@@ -330,7 +328,7 @@ public class BaseBlockRender
 		return ORIENTATION_MAP[a][b][c];
 	}
 
-	public void renderInvBlock( EnumSet<ForgeDirection> sides, AEBaseBlock block, ItemStack item, Tessellator tess, int color, RenderBlocks renderer )
+	public void renderInvBlock( EnumSet<ForgeDirection> sides, B block, ItemStack item, Tessellator tess, int color, RenderBlocks renderer )
 	{
 		int meta = 0;
 		if( block != null && block.hasSubtypes() && item != null )
@@ -405,7 +403,7 @@ public class BaseBlockRender
 		return ExtraBlockTextures.getMissing();
 	}
 
-	public boolean renderInWorld( AEBaseBlock block, IBlockAccess world, int x, int y, int z, RenderBlocks renderer )
+	public boolean renderInWorld( B block, IBlockAccess world, int x, int y, int z, RenderBlocks renderer )
 	{
 		this.preRenderInWorld( block, world, x, y, z, renderer );
 
@@ -415,7 +413,7 @@ public class BaseBlockRender
 		return o;
 	}
 
-	public void preRenderInWorld( AEBaseBlock block, IBlockAccess world, int x, int y, int z, RenderBlocks renderer )
+	public void preRenderInWorld( B block, IBlockAccess world, int x, int y, int z, RenderBlocks renderer )
 	{
 		ForgeDirection forward = ForgeDirection.SOUTH;
 		ForgeDirection up = ForgeDirection.UP;
@@ -444,17 +442,9 @@ public class BaseBlockRender
 	}
 
 	@Nullable
-	public IOrientable getOrientable( AEBaseBlock block, IBlockAccess w, int x, int y, int z )
+	public IOrientable getOrientable( B block, IBlockAccess w, int x, int y, int z )
 	{
-		if( block.hasBlockTileEntity() )
-		{
-			return (IOrientable) block.getTileEntity( w, x, y, z );
-		}
-		else if( block instanceof IOrientableBlock )
-		{
-			return ( (IOrientableBlock) block ).getOrientable( w, x, y, z );
-		}
-		return null;
+		return block.getOrientable( w, x, y, z );
 	}
 
 	protected void setInvRenderBounds( RenderBlocks renderer, int i, int j, int k, int l, int m, int n )
@@ -512,7 +502,7 @@ public class BaseBlockRender
 	}
 
 	@SideOnly( Side.CLIENT )
-	protected void renderCutoutFace( Block block, IIcon ico, int x, int y, int z, RenderBlocks renderer, ForgeDirection orientation, float edgeThickness )
+	protected void renderCutoutFace( B block, IIcon ico, int x, int y, int z, RenderBlocks renderer, ForgeDirection orientation, float edgeThickness )
 	{
 		Tessellator tess = Tessellator.instance;
 
@@ -624,7 +614,7 @@ public class BaseBlockRender
 	}
 
 	@SideOnly( Side.CLIENT )
-	protected void renderFace( int x, int y, int z, Block block, IIcon ico, RenderBlocks renderer, ForgeDirection orientation )
+	protected void renderFace( int x, int y, int z, B block, IIcon ico, RenderBlocks renderer, ForgeDirection orientation )
 	{
 		switch( orientation )
 		{
@@ -689,7 +679,7 @@ public class BaseBlockRender
 		return ( 16.0 - uv ) / 16.0;
 	}
 
-	public void renderTile( AEBaseBlock block, AEBaseTile tile, Tessellator tess, double x, double y, double z, float f, RenderBlocks renderer )
+	public void renderTile( B block, T tile, Tessellator tess, double x, double y, double z, float f, RenderBlocks renderer )
 	{
 		ForgeDirection forward = ForgeDirection.SOUTH;
 		ForgeDirection up = ForgeDirection.UP;

--- a/src/main/java/appeng/client/render/BusRenderHelper.java
+++ b/src/main/java/appeng/client/render/BusRenderHelper.java
@@ -44,6 +44,7 @@ import appeng.block.AEBaseBlock;
 import appeng.block.networking.BlockCableBus;
 import appeng.core.AEConfig;
 import appeng.core.features.AEFeature;
+import appeng.tile.AEBaseTile;
 
 
 @SideOnly( Side.CLIENT )
@@ -75,7 +76,7 @@ public final class BusRenderHelper implements IPartRenderHelper
 	{
 		this.bbc = new BoundBoxCalculator( this );
 		this.noAlphaPass = !AEConfig.instance.isFeatureEnabled( AEFeature.AlphaPass );
-		this.bbr = new BaseBlockRender();
+		this.bbr = new BaseBlockRender<AEBaseBlock, AEBaseTile>();
 		this.renderingForPass = 0;
 		this.currentPass = 0;
 		this.itemsRendered = 0;
@@ -230,7 +231,6 @@ public final class BusRenderHelper implements IPartRenderHelper
 		}
 	}
 
-
 	private static final class BaseBlockTransformFunction implements Function<Block, AEBaseBlock>
 	{
 		@Nullable
@@ -239,7 +239,7 @@ public final class BusRenderHelper implements IPartRenderHelper
 		{
 			if( input instanceof AEBaseBlock )
 			{
-				return ( (AEBaseBlock) input );
+				return( (AEBaseBlock) input );
 			}
 
 			return null;
@@ -568,7 +568,7 @@ public final class BusRenderHelper implements IPartRenderHelper
 				break;
 		}
 
-		for( Block block : this.maybeBlock.asSet() )
+		for( AEBaseBlock block : this.maybeBaseBlock.asSet() )
 		{
 			this.bbr.renderCutoutFace( block, ico, x, y, z, renderer, face, edgeThickness );
 		}
@@ -609,7 +609,7 @@ public final class BusRenderHelper implements IPartRenderHelper
 				break;
 		}
 
-		for( Block block : this.maybeBlock.asSet() )
+		for( AEBaseBlock block : this.maybeBaseBlock.asSet() )
 		{
 			this.bbr.renderFace( x, y, z, block, ico, renderer, face );
 		}

--- a/src/main/java/appeng/client/render/blocks/RenderBlockAssembler.java
+++ b/src/main/java/appeng/client/render/blocks/RenderBlockAssembler.java
@@ -36,7 +36,6 @@ import appeng.api.parts.IPart;
 import appeng.api.parts.IPartCollisionHelper;
 import appeng.api.parts.IPartHost;
 import appeng.api.util.IOrientable;
-import appeng.block.AEBaseBlock;
 import appeng.block.crafting.BlockMolecularAssembler;
 import appeng.client.render.BaseBlockRender;
 import appeng.client.render.BusRenderHelper;
@@ -48,7 +47,7 @@ import appeng.tile.crafting.TileMolecularAssembler;
 import appeng.util.Platform;
 
 
-public class RenderBlockAssembler extends BaseBlockRender implements IBoxProvider
+public class RenderBlockAssembler extends BaseBlockRender<BlockMolecularAssembler, TileMolecularAssembler> implements IBoxProvider
 {
 
 	public RenderBlockAssembler()
@@ -57,7 +56,7 @@ public class RenderBlockAssembler extends BaseBlockRender implements IBoxProvide
 	}
 
 	@Override
-	public void renderInventory( AEBaseBlock blk, ItemStack is, RenderBlocks renderer, ItemRenderType type, Object[] obj )
+	public void renderInventory( BlockMolecularAssembler blk, ItemStack is, RenderBlocks renderer, ItemRenderType type, Object[] obj )
 	{
 		renderer.setOverrideBlockTexture( blk.getIcon( 0, 0 ) );
 
@@ -104,7 +103,7 @@ public class RenderBlockAssembler extends BaseBlockRender implements IBoxProvide
 	}
 
 	@Override
-	public boolean renderInWorld( AEBaseBlock block, IBlockAccess world, int x, int y, int z, RenderBlocks renderer )
+	public boolean renderInWorld( BlockMolecularAssembler block, IBlockAccess world, int x, int y, int z, RenderBlocks renderer )
 	{
 		BlockMolecularAssembler blk = (BlockMolecularAssembler) block;
 		TileMolecularAssembler tma = blk.getTileEntity( world, x, y, z );
@@ -201,7 +200,7 @@ public class RenderBlockAssembler extends BaseBlockRender implements IBoxProvide
 		return true;
 	}
 
-	public void renderCableAt( double thickness, IBlockAccess world, int x, int y, int z, AEBaseBlock block, RenderBlocks renderer, double pull, boolean covered )
+	public void renderCableAt( double thickness, IBlockAccess world, int x, int y, int z, BlockMolecularAssembler block, RenderBlocks renderer, double pull, boolean covered )
 	{
 		IIcon texture = null;
 

--- a/src/main/java/appeng/client/render/blocks/RenderBlockCharger.java
+++ b/src/main/java/appeng/client/render/blocks/RenderBlockCharger.java
@@ -35,16 +35,15 @@ import net.minecraftforge.client.IItemRenderer.ItemRenderType;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import appeng.api.util.IOrientable;
-import appeng.block.AEBaseBlock;
 import appeng.block.misc.BlockCharger;
 import appeng.client.render.BaseBlockRender;
 import appeng.client.texture.ExtraBlockTextures;
 import appeng.core.AELog;
-import appeng.tile.AEBaseTile;
+import appeng.tile.misc.TileCharger;
 import appeng.util.Platform;
 
 
-public class RenderBlockCharger extends BaseBlockRender
+public class RenderBlockCharger extends BaseBlockRender<BlockCharger, TileCharger>
 {
 
 	public RenderBlockCharger()
@@ -53,7 +52,7 @@ public class RenderBlockCharger extends BaseBlockRender
 	}
 
 	@Override
-	public void renderInventory( AEBaseBlock blk, ItemStack is, RenderBlocks renderer, ItemRenderType type, Object[] obj )
+	public void renderInventory( BlockCharger blk, ItemStack is, RenderBlocks renderer, ItemRenderType type, Object[] obj )
 	{
 		Tessellator tess = Tessellator.instance;
 
@@ -84,7 +83,7 @@ public class RenderBlockCharger extends BaseBlockRender
 	}
 
 	@Override
-	public boolean renderInWorld( AEBaseBlock block, IBlockAccess world, int x, int y, int z, RenderBlocks renderer )
+	public boolean renderInWorld( BlockCharger block, IBlockAccess world, int x, int y, int z, RenderBlocks renderer )
 	{
 		this.preRenderInWorld( block, world, x, y, z, renderer );
 
@@ -126,7 +125,7 @@ public class RenderBlockCharger extends BaseBlockRender
 	}
 
 	@Override
-	public void renderTile( AEBaseBlock block, AEBaseTile tile, Tessellator tess, double x, double y, double z, float f, RenderBlocks renderer )
+	public void renderTile( BlockCharger block, TileCharger tile, Tessellator tess, double x, double y, double z, float f, RenderBlocks renderer )
 	{
 		ItemStack sis = null;
 		if( tile instanceof IInventory )
@@ -153,7 +152,12 @@ public class RenderBlockCharger extends BaseBlockRender
 					GL11.glRotatef( 30.0f, 0.0f, 1.0f, 0.0f );
 				}
 
-				int br = tile.getWorldObj().getLightBrightnessForSkyBlocks( tile.xCoord, tile.yCoord, tile.zCoord, 0 );// << 20 | light << 4;
+				int br = tile.getWorldObj().getLightBrightnessForSkyBlocks( tile.xCoord, tile.yCoord, tile.zCoord, 0 );// <<
+																														// 20
+																														// |
+																														// light
+																														// <<
+																														// 4;
 				int var11 = br % 65536;
 				int var12 = br / 65536;
 				OpenGlHelper.setLightmapTextureCoords( OpenGlHelper.lightmapTexUnit, var11, var12 );

--- a/src/main/java/appeng/client/render/blocks/RenderBlockController.java
+++ b/src/main/java/appeng/client/render/blocks/RenderBlockController.java
@@ -25,12 +25,13 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.IBlockAccess;
 
 import appeng.block.AEBaseBlock;
+import appeng.block.networking.BlockController;
 import appeng.client.render.BaseBlockRender;
 import appeng.client.texture.ExtraBlockTextures;
 import appeng.tile.networking.TileController;
 
 
-public class RenderBlockController extends BaseBlockRender
+public class RenderBlockController extends BaseBlockRender<BlockController, TileController>
 {
 
 	public RenderBlockController()
@@ -39,7 +40,7 @@ public class RenderBlockController extends BaseBlockRender
 	}
 
 	@Override
-	public boolean renderInWorld( AEBaseBlock blk, IBlockAccess world, int x, int y, int z, RenderBlocks renderer )
+	public boolean renderInWorld( BlockController blk, IBlockAccess world, int x, int y, int z, RenderBlocks renderer )
 	{
 
 		boolean xx = this.getTileEntity( world, x - 1, y, z ) instanceof TileController && this.getTileEntity( world, x + 1, y, z ) instanceof TileController;

--- a/src/main/java/appeng/client/render/blocks/RenderBlockCraftingCPU.java
+++ b/src/main/java/appeng/client/render/blocks/RenderBlockCraftingCPU.java
@@ -31,7 +31,6 @@ import net.minecraftforge.common.util.ForgeDirection;
 
 import appeng.api.AEApi;
 import appeng.api.util.AEColor;
-import appeng.block.AEBaseBlock;
 import appeng.block.crafting.BlockCraftingMonitor;
 import appeng.block.crafting.BlockCraftingUnit;
 import appeng.client.render.BaseBlockRender;
@@ -42,7 +41,7 @@ import appeng.tile.crafting.TileCraftingMonitorTile;
 import appeng.tile.crafting.TileCraftingTile;
 
 
-public class RenderBlockCraftingCPU extends BaseBlockRender
+public class RenderBlockCraftingCPU<B extends BlockCraftingUnit, T extends TileCraftingTile> extends BaseBlockRender<B, T>
 {
 
 	protected RenderBlockCraftingCPU( boolean useTESR, int range )
@@ -56,7 +55,7 @@ public class RenderBlockCraftingCPU extends BaseBlockRender
 	}
 
 	@Override
-	public boolean renderInWorld( AEBaseBlock blk, IBlockAccess w, int x, int y, int z, RenderBlocks renderer )
+	public boolean renderInWorld( B blk, IBlockAccess w, int x, int y, int z, RenderBlocks renderer )
 	{
 		IIcon theIcon = null;
 		boolean formed = false;
@@ -198,7 +197,7 @@ public class RenderBlockCraftingCPU extends BaseBlockRender
 		return def;
 	}
 
-	private void handleSide( AEBaseBlock blk, int meta, int x, int y, int z, BusRenderHelper i, RenderBlocks renderer, IIcon color, boolean emitsLight, boolean isMonitor, ForgeDirection side, IBlockAccess w )
+	private void handleSide( B blk, int meta, int x, int y, int z, BusRenderHelper i, RenderBlocks renderer, IIcon color, boolean emitsLight, boolean isMonitor, ForgeDirection side, IBlockAccess w )
 	{
 		if( this.isConnected( w, x, y, z, side ) )
 		{

--- a/src/main/java/appeng/client/render/blocks/RenderBlockCraftingCPUMonitor.java
+++ b/src/main/java/appeng/client/render/blocks/RenderBlockCraftingCPUMonitor.java
@@ -32,10 +32,9 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import appeng.api.storage.data.IAEItemStack;
-import appeng.block.AEBaseBlock;
+import appeng.block.crafting.BlockCraftingMonitor;
 import appeng.client.ClientHelper;
 import appeng.core.AELog;
-import appeng.tile.AEBaseTile;
 import appeng.tile.crafting.TileCraftingMonitorTile;
 import appeng.util.IWideReadableNumberConverter;
 import appeng.util.Platform;
@@ -48,7 +47,7 @@ import appeng.util.ReadableNumberConverter;
  * @version rv2
  * @since rv1
  */
-public class RenderBlockCraftingCPUMonitor extends RenderBlockCraftingCPU
+public class RenderBlockCraftingCPUMonitor extends RenderBlockCraftingCPU<BlockCraftingMonitor, TileCraftingMonitorTile>
 {
 	private static final IWideReadableNumberConverter NUMBER_CONVERTER = ReadableNumberConverter.INSTANCE;
 
@@ -58,7 +57,7 @@ public class RenderBlockCraftingCPUMonitor extends RenderBlockCraftingCPU
 	}
 
 	@Override
-	public void renderTile( AEBaseBlock block, AEBaseTile tile, Tessellator tess, double x, double y, double z, float f, RenderBlocks renderer )
+	public void renderTile( BlockCraftingMonitor block, TileCraftingMonitorTile tile, Tessellator tess, double x, double y, double z, float f, RenderBlocks renderer )
 	{
 		if( tile instanceof TileCraftingMonitorTile )
 		{

--- a/src/main/java/appeng/client/render/blocks/RenderBlockCrank.java
+++ b/src/main/java/appeng/client/render/blocks/RenderBlockCrank.java
@@ -31,13 +31,12 @@ import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.client.IItemRenderer.ItemRenderType;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import appeng.block.AEBaseBlock;
+import appeng.block.grindstone.BlockCrank;
 import appeng.client.render.BaseBlockRender;
-import appeng.tile.AEBaseTile;
 import appeng.tile.grindstone.TileCrank;
 
 
-public class RenderBlockCrank extends BaseBlockRender
+public class RenderBlockCrank extends BaseBlockRender<BlockCrank, TileCrank>
 {
 
 	public RenderBlockCrank()
@@ -46,7 +45,7 @@ public class RenderBlockCrank extends BaseBlockRender
 	}
 
 	@Override
-	public void renderInventory( AEBaseBlock blk, ItemStack is, RenderBlocks renderer, ItemRenderType type, Object[] obj )
+	public void renderInventory( BlockCrank blk, ItemStack is, RenderBlocks renderer, ItemRenderType type, Object[] obj )
 	{
 		renderer.renderAllFaces = true;
 
@@ -60,13 +59,13 @@ public class RenderBlockCrank extends BaseBlockRender
 	}
 
 	@Override
-	public boolean renderInWorld( AEBaseBlock imb, IBlockAccess world, int x, int y, int z, RenderBlocks renderer )
+	public boolean renderInWorld( BlockCrank imb, IBlockAccess world, int x, int y, int z, RenderBlocks renderer )
 	{
 		return true;
 	}
 
 	@Override
-	public void renderTile( AEBaseBlock blk, AEBaseTile tile, Tessellator tess, double x, double y, double z, float f, RenderBlocks renderBlocks )
+	public void renderTile( BlockCrank blk, TileCrank tile, Tessellator tess, double x, double y, double z, float f, RenderBlocks renderBlocks )
 	{
 		TileCrank tc = (TileCrank) tile;
 		if( tc.getUp() == null || tc.getUp() == ForgeDirection.UNKNOWN )

--- a/src/main/java/appeng/client/render/blocks/RenderBlockEnergyCube.java
+++ b/src/main/java/appeng/client/render/blocks/RenderBlockEnergyCube.java
@@ -25,11 +25,12 @@ import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.client.IItemRenderer.ItemRenderType;
 
 import appeng.api.implementations.items.IAEItemPowerStorage;
-import appeng.block.AEBaseBlock;
+import appeng.block.networking.BlockEnergyCell;
 import appeng.client.render.BaseBlockRender;
+import appeng.tile.networking.TileEnergyCell;
 
 
-public class RenderBlockEnergyCube extends BaseBlockRender
+public class RenderBlockEnergyCube extends BaseBlockRender<BlockEnergyCell, TileEnergyCell>
 {
 
 	public RenderBlockEnergyCube()
@@ -38,7 +39,7 @@ public class RenderBlockEnergyCube extends BaseBlockRender
 	}
 
 	@Override
-	public void renderInventory( AEBaseBlock blk, ItemStack is, RenderBlocks renderer, ItemRenderType type, Object[] obj )
+	public void renderInventory( BlockEnergyCell blk, ItemStack is, RenderBlocks renderer, ItemRenderType type, Object[] obj )
 	{
 		IAEItemPowerStorage myItem = (IAEItemPowerStorage) is.getItem();
 		double internalCurrentPower = myItem.getAECurrentPower( is );
@@ -61,7 +62,7 @@ public class RenderBlockEnergyCube extends BaseBlockRender
 	}
 
 	@Override
-	public boolean renderInWorld( AEBaseBlock blk, IBlockAccess world, int x, int y, int z, RenderBlocks renderer )
+	public boolean renderInWorld( BlockEnergyCell blk, IBlockAccess world, int x, int y, int z, RenderBlocks renderer )
 	{
 		int meta = world.getBlockMetadata( x, y, z );
 

--- a/src/main/java/appeng/client/render/blocks/RenderBlockInscriber.java
+++ b/src/main/java/appeng/client/render/blocks/RenderBlockInscriber.java
@@ -54,7 +54,7 @@ import appeng.util.Platform;
  * @version rv2
  * @since rv0
  */
-public class RenderBlockInscriber extends BaseBlockRender
+public class RenderBlockInscriber extends BaseBlockRender<BlockInscriber, TileInscriber>
 {
 
 	public RenderBlockInscriber()
@@ -63,7 +63,7 @@ public class RenderBlockInscriber extends BaseBlockRender
 	}
 
 	@Override
-	public void renderInventory( AEBaseBlock blk, ItemStack is, RenderBlocks renderer, ItemRenderType type, Object[] obj )
+	public void renderInventory( BlockInscriber blk, ItemStack is, RenderBlocks renderer, ItemRenderType type, Object[] obj )
 	{
 		Tessellator tess = Tessellator.instance;
 
@@ -104,7 +104,7 @@ public class RenderBlockInscriber extends BaseBlockRender
 	}
 
 	@Override
-	public boolean renderInWorld( AEBaseBlock block, IBlockAccess world, int x, int y, int z, RenderBlocks renderer )
+	public boolean renderInWorld( BlockInscriber block, IBlockAccess world, int x, int y, int z, RenderBlocks renderer )
 	{
 		this.preRenderInWorld( block, world, x, y, z, renderer );
 
@@ -149,7 +149,7 @@ public class RenderBlockInscriber extends BaseBlockRender
 	}
 
 	@Override
-	public void renderTile( AEBaseBlock block, AEBaseTile tile, Tessellator tess, double x, double y, double z, float f, RenderBlocks renderer )
+	public void renderTile( BlockInscriber block, TileInscriber tile, Tessellator tess, double x, double y, double z, float f, RenderBlocks renderer )
 	{
 		TileInscriber inv = (TileInscriber) tile;
 
@@ -163,7 +163,10 @@ public class RenderBlockInscriber extends BaseBlockRender
 		Minecraft mc = Minecraft.getMinecraft();
 		mc.renderEngine.bindTexture( TextureMap.locationBlocksTexture );
 
-		int br = tile.getWorldObj().getLightBrightnessForSkyBlocks( tile.xCoord, tile.yCoord, tile.zCoord, 0 );// << 20 | light << 4;
+		int br = tile.getWorldObj().getLightBrightnessForSkyBlocks( tile.xCoord, tile.yCoord, tile.zCoord, 0 );// << 20
+																												// |
+																												// light
+																												// << 4;
 		int var11 = br % 65536;
 		int var12 = br / 65536;
 		OpenGlHelper.setLightmapTextureCoords( OpenGlHelper.lightmapTexUnit, var11, var12 );
@@ -284,7 +287,12 @@ public class RenderBlockInscriber extends BaseBlockRender
 
 				GL11.glRotatef( 90.0f, 1, 0, 0 );
 
-				int br = tile.getWorldObj().getLightBrightnessForSkyBlocks( tile.xCoord, tile.yCoord, tile.zCoord, 0 );// << 20 | light << 4;
+				int br = tile.getWorldObj().getLightBrightnessForSkyBlocks( tile.xCoord, tile.yCoord, tile.zCoord, 0 );// <<
+																														// 20
+																														// |
+																														// light
+																														// <<
+																														// 4;
 				int var11 = br % 65536;
 				int var12 = br / 65536;
 				OpenGlHelper.setLightmapTextureCoords( OpenGlHelper.lightmapTexUnit, var11, var12 );

--- a/src/main/java/appeng/client/render/blocks/RenderBlockInterface.java
+++ b/src/main/java/appeng/client/render/blocks/RenderBlockInterface.java
@@ -24,14 +24,14 @@ import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import appeng.block.AEBaseBlock;
+import appeng.block.misc.BlockInterface;
 import appeng.client.render.BaseBlockRender;
 import appeng.client.render.BlockRenderInfo;
 import appeng.client.texture.ExtraBlockTextures;
 import appeng.tile.misc.TileInterface;
 
 
-public class RenderBlockInterface extends BaseBlockRender
+public class RenderBlockInterface extends BaseBlockRender<BlockInterface, TileInterface>
 {
 
 	public RenderBlockInterface()
@@ -40,7 +40,7 @@ public class RenderBlockInterface extends BaseBlockRender
 	}
 
 	@Override
-	public boolean renderInWorld( AEBaseBlock block, IBlockAccess world, int x, int y, int z, RenderBlocks renderer )
+	public boolean renderInWorld( BlockInterface block, IBlockAccess world, int x, int y, int z, RenderBlocks renderer )
 	{
 		TileInterface ti = block.getTileEntity( world, x, y, z );
 		BlockRenderInfo info = block.getRendererInstance();

--- a/src/main/java/appeng/client/render/blocks/RenderBlockPaint.java
+++ b/src/main/java/appeng/client/render/blocks/RenderBlockPaint.java
@@ -29,14 +29,15 @@ import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.client.IItemRenderer.ItemRenderType;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import appeng.block.AEBaseBlock;
+import appeng.block.AEBaseTileBlock;
+import appeng.block.misc.BlockPaint;
 import appeng.client.render.BaseBlockRender;
 import appeng.client.texture.ExtraBlockTextures;
 import appeng.helpers.Splotch;
 import appeng.tile.misc.TilePaint;
 
 
-public class RenderBlockPaint extends BaseBlockRender
+public class RenderBlockPaint extends BaseBlockRender<BlockPaint, TilePaint>
 {
 
 	public RenderBlockPaint()
@@ -45,13 +46,13 @@ public class RenderBlockPaint extends BaseBlockRender
 	}
 
 	@Override
-	public void renderInventory( AEBaseBlock block, ItemStack is, RenderBlocks renderer, ItemRenderType type, Object[] obj )
+	public void renderInventory( BlockPaint block, ItemStack is, RenderBlocks renderer, ItemRenderType type, Object[] obj )
 	{
 
 	}
 
 	@Override
-	public boolean renderInWorld( AEBaseBlock imb, IBlockAccess world, int x, int y, int z, RenderBlocks renderer )
+	public boolean renderInWorld( BlockPaint imb, IBlockAccess world, int x, int y, int z, RenderBlocks renderer )
 	{
 		TilePaint tp = imb.getTileEntity( world, x, y, z );
 		boolean out = false;

--- a/src/main/java/appeng/client/render/blocks/RenderBlockQuartzAccelerator.java
+++ b/src/main/java/appeng/client/render/blocks/RenderBlockQuartzAccelerator.java
@@ -24,13 +24,13 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 
-import appeng.block.AEBaseBlock;
+import appeng.block.misc.BlockQuartzGrowthAccelerator;
 import appeng.client.render.BaseBlockRender;
 import appeng.client.texture.ExtraBlockTextures;
 import appeng.tile.misc.TileQuartzGrowthAccelerator;
 
 
-public class RenderBlockQuartzAccelerator extends BaseBlockRender
+public class RenderBlockQuartzAccelerator extends BaseBlockRender<BlockQuartzGrowthAccelerator, TileQuartzGrowthAccelerator>
 {
 
 	public RenderBlockQuartzAccelerator()
@@ -39,7 +39,7 @@ public class RenderBlockQuartzAccelerator extends BaseBlockRender
 	}
 
 	@Override
-	public boolean renderInWorld( AEBaseBlock blk, IBlockAccess world, int x, int y, int z, RenderBlocks renderer )
+	public boolean renderInWorld( BlockQuartzGrowthAccelerator blk, IBlockAccess world, int x, int y, int z, RenderBlocks renderer )
 	{
 		TileEntity te = world.getTileEntity( x, y, z );
 		if( te instanceof TileQuartzGrowthAccelerator )

--- a/src/main/java/appeng/client/render/blocks/RenderBlockSkyChest.java
+++ b/src/main/java/appeng/client/render/blocks/RenderBlockSkyChest.java
@@ -30,13 +30,12 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.client.IItemRenderer.ItemRenderType;
 
-import appeng.block.AEBaseBlock;
+import appeng.block.storage.BlockSkyChest;
 import appeng.client.render.BaseBlockRender;
-import appeng.tile.AEBaseTile;
 import appeng.tile.storage.TileSkyChest;
 
 
-public class RenderBlockSkyChest extends BaseBlockRender
+public class RenderBlockSkyChest extends BaseBlockRender<BlockSkyChest, TileSkyChest>
 {
 
 	final ModelChest model = new ModelChest();
@@ -47,9 +46,9 @@ public class RenderBlockSkyChest extends BaseBlockRender
 	}
 
 	@Override
-	public void renderInventory( AEBaseBlock blk, ItemStack is, RenderBlocks renderer, ItemRenderType type, Object[] obj )
+	public void renderInventory( BlockSkyChest blk, ItemStack is, RenderBlocks renderer, ItemRenderType type, Object[] obj )
 	{
-		GL11.glEnable( 32826 /* GL_RESCALE_NORMAL_EXT */ );
+		GL11.glEnable( 32826 /* GL_RESCALE_NORMAL_EXT */);
 		GL11.glColor4f( 1.0F, 1.0F, 1.0F, 1.0F );
 
 		ResourceLocation loc;
@@ -73,18 +72,18 @@ public class RenderBlockSkyChest extends BaseBlockRender
 		this.model.chestLid.rotateAngleX = -( ( lidAngle * 3.141593F ) / 2.0F );
 		this.model.renderAll();
 
-		GL11.glDisable( 32826 /* GL_RESCALE_NORMAL_EXT */ );
+		GL11.glDisable( 32826 /* GL_RESCALE_NORMAL_EXT */);
 		GL11.glColor4f( 1.0F, 1.0F, 1.0F, 1.0F );
 	}
 
 	@Override
-	public boolean renderInWorld( AEBaseBlock blk, IBlockAccess world, int x, int y, int z, RenderBlocks renderer )
+	public boolean renderInWorld( BlockSkyChest blk, IBlockAccess world, int x, int y, int z, RenderBlocks renderer )
 	{
 		return true;
 	}
 
 	@Override
-	public void renderTile( AEBaseBlock block, AEBaseTile tile, Tessellator tess, double x, double y, double z, float partialTick, RenderBlocks renderer )
+	public void renderTile( BlockSkyChest block, TileSkyChest tile, Tessellator tess, double x, double y, double z, float partialTick, RenderBlocks renderer )
 	{
 		if( !( tile instanceof TileSkyChest ) )
 		{
@@ -98,7 +97,7 @@ public class RenderBlockSkyChest extends BaseBlockRender
 			return;
 		}
 
-		GL11.glEnable( 32826 /* GL_RESCALE_NORMAL_EXT */ );
+		GL11.glEnable( 32826 /* GL_RESCALE_NORMAL_EXT */);
 		GL11.glColor4f( 1.0F, 1.0F, 1.0F, 1.0F );
 
 		ResourceLocation loc;
@@ -149,7 +148,7 @@ public class RenderBlockSkyChest extends BaseBlockRender
 		this.model.chestLid.rotateAngleX = -( ( lidAngle * 3.141593F ) / 2.0F );
 		this.model.renderAll();
 
-		GL11.glDisable( 32826 /* GL_RESCALE_NORMAL_EXT */ );
+		GL11.glDisable( 32826 /* GL_RESCALE_NORMAL_EXT */);
 		GL11.glColor4f( 1.0F, 1.0F, 1.0F, 1.0F );
 	}
 }

--- a/src/main/java/appeng/client/render/blocks/RenderBlockSkyCompass.java
+++ b/src/main/java/appeng/client/render/blocks/RenderBlockSkyCompass.java
@@ -32,16 +32,15 @@ import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.client.IItemRenderer.ItemRenderType;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import appeng.block.AEBaseBlock;
+import appeng.block.misc.BlockSkyCompass;
 import appeng.client.render.BaseBlockRender;
 import appeng.client.render.model.ModelCompass;
 import appeng.hooks.CompassManager;
 import appeng.hooks.CompassResult;
-import appeng.tile.AEBaseTile;
 import appeng.tile.misc.TileSkyCompass;
 
 
-public class RenderBlockSkyCompass extends BaseBlockRender
+public class RenderBlockSkyCompass extends BaseBlockRender<BlockSkyCompass, TileSkyCompass>
 {
 
 	final ModelCompass model = new ModelCompass();
@@ -53,7 +52,7 @@ public class RenderBlockSkyCompass extends BaseBlockRender
 	}
 
 	@Override
-	public void renderInventory( AEBaseBlock blk, ItemStack is, RenderBlocks renderer, ItemRenderType type, Object[] obj )
+	public void renderInventory( BlockSkyCompass blk, ItemStack is, RenderBlocks renderer, ItemRenderType type, Object[] obj )
 	{
 		if( type == ItemRenderType.INVENTORY )
 		{
@@ -74,7 +73,7 @@ public class RenderBlockSkyCompass extends BaseBlockRender
 			}
 		}
 
-		GL11.glEnable( 32826 /* GL_RESCALE_NORMAL_EXT */ );
+		GL11.glEnable( 32826 /* GL_RESCALE_NORMAL_EXT */);
 		GL11.glColor4f( 1.0F, 1.0F, 1.0F, 1.0F );
 
 		ResourceLocation loc = new ResourceLocation( "appliedenergistics2", "textures/models/compass.png" );
@@ -168,18 +167,18 @@ public class RenderBlockSkyCompass extends BaseBlockRender
 			this.model.renderAll( ( now / 50000.0f ) * (float) Math.PI * 500.0f );
 		}
 
-		GL11.glDisable( 32826 /* GL_RESCALE_NORMAL_EXT */ );
+		GL11.glDisable( 32826 /* GL_RESCALE_NORMAL_EXT */);
 		GL11.glColor4f( 1.0F, 1.0F, 1.0F, 1.0F );
 	}
 
 	@Override
-	public boolean renderInWorld( AEBaseBlock blk, IBlockAccess world, int x, int y, int z, RenderBlocks renderer )
+	public boolean renderInWorld( BlockSkyCompass blk, IBlockAccess world, int x, int y, int z, RenderBlocks renderer )
 	{
 		return true;
 	}
 
 	@Override
-	public void renderTile( AEBaseBlock block, AEBaseTile tile, Tessellator tess, double x, double y, double z, float partialTick, RenderBlocks renderer )
+	public void renderTile( BlockSkyCompass block, TileSkyCompass tile, Tessellator tess, double x, double y, double z, float partialTick, RenderBlocks renderer )
 	{
 		if( !( tile instanceof TileSkyCompass ) )
 		{
@@ -193,7 +192,7 @@ public class RenderBlockSkyCompass extends BaseBlockRender
 			return;
 		}
 
-		GL11.glEnable( 32826 /* GL_RESCALE_NORMAL_EXT */ );
+		GL11.glEnable( 32826 /* GL_RESCALE_NORMAL_EXT */);
 		GL11.glColor4f( 1.0F, 1.0F, 1.0F, 1.0F );
 
 		ResourceLocation loc = new ResourceLocation( "appliedenergistics2", "textures/models/compass.png" );
@@ -235,7 +234,7 @@ public class RenderBlockSkyCompass extends BaseBlockRender
 			this.model.renderAll( ( now / 500000.0f ) * (float) Math.PI * 500.0f );
 		}
 
-		GL11.glDisable( 32826 /* GL_RESCALE_NORMAL_EXT */ );
+		GL11.glDisable( 32826 /* GL_RESCALE_NORMAL_EXT */);
 		GL11.glColor4f( 1.0F, 1.0F, 1.0F, 1.0F );
 	}
 

--- a/src/main/java/appeng/client/render/blocks/RenderBlockWireless.java
+++ b/src/main/java/appeng/client/render/blocks/RenderBlockWireless.java
@@ -30,7 +30,7 @@ import net.minecraftforge.client.IItemRenderer.ItemRenderType;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import appeng.api.util.AEColor;
-import appeng.block.AEBaseBlock;
+import appeng.block.networking.BlockWireless;
 import appeng.client.render.BaseBlockRender;
 import appeng.client.render.BlockRenderInfo;
 import appeng.client.texture.CableBusTextures;
@@ -40,15 +40,15 @@ import appeng.tile.networking.TileWireless;
 import appeng.util.Platform;
 
 
-public class RenderBlockWireless extends BaseBlockRender
+public class RenderBlockWireless extends BaseBlockRender<BlockWireless, TileWireless>
 {
 
-	int centerX = 0;
-	int centerY = 0;
-	int centerZ = 0;
-	AEBaseBlock blk;
-	boolean hasChan = false;
-	boolean hasPower = false;
+	private int centerX = 0;
+	private int centerY = 0;
+	private int centerZ = 0;
+	private BlockWireless blk;
+	private boolean hasChan = false;
+	private boolean hasPower = false;
 
 	public RenderBlockWireless()
 	{
@@ -56,7 +56,7 @@ public class RenderBlockWireless extends BaseBlockRender
 	}
 
 	@Override
-	public void renderInventory( AEBaseBlock blk, ItemStack is, RenderBlocks renderer, ItemRenderType type, Object[] obj )
+	public void renderInventory( BlockWireless blk, ItemStack is, RenderBlocks renderer, ItemRenderType type, Object[] obj )
 	{
 		this.blk = blk;
 		this.centerX = 0;
@@ -107,7 +107,7 @@ public class RenderBlockWireless extends BaseBlockRender
 	}
 
 	@Override
-	public boolean renderInWorld( AEBaseBlock blk, IBlockAccess world, int x, int y, int z, RenderBlocks renderer )
+	public boolean renderInWorld( BlockWireless blk, IBlockAccess world, int x, int y, int z, RenderBlocks renderer )
 	{
 		TileWireless tw = blk.getTileEntity( world, x, y, z );
 		this.blk = blk;

--- a/src/main/java/appeng/client/render/blocks/RenderDrive.java
+++ b/src/main/java/appeng/client/render/blocks/RenderDrive.java
@@ -29,14 +29,14 @@ import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.client.IItemRenderer.ItemRenderType;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import appeng.block.AEBaseBlock;
+import appeng.block.storage.BlockDrive;
 import appeng.client.render.BaseBlockRender;
 import appeng.client.texture.ExtraBlockTextures;
 import appeng.tile.storage.TileDrive;
 import appeng.util.Platform;
 
 
-public class RenderDrive extends BaseBlockRender
+public class RenderDrive extends BaseBlockRender<BlockDrive, TileDrive>
 {
 
 	public RenderDrive()
@@ -45,7 +45,7 @@ public class RenderDrive extends BaseBlockRender
 	}
 
 	@Override
-	public void renderInventory( AEBaseBlock block, ItemStack is, RenderBlocks renderer, ItemRenderType type, Object[] obj )
+	public void renderInventory( BlockDrive block, ItemStack is, RenderBlocks renderer, ItemRenderType type, Object[] obj )
 	{
 		renderer.overrideBlockTexture = ExtraBlockTextures.getMissing();
 		this.renderInvBlock( EnumSet.of( ForgeDirection.SOUTH ), block, is, Tessellator.instance, 0x000000, renderer );
@@ -55,7 +55,7 @@ public class RenderDrive extends BaseBlockRender
 	}
 
 	@Override
-	public boolean renderInWorld( AEBaseBlock imb, IBlockAccess world, int x, int y, int z, RenderBlocks renderer )
+	public boolean renderInWorld( BlockDrive imb, IBlockAccess world, int x, int y, int z, RenderBlocks renderer )
 	{
 		TileDrive sp = imb.getTileEntity( world, x, y, z );
 		renderer.setRenderBounds( 0, 0, 0, 1, 1, 1 );

--- a/src/main/java/appeng/client/render/blocks/RenderMEChest.java
+++ b/src/main/java/appeng/client/render/blocks/RenderMEChest.java
@@ -32,7 +32,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 import appeng.api.AEApi;
 import appeng.api.storage.ICellHandler;
 import appeng.api.util.AEColor;
-import appeng.block.AEBaseBlock;
+import appeng.block.storage.BlockChest;
 import appeng.client.render.BaseBlockRender;
 import appeng.client.texture.ExtraBlockTextures;
 import appeng.client.texture.FlippableIcon;
@@ -41,7 +41,7 @@ import appeng.tile.storage.TileChest;
 import appeng.util.Platform;
 
 
-public class RenderMEChest extends BaseBlockRender
+public class RenderMEChest extends BaseBlockRender<BlockChest, TileChest>
 {
 
 	public RenderMEChest()
@@ -50,7 +50,7 @@ public class RenderMEChest extends BaseBlockRender
 	}
 
 	@Override
-	public void renderInventory( AEBaseBlock block, ItemStack is, RenderBlocks renderer, ItemRenderType type, Object[] obj )
+	public void renderInventory( BlockChest block, ItemStack is, RenderBlocks renderer, ItemRenderType type, Object[] obj )
 	{
 		Tessellator.instance.setBrightness( 0 );
 		renderer.overrideBlockTexture = ExtraBlockTextures.getMissing();
@@ -64,7 +64,7 @@ public class RenderMEChest extends BaseBlockRender
 	}
 
 	@Override
-	public boolean renderInWorld( AEBaseBlock imb, IBlockAccess world, int x, int y, int z, RenderBlocks renderer )
+	public boolean renderInWorld( BlockChest imb, IBlockAccess world, int x, int y, int z, RenderBlocks renderer )
 	{
 		TileChest sp = imb.getTileEntity( world, x, y, z );
 		renderer.setRenderBounds( 0, 0, 0, 1, 1, 1 );
@@ -120,8 +120,8 @@ public class RenderMEChest extends BaseBlockRender
 
 		/*
 		 * 1.7.2
-		 *
-		 * else if ( forward == ForgeDirection.EAST && up == ForgeDirection.UP ) flippableIcon.setFlip( true, false ); else if (
+		 * else if ( forward == ForgeDirection.EAST && up == ForgeDirection.UP ) flippableIcon.setFlip( true, false );
+		 * else if (
 		 * forward == ForgeDirection.NORTH && up == ForgeDirection.UP ) flippableIcon.setFlip( true, false );
 		 */
 

--- a/src/main/java/appeng/client/render/blocks/RenderNull.java
+++ b/src/main/java/appeng/client/render/blocks/RenderNull.java
@@ -26,9 +26,10 @@ import net.minecraftforge.client.IItemRenderer.ItemRenderType;
 
 import appeng.block.AEBaseBlock;
 import appeng.client.render.BaseBlockRender;
+import appeng.tile.AEBaseTile;
 
 
-public class RenderNull extends BaseBlockRender
+public class RenderNull extends BaseBlockRender<AEBaseBlock, AEBaseTile>
 {
 
 	public RenderNull()

--- a/src/main/java/appeng/client/render/blocks/RenderQNB.java
+++ b/src/main/java/appeng/client/render/blocks/RenderQNB.java
@@ -37,17 +37,17 @@ import appeng.api.definitions.IBlocks;
 import appeng.api.definitions.IDefinitions;
 import appeng.api.definitions.IParts;
 import appeng.api.util.AEColor;
-import appeng.block.AEBaseBlock;
+import appeng.block.qnb.BlockQuantumBase;
 import appeng.client.render.BaseBlockRender;
 import appeng.client.texture.ExtraBlockTextures;
 import appeng.tile.qnb.TileQuantumBridge;
 
 
-public class RenderQNB extends BaseBlockRender
+public class RenderQNB extends BaseBlockRender<BlockQuantumBase, TileQuantumBridge>
 {
 
 	@Override
-	public void renderInventory( AEBaseBlock block, ItemStack item, RenderBlocks renderer, ItemRenderType type, Object[] obj )
+	public void renderInventory( BlockQuantumBase block, ItemStack item, RenderBlocks renderer, ItemRenderType type, Object[] obj )
 	{
 		float minPx = 2.0f / 16.0f;
 		float maxPx = 14.0f / 16.0f;
@@ -57,7 +57,7 @@ public class RenderQNB extends BaseBlockRender
 	}
 
 	@Override
-	public boolean renderInWorld( AEBaseBlock block, IBlockAccess world, int x, int y, int z, RenderBlocks renderer )
+	public boolean renderInWorld( BlockQuantumBase block, IBlockAccess world, int x, int y, int z, RenderBlocks renderer )
 	{
 		TileQuantumBridge tqb = block.getTileEntity( world, x, y, z );
 		if( tqb == null )
@@ -162,7 +162,7 @@ public class RenderQNB extends BaseBlockRender
 		return true;
 	}
 
-	public void renderCableAt( double thickness, IBlockAccess world, int x, int y, int z, AEBaseBlock block, RenderBlocks renderer, IIcon texture, double pull, Collection<ForgeDirection> connections )
+	private void renderCableAt( double thickness, IBlockAccess world, int x, int y, int z, BlockQuantumBase block, RenderBlocks renderer, IIcon texture, double pull, Collection<ForgeDirection> connections )
 	{
 		block.getRendererInstance().setTemporaryRenderIcon( texture );
 

--- a/src/main/java/appeng/client/render/blocks/RenderQuartzGlass.java
+++ b/src/main/java/appeng/client/render/blocks/RenderQuartzGlass.java
@@ -28,13 +28,14 @@ import net.minecraftforge.client.IItemRenderer.ItemRenderType;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import appeng.api.AEApi;
-import appeng.block.AEBaseBlock;
+import appeng.block.solids.BlockQuartzGlass;
 import appeng.client.render.BaseBlockRender;
 import appeng.client.texture.ExtraBlockTextures;
 import appeng.client.texture.OffsetIcon;
+import appeng.tile.AEBaseTile;
 
 
-public class RenderQuartzGlass extends BaseBlockRender
+public class RenderQuartzGlass extends BaseBlockRender<BlockQuartzGlass, AEBaseTile>
 {
 
 	static byte[][][] offsets;
@@ -57,7 +58,7 @@ public class RenderQuartzGlass extends BaseBlockRender
 	}
 
 	@Override
-	public void renderInventory( AEBaseBlock block, ItemStack is, RenderBlocks renderer, ItemRenderType type, Object[] obj )
+	public void renderInventory( BlockQuartzGlass block, ItemStack is, RenderBlocks renderer, ItemRenderType type, Object[] obj )
 	{
 		renderer.overrideBlockTexture = ExtraBlockTextures.GlassFrame.getIcon();
 		super.renderInventory( block, is, renderer, type, obj );
@@ -66,7 +67,7 @@ public class RenderQuartzGlass extends BaseBlockRender
 	}
 
 	@Override
-	public boolean renderInWorld( AEBaseBlock imb, IBlockAccess world, int x, int y, int z, RenderBlocks renderer )
+	public boolean renderInWorld( BlockQuartzGlass imb, IBlockAccess world, int x, int y, int z, RenderBlocks renderer )
 	{
 		renderer.setRenderBounds( 0, 0, 0, 1, 1, 1 );
 
@@ -129,7 +130,7 @@ public class RenderQuartzGlass extends BaseBlockRender
 		return result;
 	}
 
-	void renderEdge( AEBaseBlock imb, IBlockAccess world, int x, int y, int z, RenderBlocks renderer, ForgeDirection side, ForgeDirection direction )
+	private void renderEdge( BlockQuartzGlass imb, IBlockAccess world, int x, int y, int z, RenderBlocks renderer, ForgeDirection side, ForgeDirection direction )
 	{
 		if( !this.isFlush( imb, world, x + side.offsetX, y + side.offsetY, z + side.offsetZ ) )
 		{
@@ -213,12 +214,12 @@ public class RenderQuartzGlass extends BaseBlockRender
 		}
 	}
 
-	boolean isFlush( AEBaseBlock imb, IBlockAccess world, int x, int y, int z )
+	private boolean isFlush( BlockQuartzGlass imb, IBlockAccess world, int x, int y, int z )
 	{
 		return this.isGlass( imb, world, x, y, z );
 	}
 
-	boolean isGlass( AEBaseBlock imb, IBlockAccess world, int x, int y, int z )
+	private boolean isGlass( BlockQuartzGlass imb, IBlockAccess world, int x, int y, int z )
 	{
 		return this.isQuartzGlass( world, x, y, z ) || this.isVibrantQuartzGlass( world, x, y, z );
 	}

--- a/src/main/java/appeng/client/render/blocks/RenderQuartzOre.java
+++ b/src/main/java/appeng/client/render/blocks/RenderQuartzOre.java
@@ -24,13 +24,13 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.client.IItemRenderer.ItemRenderType;
 
-import appeng.block.AEBaseBlock;
 import appeng.block.solids.OreQuartz;
 import appeng.client.render.BaseBlockRender;
 import appeng.client.texture.ExtraBlockTextures;
+import appeng.tile.AEBaseTile;
 
 
-public class RenderQuartzOre extends BaseBlockRender
+public class RenderQuartzOre extends BaseBlockRender<OreQuartz, AEBaseTile>
 {
 
 	public RenderQuartzOre()
@@ -39,7 +39,7 @@ public class RenderQuartzOre extends BaseBlockRender
 	}
 
 	@Override
-	public void renderInventory( AEBaseBlock blk, ItemStack is, RenderBlocks renderer, ItemRenderType type, Object[] obj )
+	public void renderInventory( OreQuartz blk, ItemStack is, RenderBlocks renderer, ItemRenderType type, Object[] obj )
 	{
 		super.renderInventory( blk, is, renderer, type, obj );
 		blk.getRendererInstance().setTemporaryRenderIcon( ExtraBlockTextures.OreQuartzStone.getIcon() );
@@ -48,7 +48,7 @@ public class RenderQuartzOre extends BaseBlockRender
 	}
 
 	@Override
-	public boolean renderInWorld( AEBaseBlock block, IBlockAccess world, int x, int y, int z, RenderBlocks renderer )
+	public boolean renderInWorld( OreQuartz block, IBlockAccess world, int x, int y, int z, RenderBlocks renderer )
 	{
 		OreQuartz blk = (OreQuartz) block;
 		blk.setEnhanceBrightness( true );

--- a/src/main/java/appeng/client/render/blocks/RenderQuartzTorch.java
+++ b/src/main/java/appeng/client/render/blocks/RenderQuartzTorch.java
@@ -34,9 +34,10 @@ import appeng.api.util.IOrientableBlock;
 import appeng.block.AEBaseBlock;
 import appeng.block.misc.BlockQuartzTorch;
 import appeng.client.render.BaseBlockRender;
+import appeng.tile.AEBaseTile;
 
 
-public class RenderQuartzTorch extends BaseBlockRender
+public class RenderQuartzTorch extends BaseBlockRender<AEBaseBlock, AEBaseTile>
 {
 
 	public RenderQuartzTorch()

--- a/src/main/java/appeng/client/render/blocks/RenderSpatialPylon.java
+++ b/src/main/java/appeng/client/render/blocks/RenderSpatialPylon.java
@@ -27,14 +27,14 @@ import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.client.IItemRenderer.ItemRenderType;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import appeng.block.AEBaseBlock;
+import appeng.block.spatial.BlockSpatialPylon;
 import appeng.client.render.BaseBlockRender;
 import appeng.client.render.BlockRenderInfo;
 import appeng.client.texture.ExtraBlockTextures;
 import appeng.tile.spatial.TileSpatialPylon;
 
 
-public class RenderSpatialPylon extends BaseBlockRender
+public class RenderSpatialPylon extends BaseBlockRender<BlockSpatialPylon, TileSpatialPylon>
 {
 
 	public RenderSpatialPylon()
@@ -43,7 +43,7 @@ public class RenderSpatialPylon extends BaseBlockRender
 	}
 
 	@Override
-	public void renderInventory( AEBaseBlock block, ItemStack is, RenderBlocks renderer, ItemRenderType type, Object[] obj )
+	public void renderInventory( BlockSpatialPylon block, ItemStack is, RenderBlocks renderer, ItemRenderType type, Object[] obj )
 	{
 		renderer.overrideBlockTexture = ExtraBlockTextures.BlockSpatialPylon_dim.getIcon();
 		super.renderInventory( block, is, renderer, type, obj );
@@ -52,7 +52,7 @@ public class RenderSpatialPylon extends BaseBlockRender
 	}
 
 	@Override
-	public boolean renderInWorld( AEBaseBlock imb, IBlockAccess world, int x, int y, int z, RenderBlocks renderer )
+	public boolean renderInWorld( BlockSpatialPylon imb, IBlockAccess world, int x, int y, int z, RenderBlocks renderer )
 	{
 		renderer.setRenderBounds( 0, 0, 0, 1, 1, 1 );
 
@@ -63,17 +63,17 @@ public class RenderSpatialPylon extends BaseBlockRender
 
 		if( displayBits != 0 )
 		{
-			if( ( displayBits & sp.DISPLAY_Z ) == sp.DISPLAY_X )
+			if( ( displayBits & TileSpatialPylon.DISPLAY_Z ) == TileSpatialPylon.DISPLAY_X )
 			{
 				ori = ForgeDirection.EAST;
-				if( ( displayBits & sp.DISPLAY_MIDDLE ) == sp.DISPLAY_END_MAX )
+				if( ( displayBits & TileSpatialPylon.DISPLAY_MIDDLE ) == TileSpatialPylon.DISPLAY_END_MAX )
 				{
 					renderer.uvRotateEast = 1;
 					renderer.uvRotateWest = 2;
 					renderer.uvRotateTop = 2;
 					renderer.uvRotateBottom = 1;
 				}
-				else if( ( displayBits & sp.DISPLAY_MIDDLE ) == sp.DISPLAY_END_MIN )
+				else if( ( displayBits & TileSpatialPylon.DISPLAY_MIDDLE ) == TileSpatialPylon.DISPLAY_END_MIN )
 				{
 					renderer.uvRotateEast = 2;
 					renderer.uvRotateWest = 1;
@@ -89,10 +89,10 @@ public class RenderSpatialPylon extends BaseBlockRender
 				}
 			}
 
-			else if( ( displayBits & sp.DISPLAY_Z ) == sp.DISPLAY_Y )
+			else if( ( displayBits & TileSpatialPylon.DISPLAY_Z ) == TileSpatialPylon.DISPLAY_Y )
 			{
 				ori = ForgeDirection.UP;
-				if( ( displayBits & sp.DISPLAY_MIDDLE ) == sp.DISPLAY_END_MAX )
+				if( ( displayBits & TileSpatialPylon.DISPLAY_MIDDLE ) == TileSpatialPylon.DISPLAY_END_MAX )
 				{
 					renderer.uvRotateNorth = 3;
 					renderer.uvRotateSouth = 3;
@@ -101,15 +101,15 @@ public class RenderSpatialPylon extends BaseBlockRender
 				}
 			}
 
-			else if( ( displayBits & sp.DISPLAY_Z ) == sp.DISPLAY_Z )
+			else if( ( displayBits & TileSpatialPylon.DISPLAY_Z ) == TileSpatialPylon.DISPLAY_Z )
 			{
 				ori = ForgeDirection.NORTH;
-				if( ( displayBits & sp.DISPLAY_MIDDLE ) == sp.DISPLAY_END_MAX )
+				if( ( displayBits & TileSpatialPylon.DISPLAY_MIDDLE ) == TileSpatialPylon.DISPLAY_END_MAX )
 				{
 					renderer.uvRotateSouth = 1;
 					renderer.uvRotateNorth = 2;
 				}
-				else if( ( displayBits & sp.DISPLAY_MIDDLE ) == sp.DISPLAY_END_MIN )
+				else if( ( displayBits & TileSpatialPylon.DISPLAY_MIDDLE ) == TileSpatialPylon.DISPLAY_END_MIN )
 				{
 					renderer.uvRotateNorth = 1;
 					renderer.uvRotateSouth = 2;
@@ -129,7 +129,7 @@ public class RenderSpatialPylon extends BaseBlockRender
 
 			boolean r = renderer.renderStandardBlock( imb, x, y, z );
 
-			if( ( displayBits & sp.DISPLAY_POWERED_ENABLED ) == sp.DISPLAY_POWERED_ENABLED )
+			if( ( displayBits & TileSpatialPylon.DISPLAY_POWERED_ENABLED ) == TileSpatialPylon.DISPLAY_POWERED_ENABLED )
 			{
 				int bn = 15;
 				Tessellator.instance.setBrightness( bn << 20 | bn << 4 );
@@ -164,7 +164,7 @@ public class RenderSpatialPylon extends BaseBlockRender
 		return result;
 	}
 
-	private IIcon getBlockTextureFromSideOutside( AEBaseBlock blk, TileSpatialPylon sp, int displayBits, ForgeDirection ori, ForgeDirection dir )
+	private IIcon getBlockTextureFromSideOutside( BlockSpatialPylon blk, TileSpatialPylon sp, int displayBits, ForgeDirection ori, ForgeDirection dir )
 	{
 
 		if( ori == dir || ori.getOpposite() == dir )
@@ -172,15 +172,15 @@ public class RenderSpatialPylon extends BaseBlockRender
 			return blk.getRendererInstance().getTexture( dir );
 		}
 
-		if( ( displayBits & sp.DISPLAY_MIDDLE ) == sp.DISPLAY_MIDDLE )
+		if( ( displayBits & TileSpatialPylon.DISPLAY_MIDDLE ) == TileSpatialPylon.DISPLAY_MIDDLE )
 		{
 			return ExtraBlockTextures.BlockSpatialPylonC.getIcon();
 		}
-		else if( ( displayBits & sp.DISPLAY_MIDDLE ) == sp.DISPLAY_END_MIN )
+		else if( ( displayBits & TileSpatialPylon.DISPLAY_MIDDLE ) == TileSpatialPylon.DISPLAY_END_MIN )
 		{
 			return ExtraBlockTextures.BlockSpatialPylonE.getIcon();
 		}
-		else if( ( displayBits & sp.DISPLAY_MIDDLE ) == sp.DISPLAY_END_MAX )
+		else if( ( displayBits & TileSpatialPylon.DISPLAY_MIDDLE ) == TileSpatialPylon.DISPLAY_END_MAX )
 		{
 			return ExtraBlockTextures.BlockSpatialPylonE.getIcon();
 		}
@@ -188,24 +188,24 @@ public class RenderSpatialPylon extends BaseBlockRender
 		return blk.getIcon( 0, 0 );
 	}
 
-	private IIcon getBlockTextureFromSideInside( AEBaseBlock blk, TileSpatialPylon sp, int displayBits, ForgeDirection ori, ForgeDirection dir )
+	private IIcon getBlockTextureFromSideInside( BlockSpatialPylon blk, TileSpatialPylon sp, int displayBits, ForgeDirection ori, ForgeDirection dir )
 	{
-		boolean good = ( displayBits & sp.DISPLAY_ENABLED ) == sp.DISPLAY_ENABLED;
+		boolean good = ( displayBits & TileSpatialPylon.DISPLAY_ENABLED ) == TileSpatialPylon.DISPLAY_ENABLED;
 
 		if( ori == dir || ori.getOpposite() == dir )
 		{
 			return good ? ExtraBlockTextures.BlockSpatialPylon_dim.getIcon() : ExtraBlockTextures.BlockSpatialPylon_red.getIcon();
 		}
 
-		if( ( displayBits & sp.DISPLAY_MIDDLE ) == sp.DISPLAY_MIDDLE )
+		if( ( displayBits & TileSpatialPylon.DISPLAY_MIDDLE ) == TileSpatialPylon.DISPLAY_MIDDLE )
 		{
 			return good ? ExtraBlockTextures.BlockSpatialPylonC_dim.getIcon() : ExtraBlockTextures.BlockSpatialPylonC_red.getIcon();
 		}
-		else if( ( displayBits & sp.DISPLAY_MIDDLE ) == sp.DISPLAY_END_MIN )
+		else if( ( displayBits & TileSpatialPylon.DISPLAY_MIDDLE ) == TileSpatialPylon.DISPLAY_END_MIN )
 		{
 			return good ? ExtraBlockTextures.BlockSpatialPylonE_dim.getIcon() : ExtraBlockTextures.BlockSpatialPylonE_red.getIcon();
 		}
-		else if( ( displayBits & sp.DISPLAY_MIDDLE ) == sp.DISPLAY_END_MAX )
+		else if( ( displayBits & TileSpatialPylon.DISPLAY_MIDDLE ) == TileSpatialPylon.DISPLAY_END_MAX )
 		{
 			return good ? ExtraBlockTextures.BlockSpatialPylonE_dim.getIcon() : ExtraBlockTextures.BlockSpatialPylonE_red.getIcon();
 		}

--- a/src/main/java/appeng/client/render/blocks/RenderTinyTNT.java
+++ b/src/main/java/appeng/client/render/blocks/RenderTinyTNT.java
@@ -24,11 +24,12 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.client.IItemRenderer.ItemRenderType;
 
-import appeng.block.AEBaseBlock;
+import appeng.block.misc.BlockTinyTNT;
 import appeng.client.render.BaseBlockRender;
+import appeng.tile.AEBaseTile;
 
 
-public class RenderTinyTNT extends BaseBlockRender
+public class RenderTinyTNT extends BaseBlockRender<BlockTinyTNT, AEBaseTile>
 {
 
 	public RenderTinyTNT()
@@ -37,14 +38,14 @@ public class RenderTinyTNT extends BaseBlockRender
 	}
 
 	@Override
-	public void renderInventory( AEBaseBlock block, ItemStack is, RenderBlocks renderer, ItemRenderType type, Object[] obj )
+	public void renderInventory( BlockTinyTNT block, ItemStack is, RenderBlocks renderer, ItemRenderType type, Object[] obj )
 	{
 		renderer.setRenderBounds( 0.25f, 0.0f, 0.25f, 0.75f, 0.5f, 0.75f );
 		super.renderInventory( block, is, renderer, type, obj );
 	}
 
 	@Override
-	public boolean renderInWorld( AEBaseBlock imb, IBlockAccess world, int x, int y, int z, RenderBlocks renderer )
+	public boolean renderInWorld( BlockTinyTNT imb, IBlockAccess world, int x, int y, int z, RenderBlocks renderer )
 	{
 		renderer.renderAllFaces = true;
 		renderer.setRenderBounds( 0.25f, 0.0f, 0.25f, 0.75f, 0.5f, 0.75f );

--- a/src/main/java/appeng/client/render/blocks/RendererCableBus.java
+++ b/src/main/java/appeng/client/render/blocks/RendererCableBus.java
@@ -25,7 +25,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.client.IItemRenderer.ItemRenderType;
 
-import appeng.block.AEBaseBlock;
+import appeng.block.networking.BlockCableBus;
 import appeng.client.render.BaseBlockRender;
 import appeng.client.render.BusRenderHelper;
 import appeng.client.render.BusRenderer;
@@ -33,7 +33,7 @@ import appeng.tile.AEBaseTile;
 import appeng.tile.networking.TileCableBus;
 
 
-public class RendererCableBus extends BaseBlockRender
+public class RendererCableBus extends BaseBlockRender<BlockCableBus, TileCableBus>
 {
 
 	public RendererCableBus()
@@ -42,13 +42,13 @@ public class RendererCableBus extends BaseBlockRender
 	}
 
 	@Override
-	public void renderInventory( AEBaseBlock blk, ItemStack is, RenderBlocks renderer, ItemRenderType type, Object[] obj )
+	public void renderInventory( BlockCableBus blk, ItemStack is, RenderBlocks renderer, ItemRenderType type, Object[] obj )
 	{
 		// nothing.
 	}
 
 	@Override
-	public boolean renderInWorld( AEBaseBlock block, IBlockAccess world, int x, int y, int z, RenderBlocks renderer )
+	public boolean renderInWorld( BlockCableBus block, IBlockAccess world, int x, int y, int z, RenderBlocks renderer )
 	{
 		AEBaseTile t = block.getTileEntity( world, x, y, z );
 
@@ -65,7 +65,7 @@ public class RendererCableBus extends BaseBlockRender
 	}
 
 	@Override
-	public void renderTile( AEBaseBlock block, AEBaseTile t, Tessellator tess, double x, double y, double z, float f, RenderBlocks renderer )
+	public void renderTile( BlockCableBus block, TileCableBus t, Tessellator tess, double x, double y, double z, float f, RenderBlocks renderer )
 	{
 		if( t instanceof TileCableBus )
 		{

--- a/src/main/java/appeng/client/render/blocks/RendererSecurity.java
+++ b/src/main/java/appeng/client/render/blocks/RendererSecurity.java
@@ -30,13 +30,13 @@ import net.minecraftforge.client.IItemRenderer.ItemRenderType;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import appeng.api.util.AEColor;
-import appeng.block.AEBaseBlock;
+import appeng.block.misc.BlockSecurity;
 import appeng.client.render.BaseBlockRender;
 import appeng.client.texture.ExtraBlockTextures;
 import appeng.tile.misc.TileSecurity;
 
 
-public class RendererSecurity extends BaseBlockRender
+public class RendererSecurity extends BaseBlockRender<BlockSecurity, TileSecurity>
 {
 
 	public RendererSecurity()
@@ -45,7 +45,7 @@ public class RendererSecurity extends BaseBlockRender
 	}
 
 	@Override
-	public void renderInventory( AEBaseBlock block, ItemStack is, RenderBlocks renderer, ItemRenderType type, Object[] obj )
+	public void renderInventory( BlockSecurity block, ItemStack is, RenderBlocks renderer, ItemRenderType type, Object[] obj )
 	{
 		renderer.overrideBlockTexture = ExtraBlockTextures.getMissing();
 		this.renderInvBlock( EnumSet.of( ForgeDirection.SOUTH ), block, is, Tessellator.instance, 0x000000, renderer );
@@ -58,7 +58,7 @@ public class RendererSecurity extends BaseBlockRender
 	}
 
 	@Override
-	public boolean renderInWorld( AEBaseBlock imb, IBlockAccess world, int x, int y, int z, RenderBlocks renderer )
+	public boolean renderInWorld( BlockSecurity imb, IBlockAccess world, int x, int y, int z, RenderBlocks renderer )
 	{
 		TileSecurity sp = imb.getTileEntity( world, x, y, z );
 		renderer.setRenderBounds( 0, 0, 0, 1, 1, 1 );

--- a/src/main/java/appeng/core/api/definitions/ApiBlocks.java
+++ b/src/main/java/appeng/core/api/definitions/ApiBlocks.java
@@ -112,7 +112,7 @@ public final class ApiBlocks implements IBlocks
 	private final ITileDefinition inscriber;
 	private final ITileDefinition wireless;
 	private final ITileDefinition charger;
-	private final ITileDefinition tinyTNT;
+	private final IBlockDefinition tinyTNT;
 	private final ITileDefinition security;
 	private final ITileDefinition quantumRing;
 	private final ITileDefinition quantumLink;
@@ -197,7 +197,7 @@ public final class ApiBlocks implements IBlocks
 		this.inscriber = constructor.registerTileDefinition( new BlockInscriber() );
 		this.wireless = constructor.registerTileDefinition( new BlockWireless() );
 		this.charger = constructor.registerTileDefinition( new BlockCharger() );
-		this.tinyTNT = constructor.registerTileDefinition( new BlockTinyTNT() );
+		this.tinyTNT = constructor.registerBlockDefinition( new BlockTinyTNT() );
 		this.security = constructor.registerTileDefinition( new BlockSecurity() );
 		this.quantumRing = constructor.registerTileDefinition( new BlockQuantumRing() );
 		this.quantumLink = constructor.registerTileDefinition( new BlockQuantumLinkChamber() );
@@ -461,7 +461,7 @@ public final class ApiBlocks implements IBlocks
 	}
 
 	@Override
-	public ITileDefinition tinyTNT()
+	public IBlockDefinition tinyTNT()
 	{
 		return this.tinyTNT;
 	}

--- a/src/main/java/appeng/core/features/AECableBusFeatureHandler.java
+++ b/src/main/java/appeng/core/features/AECableBusFeatureHandler.java
@@ -23,30 +23,33 @@ import java.util.EnumSet;
 
 import com.google.common.base.Optional;
 
+import net.minecraft.tileentity.TileEntity;
+
 import cpw.mods.fml.common.registry.GameRegistry;
 
-import appeng.api.definitions.IBlockDefinition;
-import appeng.block.AEBaseBlock;
+import appeng.api.definitions.ITileDefinition;
+import appeng.block.AEBaseTileBlock;
+import appeng.block.networking.BlockCableBus;
 import appeng.core.CommonHelper;
 import appeng.core.CreativeTab;
 import appeng.util.Platform;
 
 
-public final class AEBlockFeatureHandler implements IFeatureHandler
+public final class AECableBusFeatureHandler implements IFeatureHandler
 {
-	private final AEBaseBlock featured;
+	private final AEBaseTileBlock featured;
 	private final FeatureNameExtractor extractor;
 	private final boolean enabled;
-	private final BlockDefinition definition;
+	private final TileDefinition definition;
 
-	public AEBlockFeatureHandler( EnumSet<AEFeature> features, AEBaseBlock featured, Optional<String> subName )
+	public AECableBusFeatureHandler( EnumSet<AEFeature> features, BlockCableBus featured, Optional<String> subName )
 	{
 		final ActivityState state = new FeaturedActiveChecker( features ).getActivityState();
 
 		this.featured = featured;
 		this.extractor = new FeatureNameExtractor( featured.getClass(), subName );
 		this.enabled = state == ActivityState.Enabled;
-		this.definition = new BlockDefinition( featured, state );
+		this.definition = new TileDefinition( featured, state );
 	}
 
 	@Override
@@ -56,11 +59,14 @@ public final class AEBlockFeatureHandler implements IFeatureHandler
 	}
 
 	@Override
-	public IBlockDefinition getDefinition()
+	public ITileDefinition getDefinition()
 	{
 		return this.definition;
 	}
 
+	/**
+	 * Registration of the {@link TileEntity} will actually be handled by {@link BlockCableBus#setupTile()}.
+	 */
 	@Override
 	public void register()
 	{
@@ -70,6 +76,11 @@ public final class AEBlockFeatureHandler implements IFeatureHandler
 			this.featured.setCreativeTab( CreativeTab.instance );
 			this.featured.setBlockName( /* "tile." */"appliedenergistics2." + name );
 			this.featured.setBlockTextureName( "appliedenergistics2:" + name );
+
+			if( Platform.isClient() )
+			{
+				CommonHelper.proxy.bindTileEntitySpecialRenderer( this.featured.getTileEntityClass(), this.featured );
+			}
 
 			final String registryName = "tile." + name;
 

--- a/src/main/java/appeng/core/features/AETileBlockFeatureHandler.java
+++ b/src/main/java/appeng/core/features/AETileBlockFeatureHandler.java
@@ -25,28 +25,28 @@ import com.google.common.base.Optional;
 
 import cpw.mods.fml.common.registry.GameRegistry;
 
-import appeng.api.definitions.IBlockDefinition;
-import appeng.block.AEBaseBlock;
+import appeng.api.definitions.ITileDefinition;
+import appeng.block.AEBaseTileBlock;
 import appeng.core.CommonHelper;
 import appeng.core.CreativeTab;
 import appeng.util.Platform;
 
 
-public final class AEBlockFeatureHandler implements IFeatureHandler
+public final class AETileBlockFeatureHandler implements IFeatureHandler
 {
-	private final AEBaseBlock featured;
+	private final AEBaseTileBlock featured;
 	private final FeatureNameExtractor extractor;
 	private final boolean enabled;
-	private final BlockDefinition definition;
+	private final TileDefinition definition;
 
-	public AEBlockFeatureHandler( EnumSet<AEFeature> features, AEBaseBlock featured, Optional<String> subName )
+	public AETileBlockFeatureHandler( EnumSet<AEFeature> features, AEBaseTileBlock featured, Optional<String> subName )
 	{
 		final ActivityState state = new FeaturedActiveChecker( features ).getActivityState();
 
 		this.featured = featured;
 		this.extractor = new FeatureNameExtractor( featured.getClass(), subName );
 		this.enabled = state == ActivityState.Enabled;
-		this.definition = new BlockDefinition( featured, state );
+		this.definition = new TileDefinition( featured, state );
 	}
 
 	@Override
@@ -56,7 +56,7 @@ public final class AEBlockFeatureHandler implements IFeatureHandler
 	}
 
 	@Override
-	public IBlockDefinition getDefinition()
+	public ITileDefinition getDefinition()
 	{
 		return this.definition;
 	}
@@ -71,11 +71,17 @@ public final class AEBlockFeatureHandler implements IFeatureHandler
 			this.featured.setBlockName( /* "tile." */"appliedenergistics2." + name );
 			this.featured.setBlockTextureName( "appliedenergistics2:" + name );
 
+			if( Platform.isClient() )
+			{
+				CommonHelper.proxy.bindTileEntitySpecialRenderer( this.featured.getTileEntityClass(), this.featured );
+			}
+
 			final String registryName = "tile." + name;
 
 			// Bypass the forge magic with null to register our own itemblock later.
 			GameRegistry.registerBlock( this.featured, null, registryName );
 			GameRegistry.registerItem( this.definition.maybeItem().get(), registryName );
+			GameRegistry.registerTileEntity( this.featured.getTileEntityClass(), this.featured.toString() );
 		}
 	}
 }

--- a/src/main/java/appeng/core/features/TileDefinition.java
+++ b/src/main/java/appeng/core/features/TileDefinition.java
@@ -25,21 +25,20 @@ import com.google.common.base.Preconditions;
 import net.minecraft.tileentity.TileEntity;
 
 import appeng.api.definitions.ITileDefinition;
-import appeng.block.AEBaseBlock;
+import appeng.block.AEBaseTileBlock;
 
 
 public final class TileDefinition extends BlockDefinition implements ITileDefinition
 {
-	private final AEBaseBlock block;
+	private final AEBaseTileBlock block;
 
-	public TileDefinition( AEBaseBlock block, ActivityState state )
+	public TileDefinition( AEBaseTileBlock block, ActivityState state )
 	{
 		super( block, state );
 
 		Preconditions.checkNotNull( block );
 		Preconditions.checkNotNull( state );
-
-		Preconditions.checkState( !block.hasBlockTileEntity() || block.getTileEntityClass() != null );
+		Preconditions.checkNotNull( block.getTileEntityClass() );
 
 		this.block = block;
 	}

--- a/src/main/java/appeng/debug/BlockChunkloader.java
+++ b/src/main/java/appeng/debug/BlockChunkloader.java
@@ -29,12 +29,12 @@ import net.minecraftforge.common.ForgeChunkManager;
 import net.minecraftforge.common.ForgeChunkManager.LoadingCallback;
 import net.minecraftforge.common.ForgeChunkManager.Ticket;
 
-import appeng.block.AEBaseBlock;
+import appeng.block.AEBaseTileBlock;
 import appeng.core.AppEng;
 import appeng.core.features.AEFeature;
 
 
-public class BlockChunkloader extends AEBaseBlock implements LoadingCallback
+public class BlockChunkloader extends AEBaseTileBlock implements LoadingCallback
 {
 
 	public BlockChunkloader()

--- a/src/main/java/appeng/debug/BlockCubeGenerator.java
+++ b/src/main/java/appeng/debug/BlockCubeGenerator.java
@@ -26,11 +26,11 @@ import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.world.World;
 
-import appeng.block.AEBaseBlock;
+import appeng.block.AEBaseTileBlock;
 import appeng.core.features.AEFeature;
 
 
-public class BlockCubeGenerator extends AEBaseBlock
+public class BlockCubeGenerator extends AEBaseTileBlock
 {
 
 	public BlockCubeGenerator()

--- a/src/main/java/appeng/debug/BlockItemGen.java
+++ b/src/main/java/appeng/debug/BlockItemGen.java
@@ -24,11 +24,11 @@ import java.util.EnumSet;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
 
-import appeng.block.AEBaseBlock;
+import appeng.block.AEBaseTileBlock;
 import appeng.core.features.AEFeature;
 
 
-public class BlockItemGen extends AEBaseBlock
+public class BlockItemGen extends AEBaseTileBlock
 {
 
 	public BlockItemGen()

--- a/src/main/java/appeng/debug/BlockPhantomNode.java
+++ b/src/main/java/appeng/debug/BlockPhantomNode.java
@@ -26,11 +26,11 @@ import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.world.World;
 
-import appeng.block.AEBaseBlock;
+import appeng.block.AEBaseTileBlock;
 import appeng.core.features.AEFeature;
 
 
-public class BlockPhantomNode extends AEBaseBlock
+public class BlockPhantomNode extends AEBaseTileBlock
 {
 
 	public BlockPhantomNode()


### PR DESCRIPTION
**First iteration not ready to be merged**

Splits the `AEBaseBlock` (with TE support) into a `AEBaseBlock` (no TE) and `AEBaseTileBlock`.

The `BaseBlockRender` is now a generic as some subclasses need a `AEBaseTileBlock` and this is a bit more sane to change the types of the method parameters.
But I will probably rename `BaseBlockRender` to `GenericBlockRender` add 2 intermediate classes `BaseBlockRender extends GenericBlockRender<AEBaseBlock>` and `BaseTileBlockRender extends GenericBlockRender<AEBaseTileBlock>`.

Also a separate commit/PR with an optimise import would be recommended to reduce the clutter.