### PR TITLE
Meteorites can now spawn in stained clay biomes

### DIFF
--- a/src/main/java/appeng/worldgen/MeteoritePlacer.java
+++ b/src/main/java/appeng/worldgen/MeteoritePlacer.java
@@ -90,6 +90,7 @@ public final class MeteoritePlacer
 		this.validSpawn.add( Blocks.hardened_clay );
 		this.validSpawn.add( Blocks.ice );
 		this.validSpawn.add( Blocks.snow );
+		this.validSpawn.add( Blocks.stained_hardened_clay );
 
 		for( Block skyStoneBlock : this.skyStoneDefinition.maybeBlock().asSet() )
 		{


### PR DESCRIPTION
This add stained clay to the meteorite whitelist so they can spawn in clay biomes.
If requested I can also PR this for rv2.