### PR TITLE
Fixes #1442 - Don't add the player inventory two times (Inscriber)

### DIFF
--- a/src/main/java/appeng/container/implementations/ContainerInscriber.java
+++ b/src/main/java/appeng/container/implementations/ContainerInscriber.java
@@ -65,8 +65,6 @@ public class ContainerInscriber extends ContainerUpgradeable implements IProgres
 		this.addSlotToContainer( this.middle = new SlotRestrictedInput( SlotRestrictedInput.PlacableItemType.INSCRIBER_INPUT, this.ti, 2, 63, 39, this.invPlayer ) );
 
 		this.addSlotToContainer( new SlotOutput( this.ti, 3, 113, 40, -1 ) );
-
-		this.bindPlayerInventory( ip, 0, this.getHeight() - /* height of player inventory */82 );
 	}
 
 	@Override


### PR DESCRIPTION
The player inventory is already binded in ContainerUpgradeable. This also prevents some dupes with other mods. Screenshot: http://imgur.com/bw8wQGu

If wanted I can also PR this to rv2.