### PR TITLE
Uses an instance factory access for AE2

### DIFF
--- a/src/main/java/appeng/block/misc/BlockTinyTNT.java
+++ b/src/main/java/appeng/block/misc/BlockTinyTNT.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of Applied Energistics 2.
- * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
  *
  * Applied Energistics 2 is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -66,7 +66,7 @@ public class BlockTinyTNT extends AEBaseBlock implements ICustomCollision
 		this.setHardness( 0F );
 		this.setFeature( EnumSet.of( AEFeature.TinyTNT ) );
 
-		EntityRegistry.registerModEntity( EntityTinyTNTPrimed.class, "EntityTinyTNTPrimed", EntityIds.TINY_TNT, AppEng.instance, 16, 4, true );
+		EntityRegistry.registerModEntity( EntityTinyTNTPrimed.class, "EntityTinyTNTPrimed", EntityIds.TINY_TNT, AppEng.instance(), 16, 4, true );
 	}
 
 	@Override

--- a/src/main/java/appeng/block/networking/BlockCableBus.java
+++ b/src/main/java/appeng/block/networking/BlockCableBus.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of Applied Energistics 2.
- * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
  *
  * Applied Energistics 2 is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -60,10 +60,10 @@ import appeng.client.render.blocks.RendererCableBus;
 import appeng.client.texture.ExtraBlockTextures;
 import appeng.core.AEConfig;
 import appeng.core.Api;
-import appeng.core.AppEng;
 import appeng.core.CommonHelper;
 import appeng.core.features.AEFeature;
 import appeng.helpers.AEGlassMaterial;
+import appeng.integration.IntegrationRegistry;
 import appeng.integration.IntegrationType;
 import appeng.integration.abstraction.IFMP;
 import appeng.parts.ICableBusContainer;
@@ -394,9 +394,9 @@ public class BlockCableBus extends AEBaseBlock implements IRedNetConnection
 		{
 			out = ( (TileCableBus) te ).cb;
 		}
-		else if( AppEng.instance.isIntegrationEnabled( IntegrationType.FMP ) )
+		else if( IntegrationRegistry.INSTANCE.isEnabled( IntegrationType.FMP ) )
 		{
-			out = ( (IFMP) AppEng.instance.getIntegration( IntegrationType.FMP ) ).getCableContainer( te );
+			out = ( (IFMP) IntegrationRegistry.INSTANCE.getInstance( IntegrationType.FMP ) ).getCableContainer( te );
 		}
 
 		return out == null ? NULL_CABLE_BUS : out;

--- a/src/main/java/appeng/client/gui/AEBaseGui.java
+++ b/src/main/java/appeng/client/gui/AEBaseGui.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of Applied Energistics 2.
- * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
  *
  * Applied Energistics 2 is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -72,11 +72,11 @@ import appeng.container.slot.SlotOutput;
 import appeng.container.slot.SlotPatternTerm;
 import appeng.container.slot.SlotRestrictedInput;
 import appeng.core.AELog;
-import appeng.core.AppEng;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketInventoryAction;
 import appeng.core.sync.packets.PacketSwapSlots;
 import appeng.helpers.InventoryAction;
+import appeng.integration.IntegrationRegistry;
 import appeng.integration.IntegrationType;
 import appeng.integration.abstraction.INEI;
 
@@ -895,9 +895,9 @@ public abstract class AEBaseGui extends GuiContainer
 
 	private RenderItem setItemRender( RenderItem item )
 	{
-		if( AppEng.instance.isIntegrationEnabled( IntegrationType.NEI ) )
+		if( IntegrationRegistry.INSTANCE.isEnabled( IntegrationType.NEI ) )
 		{
-			return ( (INEI) AppEng.instance.getIntegration( IntegrationType.NEI ) ).setItemRender( item );
+			return ( (INEI) IntegrationRegistry.INSTANCE.getInstance( IntegrationType.NEI ) ).setItemRender( item );
 		}
 		else
 		{

--- a/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of Applied Energistics 2.
- * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
  *
  * Applied Energistics 2 is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -53,13 +53,13 @@ import appeng.container.slot.SlotCraftingMatrix;
 import appeng.container.slot.SlotFakeCraftingMatrix;
 import appeng.core.AEConfig;
 import appeng.core.AELog;
-import appeng.core.AppEng;
 import appeng.core.localization.GuiText;
 import appeng.core.sync.GuiBridge;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketSwitchGuis;
 import appeng.core.sync.packets.PacketValueConfig;
 import appeng.helpers.WirelessTerminalGuiObject;
+import appeng.integration.IntegrationRegistry;
 import appeng.integration.IntegrationType;
 import appeng.parts.reporting.PartTerminal;
 import appeng.tile.misc.TileSecurity;
@@ -221,7 +221,7 @@ public class GuiMEMonitorable extends AEBaseMEGui implements ISortSource, IConfi
 		this.maxRows = this.getMaxRows();
 		this.perRow = AEConfig.instance.getConfigManager().getSetting( Settings.TERMINAL_STYLE ) != TerminalStyle.FULL ? 9 : 9 + ( ( this.width - this.standardSize ) / 18 );
 
-		boolean hasNEI = AppEng.instance.isIntegrationEnabled( IntegrationType.NEI );
+		boolean hasNEI = IntegrationRegistry.INSTANCE.isEnabled( IntegrationType.NEI );
 
 		int NEI = hasNEI ? 0 : 0;
 		int top = hasNEI ? 22 : 0;

--- a/src/main/java/appeng/client/gui/implementations/GuiSkyChest.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiSkyChest.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of Applied Energistics 2.
- * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
  *
  * Applied Energistics 2 is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -23,8 +23,8 @@ import net.minecraft.entity.player.InventoryPlayer;
 
 import appeng.client.gui.AEBaseGui;
 import appeng.container.implementations.ContainerSkyChest;
-import appeng.core.AppEng;
 import appeng.core.localization.GuiText;
+import appeng.integration.IntegrationRegistry;
 import appeng.integration.IntegrationType;
 import appeng.tile.storage.TileSkyChest;
 
@@ -55,6 +55,6 @@ public class GuiSkyChest extends AEBaseGui
 	@Override
 	protected boolean enableSpaceClicking()
 	{
-		return !AppEng.instance.isIntegrationEnabled( IntegrationType.InvTweaks );
+		return !IntegrationRegistry.INSTANCE.isEnabled( IntegrationType.InvTweaks );
 	}
 }

--- a/src/main/java/appeng/core/AppEng.java
+++ b/src/main/java/appeng/core/AppEng.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of Applied Energistics 2.
- * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
  *
  * Applied Energistics 2 is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -21,6 +21,7 @@ package appeng.core;
 
 import java.io.File;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nonnull;
 
 import com.google.common.base.Stopwatch;
 
@@ -45,7 +46,6 @@ import appeng.core.sync.GuiBridge;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.hooks.TickHandler;
 import appeng.integration.IntegrationRegistry;
-import appeng.integration.IntegrationType;
 import appeng.server.AECommand;
 import appeng.services.VersionChecker;
 import appeng.services.version.VersionCheckerConfig;
@@ -68,19 +68,26 @@ public final class AppEng
 					+ net.minecraftforge.common.ForgeVersion.minorVersion + '.' // minorVersion
 					+ net.minecraftforge.common.ForgeVersion.revisionVersion + '.' // revisionVersion
 					+ net.minecraftforge.common.ForgeVersion.buildVersion + ",)"; // buildVersion
-	public static AppEng instance;
+
+	@Nonnull
+	private static final AppEng INSTANCE = new AppEng();
 
 	private final IMCHandler imcHandler;
 
 	private File configDirectory;
 
-	public AppEng()
+	AppEng()
 	{
-		instance = this;
-
 		this.imcHandler = new IMCHandler();
 
 		FMLCommonHandler.instance().registerCrashCallable( new ModCrashEnhancement( CrashInfo.MOD_VERSION ) );
+	}
+
+	@Nonnull
+	@Mod.InstanceFactory
+	public static AppEng instance()
+	{
+		return INSTANCE;
 	}
 
 	public final File getConfigDirectory()
@@ -88,18 +95,8 @@ public final class AppEng
 		return this.configDirectory;
 	}
 
-	public boolean isIntegrationEnabled( IntegrationType integrationName )
-	{
-		return IntegrationRegistry.INSTANCE.isEnabled( integrationName );
-	}
-
-	public Object getIntegration( IntegrationType integrationName )
-	{
-		return IntegrationRegistry.INSTANCE.getInstance( integrationName );
-	}
-
 	@EventHandler
-	void preInit( FMLPreInitializationEvent event )
+	private void preInit( FMLPreInitializationEvent event )
 	{
 		if( !Loader.isModLoaded( "appliedenergistics2-core" ) )
 		{
@@ -153,7 +150,7 @@ public final class AppEng
 	}
 
 	@EventHandler
-	void init( FMLInitializationEvent event )
+	private void init( FMLInitializationEvent event )
 	{
 		Stopwatch star = Stopwatch.createStarted();
 		AELog.info( "Initialization ( started )" );
@@ -165,7 +162,7 @@ public final class AppEng
 	}
 
 	@EventHandler
-	void postInit( FMLPostInitializationEvent event )
+	private void postInit( FMLPostInitializationEvent event )
 	{
 		Stopwatch star = Stopwatch.createStarted();
 		AELog.info( "Post Initialization ( started )" );
@@ -184,26 +181,26 @@ public final class AppEng
 	}
 
 	@EventHandler
-	public void handleIMCEvent( FMLInterModComms.IMCEvent event )
+	private void handleIMCEvent( FMLInterModComms.IMCEvent event )
 	{
 		this.imcHandler.handleIMCEvent( event );
 	}
 
 	@EventHandler
-	public void serverStopping( FMLServerStoppingEvent event )
+	private void serverStopping( FMLServerStoppingEvent event )
 	{
 		WorldSettings.getInstance().shutdown();
 		TickHandler.INSTANCE.shutdown();
 	}
 
 	@EventHandler
-	public void serverAboutToStart( FMLServerAboutToStartEvent evt )
+	private void serverAboutToStart( FMLServerAboutToStartEvent evt )
 	{
 		WorldSettings.getInstance().init();
 	}
 
 	@EventHandler
-	public void serverStarting( FMLServerStartingEvent evt )
+	private void serverStarting( FMLServerStartingEvent evt )
 	{
 		evt.registerServerCommand( new AECommand( evt.getServer() ) );
 	}

--- a/src/main/java/appeng/core/IMCHandler.java
+++ b/src/main/java/appeng/core/IMCHandler.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of Applied Energistics 2.
- * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
  *
  * Applied Energistics 2 is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -38,6 +38,8 @@ import appeng.core.api.imc.IMCSpatial;
  */
 public class IMCHandler
 {
+	private static final int INITIAL_PROCESSORS_CAPACITY = 20;
+
 	/**
 	 * Contains the processors,
 	 *
@@ -51,7 +53,7 @@ public class IMCHandler
 	 */
 	public IMCHandler()
 	{
-		this.processors = new HashMap<String, IIMCProcessor>();
+		this.processors = new HashMap<String, IIMCProcessor>( INITIAL_PROCESSORS_CAPACITY );
 
 		this.processors.put( "blacklist-block-spatial", new IMCBlackListSpatial() );
 		this.processors.put( "whitelist-spatial", new IMCSpatial() );

--- a/src/main/java/appeng/core/Registration.java
+++ b/src/main/java/appeng/core/Registration.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of Applied Energistics 2.
- * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
  *
  * Applied Energistics 2 is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -76,6 +76,7 @@ import appeng.core.localization.PlayerMessages;
 import appeng.core.stats.PlayerStatsRegistration;
 import appeng.hooks.AETrading;
 import appeng.hooks.TickHandler;
+import appeng.integration.IntegrationRegistry;
 import appeng.integration.IntegrationType;
 import appeng.items.materials.ItemMultiMaterial;
 import appeng.me.cache.CraftingGridCache;
@@ -517,7 +518,7 @@ public final class Registration
 
 		if( AEConfig.instance.isFeatureEnabled( AEFeature.CustomRecipes ) )
 		{
-			this.recipeHandler.parseRecipes( new ConfigLoader( AppEng.instance.getConfigDirectory() ), "index.recipe" );
+			this.recipeHandler.parseRecipes( new ConfigLoader( AppEng.instance().getConfigDirectory() ), "index.recipe" );
 		}
 		else
 		{
@@ -528,18 +529,18 @@ public final class Registration
 		partHelper.registerNewLayer( "appeng.parts.layers.LayerIFluidHandler", "net.minecraftforge.fluids.IFluidHandler" );
 		partHelper.registerNewLayer( "appeng.parts.layers.LayerITileStorageMonitorable", "appeng.api.implementations.tiles.ITileStorageMonitorable" );
 
-		if( AppEng.instance.isIntegrationEnabled( IntegrationType.IC2 ) )
+		if( IntegrationRegistry.INSTANCE.isEnabled( IntegrationType.IC2 ) )
 		{
 			partHelper.registerNewLayer( "appeng.parts.layers.LayerIEnergySink", "ic2.api.energy.tile.IEnergySink" );
 			partHelper.registerNewLayer( "appeng.parts.layers.LayerIEnergySource", "ic2.api.energy.tile.IEnergySource" );
 		}
 
-		if( AppEng.instance.isIntegrationEnabled( IntegrationType.RF ) )
+		if( IntegrationRegistry.INSTANCE.isEnabled( IntegrationType.RF ) )
 		{
 			partHelper.registerNewLayer( "appeng.parts.layers.LayerIEnergyHandler", "cofh.api.energy.IEnergyReceiver" );
 		}
 
-		if ( AppEng.instance.isIntegrationEnabled( IntegrationType.OpenComputers ) )
+		if ( IntegrationRegistry.INSTANCE.isEnabled( IntegrationType.OpenComputers ) )
 		{
 			partHelper.registerNewLayer( "appeng.parts.layers.LayerSidedEnvironment", "li.cil.oc.api.network.SidedEnvironment" );
 		}

--- a/src/main/java/appeng/core/api/ApiPart.java
+++ b/src/main/java/appeng/core/api/ApiPart.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of Applied Energistics 2.
- * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
  *
  * Applied Energistics 2 is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -52,8 +52,8 @@ import appeng.api.parts.IPartItem;
 import appeng.api.parts.LayerBase;
 import appeng.client.render.BusRenderer;
 import appeng.core.AELog;
-import appeng.core.AppEng;
 import appeng.core.CommonHelper;
+import appeng.integration.IntegrationRegistry;
 import appeng.integration.IntegrationType;
 import appeng.integration.abstraction.IFMP;
 import appeng.parts.PartPlacement;
@@ -73,9 +73,9 @@ public class ApiPart implements IPartHelper
 	{
 		for( Class layerInterface : this.interfaces2Layer.keySet() )
 		{
-			if( AppEng.instance.isIntegrationEnabled( IntegrationType.FMP ) )
+			if( IntegrationRegistry.INSTANCE.isEnabled( IntegrationType.FMP ) )
 			{
-				( (IFMP) AppEng.instance.getIntegration( IntegrationType.FMP ) ).registerPassThrough( layerInterface );
+				( (IFMP) IntegrationRegistry.INSTANCE.getInstance( IntegrationType.FMP ) ).registerPassThrough( layerInterface );
 			}
 		}
 	}

--- a/src/main/java/appeng/core/sync/packets/PacketMultiPart.java
+++ b/src/main/java/appeng/core/sync/packets/PacketMultiPart.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of Applied Energistics 2.
- * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
  *
  * Applied Energistics 2 is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -26,9 +26,9 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraftforge.common.MinecraftForge;
 
-import appeng.core.AppEng;
 import appeng.core.sync.AppEngPacket;
 import appeng.core.sync.network.INetworkInfo;
+import appeng.integration.IntegrationRegistry;
 import appeng.integration.IntegrationType;
 import appeng.integration.abstraction.IFMP;
 
@@ -54,7 +54,7 @@ public class PacketMultiPart extends AppEngPacket
 	@Override
 	public void serverPacketData( INetworkInfo manager, AppEngPacket packet, EntityPlayer player )
 	{
-		IFMP fmp = (IFMP) AppEng.instance.getIntegration( IntegrationType.FMP );
+		IFMP fmp = (IFMP) IntegrationRegistry.INSTANCE.getInstance( IntegrationType.FMP );
 		if( fmp != null )
 		{
 			EntityPlayerMP sender = (EntityPlayerMP) player;

--- a/src/main/java/appeng/debug/BlockChunkloader.java
+++ b/src/main/java/appeng/debug/BlockChunkloader.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of Applied Energistics 2.
- * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
  *
  * Applied Energistics 2 is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -41,7 +41,7 @@ public class BlockChunkloader extends AEBaseBlock implements LoadingCallback
 	{
 		super( Material.iron );
 		this.setTileEntity( TileChunkLoader.class );
-		ForgeChunkManager.setForcedChunkLoadingCallback( AppEng.instance, this );
+		ForgeChunkManager.setForcedChunkLoadingCallback( AppEng.instance(), this );
 		this.setFeature( EnumSet.of( AEFeature.UnsupportedDeveloperTools, AEFeature.Creative ) );
 	}
 

--- a/src/main/java/appeng/debug/TileChunkLoader.java
+++ b/src/main/java/appeng/debug/TileChunkLoader.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of Applied Energistics 2.
- * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
  *
  * Applied Energistics 2 is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -62,7 +62,7 @@ public class TileChunkLoader extends AEBaseTile
 			return;
 		}
 
-		this.ct = ForgeChunkManager.requestTicket( AppEng.instance, this.worldObj, Type.NORMAL );
+		this.ct = ForgeChunkManager.requestTicket( AppEng.instance(), this.worldObj, Type.NORMAL );
 
 		if( this.ct == null )
 		{

--- a/src/main/java/appeng/facade/FacadeContainer.java
+++ b/src/main/java/appeng/facade/FacadeContainer.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of Applied Energistics 2.
- * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
  *
  * Applied Energistics 2 is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -33,7 +33,7 @@ import appeng.api.AEApi;
 import appeng.api.parts.IFacadeContainer;
 import appeng.api.parts.IFacadePart;
 import appeng.api.parts.IPartHost;
-import appeng.core.AppEng;
+import appeng.integration.IntegrationRegistry;
 import appeng.integration.IntegrationType;
 import appeng.integration.abstraction.IBC;
 import appeng.items.parts.ItemFacade;
@@ -137,9 +137,9 @@ public class FacadeContainer implements IFacadeContainer
 				boolean isBC = ids[0] < 0;
 				ids[0] = Math.abs( ids[0] );
 
-				if( isBC && AppEng.instance.isIntegrationEnabled( IntegrationType.BC ) )
+				if( isBC && IntegrationRegistry.INSTANCE.isEnabled( IntegrationType.BC ) )
 				{
-					IBC bc = (IBC) AppEng.instance.getIntegration( IntegrationType.BC );
+					IBC bc = (IBC) IntegrationRegistry.INSTANCE.getInstance( IntegrationType.BC );
 					changed = changed || this.storage.getFacade( x ) == null;
 					this.storage.setFacade( x, bc.createFacadePart( (Block) Block.blockRegistry.getObjectById( ids[0] ), ids[1], side ) );
 				}
@@ -187,9 +187,9 @@ public class FacadeContainer implements IFacadeContainer
 					}
 					else
 					{
-						if( AppEng.instance.isIntegrationEnabled( IntegrationType.BC ) )
+						if( IntegrationRegistry.INSTANCE.isEnabled( IntegrationType.BC ) )
 						{
-							IBC bc = (IBC) AppEng.instance.getIntegration( IntegrationType.BC );
+							IBC bc = (IBC) IntegrationRegistry.INSTANCE.getInstance( IntegrationType.BC );
 							if( bc.isFacade( is ) )
 							{
 								this.storage.setFacade( x, bc.createFacadePart( is, ForgeDirection.getOrientation( x ) ) );

--- a/src/main/java/appeng/facade/FacadePart.java
+++ b/src/main/java/appeng/facade/FacadePart.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of Applied Energistics 2.
- * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
  *
  * Applied Energistics 2 is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -51,7 +51,7 @@ import appeng.api.parts.ISimplifiedBundle;
 import appeng.client.render.BusRenderHelper;
 import appeng.client.render.RenderBlocksWorkaround;
 import appeng.core.AELog;
-import appeng.core.AppEng;
+import appeng.integration.IntegrationRegistry;
 import appeng.integration.IntegrationType;
 import appeng.integration.abstraction.IBC;
 import appeng.util.Platform;
@@ -133,7 +133,7 @@ public class FacadePart implements IFacadePart, IBoxProvider
 					IIcon myIcon = null;
 					if( this.isBC() )
 					{
-						IBC bc = (IBC) AppEng.instance.getIntegration( IntegrationType.BC );
+						IBC bc = (IBC) IntegrationRegistry.INSTANCE.getInstance( IntegrationType.BC );
 						myIcon = bc.getFacadeTexture();
 					}
 
@@ -353,9 +353,9 @@ public class FacadePart implements IFacadePart, IBoxProvider
 
 			return facade.getTextureItem( this.facade );
 		}
-		else if( AppEng.instance.isIntegrationEnabled( IntegrationType.BC ) )
+		else if( IntegrationRegistry.INSTANCE.isEnabled( IntegrationType.BC ) )
 		{
-			IBC bc = (IBC) AppEng.instance.getIntegration( IntegrationType.BC );
+			IBC bc = (IBC) IntegrationRegistry.INSTANCE.getInstance( IntegrationType.BC );
 
 			return bc.getTextureForFacade( this.facade );
 		}

--- a/src/main/java/appeng/items/materials/MaterialType.java
+++ b/src/main/java/appeng/items/materials/MaterialType.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of Applied Energistics 2.
- * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
  *
  * Applied Energistics 2 is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -114,7 +114,7 @@ public enum MaterialType
 		this.damageValue = metaValue;
 		this.droppedEntity = c;
 
-		EntityRegistry.registerModEntity( this.droppedEntity, this.droppedEntity.getSimpleName(), EntityIds.get( this.droppedEntity ), AppEng.instance, 16, 4, true );
+		EntityRegistry.registerModEntity( this.droppedEntity, this.droppedEntity.getSimpleName(), EntityIds.get( this.droppedEntity ), AppEng.instance(), 16, 4, true );
 	}
 
 	MaterialType( int metaValue, AEFeature part, String oreDictionary, Class<? extends Entity> c )
@@ -123,7 +123,7 @@ public enum MaterialType
 		this.damageValue = metaValue;
 		this.oreName = oreDictionary;
 		this.droppedEntity = c;
-		EntityRegistry.registerModEntity( this.droppedEntity, this.droppedEntity.getSimpleName(), EntityIds.get( this.droppedEntity ), AppEng.instance, 16, 4, true );
+		EntityRegistry.registerModEntity( this.droppedEntity, this.droppedEntity.getSimpleName(), EntityIds.get( this.droppedEntity ), AppEng.instance(), 16, 4, true );
 	}
 
 	MaterialType( int metaValue, AEFeature part, String oreDictionary )

--- a/src/main/java/appeng/items/misc/ItemCrystalSeed.java
+++ b/src/main/java/appeng/items/misc/ItemCrystalSeed.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of Applied Energistics 2.
- * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
  *
  * Applied Energistics 2 is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -21,7 +21,6 @@ package appeng.items.misc;
 
 import java.util.EnumSet;
 import java.util.List;
-
 import javax.annotation.Nullable;
 
 import net.minecraft.block.Block;
@@ -73,7 +72,7 @@ public class ItemCrystalSeed extends AEBaseItem implements IGrowableCrystal
 		this.setHasSubtypes( true );
 		this.setFeature( EnumSet.of( AEFeature.Core ) );
 
-		EntityRegistry.registerModEntity( EntityGrowingCrystal.class, EntityGrowingCrystal.class.getSimpleName(), EntityIds.get( EntityGrowingCrystal.class ), AppEng.instance, 16, 4, true );
+		EntityRegistry.registerModEntity( EntityGrowingCrystal.class, EntityGrowingCrystal.class.getSimpleName(), EntityIds.get( EntityGrowingCrystal.class ), AppEng.instance(), 16, 4, true );
 	}
 
 	@Nullable

--- a/src/main/java/appeng/parts/CableBusContainer.java
+++ b/src/main/java/appeng/parts/CableBusContainer.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of Applied Energistics 2.
- * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
  *
  * Applied Energistics 2 is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -63,9 +63,9 @@ import appeng.api.util.AEColor;
 import appeng.api.util.DimensionalCoord;
 import appeng.client.render.CableRenderHelper;
 import appeng.core.AELog;
-import appeng.core.AppEng;
 import appeng.facade.FacadeContainer;
 import appeng.helpers.AEMultiTile;
+import appeng.integration.IntegrationRegistry;
 import appeng.integration.IntegrationType;
 import appeng.integration.abstraction.ICLApi;
 import appeng.me.GridConnection;
@@ -885,9 +885,9 @@ public class CableBusContainer extends CableBusStorage implements AEMultiTile, I
 			}
 		}
 
-		if( light > 0 && AppEng.instance.isIntegrationEnabled( IntegrationType.CLApi ) )
+		if( light > 0 && IntegrationRegistry.INSTANCE.isEnabled( IntegrationType.CLApi ) )
 		{
-			return ( (ICLApi) AppEng.instance.getIntegration( IntegrationType.CLApi ) ).colorLight( this.getColor(), light );
+			return ( (ICLApi) IntegrationRegistry.INSTANCE.getInstance( IntegrationType.CLApi ) ).colorLight( this.getColor(), light );
 		}
 
 		return light;

--- a/src/main/java/appeng/parts/PartPlacement.java
+++ b/src/main/java/appeng/parts/PartPlacement.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of Applied Energistics 2.
- * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
  *
  * Applied Energistics 2 is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -52,12 +52,12 @@ import appeng.api.parts.IPartItem;
 import appeng.api.parts.PartItemStack;
 import appeng.api.parts.SelectedPart;
 import appeng.api.util.DimensionalCoord;
-import appeng.core.AppEng;
 import appeng.core.CommonHelper;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketClick;
 import appeng.core.sync.packets.PacketPartPlacement;
 import appeng.facade.IFacadeItem;
+import appeng.integration.IntegrationRegistry;
 import appeng.integration.IntegrationType;
 import appeng.integration.abstraction.IBC;
 import appeng.integration.abstraction.IFMP;
@@ -196,14 +196,14 @@ public class PartPlacement
 			}
 		}
 
-		if( host == null && tile != null && AppEng.instance.isIntegrationEnabled( IntegrationType.FMP ) )
+		if( host == null && tile != null && IntegrationRegistry.INSTANCE.isEnabled( IntegrationType.FMP ) )
 		{
-			host = ( (IFMP) AppEng.instance.getIntegration( IntegrationType.FMP ) ).getOrCreateHost( tile );
+			host = ( (IFMP) IntegrationRegistry.INSTANCE.getInstance( IntegrationType.FMP ) ).getOrCreateHost( tile );
 		}
 
-		if( host == null && tile != null && AppEng.instance.isIntegrationEnabled( IntegrationType.ImmibisMicroblocks ) )
+		if( host == null && tile != null && IntegrationRegistry.INSTANCE.isEnabled( IntegrationType.ImmibisMicroblocks ) )
 		{
-			host = ( (IImmibisMicroblocks) AppEng.instance.getIntegration( IntegrationType.ImmibisMicroblocks ) ).getOrCreateHost( player, face, tile );
+			host = ( (IImmibisMicroblocks) IntegrationRegistry.INSTANCE.getInstance( IntegrationType.ImmibisMicroblocks ) ).getOrCreateHost( player, face, tile );
 		}
 
 		// if ( held == null )
@@ -266,14 +266,14 @@ public class PartPlacement
 				host = (IPartHost) tile;
 			}
 
-			if( host == null && tile != null && AppEng.instance.isIntegrationEnabled( IntegrationType.FMP ) )
+			if( host == null && tile != null && IntegrationRegistry.INSTANCE.isEnabled( IntegrationType.FMP ) )
 			{
-				host = ( (IFMP) AppEng.instance.getIntegration( IntegrationType.FMP ) ).getOrCreateHost( tile );
+				host = ( (IFMP) IntegrationRegistry.INSTANCE.getInstance( IntegrationType.FMP ) ).getOrCreateHost( tile );
 			}
 
-			if( host == null && tile != null && AppEng.instance.isIntegrationEnabled( IntegrationType.ImmibisMicroblocks ) )
+			if( host == null && tile != null && IntegrationRegistry.INSTANCE.isEnabled( IntegrationType.ImmibisMicroblocks ) )
 			{
-				host = ( (IImmibisMicroblocks) AppEng.instance.getIntegration( IntegrationType.ImmibisMicroblocks ) ).getOrCreateHost( player, face, tile );
+				host = ( (IImmibisMicroblocks) IntegrationRegistry.INSTANCE.getInstance( IntegrationType.ImmibisMicroblocks ) ).getOrCreateHost( player, face, tile );
 			}
 
 			final Optional<ItemStack> maybeMultiPartStack = multiPart.maybeStack( 1 );
@@ -326,9 +326,9 @@ public class PartPlacement
 				Block blkID = world.getBlock( te_x, te_y, te_z );
 				tile = world.getTileEntity( te_x, te_y, te_z );
 
-				if( tile != null && AppEng.instance.isIntegrationEnabled( IntegrationType.FMP ) )
+				if( tile != null && IntegrationRegistry.INSTANCE.isEnabled( IntegrationType.FMP ) )
 				{
-					host = ( (IFMP) AppEng.instance.getIntegration( IntegrationType.FMP ) ).getOrCreateHost( tile );
+					host = ( (IFMP) IntegrationRegistry.INSTANCE.getInstance( IntegrationType.FMP ) ).getOrCreateHost( tile );
 				}
 
 				if( ( blkID == null || blkID.isReplaceable( world, te_x, te_y, te_z ) || host != null ) && side != ForgeDirection.UNKNOWN )
@@ -418,9 +418,9 @@ public class PartPlacement
 			return ( (IFacadeItem) held.getItem() ).createPartFromItemStack( held, side );
 		}
 
-		if( AppEng.instance.isIntegrationEnabled( IntegrationType.BC ) )
+		if( IntegrationRegistry.INSTANCE.isEnabled( IntegrationType.BC ) )
 		{
-			IBC bc = (IBC) AppEng.instance.getIntegration( IntegrationType.BC );
+			IBC bc = (IBC) IntegrationRegistry.INSTANCE.getInstance( IntegrationType.BC );
 			if( bc.isFacade( held ) )
 			{
 				return bc.createFacadePart( held, side );

--- a/src/main/java/appeng/parts/p2p/PartP2PItems.java
+++ b/src/main/java/appeng/parts/p2p/PartP2PItems.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of Applied Energistics 2.
- * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
  *
  * Applied Energistics 2 is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -46,8 +46,8 @@ import appeng.api.networking.events.MENetworkPowerStatusChange;
 import appeng.api.networking.ticking.IGridTickable;
 import appeng.api.networking.ticking.TickRateModulation;
 import appeng.api.networking.ticking.TickingRequest;
-import appeng.core.AppEng;
 import appeng.core.settings.TickRates;
+import appeng.integration.IntegrationRegistry;
 import appeng.integration.IntegrationType;
 import appeng.integration.abstraction.IBC;
 import appeng.me.GridAccessException;
@@ -141,9 +141,9 @@ public class PartP2PItems extends PartP2PTunnel<PartP2PItems> implements IPipeCo
 
 			this.which.add( this );
 
-			if( AppEng.instance.isIntegrationEnabled( IntegrationType.BC ) )
+			if( IntegrationRegistry.INSTANCE.isEnabled( IntegrationType.BC ) )
 			{
-				IBC buildcraft = (IBC) AppEng.instance.getIntegration( IntegrationType.BC );
+				IBC buildcraft = (IBC) IntegrationRegistry.INSTANCE.getInstance( IntegrationType.BC );
 				if( buildcraft != null )
 				{
 					if( buildcraft.isPipe( te, this.side.getOpposite() ) )

--- a/src/main/java/appeng/parts/p2p/PartP2POpenComputers.java
+++ b/src/main/java/appeng/parts/p2p/PartP2POpenComputers.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of Applied Energistics 2.
- * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
  *
  * Applied Energistics 2 is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -20,7 +20,6 @@ package appeng.parts.p2p;
 
 
 import java.util.concurrent.Callable;
-
 import javax.annotation.Nullable;
 
 import net.minecraft.item.ItemStack;
@@ -45,9 +44,9 @@ import appeng.api.networking.ticking.IGridTickable;
 import appeng.api.networking.ticking.TickRateModulation;
 import appeng.api.networking.ticking.TickingRequest;
 import appeng.core.AELog;
-import appeng.core.AppEng;
 import appeng.core.settings.TickRates;
 import appeng.hooks.TickHandler;
+import appeng.integration.IntegrationRegistry;
 import appeng.integration.IntegrationType;
 import appeng.me.GridAccessException;
 import appeng.transformer.annotations.Integration.Interface;
@@ -66,7 +65,7 @@ public final class PartP2POpenComputers extends PartP2PTunnel<PartP2POpenCompute
 	{
 		super( is );
 
-		if ( !AppEng.instance.isIntegrationEnabled( IntegrationType.OpenComputers ) )
+		if ( !IntegrationRegistry.INSTANCE.isEnabled( IntegrationType.OpenComputers ) )
 		{
 			throw new RuntimeException( "OpenComputers is not installed!" );
 		}

--- a/src/main/java/appeng/recipes/handlers/Crusher.java
+++ b/src/main/java/appeng/recipes/handlers/Crusher.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of Applied Energistics 2.
- * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
  *
  * Applied Energistics 2 is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -29,7 +29,7 @@ import appeng.api.exceptions.RegistrationError;
 import appeng.api.recipes.ICraftHandler;
 import appeng.api.recipes.IIngredient;
 import appeng.core.AELog;
-import appeng.core.AppEng;
+import appeng.integration.IntegrationRegistry;
 import appeng.integration.IntegrationType;
 import appeng.integration.abstraction.IRC;
 import appeng.recipes.RecipeHandler;
@@ -61,9 +61,9 @@ public class Crusher implements ICraftHandler, IWebsiteSerializer
 	@Override
 	public void register() throws RegistrationError, MissingIngredientError
 	{
-		if( AppEng.instance.isIntegrationEnabled( IntegrationType.RC ) )
+		if( IntegrationRegistry.INSTANCE.isEnabled( IntegrationType.RC ) )
 		{
-			IRC rc = (IRC) AppEng.instance.getIntegration( IntegrationType.RC );
+			IRC rc = (IRC) IntegrationRegistry.INSTANCE.getInstance( IntegrationType.RC );
 			for( ItemStack is : this.pro_input.getItemStackSet() )
 			{
 				try

--- a/src/main/java/appeng/recipes/handlers/GrindFZ.java
+++ b/src/main/java/appeng/recipes/handlers/GrindFZ.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of Applied Energistics 2.
- * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
  *
  * Applied Energistics 2 is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -29,7 +29,7 @@ import appeng.api.exceptions.RegistrationError;
 import appeng.api.recipes.ICraftHandler;
 import appeng.api.recipes.IIngredient;
 import appeng.core.AELog;
-import appeng.core.AppEng;
+import appeng.integration.IntegrationRegistry;
 import appeng.integration.IntegrationType;
 import appeng.integration.abstraction.IFZ;
 import appeng.recipes.RecipeHandler;
@@ -61,9 +61,9 @@ public class GrindFZ implements ICraftHandler, IWebsiteSerializer
 	@Override
 	public void register() throws RegistrationError, MissingIngredientError
 	{
-		if( AppEng.instance.isIntegrationEnabled( IntegrationType.FZ ) )
+		if( IntegrationRegistry.INSTANCE.isEnabled( IntegrationType.FZ ) )
 		{
-			IFZ fz = (IFZ) AppEng.instance.getIntegration( IntegrationType.FZ );
+			IFZ fz = (IFZ) IntegrationRegistry.INSTANCE.getInstance( IntegrationType.FZ );
 			for( ItemStack is : this.pro_input.getItemStackSet() )
 			{
 				try

--- a/src/main/java/appeng/recipes/handlers/Macerator.java
+++ b/src/main/java/appeng/recipes/handlers/Macerator.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of Applied Energistics 2.
- * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
  *
  * Applied Energistics 2 is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -29,7 +29,7 @@ import appeng.api.exceptions.RegistrationError;
 import appeng.api.recipes.ICraftHandler;
 import appeng.api.recipes.IIngredient;
 import appeng.core.AELog;
-import appeng.core.AppEng;
+import appeng.integration.IntegrationRegistry;
 import appeng.integration.IntegrationType;
 import appeng.integration.abstraction.IIC2;
 import appeng.recipes.RecipeHandler;
@@ -61,9 +61,9 @@ public class Macerator implements ICraftHandler, IWebsiteSerializer
 	@Override
 	public void register() throws RegistrationError, MissingIngredientError
 	{
-		if( AppEng.instance.isIntegrationEnabled( IntegrationType.IC2 ) )
+		if( IntegrationRegistry.INSTANCE.isEnabled( IntegrationType.IC2 ) )
 		{
-			IIC2 ic2 = (IIC2) AppEng.instance.getIntegration( IntegrationType.IC2 );
+			IIC2 ic2 = (IIC2) IntegrationRegistry.INSTANCE.getInstance( IntegrationType.IC2 );
 			for( ItemStack is : this.pro_input.getItemStackSet() )
 			{
 				try

--- a/src/main/java/appeng/recipes/handlers/MekCrusher.java
+++ b/src/main/java/appeng/recipes/handlers/MekCrusher.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of Applied Energistics 2.
- * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
  *
  * Applied Energistics 2 is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -29,7 +29,7 @@ import appeng.api.exceptions.RegistrationError;
 import appeng.api.recipes.ICraftHandler;
 import appeng.api.recipes.IIngredient;
 import appeng.core.AELog;
-import appeng.core.AppEng;
+import appeng.integration.IntegrationRegistry;
 import appeng.integration.IntegrationType;
 import appeng.integration.abstraction.IMekanism;
 import appeng.recipes.RecipeHandler;
@@ -62,9 +62,9 @@ public class MekCrusher implements ICraftHandler, IWebsiteSerializer
 	@Override
 	public void register() throws RegistrationError, MissingIngredientError
 	{
-		if( AppEng.instance.isIntegrationEnabled( IntegrationType.Mekanism ) )
+		if( IntegrationRegistry.INSTANCE.isEnabled( IntegrationType.Mekanism ) )
 		{
-			IMekanism rc = (IMekanism) AppEng.instance.getIntegration( IntegrationType.Mekanism );
+			IMekanism rc = (IMekanism) IntegrationRegistry.INSTANCE.getInstance( IntegrationType.Mekanism );
 			for( ItemStack is : this.pro_input.getItemStackSet() )
 			{
 				try

--- a/src/main/java/appeng/recipes/handlers/MekEnrichment.java
+++ b/src/main/java/appeng/recipes/handlers/MekEnrichment.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of Applied Energistics 2.
- * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
  *
  * Applied Energistics 2 is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -29,7 +29,7 @@ import appeng.api.exceptions.RegistrationError;
 import appeng.api.recipes.ICraftHandler;
 import appeng.api.recipes.IIngredient;
 import appeng.core.AELog;
-import appeng.core.AppEng;
+import appeng.integration.IntegrationRegistry;
 import appeng.integration.IntegrationType;
 import appeng.integration.abstraction.IMekanism;
 import appeng.recipes.RecipeHandler;
@@ -61,9 +61,9 @@ public class MekEnrichment implements ICraftHandler, IWebsiteSerializer
 	@Override
 	public void register() throws RegistrationError, MissingIngredientError
 	{
-		if( AppEng.instance.isIntegrationEnabled( IntegrationType.Mekanism ) )
+		if( IntegrationRegistry.INSTANCE.isEnabled( IntegrationType.Mekanism ) )
 		{
-			IMekanism rc = (IMekanism) AppEng.instance.getIntegration( IntegrationType.Mekanism );
+			IMekanism rc = (IMekanism) IntegrationRegistry.INSTANCE.getInstance( IntegrationType.Mekanism );
 			for( ItemStack is : this.pro_input.getItemStackSet() )
 			{
 				try

--- a/src/main/java/appeng/services/VersionChecker.java
+++ b/src/main/java/appeng/services/VersionChecker.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of Applied Energistics 2.
- * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
  *
  * Applied Energistics 2 is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -173,7 +173,7 @@ public final class VersionChecker implements Runnable
 			}
 
 			versionInf.setString( "newFileName", "appliedenergistics2-" + ghFormatted + ".jar" );
-			FMLInterModComms.sendRuntimeMessage( AppEng.instance, "VersionChecker", "addUpdate", versionInf );
+			FMLInterModComms.sendRuntimeMessage( AppEng.instance(), "VersionChecker", "addUpdate", versionInf );
 
 			AELog.info( "Reported new version to VersionChecker mod." );
 		}

--- a/src/main/java/appeng/tile/networking/TileCableBus.java
+++ b/src/main/java/appeng/tile/networking/TileCableBus.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of Applied Energistics 2.
- * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
  *
  * Applied Energistics 2 is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -20,7 +20,6 @@ package appeng.tile.networking;
 
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -44,10 +43,10 @@ import appeng.api.util.AECableType;
 import appeng.api.util.AEColor;
 import appeng.api.util.DimensionalCoord;
 import appeng.block.networking.BlockCableBus;
-import appeng.core.AppEng;
 import appeng.helpers.AEMultiTile;
 import appeng.helpers.ICustomCollision;
 import appeng.hooks.TickHandler;
+import appeng.integration.IntegrationRegistry;
 import appeng.integration.IntegrationType;
 import appeng.integration.abstraction.IImmibisMicroblocks;
 import appeng.parts.CableBusContainer;
@@ -325,9 +324,9 @@ public class TileCableBus extends AEBaseTile implements AEMultiTile, ICustomColl
 	@Override
 	public void cleanup()
 	{
-		if( AppEng.instance.isIntegrationEnabled( IntegrationType.ImmibisMicroblocks ) )
+		if( IntegrationRegistry.INSTANCE.isEnabled( IntegrationType.ImmibisMicroblocks ) )
 		{
-			IImmibisMicroblocks imb = (IImmibisMicroblocks) AppEng.instance.getIntegration( IntegrationType.ImmibisMicroblocks );
+			IImmibisMicroblocks imb = (IImmibisMicroblocks) IntegrationRegistry.INSTANCE.getInstance( IntegrationType.ImmibisMicroblocks );
 			if( imb != null && imb.leaveParts( this ) )
 			{
 				return;

--- a/src/main/java/appeng/tile/powersink/IC2.java
+++ b/src/main/java/appeng/tile/powersink/IC2.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of Applied Energistics 2.
- * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
  *
  * Applied Energistics 2 is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -27,7 +27,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 import ic2.api.energy.tile.IEnergySink;
 
 import appeng.api.config.PowerUnits;
-import appeng.core.AppEng;
+import appeng.integration.IntegrationRegistry;
 import appeng.integration.IntegrationType;
 import appeng.integration.abstraction.IIC2;
 import appeng.transformer.annotations.Integration.Interface;
@@ -77,9 +77,9 @@ public abstract class IC2 extends AERootPoweredTile implements IEnergySink
 
 	private void removeFromENet()
 	{
-		if( AppEng.instance.isIntegrationEnabled( IntegrationType.IC2 ) )
+		if( IntegrationRegistry.INSTANCE.isEnabled( IntegrationType.IC2 ) )
 		{
-			IIC2 ic2Integration = (IIC2) AppEng.instance.getIntegration( IntegrationType.IC2 );
+			IIC2 ic2Integration = (IIC2) IntegrationRegistry.INSTANCE.getInstance( IntegrationType.IC2 );
 			if( this.isInIC2 && Platform.isServer() && ic2Integration != null )
 			{
 				ic2Integration.removeFromEnergyNet( this );
@@ -104,9 +104,9 @@ public abstract class IC2 extends AERootPoweredTile implements IEnergySink
 
 	private void addToENet()
 	{
-		if( AppEng.instance.isIntegrationEnabled( IntegrationType.IC2 ) )
+		if( IntegrationRegistry.INSTANCE.isEnabled( IntegrationType.IC2 ) )
 		{
-			IIC2 ic2Integration = (IIC2) AppEng.instance.getIntegration( IntegrationType.IC2 );
+			IIC2 ic2Integration = (IIC2) IntegrationRegistry.INSTANCE.getInstance( IntegrationType.IC2 );
 			if( !this.isInIC2 && Platform.isServer() && ic2Integration != null )
 			{
 				ic2Integration.addToEnergyNet( this );

--- a/src/main/java/appeng/util/InventoryAdaptor.java
+++ b/src/main/java/appeng/util/InventoryAdaptor.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of Applied Energistics 2.
- * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
  *
  * Applied Energistics 2 is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -29,7 +29,7 @@ import net.minecraft.tileentity.TileEntityChest;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import appeng.api.config.FuzzyMode;
-import appeng.core.AppEng;
+import appeng.integration.IntegrationRegistry;
 import appeng.integration.IntegrationType;
 import appeng.integration.abstraction.IBetterStorage;
 import appeng.util.inv.AdaptorIInventory;
@@ -51,7 +51,7 @@ public abstract class InventoryAdaptor implements Iterable<ItemSlot>
 			return null;
 		}
 
-		IBetterStorage bs = (IBetterStorage) ( AppEng.instance.isIntegrationEnabled( IntegrationType.BetterStorage ) ? AppEng.instance.getIntegration( IntegrationType.BetterStorage ) : null );
+		IBetterStorage bs = (IBetterStorage) ( IntegrationRegistry.INSTANCE.isEnabled( IntegrationType.BetterStorage ) ? IntegrationRegistry.INSTANCE.getInstance( IntegrationType.BetterStorage ) : null );
 
 		if( te instanceof EntityPlayer )
 		{

--- a/src/main/java/appeng/util/ItemSorters.java
+++ b/src/main/java/appeng/util/ItemSorters.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of Applied Energistics 2.
- * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
  *
  * Applied Energistics 2 is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -23,7 +23,7 @@ import java.util.Comparator;
 
 import appeng.api.config.SortDir;
 import appeng.api.storage.data.IAEItemStack;
-import appeng.core.AppEng;
+import appeng.integration.IntegrationRegistry;
 import appeng.integration.IntegrationType;
 import appeng.integration.abstraction.IInvTweaks;
 import appeng.util.item.AEItemStack;
@@ -114,9 +114,9 @@ public class ItemSorters
 			return;
 		}
 
-		if( AppEng.instance.isIntegrationEnabled( IntegrationType.InvTweaks ) )
+		if( IntegrationRegistry.INSTANCE.isEnabled( IntegrationType.InvTweaks ) )
 		{
-			api = (IInvTweaks) AppEng.instance.getIntegration( IntegrationType.InvTweaks );
+			api = (IInvTweaks) IntegrationRegistry.INSTANCE.getInstance( IntegrationType.InvTweaks );
 		}
 		else
 		{

--- a/src/main/java/appeng/util/Platform.java
+++ b/src/main/java/appeng/util/Platform.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of Applied Energistics 2.
- * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
  *
  * Applied Energistics 2 is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -32,7 +32,6 @@ import java.util.List;
 import java.util.Random;
 import java.util.Set;
 import java.util.WeakHashMap;
-
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -53,13 +52,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.CraftingManager;
 import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.nbt.NBTBase;
-import net.minecraft.nbt.NBTTagByte;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.nbt.NBTTagDouble;
-import net.minecraft.nbt.NBTTagFloat;
-import net.minecraft.nbt.NBTTagInt;
 import net.minecraft.nbt.NBTTagList;
-import net.minecraft.nbt.NBTTagLong;
 import net.minecraft.nbt.NBTTagString;
 import net.minecraft.network.Packet;
 import net.minecraft.network.play.server.S21PacketChunkData;
@@ -132,6 +126,7 @@ import appeng.core.stats.Stats;
 import appeng.core.sync.GuiBridge;
 import appeng.core.sync.GuiHostType;
 import appeng.hooks.TickHandler;
+import appeng.integration.IntegrationRegistry;
 import appeng.integration.IntegrationType;
 import appeng.me.GridAccessException;
 import appeng.me.GridNode;
@@ -326,17 +321,17 @@ public class Platform
 
 	private static boolean isNotValidSetting( Enum e )
 	{
-		if( e == SortOrder.INVTWEAKS && !AppEng.instance.isIntegrationEnabled( IntegrationType.InvTweaks ) )
+		if( e == SortOrder.INVTWEAKS && !IntegrationRegistry.INSTANCE.isEnabled( IntegrationType.InvTweaks ) )
 		{
 			return true;
 		}
 
-		if( e == SearchBoxMode.NEI_AUTOSEARCH && !AppEng.instance.isIntegrationEnabled( IntegrationType.NEI ) )
+		if( e == SearchBoxMode.NEI_AUTOSEARCH && !IntegrationRegistry.INSTANCE.isEnabled( IntegrationType.NEI ) )
 		{
 			return true;
 		}
 
-		if( e == SearchBoxMode.NEI_MANUAL_SEARCH && !AppEng.instance.isIntegrationEnabled( IntegrationType.NEI ) )
+		if( e == SearchBoxMode.NEI_MANUAL_SEARCH && !IntegrationRegistry.INSTANCE.isEnabled( IntegrationType.NEI ) )
 		{
 			return true;
 		}
@@ -365,15 +360,15 @@ public class Platform
 		{
 			if( tile == null && type.getType() == GuiHostType.ITEM )
 			{
-				p.openGui( AppEng.instance, type.ordinal() << 4, p.getEntityWorld(), p.inventory.currentItem, 0, 0 );
+				p.openGui( AppEng.instance(), type.ordinal() << 4, p.getEntityWorld(), p.inventory.currentItem, 0, 0 );
 			}
 			else if( tile == null || type.getType() == GuiHostType.ITEM )
 			{
-				p.openGui( AppEng.instance, type.ordinal() << 4 | ( 1 << 3 ), p.getEntityWorld(), x, y, z );
+				p.openGui( AppEng.instance(), type.ordinal() << 4 | ( 1 << 3 ), p.getEntityWorld(), x, y, z );
 			}
 			else
 			{
-				p.openGui( AppEng.instance, type.ordinal() << 4 | ( side.ordinal() ), tile.getWorldObj(), x, y, z );
+				p.openGui( AppEng.instance(), type.ordinal() << 4 | ( side.ordinal() ), tile.getWorldObj(), x, y, z );
 			}
 		}
 	}

--- a/src/main/java/appeng/util/inv/AdaptorBCPipe.java
+++ b/src/main/java/appeng/util/inv/AdaptorBCPipe.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of Applied Energistics 2.
- * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
  *
  * Applied Energistics 2 is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -26,7 +26,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import appeng.api.config.FuzzyMode;
-import appeng.core.AppEng;
+import appeng.integration.IntegrationRegistry;
 import appeng.integration.IntegrationType;
 import appeng.integration.abstraction.IBC;
 import appeng.util.InventoryAdaptor;
@@ -42,7 +42,7 @@ public class AdaptorBCPipe extends InventoryAdaptor
 
 	public AdaptorBCPipe( TileEntity s, ForgeDirection dd )
 	{
-		this.bc = (IBC) AppEng.instance.getIntegration( IntegrationType.BC );
+		this.bc = (IBC) IntegrationRegistry.INSTANCE.getInstance( IntegrationType.BC );
 		if( this.bc != null )
 		{
 			if( this.bc.isPipe( s, dd ) )

--- a/src/main/java/appeng/util/inv/WrapperBCPipe.java
+++ b/src/main/java/appeng/util/inv/WrapperBCPipe.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of Applied Energistics 2.
- * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
  *
  * Applied Energistics 2 is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -25,7 +25,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import appeng.core.AppEng;
+import appeng.integration.IntegrationRegistry;
 import appeng.integration.IntegrationType;
 import appeng.integration.abstraction.IBC;
 
@@ -39,7 +39,7 @@ public class WrapperBCPipe implements IInventory
 
 	public WrapperBCPipe( TileEntity te, ForgeDirection d )
 	{
-		this.bc = (IBC) AppEng.instance.getIntegration( IntegrationType.BC );
+		this.bc = (IBC) IntegrationRegistry.INSTANCE.getInstance( IntegrationType.BC );
 		this.ad = te;
 		this.dir = d;
 	}


### PR DESCRIPTION
**Intention** Single-Entry-Point like `AEApi`
**Possible Problems** Life-Cycle

Removes the improper way to set itself into a `public` `static` non-`final` variable.
Removes the direct access to the `IntegrationRegistry` from `AppEng`. Will be added at some later point somewhere else for non-singleton access.
Constructor is set to `package` `private` to enable possible construction from unit tests. Are currently not runnable since it is currently tied to the `FML` `Loader` instance.