### PR TITLE
Fix #1362 - Parts display in WAILA

### DIFF
--- a/src/main/java/appeng/integration/modules/Waila.java
+++ b/src/main/java/appeng/integration/modules/Waila.java
@@ -38,6 +38,7 @@ public class Waila extends BaseModule
 	{
 		final IWailaDataProvider partHost = new PartWailaDataProvider();
 
+		registrar.registerStackProvider( partHost, AEBaseTile.class );
 		registrar.registerBodyProvider( partHost, AEBaseTile.class );
 		registrar.registerNBTProvider( partHost, AEBaseTile.class );
 

--- a/src/main/java/appeng/integration/modules/waila/PartWailaDataProvider.java
+++ b/src/main/java/appeng/integration/modules/waila/PartWailaDataProvider.java
@@ -39,6 +39,7 @@ import appeng.api.parts.IPart;
 import appeng.integration.modules.waila.part.ChannelWailaDataProvider;
 import appeng.integration.modules.waila.part.IPartWailaDataProvider;
 import appeng.integration.modules.waila.part.PartAccessor;
+import appeng.integration.modules.waila.part.PartStackWailaDataProvider;
 import appeng.integration.modules.waila.part.PowerStateWailaDataProvider;
 import appeng.integration.modules.waila.part.StorageMonitorWailaDataProvider;
 import appeng.integration.modules.waila.part.Tracer;
@@ -76,13 +77,32 @@ public final class PartWailaDataProvider implements IWailaDataProvider
 		final IPartWailaDataProvider channel = new ChannelWailaDataProvider();
 		final IPartWailaDataProvider storageMonitor = new StorageMonitorWailaDataProvider();
 		final IPartWailaDataProvider powerState = new PowerStateWailaDataProvider();
+		final IPartWailaDataProvider partStack = new PartStackWailaDataProvider();
 
-		this.providers = Lists.newArrayList( channel, storageMonitor, powerState );
+		this.providers = Lists.newArrayList( channel, storageMonitor, powerState, partStack );
 	}
 
 	@Override
 	public ItemStack getWailaStack( IWailaDataAccessor accessor, IWailaConfigHandler config )
 	{
+		final TileEntity te = accessor.getTileEntity();
+		final MovingObjectPosition mop = accessor.getPosition();
+
+		final Optional<IPart> maybePart = this.accessor.getMaybePart( te, mop );
+
+		if( maybePart.isPresent() )
+		{
+			final IPart part = maybePart.get();
+
+			ItemStack wailaStack = null;
+
+			for( IPartWailaDataProvider provider : this.providers )
+			{
+				wailaStack = provider.getWailaStack( part, config, wailaStack );
+			}
+			return wailaStack;
+		}
+
 		return null;
 	}
 

--- a/src/main/java/appeng/integration/modules/waila/part/BasePartWailaDataProvider.java
+++ b/src/main/java/appeng/integration/modules/waila/part/BasePartWailaDataProvider.java
@@ -22,6 +22,7 @@ package appeng.integration.modules.waila.part;
 import java.util.List;
 
 import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
@@ -41,6 +42,12 @@ import appeng.api.parts.IPart;
  */
 public abstract class BasePartWailaDataProvider implements IPartWailaDataProvider
 {
+	@Override
+	public ItemStack getWailaStack( IPart part, IWailaConfigHandler config, ItemStack partStack )
+	{
+		return null;
+	}
+
 	@Override
 	public List<String> getWailaHead( IPart part, List<String> currentToolTip, IWailaDataAccessor accessor, IWailaConfigHandler config )
 	{

--- a/src/main/java/appeng/integration/modules/waila/part/IPartWailaDataProvider.java
+++ b/src/main/java/appeng/integration/modules/waila/part/IPartWailaDataProvider.java
@@ -22,6 +22,7 @@ package appeng.integration.modules.waila.part;
 import java.util.List;
 
 import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
@@ -41,6 +42,8 @@ import appeng.api.parts.IPart;
  */
 public interface IPartWailaDataProvider
 {
+	ItemStack getWailaStack( IPart part, IWailaConfigHandler config, ItemStack partStack );
+
 	List<String> getWailaHead( IPart part, List<String> currentToolTip, IWailaDataAccessor accessor, IWailaConfigHandler config );
 
 	List<String> getWailaBody( IPart part, List<String> currentToolTip, IWailaDataAccessor accessor, IWailaConfigHandler config );

--- a/src/main/java/appeng/integration/modules/waila/part/PartStackWailaDataProvider.java
+++ b/src/main/java/appeng/integration/modules/waila/part/PartStackWailaDataProvider.java
@@ -1,0 +1,42 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.integration.modules.waila.part;
+
+import appeng.api.parts.IPart;
+import appeng.api.parts.PartItemStack;
+import mcp.mobius.waila.api.IWailaConfigHandler;
+import net.minecraft.item.ItemStack;
+
+/**
+ *  Part ItemStack provider for WAILA
+ *
+ * @author TheJulianJES
+ * @version rv3
+ * @since rv3
+ */
+public class PartStackWailaDataProvider extends BasePartWailaDataProvider {
+
+	@Override
+	public ItemStack getWailaStack( IPart part, IWailaConfigHandler config, ItemStack partStack )
+	{
+		partStack = part.getItemStack( PartItemStack.Pick );
+		return partStack;
+	}
+
+}


### PR DESCRIPTION
I will squash this if the review is accepted. (Fix for #1362)
I would not consider this as a workaround because that is actually done for other things in AE2 and this is also not a WAILA bug. This basicly picks the item from the AE2 multipart and display it to WAILA.
Can also do this to rv2 but I don't think this is really needed.