### PR TITLE
Fixes #1465 faulty item comparison

### DIFF
--- a/src/main/java/appeng/core/features/WrappedDamageItemDefinition.java
+++ b/src/main/java/appeng/core/features/WrappedDamageItemDefinition.java
@@ -85,7 +85,10 @@ public final class WrappedDamageItemDefinition implements ITileDefinition
 			return false;
 		}
 
-		return this.definition.isSameAs( comparableStack ) && comparableStack.getItemDamage() == this.damage;
+		final boolean sameItem = this.definition.isSameAs( new ItemStack( comparableStack.getItem() ) );
+		final boolean sameDamage = comparableStack.getItemDamage() == this.damage;
+
+		return sameItem && sameDamage;
 	}
 
 	@Override

--- a/src/main/java/appeng/recipes/game/DisassembleRecipe.java
+++ b/src/main/java/appeng/recipes/game/DisassembleRecipe.java
@@ -93,7 +93,7 @@ public final class DisassembleRecipe implements IRecipe
 			{
 				// needs a single input in the recipe
 				itemCount++;
-				if ( itemCount > 1 )
+				if( itemCount > 1 )
 				{
 					return MISMATCHED_STACK;
 				}

--- a/src/main/java/appeng/util/Platform.java
+++ b/src/main/java/appeng/util/Platform.java
@@ -1858,15 +1858,15 @@ public class Platform
 		return null;
 	}
 
-	public static boolean isSameItemType( ItemStack ol, ItemStack op )
+	public static boolean isSameItemType( ItemStack that, ItemStack other )
 	{
-		if( ol != null && op != null && ol.getItem() == op.getItem() )
+		if( that != null && other != null && that.getItem() == other.getItem() )
 		{
-			if( ol.isItemStackDamageable() )
+			if( that.isItemStackDamageable() )
 			{
 				return true;
 			}
-			return ol.getItemDamage() == ol.getItemDamage();
+			return that.getItemDamage() == other.getItemDamage();
 		}
 		return false;
 	}


### PR DESCRIPTION
`WrappedDamageItemDefinition` needs to compare the actual item without any metadata as this is not stored for `IItemDefinition` and actualy handled by `WrappedDamageItemDefinition` itself.

`Platform.isSameItemType()` is most likely a typo, otherwise the while block is useless as it will always return true regardless of the itemdata.