### PR TITLE
Improve CraftGuide integration

### DIFF
--- a/src/main/java/appeng/integration/modules/CraftGuide.java
+++ b/src/main/java/appeng/integration/modules/CraftGuide.java
@@ -24,7 +24,6 @@ import java.util.List;
 
 import com.google.common.base.Optional;
 
-import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.CraftingManager;
 import net.minecraft.item.crafting.IRecipe;
@@ -34,7 +33,6 @@ import uristqwerty.CraftGuide.DefaultRecipeTemplate;
 import uristqwerty.CraftGuide.RecipeGeneratorImplementation;
 import uristqwerty.CraftGuide.api.ChanceSlot;
 import uristqwerty.CraftGuide.api.CraftGuideAPIObject;
-import uristqwerty.CraftGuide.api.CraftGuideRecipe;
 import uristqwerty.CraftGuide.api.ExtraSlot;
 import uristqwerty.CraftGuide.api.ItemSlot;
 import uristqwerty.CraftGuide.api.RecipeGenerator;
@@ -44,6 +42,7 @@ import uristqwerty.CraftGuide.api.Slot;
 import uristqwerty.CraftGuide.api.SlotType;
 import uristqwerty.gui_craftguide.texture.DynamicTexture;
 import uristqwerty.gui_craftguide.texture.TextureClip;
+
 import appeng.api.AEApi;
 import appeng.api.IAppEngApi;
 import appeng.api.definitions.IBlocks;
@@ -72,6 +71,21 @@ public class CraftGuide extends CraftGuideAPIObject implements IIntegrationModul
 
 	private final Slot[] smallCraftingSlots = new ItemSlot[] { new ItemSlot( 12, 12, 16, 16 ), new ItemSlot( 30, 12, 16, 16 ), new ItemSlot( 12, 30, 16, 16 ), new ItemSlot( 30, 30, 16, 16 ), new ItemSlot( 59, 21, 16, 16, true ).setSlotType( SlotType.OUTPUT_SLOT ), };
 
+	private static final Slot[] grinderSlots = new ItemSlot[] {
+			new ItemSlot( 3, 21, 16, 16 ).drawOwnBackground(),
+			new ItemSlot( 41, 21, 16, 16, true ).drawOwnBackground().setSlotType( SlotType.OUTPUT_SLOT ),
+			new ChanceSlot( 59, 12, 16, 16, true).setRatio( 10000 ).setFormatString( " (%1$.2f%% chance)" ).drawOwnBackground().setSlotType( SlotType.OUTPUT_SLOT ),
+			new ChanceSlot( 59, 30, 16, 16, true).setRatio( 10000 ).setFormatString( " (%1$.2f%% chance)" ).drawOwnBackground().setSlotType( SlotType.OUTPUT_SLOT ),
+			new ItemSlot( 22, 12, 16, 16 ).setSlotType( SlotType.MACHINE_SLOT ),
+			new ItemSlot( 22, 30, 16, 16 ).setSlotType( SlotType.MACHINE_SLOT ) };
+
+	private static final Slot[] inscriberSlots = new ItemSlot[] {
+			new ItemSlot( 12, 21, 16, 16 ).drawOwnBackground(),
+			new ItemSlot( 21, 3, 16, 16 ).drawOwnBackground(),
+			new ItemSlot( 21, 39, 16, 16 ).drawOwnBackground(),
+			new ItemSlot( 50, 21, 16, 16, true ).drawOwnBackground().setSlotType( SlotType.OUTPUT_SLOT ),
+			new ItemSlot( 31, 21, 16, 16 ).setSlotType( SlotType.MACHINE_SLOT ) };
+
 	@Override
 	public void generateRecipes( RecipeGenerator generator )
 	{
@@ -95,7 +109,7 @@ public class CraftGuide extends CraftGuideAPIObject implements IIntegrationModul
 		this.addCraftingRecipes( craftingTemplate, smallTemplate, shapelessTemplate, generator );
 
 		final IAppEngApi api = AEApi.instance();
-		IBlocks aeBlocks = api.definitions().blocks();
+		final IBlocks aeBlocks = api.definitions().blocks();
 		Optional<ItemStack> grindstone = aeBlocks.grindStone().maybeStack(1);
 		Optional<ItemStack> inscriber = aeBlocks.inscriber().maybeStack(1);
 
@@ -161,13 +175,6 @@ public class CraftGuide extends CraftGuideAPIObject implements IIntegrationModul
 	private void addGrinderRecipes( IAppEngApi api, ItemStack grindstone, RecipeGenerator generator )
 	{
 		ItemStack handle = api.definitions().blocks().crankHandle().maybeStack(1).orNull();
-		Slot[] grinderSlots = new ItemSlot[] {
-				new ItemSlot( 3, 21, 16, 16 ).drawOwnBackground(),
-				new ItemSlot( 41, 21, 16, 16, true ).drawOwnBackground().setSlotType( SlotType.OUTPUT_SLOT ),
-				new ChanceSlot( 59, 12, 16, 16, true).setRatio( 10000 ).setFormatString( " (%1$.2f%% chance)" ).drawOwnBackground().setSlotType( SlotType.OUTPUT_SLOT ),
-				new ChanceSlot( 59, 30, 16, 16, true).setRatio( 10000 ).setFormatString( " (%1$.2f%% chance)" ).drawOwnBackground().setSlotType( SlotType.OUTPUT_SLOT ),
-				new ExtraSlot( 22, 12, 16, 16, handle ).clickable( true ).showName( true ).setSlotType( SlotType.MACHINE_SLOT ),
-				new ExtraSlot( 22, 30, 16, 16, grindstone ).clickable( true ).showName( true ).setSlotType( SlotType.MACHINE_SLOT ) };
 		RecipeTemplate grinderTemplate = generator.createRecipeTemplate( grinderSlots, grindstone );
 
 		for( IGrinderEntry recipe : api.registries().grinder().getRecipes() )
@@ -185,13 +192,6 @@ public class CraftGuide extends CraftGuideAPIObject implements IIntegrationModul
 
 	private void addInscriberRecipes( IAppEngApi api, ItemStack inscriber, RecipeGenerator generator )
 	{
-		Slot[] inscriberSlots = new ItemSlot[] {
-				new ItemSlot( 12, 21, 16, 16 ).drawOwnBackground(),
-				new ItemSlot( 21, 3, 16, 16 ).drawOwnBackground(),
-				new ItemSlot( 21, 39, 16, 16 ).drawOwnBackground(),
-				new ItemSlot( 50, 21, 16, 16, true ).drawOwnBackground().setSlotType( SlotType.OUTPUT_SLOT ),
-				new ExtraSlot( 31, 21, 16, 16, inscriber ).clickable( true ).showName( true ).setSlotType( SlotType.MACHINE_SLOT ) };
-
 		RecipeTemplate inscriberTemplate = generator.createRecipeTemplate( inscriberSlots, inscriber );
 
 		for( IInscriberRecipe recipe : api.registries().inscriber().getRecipes() )

--- a/src/main/java/appeng/integration/modules/CraftGuide.java
+++ b/src/main/java/appeng/integration/modules/CraftGuide.java
@@ -40,8 +40,6 @@ import uristqwerty.CraftGuide.api.RecipeProvider;
 import uristqwerty.CraftGuide.api.RecipeTemplate;
 import uristqwerty.CraftGuide.api.Slot;
 import uristqwerty.CraftGuide.api.SlotType;
-import uristqwerty.CraftGuide.api.StackInfo;
-import uristqwerty.CraftGuide.api.StackInfoSource;
 import uristqwerty.gui_craftguide.texture.DynamicTexture;
 import uristqwerty.gui_craftguide.texture.TextureClip;
 
@@ -53,7 +51,7 @@ import appeng.recipes.game.ShapedRecipe;
 import appeng.recipes.game.ShapelessRecipe;
 
 
-public class CraftGuide extends CraftGuideAPIObject implements IIntegrationModule, RecipeProvider, StackInfoSource, RecipeGenerator
+public class CraftGuide extends CraftGuideAPIObject implements IIntegrationModule, RecipeProvider
 {
 
 	public static CraftGuide instance;
@@ -69,20 +67,10 @@ public class CraftGuide extends CraftGuideAPIObject implements IIntegrationModul
 	private final Slot[] smallCraftingSlots = new ItemSlot[] { new ItemSlot( 12, 12, 16, 16 ), new ItemSlot( 30, 12, 16, 16 ), new ItemSlot( 12, 30, 16, 16 ), new ItemSlot( 30, 30, 16, 16 ), new ItemSlot( 59, 21, 16, 16, true ).setSlotType( SlotType.OUTPUT_SLOT ), };
 
 	private final Slot[] furnaceSlots = new ItemSlot[] { new ItemSlot( 13, 21, 16, 16 ), new ItemSlot( 50, 21, 16, 16, true ).setSlotType( SlotType.OUTPUT_SLOT ), };
-	RecipeGenerator parent;
-
-	@Override
-	public String getInfo( ItemStack itemStack )
-	{
-		// :P
-		return null;
-	}
 
 	@Override
 	public void generateRecipes( RecipeGenerator generator )
 	{
-		this.parent = generator;
-
 		RecipeTemplate craftingTemplate;
 		RecipeTemplate smallTemplate;
 
@@ -102,9 +90,9 @@ public class CraftGuide extends CraftGuideAPIObject implements IIntegrationModul
 
 		RecipeTemplate furnaceTemplate = new DefaultRecipeTemplate( this.furnaceSlots, new ItemStack( Blocks.furnace ), new TextureClip( DynamicTexture.instance( "recipe_backgrounds" ), 1, 181, 79, 58 ), new TextureClip( DynamicTexture.instance( "recipe_backgrounds" ), 82, 181, 79, 58 ) );
 
-		this.addCraftingRecipes( craftingTemplate, smallTemplate, shapelessTemplate, this );
-		this.addGrinderRecipes( furnaceTemplate, this );
-		this.addInscriberRecipes( furnaceTemplate, this );
+		this.addCraftingRecipes( craftingTemplate, smallTemplate, shapelessTemplate, generator );
+		this.addGrinderRecipes( furnaceTemplate, generator );
+		this.addInscriberRecipes( furnaceTemplate, generator );
 	}
 
 	private void addCraftingRecipes( RecipeTemplate template, RecipeTemplate templateSmall, RecipeTemplate templateShapeless, RecipeGenerator generator )
@@ -119,8 +107,12 @@ public class CraftGuide extends CraftGuideAPIObject implements IIntegrationModul
 			{
 				IRecipe recipe = (IRecipe) o;
 
-				Object[] items = generator.getCraftingRecipe( recipe, true );
+				Object[] items = this.getCraftingRecipe( recipe, true );
 
+				if( items == null )
+				{
+					continue;
+				}
 				if( items.length == 5 )
 				{
 					generator.addRecipe( templateSmall, items );
@@ -138,8 +130,7 @@ public class CraftGuide extends CraftGuideAPIObject implements IIntegrationModul
 			{
 				if( errCount >= 5 )
 				{
-					CraftGuideLog.log( "CraftGuide DefaultRecipeProvider: Stack trace limit reached, further stack traces from this invocation will not be logged to the console. They will still be logged to (.minecraft)/config/CraftGuide/CraftGuide.log", true );
-					errCount = -1;
+					CraftGuideLog.log( "AppEng CraftGuide integration: Stack trace limit reached, further stack traces from this invocation will not be logged to the console. They will still be logged to (.minecraft)/config/CraftGuide/CraftGuide.log", true );
 				}
 				else
 				{
@@ -160,48 +151,6 @@ public class CraftGuide extends CraftGuideAPIObject implements IIntegrationModul
 	private void addInscriberRecipes( RecipeTemplate template, RecipeGenerator generator )
 	{
 
-	}
-
-	@Override
-	public RecipeTemplate createRecipeTemplate( Slot[] slots, ItemStack craftingType )
-	{
-		return this.parent.createRecipeTemplate( slots, craftingType );
-	}
-
-	@Override
-	public RecipeTemplate createRecipeTemplate( Slot[] slots, ItemStack craftingType, String backgroundTexture, int backgroundX, int backgroundY, int backgroundSelectedX, int backgroundSelectedY )
-	{
-		return this.parent.createRecipeTemplate( slots, craftingType, backgroundTexture, backgroundX, backgroundY, backgroundSelectedX, backgroundSelectedY );
-	}
-
-	@Override
-	public RecipeTemplate createRecipeTemplate( Slot[] slots, ItemStack craftingType, String bgTexture, int bgX, int bgY, String selectedBGTexture, int selectedBGX, int selectedBGY )
-	{
-		return this.parent.createRecipeTemplate( slots, craftingType, bgTexture, bgX, bgY, selectedBGTexture, selectedBGX, selectedBGY );
-	}
-
-	@Override
-	public void addRecipe( RecipeTemplate template, Object[] crafting )
-	{
-		this.parent.addRecipe( template, crafting );
-	}
-
-	@Override
-	public void addRecipe( CraftGuideRecipe recipe, ItemStack craftingType )
-	{
-		this.parent.addRecipe( recipe, craftingType );
-	}
-
-	@Override
-	public void setDefaultTypeVisibility( ItemStack type, boolean visible )
-	{
-		this.parent.setDefaultTypeVisibility( type, visible );
-	}
-
-	@Override
-	public Object[] getCraftingRecipe( IRecipe recipe )
-	{
-		return this.getCraftingRecipe( recipe, true );
 	}
 
 	Object[] getCraftingShapelessRecipe( List items, ItemStack recipeOutput )
@@ -330,7 +279,6 @@ public class CraftGuide extends CraftGuideAPIObject implements IIntegrationModul
 		return list;
 	}
 
-	@Override
 	public Object[] getCraftingRecipe( IRecipe recipe, boolean allowSmallGrid )
 	{
 		if( recipe instanceof ShapelessRecipe )
@@ -360,7 +308,6 @@ public class CraftGuide extends CraftGuideAPIObject implements IIntegrationModul
 	@Override
 	public void init() throws Throwable
 	{
-		StackInfo.addSource( this );
 	}
 
 	@Override


### PR DESCRIPTION
A bug had crept in that caused the CraftGuide to NPE once for each non-AE2 crafting recipe, extending CraftGuide recipe loading time by tens of seconds.

While doing that, I cleaned up the rest of the file by removing two unnessecary interface implementations, and added support for inscriber and grinder recipes.

I hope that I adequately imitated the code style of AE2.