### PR TITLE
Fixes #1517 improved performance of TESRWrapper

### DIFF
--- a/src/main/java/appeng/client/render/BaseBlockRender.java
+++ b/src/main/java/appeng/client/render/BaseBlockRender.java
@@ -754,7 +754,6 @@ public class BaseBlockRender<B extends AEBaseBlock, T extends AEBaseTile>
 			GL11.glTranslated( x + 0.5, y + 0.5, z + 0.5 );
 			GL11.glMultMatrix( this.rotMat );
 			GL11.glTranslated( -0.5, -0.5, -0.5 );
-			GL11.glCullFace( GL11.GL_FRONT );
 		}
 		else
 		{

--- a/src/main/java/appeng/client/render/TESRWrapper.java
+++ b/src/main/java/appeng/client/render/TESRWrapper.java
@@ -41,7 +41,7 @@ public class TESRWrapper extends TileEntitySpecialRenderer
 
 	public final RenderBlocks renderBlocksInstance = new RenderBlocks();
 
-	final BaseBlockRender blkRender;
+	private final BaseBlockRender blkRender;
 	private final double maxDistance;
 
 	public TESRWrapper( BaseBlockRender render )
@@ -69,12 +69,10 @@ public class TESRWrapper extends TileEntitySpecialRenderer
 				try
 				{
 					GL11.glPushMatrix();
-					GL11.glPushAttrib( GL11.GL_ALL_ATTRIB_BITS );
 
 					this.renderBlocksInstance.blockAccess = te.getWorldObj();
 					this.blkRender.renderTile( (AEBaseBlock) b, (AEBaseTile) te, tess, x, y, z, f, this.renderBlocksInstance );
 
-					GL11.glPopAttrib();
 					GL11.glPopMatrix();
 				}
 				catch( Throwable t )

--- a/src/main/java/appeng/client/render/blocks/RenderBlockCharger.java
+++ b/src/main/java/appeng/client/render/blocks/RenderBlockCharger.java
@@ -54,7 +54,7 @@ public class RenderBlockCharger extends BaseBlockRender<BlockCharger, TileCharge
 	@Override
 	public void renderInventory( BlockCharger blk, ItemStack is, RenderBlocks renderer, ItemRenderType type, Object[] obj )
 	{
-		Tessellator tess = Tessellator.instance;
+		final Tessellator tess = Tessellator.instance;
 
 		renderer.renderAllFaces = true;
 		this.setInvRenderBounds( renderer, 6, 1, 0, 10, 15, 2 );
@@ -87,13 +87,13 @@ public class RenderBlockCharger extends BaseBlockRender<BlockCharger, TileCharge
 	{
 		this.preRenderInWorld( block, world, x, y, z, renderer );
 
-		BlockCharger blk = (BlockCharger) block;
+		final BlockCharger blk = (BlockCharger) block;
 
-		IOrientable te = this.getOrientable( block, world, x, y, z );
+		final IOrientable te = this.getOrientable( block, world, x, y, z );
 
-		ForgeDirection fdy = te.getUp();
-		ForgeDirection fdz = te.getForward();
-		ForgeDirection fdx = Platform.crossProduct( fdz, fdy ).getOpposite();
+		final ForgeDirection fdy = te.getUp();
+		final ForgeDirection fdz = te.getForward();
+		final ForgeDirection fdx = Platform.crossProduct( fdz, fdy ).getOpposite();
 
 		renderer.renderAllFaces = true;
 		this.renderBlockBounds( renderer, 6, 1, 0, 10, 15, 2, fdx, fdy, fdz );
@@ -144,7 +144,7 @@ public class RenderBlockCharger extends BaseBlockRender<BlockCharger, TileCharge
 				GL11.glScalef( 1.0f / 1.1f, 1.0f / 1.1f, 1.0f / 1.1f );
 				GL11.glScalef( 1.0f, 1.0f, 1.0f );
 
-				Block blk = Block.getBlockFromItem( sis.getItem() );
+				final Block blk = Block.getBlockFromItem( sis.getItem() );
 				if( sis.getItemSpriteNumber() == 0 && block != null && RenderBlocks.renderItemIn3d( blk.getRenderType() ) )
 				{
 					GL11.glRotatef( 25.0f, 1.0f, 0.0f, 0.0f );
@@ -152,14 +152,11 @@ public class RenderBlockCharger extends BaseBlockRender<BlockCharger, TileCharge
 					GL11.glRotatef( 30.0f, 0.0f, 1.0f, 0.0f );
 				}
 
-				int br = tile.getWorldObj().getLightBrightnessForSkyBlocks( tile.xCoord, tile.yCoord, tile.zCoord, 0 );// <<
-																														// 20
-																														// |
-																														// light
-																														// <<
-																														// 4;
-				int var11 = br % 65536;
-				int var12 = br / 65536;
+				// << 20 | light << 4;
+				final int br = tile.getWorldObj().getLightBrightnessForSkyBlocks( tile.xCoord, tile.yCoord, tile.zCoord, 0 );
+				final int var11 = br % 65536;
+				final int var12 = br / 65536;
+
 				OpenGlHelper.setLightmapTextureCoords( OpenGlHelper.lightmapTexUnit, var11, var12 );
 
 				GL11.glColor4f( 1.0F, 1.0F, 1.0F, 1.0F );

--- a/src/main/java/appeng/client/render/blocks/RenderBlockInscriber.java
+++ b/src/main/java/appeng/client/render/blocks/RenderBlockInscriber.java
@@ -65,7 +65,7 @@ public class RenderBlockInscriber extends BaseBlockRender<BlockInscriber, TileIn
 	@Override
 	public void renderInventory( BlockInscriber blk, ItemStack is, RenderBlocks renderer, ItemRenderType type, Object[] obj )
 	{
-		Tessellator tess = Tessellator.instance;
+		final Tessellator tess = Tessellator.instance;
 
 		renderer.renderAllFaces = true;
 		this.setInvRenderBounds( renderer, 6, 1, 0, 10, 15, 2 );
@@ -108,17 +108,17 @@ public class RenderBlockInscriber extends BaseBlockRender<BlockInscriber, TileIn
 	{
 		this.preRenderInWorld( block, world, x, y, z, renderer );
 
-		BlockInscriber blk = (BlockInscriber) block;
+		final BlockInscriber blk = (BlockInscriber) block;
 
-		IOrientable te = this.getOrientable( block, world, x, y, z );
+		final IOrientable te = this.getOrientable( block, world, x, y, z );
 		if( te == null )
 		{
 			return false;
 		}
 
-		ForgeDirection fdy = te.getUp();
-		ForgeDirection fdz = te.getForward();
-		ForgeDirection fdx = Platform.crossProduct( fdz, fdy ).getOpposite();
+		final ForgeDirection fdy = te.getUp();
+		final ForgeDirection fdz = te.getForward();
+		final ForgeDirection fdx = Platform.crossProduct( fdz, fdy ).getOpposite();
 
 		renderer.renderAllFaces = true;
 
@@ -163,21 +163,21 @@ public class RenderBlockInscriber extends BaseBlockRender<BlockInscriber, TileIn
 		Minecraft mc = Minecraft.getMinecraft();
 		mc.renderEngine.bindTexture( TextureMap.locationBlocksTexture );
 
-		int br = tile.getWorldObj().getLightBrightnessForSkyBlocks( tile.xCoord, tile.yCoord, tile.zCoord, 0 );// << 20
-																												// |
-																												// light
-																												// << 4;
-		int var11 = br % 65536;
-		int var12 = br / 65536;
+		// << 20 | light << 4;
+		final int br = tile.getWorldObj().getLightBrightnessForSkyBlocks( tile.xCoord, tile.yCoord, tile.zCoord, 0 );
+		final int var11 = br % 65536;
+		final int var12 = br / 65536;
+
 		OpenGlHelper.setLightmapTextureCoords( OpenGlHelper.lightmapTexUnit, var11, var12 );
 
-		float TwoPx = 2.0f / 16.0f;
+		final float TwoPx = 2.0f / 16.0f;
 		float middle = 0.5f;
 
 		float press = 0.2f;
-		float base = 0.4f;
+		final float base = 0.4f;
 
 		long absoluteProgress = 0;
+
 		if( inv.smash )
 		{
 			long currentTime = System.currentTimeMillis();
@@ -277,7 +277,8 @@ public class RenderBlockInscriber extends BaseBlockRender<BlockInscriber, TileIn
 				GL11.glScalef( 1.0f / 1.1f, 1.0f / 1.1f, 1.0f / 1.1f );
 				GL11.glScalef( 1.0f, 1.0f, 1.0f );
 
-				Block blk = Block.getBlockFromItem( sis.getItem() );
+				final Block blk = Block.getBlockFromItem( sis.getItem() );
+
 				if( sis.getItemSpriteNumber() == 0 && block != null && RenderBlocks.renderItemIn3d( blk.getRenderType() ) )
 				{
 					GL11.glRotatef( 25.0f, 1.0f, 0.0f, 0.0f );
@@ -287,14 +288,11 @@ public class RenderBlockInscriber extends BaseBlockRender<BlockInscriber, TileIn
 
 				GL11.glRotatef( 90.0f, 1, 0, 0 );
 
-				int br = tile.getWorldObj().getLightBrightnessForSkyBlocks( tile.xCoord, tile.yCoord, tile.zCoord, 0 );// <<
-																														// 20
-																														// |
-																														// light
-																														// <<
-																														// 4;
-				int var11 = br % 65536;
-				int var12 = br / 65536;
+				// << 20 | light << 4;
+				final int br = tile.getWorldObj().getLightBrightnessForSkyBlocks( tile.xCoord, tile.yCoord, tile.zCoord, 0 );
+				final int var11 = br % 65536;
+				final int var12 = br / 65536;
+
 				OpenGlHelper.setLightmapTextureCoords( OpenGlHelper.lightmapTexUnit, var11, var12 );
 
 				GL11.glColor4f( 1.0F, 1.0F, 1.0F, 1.0F );

--- a/src/main/java/appeng/client/render/blocks/RenderBlockSkyChest.java
+++ b/src/main/java/appeng/client/render/blocks/RenderBlockSkyChest.java
@@ -20,6 +20,7 @@ package appeng.client.render.blocks;
 
 
 import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.model.ModelChest;
@@ -38,7 +39,11 @@ import appeng.tile.storage.TileSkyChest;
 public class RenderBlockSkyChest extends BaseBlockRender<BlockSkyChest, TileSkyChest>
 {
 
-	final ModelChest model = new ModelChest();
+	private final static ResourceLocation SKY_STONE_CHEST = new ResourceLocation( "appliedenergistics2", "textures/models/skychest.png" );
+	private final static ResourceLocation SKY_BLOCK_CHEST = new ResourceLocation( "appliedenergistics2", "textures/models/skyblockchest.png" );
+	private final static ResourceLocation METADATA_TO_TEXTURE[] = new ResourceLocation[] { SKY_STONE_CHEST, SKY_BLOCK_CHEST };
+
+	private final ModelChest model = new ModelChest();
 
 	public RenderBlockSkyChest()
 	{
@@ -48,22 +53,15 @@ public class RenderBlockSkyChest extends BaseBlockRender<BlockSkyChest, TileSkyC
 	@Override
 	public void renderInventory( BlockSkyChest blk, ItemStack is, RenderBlocks renderer, ItemRenderType type, Object[] obj )
 	{
-		GL11.glEnable( 32826 /* GL_RESCALE_NORMAL_EXT */);
+		GL11.glEnable( GL12.GL_RESCALE_NORMAL );
 		GL11.glColor4f( 1.0F, 1.0F, 1.0F, 1.0F );
 
-		ResourceLocation loc;
-		if( is.getItemDamage() == 1 )
-		{
-			loc = new ResourceLocation( "appliedenergistics2", "textures/models/skyblockchest.png" );
-		}
-		else
-		{
-			loc = new ResourceLocation( "appliedenergistics2", "textures/models/skychest.png" );
-		}
+		final int metaData = is.getItemDamage();
+		final ResourceLocation loc = METADATA_TO_TEXTURE[metaData];
 
 		Minecraft.getMinecraft().getTextureManager().bindTexture( loc );
 
-		float lidAngle = 0.0f;
+		final float lidAngle = 0.0f;
 
 		GL11.glScalef( 1.0F, -1F, -1F );
 		GL11.glTranslatef( -0.0F, -1.0F, -1.0F );
@@ -72,7 +70,7 @@ public class RenderBlockSkyChest extends BaseBlockRender<BlockSkyChest, TileSkyC
 		this.model.chestLid.rotateAngleX = -( ( lidAngle * 3.141593F ) / 2.0F );
 		this.model.renderAll();
 
-		GL11.glDisable( 32826 /* GL_RESCALE_NORMAL_EXT */);
+		GL11.glDisable( GL12.GL_RESCALE_NORMAL );
 		GL11.glColor4f( 1.0F, 1.0F, 1.0F, 1.0F );
 	}
 
@@ -90,26 +88,18 @@ public class RenderBlockSkyChest extends BaseBlockRender<BlockSkyChest, TileSkyC
 			return;
 		}
 
-		TileSkyChest skyChest = (TileSkyChest) tile;
+		final TileSkyChest skyChest = (TileSkyChest) tile;
 
 		if( !skyChest.hasWorldObj() )
 		{
 			return;
 		}
 
-		GL11.glEnable( 32826 /* GL_RESCALE_NORMAL_EXT */);
+		GL11.glEnable( GL12.GL_RESCALE_NORMAL );
 		GL11.glColor4f( 1.0F, 1.0F, 1.0F, 1.0F );
 
-		ResourceLocation loc;
-
-		if( tile.getWorldObj().getBlockMetadata( tile.xCoord, tile.yCoord, tile.zCoord ) == 1 )
-		{
-			loc = new ResourceLocation( "appliedenergistics2", "textures/models/skyblockchest.png" );
-		}
-		else
-		{
-			loc = new ResourceLocation( "appliedenergistics2", "textures/models/skychest.png" );
-		}
+		final int metaData = tile.getWorldObj().getBlockMetadata( tile.xCoord, tile.yCoord, tile.zCoord );
+		final ResourceLocation loc = METADATA_TO_TEXTURE[metaData];
 
 		Minecraft.getMinecraft().getTextureManager().bindTexture( loc );
 
@@ -118,8 +108,8 @@ public class RenderBlockSkyChest extends BaseBlockRender<BlockSkyChest, TileSkyC
 		GL11.glScalef( 1.0F, -1F, -1F );
 		GL11.glTranslatef( -0.0F, -1.0F, -1.0F );
 
-		long now = System.currentTimeMillis();
-		long distance = now - skyChest.lastEvent;
+		final long now = System.currentTimeMillis();
+		final long distance = now - skyChest.lastEvent;
 
 		if( skyChest.playerOpen > 0 )
 		{
@@ -146,9 +136,13 @@ public class RenderBlockSkyChest extends BaseBlockRender<BlockSkyChest, TileSkyC
 
 		this.model.chestLid.offsetY = -( 1.01f / 16.0f );
 		this.model.chestLid.rotateAngleX = -( ( lidAngle * 3.141593F ) / 2.0F );
-		this.model.renderAll();
 
-		GL11.glDisable( 32826 /* GL_RESCALE_NORMAL_EXT */);
+		// The vanilla chests wants culling reversed...
+		GL11.glCullFace( GL11.GL_FRONT );
+		this.model.renderAll();
+		GL11.glCullFace( GL11.GL_BACK );
+
+		GL11.glDisable( GL12.GL_RESCALE_NORMAL );
 		GL11.glColor4f( 1.0F, 1.0F, 1.0F, 1.0F );
 	}
 }


### PR DESCRIPTION
Instead of spending the majority of the time with `glPushAttrib()` and `glPopAttrib()`, the bottleneck is now the the skystone chest itself. The other blocks like chargers or inscribers are not that taxing in comparison.

This is mostly caused by the chests reusing the vanilla chest model. So this could potentially also be optimized. As far is I understand it, `glPushAttrib()` and `glPopAttrib()` is actually only needed for the chest itself and none of the other blocks. At least I cannot notice any issue with moving it into `RenderBlockSkyChest`.