### PR TITLE
Fixes #1599: Removes preconditions for world data and children

### DIFF
--- a/src/main/java/appeng/core/worlddata/CompassData.java
+++ b/src/main/java/appeng/core/worlddata/CompassData.java
@@ -32,7 +32,7 @@ import appeng.services.CompassService;
  * @version rv3 - 30.05.2015
  * @since rv3 30.05.2015
  */
-final class CompassData implements IWorldCompassData, IOnWorldStartable, IOnWorldStoppable
+final class CompassData implements IWorldCompassData, IOnWorldStoppable
 {
 	@Nonnull
 	private final CompassService service;
@@ -40,7 +40,6 @@ final class CompassData implements IWorldCompassData, IOnWorldStartable, IOnWorl
 	public CompassData( @Nonnull final File compassDirectory, @Nonnull final CompassService service )
 	{
 		Preconditions.checkNotNull( compassDirectory );
-		Preconditions.checkArgument( compassDirectory.isDirectory() );
 		Preconditions.checkNotNull( service );
 
 		this.service = service;
@@ -50,12 +49,6 @@ final class CompassData implements IWorldCompassData, IOnWorldStartable, IOnWorl
 	public CompassService service()
 	{
 		return this.service;
-	}
-
-	@Override
-	public void onWorldStart()
-	{
-
 	}
 
 	@Override

--- a/src/main/java/appeng/core/worlddata/DimensionData.java
+++ b/src/main/java/appeng/core/worlddata/DimensionData.java
@@ -66,7 +66,6 @@ final class DimensionData implements IWorldDimensionData, IOnWorldStartable, IOn
 	DimensionData( @Nonnull final File parentFile, @Nonnull final String configVersion )
 	{
 		Preconditions.checkNotNull( parentFile );
-		Preconditions.checkArgument( parentFile.isFile() );
 		Preconditions.checkNotNull( configVersion );
 		Preconditions.checkArgument( !configVersion.isEmpty() );
 

--- a/src/main/java/appeng/core/worlddata/PlayerData.java
+++ b/src/main/java/appeng/core/worlddata/PlayerData.java
@@ -60,7 +60,6 @@ final class PlayerData implements IWorldPlayerData, IOnWorldStartable, IOnWorldS
 	public PlayerData( @Nonnull final File configFile, @Nonnull final String configVersion )
 	{
 		Preconditions.checkNotNull( configFile );
-		Preconditions.checkArgument( configFile.isFile() );
 		Preconditions.checkNotNull( configVersion );
 		Preconditions.checkArgument( !configVersion.isEmpty() );
 

--- a/src/main/java/appeng/core/worlddata/SpawnData.java
+++ b/src/main/java/appeng/core/worlddata/SpawnData.java
@@ -40,7 +40,7 @@ import appeng.core.AELog;
  * @version rv3 - 30.05.2015
  * @since rv3 30.05.2015
  */
-final class SpawnData implements IWorldSpawnData, IOnWorldStartable, IOnWorldStoppable
+final class SpawnData implements IWorldSpawnData
 {
 	@Nonnull
 	private final File spawnDirectory;
@@ -50,16 +50,9 @@ final class SpawnData implements IWorldSpawnData, IOnWorldStartable, IOnWorldSto
 	public SpawnData( @Nonnull final File spawnDirectory )
 	{
 		Preconditions.checkNotNull( spawnDirectory );
-		Preconditions.checkArgument( spawnDirectory.isDirectory() );
 
 		this.spawnDirectory = spawnDirectory;
 		this.encoder = new MeteorDataNameEncoder( 4 );
-	}
-
-	@Override
-	public void onWorldStart()
-	{
-
 	}
 
 	@Override
@@ -133,12 +126,6 @@ final class SpawnData implements IWorldSpawnData, IOnWorldStartable, IOnWorldSto
 		}
 
 		return ll;
-	}
-
-	@Override
-	public void onWorldStop()
-	{
-
 	}
 
 	private NBTTagCompound loadSpawnData( int dim, int chunkX, int chunkZ )

--- a/src/main/java/appeng/core/worlddata/StorageData.java
+++ b/src/main/java/appeng/core/worlddata/StorageData.java
@@ -57,7 +57,6 @@ final class StorageData implements IWorldGridStorageData, IOnWorldStartable, IOn
 	public StorageData( @Nonnull final File settingsFile, @Nonnull final String version )
 	{
 		Preconditions.checkNotNull( settingsFile );
-		Preconditions.checkArgument( settingsFile.isFile() );
 		Preconditions.checkNotNull( version );
 		Preconditions.checkArgument( !version.isEmpty() );
 

--- a/src/main/java/appeng/core/worlddata/WorldData.java
+++ b/src/main/java/appeng/core/worlddata/WorldData.java
@@ -38,9 +38,8 @@ import appeng.services.compass.CompassThreadFactory;
 /**
  * Singleton access to anything related to world-based data.
  *
- * Data will change depending which world is loaded.
- * Will probably not affect SMP at all since only one world is loaded,
- * but SSP more, cause they play on different worlds.
+ * Data will change depending which world is loaded. Will probably not affect SMP at all since only one world is loaded, but SSP more, cause they play on
+ * different worlds.
  *
  * @author thatsIch
  * @version rv3 - 30.05.2015
@@ -64,6 +63,7 @@ public final class WorldData implements IWorldData
 
 	private final List<IOnWorldStartable> startables;
 	private final List<IOnWorldStoppable> stoppables;
+
 	private final File ae2directory;
 	private final File spawnDirectory;
 	private final File compassDirectory;
@@ -74,19 +74,20 @@ public final class WorldData implements IWorldData
 		Preconditions.checkArgument( worldDirectory.isDirectory() );
 
 		this.ae2directory = new File( worldDirectory, AE2_DIRECTORY_NAME );
-		final File settingsFile = new File( this.ae2directory, SETTING_FILE_NAME );
 		this.spawnDirectory = new File( this.ae2directory, SPAWNDATA_DIR_NAME );
+		this.compassDirectory = new File( this.ae2directory, COMPASS_DIR_NAME );
+
+		final File settingsFile = new File( this.ae2directory, SETTING_FILE_NAME );
 
 		final PlayerData playerData = new PlayerData( settingsFile, AEConfig.VERSION );
 		final DimensionData dimensionData = new DimensionData( settingsFile, AEConfig.VERSION );
 		final StorageData storageData = new StorageData( settingsFile, AEConfig.VERSION );
 
-		this.compassDirectory = new File( this.ae2directory, COMPASS_DIR_NAME );
 		final ThreadFactory compassThreadFactory = new CompassThreadFactory();
 		final CompassService compassService = new CompassService( this.compassDirectory, compassThreadFactory );
 		final CompassData compassData = new CompassData( this.compassDirectory, compassService );
 
-		final SpawnData spawnData = new SpawnData( this.spawnDirectory );
+		final IWorldSpawnData spawnData = new SpawnData( this.spawnDirectory );
 
 		this.playerData = playerData;
 		this.dimensionData = dimensionData;
@@ -94,8 +95,8 @@ public final class WorldData implements IWorldData
 		this.compassData = compassData;
 		this.spawnData = spawnData;
 
-		this.startables = Lists.<IOnWorldStartable>newArrayList( playerData, dimensionData, storageData, compassData, spawnData );
-		this.stoppables = Lists.<IOnWorldStoppable>newArrayList( playerData, dimensionData, storageData, compassData, spawnData );
+		this.startables = Lists.<IOnWorldStartable>newArrayList( playerData, dimensionData, storageData );
+		this.stoppables = Lists.<IOnWorldStoppable>newArrayList( playerData, dimensionData, storageData, compassData );
 	}
 
 	/**

--- a/src/main/java/appeng/services/CompassService.java
+++ b/src/main/java/appeng/services/CompassService.java
@@ -58,7 +58,6 @@ public final class CompassService
 	public CompassService( @Nonnull final File worldCompassFolder, @Nonnull final ThreadFactory factory )
 	{
 		Preconditions.checkNotNull( worldCompassFolder );
-		Preconditions.checkArgument( worldCompassFolder.isDirectory() );
 
 		this.worldCompassFolder = worldCompassFolder;
 		this.executor = Executors.newSingleThreadExecutor( factory );


### PR DESCRIPTION
Removes the preconditions on the children, 

optimized the process a bit, by selecting which of the classes are actually required on start and end.