### PR TITLE
Splitted channeldata into two ints

### DIFF
--- a/src/main/java/appeng/me/GridNode.java
+++ b/src/main/java/appeng/me/GridNode.java
@@ -71,7 +71,8 @@ public class GridNode implements IGridNode, IPathItem
 	private Object visitorIterationNumber = null;
 	// connection criteria
 	private int compressedData = 0;
-	private int channelData = 0;
+	private int usedChannels = 0;
+	private int lastUsedChannels = 0;
 
 	public GridNode( IGridBlock what )
 	{
@@ -90,7 +91,7 @@ public class GridNode implements IGridNode, IPathItem
 
 	public int usedChannels()
 	{
-		return this.channelData >> 8;
+		return this.lastUsedChannels;
 	}
 
 	public Class<? extends IGridHost> getMachineClass()
@@ -361,7 +362,7 @@ public class GridNode implements IGridNode, IPathItem
 	@Override
 	public boolean meetsChannelRequirements()
 	{
-		return ( !this.gridProxy.getFlags().contains( GridFlags.REQUIRE_CHANNEL ) || this.getUsedChannels() > 0 );
+		return( !this.gridProxy.getFlags().contains( GridFlags.REQUIRE_CHANNEL ) || this.getUsedChannels() > 0 );
 	}
 
 	@Override
@@ -387,7 +388,7 @@ public class GridNode implements IGridNode, IPathItem
 
 	public int getUsedChannels()
 	{
-		return this.channelData & 0xff;
+		return this.usedChannels;
 	}
 
 	public void FindConnections()
@@ -584,7 +585,7 @@ public class GridNode implements IGridNode, IPathItem
 	public void setGridStorage( GridStorage s )
 	{
 		this.myStorage = s;
-		this.channelData = 0;
+		this.usedChannels = 0;
 	}
 
 	@Override
@@ -603,7 +604,7 @@ public class GridNode implements IGridNode, IPathItem
 	{
 		if( zeroOut )
 		{
-			this.channelData &= ~0xff;
+			this.usedChannels = 0;
 		}
 
 		int idx = this.connections.indexOf( fast );
@@ -634,7 +635,7 @@ public class GridNode implements IGridNode, IPathItem
 	@Override
 	public void incrementChannelCount( int usedChannels )
 	{
-		this.channelData += usedChannels;
+		this.usedChannels += usedChannels;
 	}
 
 	@Override
@@ -653,8 +654,7 @@ public class GridNode implements IGridNode, IPathItem
 
 		if( this.getLastUsedChannels() != this.getUsedChannels() )
 		{
-			this.channelData &= 0xff;
-			this.channelData |= this.channelData << 8;
+			this.lastUsedChannels = this.usedChannels;
 
 			if( this.getInternalGrid() != null )
 			{
@@ -665,7 +665,7 @@ public class GridNode implements IGridNode, IPathItem
 
 	public int getLastUsedChannels()
 	{
-		return ( this.channelData >> 8 ) & 0xff;
+		return lastUsedChannels;
 	}
 
 	private static class MachineSecurityBreak implements Callable<Void>
@@ -685,7 +685,6 @@ public class GridNode implements IGridNode, IPathItem
 			return null;
 		}
 	}
-
 
 	private static class ConnectionComparator implements Comparator<IGridConnection>
 	{


### PR DESCRIPTION
Previously it did encode the current and previous used channels into the
same as well as mask it with 0xFF. Which lead to an overflow every 256
gridnodes requiring a channel. This will not happen at > 2^31

Also removes the need to bitshift them for every access.

`usedChannels` is only used by the debug tool and did report the last used channels not the current ones. For whatever reason. It did not mask it with 0xFF, but as it depends on the masked LSB of the int, it will also never exceed 256.
The debug tool should be changed to either use the already existing methods for the last or current channels. The question is mostly which one.

Fixes #1510