### PR TITLE
Fixes #1686: Let PlayerRegistry handle nonexistent players

### DIFF
--- a/src/main/java/appeng/core/features/registries/PlayerRegistry.java
+++ b/src/main/java/appeng/core/features/registries/PlayerRegistry.java
@@ -35,13 +35,18 @@ public class PlayerRegistry implements IPlayerRegistry
 	@Override
 	public int getID( GameProfile username )
 	{
+		if( username == null || !username.isComplete() )
+		{
+			return -1;
+		}
+
 		return WorldData.instance().playerData().getPlayerID( username );
 	}
 
 	@Override
 	public int getID( EntityPlayer player )
 	{
-		return WorldData.instance().playerData().getPlayerID( player.getGameProfile() );
+		return this.getID( player.getGameProfile() );
 	}
 
 	@Nullable

--- a/src/main/java/appeng/core/worlddata/PlayerData.java
+++ b/src/main/java/appeng/core/worlddata/PlayerData.java
@@ -94,17 +94,13 @@ final class PlayerData implements IWorldPlayerData, IOnWorldStartable, IOnWorldS
 	public int getPlayerID( @Nonnull final GameProfile profile )
 	{
 		Preconditions.checkNotNull( profile );
+		Preconditions.checkNotNull( this.config.getCategory( "players" ) );
+		Preconditions.checkState( profile.isComplete() );
 
 		final ConfigCategory players = this.config.getCategory( "players" );
-
-		if( players == null || !profile.isComplete() )
-		{
-			return -1;
-		}
-
 		final String uuid = profile.getId().toString();
-
 		final Property maybePlayerID = players.get( uuid );
+
 		if( maybePlayerID != null && maybePlayerID.isIntValue() )
 		{
 			return maybePlayerID.getInt();


### PR DESCRIPTION
The `PlayerRegistry` now handles the case for null as player used for blank cards instead of passing it to the `PlayerData`, which should only handle existing players.