### PR TITLE
Fixes #1581: Uses 32767 as wildcard meta like IC2

### DIFF
--- a/src/main/java/appeng/util/Platform.java
+++ b/src/main/java/appeng/util/Platform.java
@@ -1867,6 +1867,13 @@ public class Platform
 			{
 				return true;
 			}
+
+			// IC2 uses 32767 as a wildcard meta in its recipes
+			if( that.getItemDamage() == 32767 || other.getItemDamage() == 32767 )
+			{
+				return true;
+			}
+
 			return that.getItemDamage() == other.getItemDamage();
 		}
 		return false;


### PR DESCRIPTION
Whenever an ingredient in `...\assets\ic2\config\shaped_recipes.ini` and `...\assets\ic2\config\shapless_recipes.ini` ends in a `@*` IC2 give the ingredient a meta of 32767. When IC2 compares `ItemStack`s it uses 32767 as a meta wildcard.