### PR TITLE
Closes #1726: Added Pressure P2P tunnel (PneumaticCraft)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -35,6 +35,7 @@ code_chicken_core_version=1.0.7.46
 nei_version=1.0.5.111
 bc_version=7.0.9
 opencomputers_version=1.5.12.26
+pneumaticcraft_version=1.9.15-105
 
 #########################################################
 # Self Compiled APIs                                    #

--- a/gradle/scripts/dependencies.gradle
+++ b/gradle/scripts/dependencies.gradle
@@ -56,6 +56,11 @@ repositories {
         url = "http://maven.cil.li/"
     }
 
+    maven {
+        name = "MM repo"
+        url = "http://maven.k-4u.nl/"
+    }
+
     ivy {
         name "BuildCraft"
         artifactPattern "http://www.mod-buildcraft.com/releases/BuildCraft/[revision]/[module]-[revision]-[classifier].[ext]"
@@ -109,6 +114,7 @@ dependencies {
     compile "codechicken:CodeChickenCore:${minecraft_version}-${code_chicken_core_version}:dev"
     compile "codechicken:NotEnoughItems:${minecraft_version}-${nei_version}:dev"
     compile "com.mod-buildcraft:buildcraft:${bc_version}:dev"
+    compile "pneumaticCraft:PneumaticCraft-${minecraft_version}:${pneumaticcraft_version}:api"
 
     // provided APIs
     compile "li.cil.oc:OpenComputers:MC${minecraft_version}-${opencomputers_version}:api"

--- a/src/api/java/appeng/api/config/TunnelType.java
+++ b/src/api/java/appeng/api/config/TunnelType.java
@@ -34,5 +34,6 @@ public enum TunnelType
 	ITEM, // Item Tunnel
 	LIGHT, // Light Tunnel
 	BUNDLED_REDSTONE, // Bundled Redstone Tunnel
-	COMPUTER_MESSAGE // Computer Message Tunnel
+	COMPUTER_MESSAGE, // Computer Message Tunnel
+	PRESSURE // PneumaticCraft Tunnel
 }

--- a/src/api/java/appeng/api/definitions/IParts.java
+++ b/src/api/java/appeng/api/definitions/IParts.java
@@ -86,6 +86,8 @@ public interface IParts
 
 	IItemDefinition p2PTunnelOpenComputers();
 
+	IItemDefinition p2PTunnelPneumaticCraft();
+
 	IItemDefinition cableAnchor();
 
 	IItemDefinition monitor();

--- a/src/main/java/appeng/core/api/definitions/ApiParts.java
+++ b/src/main/java/appeng/core/api/definitions/ApiParts.java
@@ -61,6 +61,7 @@ public final class ApiParts implements IParts
 	private final IItemDefinition p2PTunnelRF;
 	private final IItemDefinition p2PTunnelLight;
 	private final IItemDefinition p2PTunnelOpenComputers;
+	private final IItemDefinition p2PTunnelPneumaticCraft;
 	private final IItemDefinition cableAnchor;
 	private final IItemDefinition monitor;
 	private final IItemDefinition semiDarkMonitor;
@@ -104,6 +105,7 @@ public final class ApiParts implements IParts
 		this.p2PTunnelRF = new DamagedItemDefinition( itemMultiPart.createPart( PartType.P2PTunnelRF ) );
 		this.p2PTunnelLight = new DamagedItemDefinition( itemMultiPart.createPart( PartType.P2PTunnelLight ) );
 		this.p2PTunnelOpenComputers = new DamagedItemDefinition( itemMultiPart.createPart( PartType.P2PTunnelOpenComputers ) );
+		this.p2PTunnelPneumaticCraft = new DamagedItemDefinition( itemMultiPart.createPart( PartType.P2PTunnelPressure ) );
 		this.cableAnchor = new DamagedItemDefinition( itemMultiPart.createPart( PartType.CableAnchor ) );
 		this.monitor = new DamagedItemDefinition( itemMultiPart.createPart( PartType.Monitor ) );
 		this.semiDarkMonitor = new DamagedItemDefinition( itemMultiPart.createPart( PartType.SemiDarkMonitor ) );
@@ -280,6 +282,12 @@ public final class ApiParts implements IParts
 	public IItemDefinition p2PTunnelOpenComputers()
 	{
 		return this.p2PTunnelOpenComputers;
+	}
+
+	@Override
+	public IItemDefinition p2PTunnelPneumaticCraft()
+	{
+		return this.p2PTunnelPneumaticCraft;
 	}
 
 	@Override

--- a/src/main/java/appeng/core/features/AEFeature.java
+++ b/src/main/java/appeng/core/features/AEFeature.java
@@ -57,7 +57,7 @@ public enum AEFeature
 
 	DenseEnergyCells( "HigherCapacity" ), DenseCables( "HigherCapacity" ),
 
-	P2PTunnelRF( "P2PTunnels" ), P2PTunnelME( "P2PTunnels" ), P2PTunnelItems( "P2PTunnels" ), P2PTunnelRedstone( "P2PTunnels" ), P2PTunnelEU( "P2PTunnels" ), P2PTunnelLiquids( "P2PTunnels" ), P2PTunnelLight( "P2PTunnels" ), P2PTunnelOpenComputers( "P2PTunnels" ),
+	P2PTunnelRF( "P2PTunnels" ), P2PTunnelME( "P2PTunnels" ), P2PTunnelItems( "P2PTunnels" ), P2PTunnelRedstone( "P2PTunnels" ), P2PTunnelEU( "P2PTunnels" ), P2PTunnelLiquids( "P2PTunnels" ), P2PTunnelLight( "P2PTunnels" ), P2PTunnelOpenComputers( "P2PTunnels" ), P2PTunnelPressure( "P2PTunnels" ),
 
 	MassCannonBlockDamage( "BlockFeatures" ), TinyTNTBlockDamage( "BlockFeatures" ), Facades( "Facades" ),
 

--- a/src/main/java/appeng/core/localization/GuiText.java
+++ b/src/main/java/appeng/core/localization/GuiText.java
@@ -45,7 +45,7 @@ public enum GuiText
 	CraftingTerminal, FormationPlane, Inscriber, QuartzCuttingKnife,
 
 	// tunnel names
-	METunnel, ItemTunnel, RedstoneTunnel, EUTunnel, FluidTunnel, OCTunnel, LightTunnel, RFTunnel,
+	METunnel, ItemTunnel, RedstoneTunnel, EUTunnel, FluidTunnel, OCTunnel, LightTunnel, RFTunnel, PressureTunnel,
 
 	StoredSize, CopyMode, CopyModeDesc, PatternTerminal, CraftingPattern,
 

--- a/src/main/java/appeng/core/settings/TickRates.java
+++ b/src/main/java/appeng/core/settings/TickRates.java
@@ -47,7 +47,9 @@ public enum TickRates
 
 	LightTunnel( 5, 120 ),
 
-	OpenComputersTunnel( 1, 5 );
+	OpenComputersTunnel( 1, 5 ),
+
+	PressureTunnel( 1, 120 );
 
 	public int min;
 	public int max;

--- a/src/main/java/appeng/integration/IntegrationType.java
+++ b/src/main/java/appeng/integration/IntegrationType.java
@@ -63,7 +63,9 @@ public enum IntegrationType
 
 	BetterStorage( IntegrationSide.BOTH, "BetterStorage", "betterstorage" ),
 
-	OpenComputers( IntegrationSide.BOTH, "OpenComputers", "OpenComputers" );
+	OpenComputers( IntegrationSide.BOTH, "OpenComputers", "OpenComputers" ),
+
+	PneumaticCraft( IntegrationSide.BOTH, "PneumaticCraft", "PneumaticCraft" );
 
 	public final IntegrationSide side;
 	public final String dspName;

--- a/src/main/java/appeng/integration/modules/PneumaticCraft.java
+++ b/src/main/java/appeng/integration/modules/PneumaticCraft.java
@@ -1,0 +1,84 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.integration.modules;
+
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.oredict.OreDictionary;
+
+import cpw.mods.fml.common.registry.GameRegistry;
+
+import appeng.api.AEApi;
+import appeng.api.IAppEngApi;
+import appeng.api.config.TunnelType;
+import appeng.api.features.IP2PTunnelRegistry;
+import appeng.api.parts.IPartHelper;
+import appeng.helpers.Reflected;
+import appeng.integration.BaseModule;
+import appeng.integration.IntegrationRegistry;
+import appeng.integration.IntegrationType;
+
+
+public class PneumaticCraft extends BaseModule
+{
+	@Reflected
+	public static PneumaticCraft instance;
+
+	private static final String PNEUMATIC_CRAFT_MOD_ID = "PneumaticCraft";
+
+	@Reflected
+	public PneumaticCraft()
+	{
+		this.testClassExistence( pneumaticCraft.api.block.BlockSupplier.class );
+		this.testClassExistence( pneumaticCraft.api.tileentity.ISidedPneumaticMachine.class );
+		this.testClassExistence( pneumaticCraft.api.tileentity.AirHandlerSupplier.class );
+		this.testClassExistence( pneumaticCraft.api.tileentity.IAirHandler.class );
+	}
+
+	@Override
+	public void init()
+	{
+		final IAppEngApi api = AEApi.instance();
+		final IPartHelper partHelper = api.partHelper();
+
+		if( IntegrationRegistry.INSTANCE.isEnabled( IntegrationType.PneumaticCraft ) )
+		{
+			partHelper.registerNewLayer( appeng.parts.layers.LayerPressure.class.getName(), pneumaticCraft.api.tileentity.ISidedPneumaticMachine.class.getName() );
+		}
+	}
+
+	@Override
+	public void postInit()
+	{
+		this.registerPressureAttunement( "pressureTube" );
+		this.registerPressureAttunement( "advancedPressureTube" );
+	}
+
+	private void registerPressureAttunement( String itemID )
+	{
+		final IP2PTunnelRegistry registry = AEApi.instance().registries().p2pTunnel();
+		final ItemStack modItem = GameRegistry.findItemStack( PNEUMATIC_CRAFT_MOD_ID, itemID, 1 );
+
+		if( modItem != null )
+		{
+			modItem.setItemDamage( OreDictionary.WILDCARD_VALUE );
+			registry.addNewAttunement( modItem, TunnelType.PRESSURE );
+		}
+	}
+}

--- a/src/main/java/appeng/items/parts/PartType.java
+++ b/src/main/java/appeng/items/parts/PartType.java
@@ -49,6 +49,7 @@ import appeng.parts.p2p.PartP2PItems;
 import appeng.parts.p2p.PartP2PLight;
 import appeng.parts.p2p.PartP2PLiquids;
 import appeng.parts.p2p.PartP2POpenComputers;
+import appeng.parts.p2p.PartP2PPressure;
 import appeng.parts.p2p.PartP2PRFPower;
 import appeng.parts.p2p.PartP2PRedstone;
 import appeng.parts.p2p.PartP2PTunnelME;
@@ -158,6 +159,8 @@ public enum PartType
 	P2PTunnelLight( 467, EnumSet.of( AEFeature.P2PTunnel, AEFeature.P2PTunnelLight ), EnumSet.noneOf( IntegrationType.class ), PartP2PLight.class, GuiText.LightTunnel ),
 
 	P2PTunnelOpenComputers( 468, EnumSet.of( AEFeature.P2PTunnel, AEFeature.P2PTunnelOpenComputers ), EnumSet.of( IntegrationType.OpenComputers ), PartP2POpenComputers.class, GuiText.OCTunnel ),
+
+	P2PTunnelPressure( 469, EnumSet.of( AEFeature.P2PTunnel, AEFeature.P2PTunnelPressure ), EnumSet.of( IntegrationType.PneumaticCraft ), PartP2PPressure.class, GuiText.PressureTunnel ),
 
 	InterfaceTerminal( 480, EnumSet.of( AEFeature.InterfaceTerminal ), EnumSet.noneOf( IntegrationType.class ), PartInterfaceTerminal.class );
 

--- a/src/main/java/appeng/parts/layers/LayerPressure.java
+++ b/src/main/java/appeng/parts/layers/LayerPressure.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.parts.layers;
+
+
+import javax.annotation.Nullable;
+
+import net.minecraftforge.common.util.ForgeDirection;
+
+import pneumaticCraft.api.tileentity.IAirHandler;
+import pneumaticCraft.api.tileentity.ISidedPneumaticMachine;
+
+import appeng.api.parts.IPart;
+import appeng.api.parts.LayerBase;
+
+
+public class LayerPressure extends LayerBase implements ISidedPneumaticMachine
+{
+
+	@Nullable
+	@Override
+	public IAirHandler getAirHandler( ForgeDirection side )
+	{
+		IPart part = this.getPart( side );
+		if( part instanceof ISidedPneumaticMachine )
+		{
+			return ( (ISidedPneumaticMachine) part ).getAirHandler( side );
+		}
+
+		return null;
+	}
+
+}

--- a/src/main/java/appeng/parts/p2p/PartP2PPressure.java
+++ b/src/main/java/appeng/parts/p2p/PartP2PPressure.java
@@ -1,0 +1,173 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.parts.p2p;
+
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.IIcon;
+import net.minecraftforge.common.util.ForgeDirection;
+
+import pneumaticCraft.api.block.BlockSupplier;
+import pneumaticCraft.api.tileentity.AirHandlerSupplier;
+import pneumaticCraft.api.tileentity.IAirHandler;
+import pneumaticCraft.api.tileentity.ISidedPneumaticMachine;
+
+import appeng.api.networking.IGridNode;
+import appeng.api.networking.ticking.IGridTickable;
+import appeng.api.networking.ticking.TickRateModulation;
+import appeng.api.networking.ticking.TickingRequest;
+import appeng.core.settings.TickRates;
+import appeng.transformer.annotations.Integration.Interface;
+import appeng.util.Platform;
+
+
+@Interface( iface = "pneumaticCraft.api.tileentity.ISidedPneumaticMachine", iname = "PneumaticCraft" )
+public final class PartP2PPressure extends PartP2PTunnel<PartP2PPressure> implements ISidedPneumaticMachine, IGridTickable
+{
+	private static final String PRESSURE_NBT_TAG = "pneumaticCraft";
+	private static final String PRESSURE_TYPE_ICON_NAME = "compressedIronBlock";
+
+	/**
+	 * The pressure should never exceed 30f, thus preventing the tunnel from exploding.
+	 */
+	private static final float MAX_PRESSURE = 30f;
+	private static final int VOLUME = 1000;
+
+	@Nonnull
+	private final IAirHandler handler;
+	private boolean isConnected = false;
+
+	public PartP2PPressure( ItemStack is )
+	{
+		super( is );
+		this.handler = AirHandlerSupplier.getAirHandler( MAX_PRESSURE, MAX_PRESSURE, VOLUME );
+	}
+
+	@Override
+	protected IIcon getTypeTexture()
+	{
+		return BlockSupplier.getBlock( PRESSURE_TYPE_ICON_NAME ).getIcon( 0, 0 );
+	}
+
+	@Nullable
+	@Override
+	public IAirHandler getAirHandler( ForgeDirection side )
+	{
+		if( side == this.side )
+		{
+			return this.getInternalHandler();
+		}
+
+		return null;
+	}
+
+	@Override
+	public void onNeighborChanged()
+	{
+		super.onNeighborChanged();
+		this.getInternalHandler().onNeighborChange();
+	}
+
+	@Override
+	public void addToWorld()
+	{
+		super.addToWorld();
+		this.getInternalHandler().validateI( this.getTile() );
+	}
+
+	@Override
+	public void removeFromWorld()
+	{
+		super.removeFromWorld();
+
+		if( this.output && this.getInput() != null )
+		{
+			this.getInternalHandler().removeConnection( this.getInput().getInternalHandler() );
+			this.isConnected = false;
+		}
+	}
+
+	@Override
+	public TickingRequest getTickingRequest( IGridNode node )
+	{
+		return new TickingRequest( TickRates.PressureTunnel.min, TickRates.PressureTunnel.max, false, false );
+	}
+
+	@Override
+	public TickRateModulation tickingRequest( IGridNode node, int TicksSinceLastCall )
+	{
+		if( this.proxy.isPowered() && this.proxy.isActive() )
+		{
+			if( !this.isConnected )
+			{
+				this.updateHandler();
+			}
+
+			this.getInternalHandler().updateEntityI();
+			return TickRateModulation.URGENT;
+		}
+
+		return TickRateModulation.IDLE;
+	}
+
+	@Override
+	public void writeToNBT( NBTTagCompound data )
+	{
+		super.writeToNBT( data );
+		final NBTTagCompound pneumaticNBT = new NBTTagCompound();
+
+		this.getInternalHandler().writeToNBTI( pneumaticNBT );
+		data.setTag( PRESSURE_NBT_TAG, pneumaticNBT );
+	}
+
+	@Override
+	public void readFromNBT( NBTTagCompound data )
+	{
+		super.readFromNBT( data );
+		this.getInternalHandler().readFromNBTI( data.getCompoundTag( PRESSURE_NBT_TAG ) );
+	}
+
+	@Nonnull
+	private IAirHandler getInternalHandler()
+	{
+		return this.handler;
+	}
+
+	private void updateHandler()
+	{
+		if( this.proxy.isPowered() && this.proxy.isActive() )
+		{
+
+			if( this.output && this.getInput() != null )
+			{
+				this.getInternalHandler().createConnection( this.getInput().getInternalHandler() );
+				this.isConnected = true;
+			}
+
+			final TileEntity te = this.getTile();
+			Platform.notifyBlocksOfNeighbors( te.getWorldObj(), te.xCoord, te.yCoord, te.zCoord );
+		}
+	}
+
+}

--- a/src/main/java/appeng/parts/p2p/PartP2PTunnel.java
+++ b/src/main/java/appeng/parts/p2p/PartP2PTunnel.java
@@ -343,6 +343,13 @@ public abstract class PartP2PTunnel<T extends PartP2PTunnel> extends PartBasicSt
 					}
 					break;
 
+				case PRESSURE:
+					for( ItemStack stack : parts.p2PTunnelPneumaticCraft().maybeStack( 1 ).asSet() )
+					{
+						newType = stack;
+					}
+					break;
+
 				default:
 					break;
 			}

--- a/src/main/resources/assets/appliedenergistics2/lang/en_US.lang
+++ b/src/main/resources/assets/appliedenergistics2/lang/en_US.lang
@@ -102,6 +102,7 @@ gui.appliedenergistics2.EUTunnel=EU
 gui.appliedenergistics2.RFTunnel=RF
 gui.appliedenergistics2.LightTunnel=Light
 gui.appliedenergistics2.OCTunnel=OpenComputers
+gui.appliedenergistics2.PressureTunnel=Pressure
 
 gui.appliedenergistics2.security.extract.name=Withdraw
 gui.appliedenergistics2.security.inject.name=Deposit


### PR DESCRIPTION
Similar to the ME Tunnel, this one is bidirectional as the PneumaticCraft API is designed with this in mind.

According to @MineMaarten it might be possible by only ticking one side, but this is mostly a workaround by using an undocumented feature. Thus being a potential future issue and should be avoided.

Closes #1726 