### PR TITLE
Feature 1569 Typesafe Integration Modules

### DIFF
--- a/src/main/java/appeng/block/networking/BlockCableBus.java
+++ b/src/main/java/appeng/block/networking/BlockCableBus.java
@@ -77,7 +77,7 @@ import appeng.transformer.annotations.Integration.Method;
 import appeng.util.Platform;
 
 
-@Interface( iface = "powercrystals.minefactoryreloaded.api.rednet.connectivity.IRedNetConnection", iname = "MFR" )
+@Interface( iface = "powercrystals.minefactoryreloaded.api.rednet.connectivity.IRedNetConnection", iname = IntegrationType.MFR )
 public class BlockCableBus extends AEBaseTileBlock implements IRedNetConnection
 {
 
@@ -506,7 +506,7 @@ public class BlockCableBus extends AEBaseTileBlock implements IRedNetConnection
 	}
 
 	@Override
-	@Method( iname = "MFR" )
+	@Method( iname = IntegrationType.MFR )
 	public RedNetConnectionType getConnectionType( World world, int x, int y, int z, ForgeDirection side )
 	{
 		return this.cb( world, x, y, z ).canConnectRedstone( EnumSet.allOf( ForgeDirection.class ) ) ? RedNetConnectionType.CableSingle : RedNetConnectionType.None;

--- a/src/main/java/appeng/core/Registration.java
+++ b/src/main/java/appeng/core/Registration.java
@@ -521,22 +521,6 @@ public final class Registration
 		partHelper.registerNewLayer( "appeng.parts.layers.LayerIFluidHandler", "net.minecraftforge.fluids.IFluidHandler" );
 		partHelper.registerNewLayer( "appeng.parts.layers.LayerITileStorageMonitorable", "appeng.api.implementations.tiles.ITileStorageMonitorable" );
 
-		if( IntegrationRegistry.INSTANCE.isEnabled( IntegrationType.IC2 ) )
-		{
-			partHelper.registerNewLayer( "appeng.parts.layers.LayerIEnergySink", "ic2.api.energy.tile.IEnergySink" );
-			partHelper.registerNewLayer( "appeng.parts.layers.LayerIEnergySource", "ic2.api.energy.tile.IEnergySource" );
-		}
-
-		if( IntegrationRegistry.INSTANCE.isEnabled( IntegrationType.RF ) )
-		{
-			partHelper.registerNewLayer( "appeng.parts.layers.LayerIEnergyHandler", "cofh.api.energy.IEnergyReceiver" );
-		}
-
-		if( IntegrationRegistry.INSTANCE.isEnabled( IntegrationType.OpenComputers ) )
-		{
-			partHelper.registerNewLayer( "appeng.parts.layers.LayerSidedEnvironment", "li.cil.oc.api.network.SidedEnvironment" );
-		}
-
 		FMLCommonHandler.instance().bus().register( TickHandler.INSTANCE );
 		MinecraftForge.EVENT_BUS.register( TickHandler.INSTANCE );
 

--- a/src/main/java/appeng/integration/BaseModule.java
+++ b/src/main/java/appeng/integration/BaseModule.java
@@ -21,12 +21,6 @@ package appeng.integration;
 
 public abstract class BaseModule implements IIntegrationModule
 {
-
-	protected void testClassExistence( Class<?> clz )
-	{
-		clz.isInstance( this );
-	}
-
 	@Override
 	public abstract void init() throws Throwable;
 

--- a/src/main/java/appeng/integration/IntegrationHelper.java
+++ b/src/main/java/appeng/integration/IntegrationHelper.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of Applied Energistics 2.
- * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
  *
  * Applied Energistics 2 is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -16,32 +16,14 @@
  * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
  */
 
-package appeng.integration.modules;
+package appeng.integration;
 
 
-import appeng.helpers.Reflected;
-import appeng.integration.BaseModule;
-import appeng.integration.IntegrationHelper;
-
-
-public class RFItem extends BaseModule
+public class IntegrationHelper
 {
-	@Reflected
-	public static RFItem instance;
 
-	@Reflected
-	public RFItem()
+	public static void testClassExistence( Object o, Class<?> clz )
 	{
-		IntegrationHelper.testClassExistence( this, cofh.api.energy.IEnergyContainerItem.class );
-	}
-
-	@Override
-	public void init()
-	{
-	}
-
-	@Override
-	public void postInit()
-	{
+		clz.isInstance( o );
 	}
 }

--- a/src/main/java/appeng/integration/IntegrationNode.java
+++ b/src/main/java/appeng/integration/IntegrationNode.java
@@ -39,7 +39,7 @@ public final class IntegrationNode
 	IntegrationStage failedStage = IntegrationStage.PRE_INIT;
 	Throwable exception = null;
 	String name = null;
-	Class classValue = null;
+	Class<?> classValue = null;
 	Object instance;
 	IIntegrationModule mod = null;
 

--- a/src/main/java/appeng/integration/IntegrationRegistry.java
+++ b/src/main/java/appeng/integration/IntegrationRegistry.java
@@ -32,6 +32,8 @@ public enum IntegrationRegistry
 {
 	INSTANCE;
 
+	private static final String PACKAGE_PREFIX = "appeng.integration.modules.";
+
 	private final Collection<IntegrationNode> modules = new LinkedList<IntegrationNode>();
 
 	public void add( IntegrationType type )
@@ -46,7 +48,7 @@ public enum IntegrationRegistry
 			return;
 		}
 
-		this.modules.add( new IntegrationNode( type.dspName, type.modID, type, "appeng.integration.modules." + type.name() ) );
+		this.modules.add( new IntegrationNode( type.dspName, type.modID, type, PACKAGE_PREFIX + type.name() ) );
 	}
 
 	public void init()

--- a/src/main/java/appeng/integration/modules/BetterStorage.java
+++ b/src/main/java/appeng/integration/modules/BetterStorage.java
@@ -23,8 +23,10 @@ import net.mcft.copy.betterstorage.api.crate.ICrateStorage;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import appeng.api.AEApi;
+import appeng.helpers.Reflected;
 import appeng.integration.BaseModule;
 import appeng.integration.IIntegrationModule;
+import appeng.integration.IntegrationHelper;
 import appeng.integration.abstraction.IBetterStorage;
 import appeng.integration.modules.helpers.BSCrateHandler;
 import appeng.integration.modules.helpers.BSCrateStorageAdaptor;
@@ -33,12 +35,13 @@ import appeng.util.InventoryAdaptor;
 
 public class BetterStorage extends BaseModule implements IIntegrationModule, IBetterStorage
 {
-
+	@Reflected
 	public static BetterStorage instance;
 
+	@Reflected
 	public BetterStorage()
 	{
-		this.testClassExistence( net.mcft.copy.betterstorage.api.crate.ICrateStorage.class );
+		IntegrationHelper.testClassExistence( this, net.mcft.copy.betterstorage.api.crate.ICrateStorage.class );
 	}
 
 	@Override
@@ -60,7 +63,6 @@ public class BetterStorage extends BaseModule implements IIntegrationModule, IBe
 	@Override
 	public void init()
 	{
-
 	}
 
 	@Override

--- a/src/main/java/appeng/integration/modules/BuildCraftBuilder.java
+++ b/src/main/java/appeng/integration/modules/BuildCraftBuilder.java
@@ -28,10 +28,7 @@ import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
 
 import buildcraft.api.blueprints.BuilderAPI;
-import buildcraft.api.blueprints.IBuilderContext;
 import buildcraft.api.blueprints.ISchematicRegistry;
-import buildcraft.api.blueprints.SchematicBlock;
-import buildcraft.api.blueprints.SchematicTile;
 
 import appeng.api.AEApi;
 import appeng.api.definitions.IBlockDefinition;
@@ -41,6 +38,7 @@ import appeng.api.util.IOrientableBlock;
 import appeng.core.AELog;
 import appeng.helpers.Reflected;
 import appeng.integration.BaseModule;
+import appeng.integration.IntegrationHelper;
 import appeng.integration.modules.BCHelpers.AECableSchematicTile;
 import appeng.integration.modules.BCHelpers.AEGenericSchematicTile;
 import appeng.integration.modules.BCHelpers.AERotatableBlockSchematic;
@@ -62,11 +60,11 @@ public class BuildCraftBuilder extends BaseModule
 	@Reflected
 	public BuildCraftBuilder()
 	{
-		this.testClassExistence( BuilderAPI.class );
-		this.testClassExistence( IBuilderContext.class );
-		this.testClassExistence( ISchematicRegistry.class );
-		this.testClassExistence( SchematicTile.class );
-		this.testClassExistence( SchematicBlock.class );
+		IntegrationHelper.testClassExistence( this, buildcraft.api.blueprints.BuilderAPI.class );
+		IntegrationHelper.testClassExistence( this, buildcraft.api.blueprints.IBuilderContext.class );
+		IntegrationHelper.testClassExistence( this, buildcraft.api.blueprints.ISchematicRegistry.class );
+		IntegrationHelper.testClassExistence( this, buildcraft.api.blueprints.SchematicTile.class );
+		IntegrationHelper.testClassExistence( this, buildcraft.api.blueprints.SchematicBlock.class );
 	}
 
 	@Override
@@ -85,7 +83,6 @@ public class BuildCraftBuilder extends BaseModule
 	@Override
 	public void postInit()
 	{
-
 	}
 
 	private void initBuilderSupport()

--- a/src/main/java/appeng/integration/modules/BuildCraftCore.java
+++ b/src/main/java/appeng/integration/modules/BuildCraftCore.java
@@ -25,7 +25,6 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
-import buildcraft.BuildCraftTransport;
 import buildcraft.api.tools.IToolWrench;
 
 import appeng.api.AEApi;
@@ -33,6 +32,7 @@ import appeng.api.config.TunnelType;
 import appeng.api.features.IP2PTunnelRegistry;
 import appeng.helpers.Reflected;
 import appeng.integration.BaseModule;
+import appeng.integration.IntegrationHelper;
 import appeng.integration.abstraction.IBuildCraftCore;
 
 
@@ -45,9 +45,9 @@ public final class BuildCraftCore extends BaseModule implements IBuildCraftCore
 	@Reflected
 	public BuildCraftCore()
 	{
-		this.testClassExistence( buildcraft.BuildCraftCore.class );
-		this.testClassExistence( BuildCraftTransport.class );
-		this.testClassExistence( IToolWrench.class );
+		IntegrationHelper.testClassExistence( this, buildcraft.BuildCraftCore.class );
+		IntegrationHelper.testClassExistence( this, buildcraft.BuildCraftTransport.class );
+		IntegrationHelper.testClassExistence( this, buildcraft.api.tools.IToolWrench.class );
 	}
 
 	@Override
@@ -71,7 +71,6 @@ public final class BuildCraftCore extends BaseModule implements IBuildCraftCore
 	@Override
 	public void init()
 	{
-
 	}
 
 	@Override

--- a/src/main/java/appeng/integration/modules/BuildCraftTransport.java
+++ b/src/main/java/appeng/integration/modules/BuildCraftTransport.java
@@ -33,7 +33,6 @@ import cpw.mods.fml.common.event.FMLInterModComms;
 
 import buildcraft.api.facades.IFacadeItem;
 import buildcraft.api.transport.IInjectable;
-import buildcraft.api.transport.IPipeConnection;
 import buildcraft.api.transport.IPipeTile;
 import buildcraft.transport.ItemFacade;
 import buildcraft.transport.PipeIconProvider;
@@ -48,6 +47,7 @@ import appeng.api.parts.IFacadePart;
 import appeng.facade.FacadePart;
 import appeng.helpers.Reflected;
 import appeng.integration.BaseModule;
+import appeng.integration.IntegrationHelper;
 import appeng.integration.abstraction.IBuildCraftTransport;
 import appeng.integration.modules.BCHelpers.BCPipeHandler;
 
@@ -66,14 +66,14 @@ public class BuildCraftTransport extends BaseModule implements IBuildCraftTransp
 	@Reflected
 	public BuildCraftTransport()
 	{
-		this.testClassExistence( buildcraft.BuildCraftTransport.class );
-		this.testClassExistence( IFacadeItem.class );
-		this.testClassExistence( IInjectable.class );
-		this.testClassExistence( IPipeConnection.class );
-		this.testClassExistence( IPipeTile.class );
-		this.testClassExistence( ItemFacade.class );
-		this.testClassExistence( PipeIconProvider.class );
-		this.testClassExistence( IPipeTile.PipeType.class );
+		IntegrationHelper.testClassExistence( this, buildcraft.BuildCraftTransport.class );
+		IntegrationHelper.testClassExistence( this, buildcraft.api.facades.IFacadeItem.class );
+		IntegrationHelper.testClassExistence( this, buildcraft.api.transport.IInjectable.class );
+		IntegrationHelper.testClassExistence( this, buildcraft.api.transport.IPipeConnection.class );
+		IntegrationHelper.testClassExistence( this, buildcraft.api.transport.IPipeTile.class );
+		IntegrationHelper.testClassExistence( this, buildcraft.api.transport.IPipeTile.PipeType.class );
+		IntegrationHelper.testClassExistence( this, buildcraft.transport.ItemFacade.class );
+		IntegrationHelper.testClassExistence( this, buildcraft.transport.PipeIconProvider.class );
 	}
 
 	@Override

--- a/src/main/java/appeng/integration/modules/CLApi.java
+++ b/src/main/java/appeng/integration/modules/CLApi.java
@@ -20,19 +20,26 @@ package appeng.integration.modules;
 
 
 import appeng.api.util.AEColor;
+import appeng.helpers.Reflected;
 import appeng.integration.BaseModule;
+import appeng.integration.IntegrationHelper;
 import appeng.integration.abstraction.ICLApi;
 
 
 public class CLApi extends BaseModule implements ICLApi
 {
-
+	@Reflected
 	public static CLApi instance;
+
+	@Reflected
+	public CLApi()
+	{
+		IntegrationHelper.testClassExistence( this, coloredlightscore.src.api.CLApi.class );
+	}
 
 	@Override
 	public void init() throws Throwable
 	{
-		this.testClassExistence( coloredlightscore.src.api.CLApi.class );
 	}
 
 	@Override

--- a/src/main/java/appeng/integration/modules/CraftGuide.java
+++ b/src/main/java/appeng/integration/modules/CraftGuide.java
@@ -56,6 +56,7 @@ import appeng.api.features.IInscriberRecipe;
 import appeng.api.recipes.IIngredient;
 import appeng.helpers.Reflected;
 import appeng.integration.IIntegrationModule;
+import appeng.integration.IntegrationHelper;
 import appeng.recipes.game.ShapedRecipe;
 import appeng.recipes.game.ShapelessRecipe;
 
@@ -135,6 +136,33 @@ public final class CraftGuide extends CraftGuideAPIObject implements IIntegratio
 
 	@Reflected
 	public static CraftGuide instance;
+
+	public CraftGuide()
+	{
+		IntegrationHelper.testClassExistence( this, uristqwerty.CraftGuide.CraftGuideLog.class );
+		IntegrationHelper.testClassExistence( this, uristqwerty.CraftGuide.DefaultRecipeTemplate.class );
+		IntegrationHelper.testClassExistence( this, uristqwerty.CraftGuide.RecipeGeneratorImplementation.class );
+		IntegrationHelper.testClassExistence( this, uristqwerty.CraftGuide.api.ChanceSlot.class );
+		IntegrationHelper.testClassExistence( this, uristqwerty.CraftGuide.api.CraftGuideAPIObject.class );
+		IntegrationHelper.testClassExistence( this, uristqwerty.CraftGuide.api.ItemSlot.class );
+		IntegrationHelper.testClassExistence( this, uristqwerty.CraftGuide.api.RecipeGenerator.class );
+		IntegrationHelper.testClassExistence( this, uristqwerty.CraftGuide.api.RecipeProvider.class );
+		IntegrationHelper.testClassExistence( this, uristqwerty.CraftGuide.api.RecipeTemplate.class );
+		IntegrationHelper.testClassExistence( this, uristqwerty.CraftGuide.api.Slot.class );
+		IntegrationHelper.testClassExistence( this, uristqwerty.CraftGuide.api.SlotType.class );
+		IntegrationHelper.testClassExistence( this, uristqwerty.gui_craftguide.texture.DynamicTexture.class );
+		IntegrationHelper.testClassExistence( this, uristqwerty.gui_craftguide.texture.TextureClip.class );
+	}
+
+	@Override
+	public void init() throws Throwable
+	{
+	}
+
+	@Override
+	public void postInit()
+	{
+	}
 
 	@Override
 	public void generateRecipes( RecipeGenerator generator )
@@ -427,16 +455,5 @@ public final class CraftGuide extends CraftGuideAPIObject implements IIntegratio
 		}
 
 		return null;
-	}
-
-	@Override
-	public void init() throws Throwable
-	{
-	}
-
-	@Override
-	public void postInit()
-	{
-
 	}
 }

--- a/src/main/java/appeng/integration/modules/DSU.java
+++ b/src/main/java/appeng/integration/modules/DSU.java
@@ -25,7 +25,9 @@ import powercrystals.minefactoryreloaded.api.IDeepStorageUnit;
 
 import appeng.api.AEApi;
 import appeng.api.storage.IMEInventory;
+import appeng.helpers.Reflected;
 import appeng.integration.BaseModule;
+import appeng.integration.IntegrationHelper;
 import appeng.integration.abstraction.IDSU;
 import appeng.integration.modules.helpers.MFRDSUHandler;
 import appeng.integration.modules.helpers.MinefactoryReloadedDeepStorageUnit;
@@ -33,7 +35,14 @@ import appeng.integration.modules.helpers.MinefactoryReloadedDeepStorageUnit;
 
 public class DSU extends BaseModule implements IDSU
 {
+	@Reflected
 	public static DSU instance;
+
+	@Reflected
+	public DSU()
+	{
+		IntegrationHelper.testClassExistence( this, powercrystals.minefactoryreloaded.api.IDeepStorageUnit.class );
+	}
 
 	@Override
 	public IMEInventory getDSU( TileEntity te )
@@ -50,7 +59,6 @@ public class DSU extends BaseModule implements IDSU
 	@Override
 	public void init()
 	{
-		this.testClassExistence( IDeepStorageUnit.class );
 	}
 
 	@Override

--- a/src/main/java/appeng/integration/modules/FMP.java
+++ b/src/main/java/appeng/integration/modules/FMP.java
@@ -50,6 +50,7 @@ import appeng.fmp.CableBusPart;
 import appeng.fmp.FMPEvent;
 import appeng.fmp.FMPPlacementHelper;
 import appeng.fmp.PartRegistry;
+import appeng.helpers.Reflected;
 import appeng.integration.IIntegrationModule;
 import appeng.integration.abstraction.IFMP;
 import appeng.integration.modules.helpers.FMPPacketEvent;
@@ -58,7 +59,7 @@ import appeng.parts.CableBusContainer;
 
 public class FMP implements IIntegrationModule, IPartFactory, IPartConverter, IFMP
 {
-
+	@Reflected
 	public static FMP instance;
 
 	@Override

--- a/src/main/java/appeng/integration/modules/FZ.java
+++ b/src/main/java/appeng/integration/modules/FZ.java
@@ -28,6 +28,8 @@ import net.minecraft.tileentity.TileEntity;
 
 import appeng.api.AEApi;
 import appeng.api.storage.IMEInventory;
+import appeng.helpers.Reflected;
+import appeng.integration.BaseModule;
 import appeng.integration.IIntegrationModule;
 import appeng.integration.abstraction.IFZ;
 import appeng.integration.modules.helpers.FactorizationBarrel;
@@ -38,9 +40,9 @@ import appeng.util.Platform;
 /**
  * 100% Hacks.
  */
-public class FZ implements IFZ, IIntegrationModule
+public class FZ extends BaseModule implements IFZ, IIntegrationModule
 {
-
+	@Reflected
 	public static FZ instance;
 
 	private static Class<?> day_BarrelClass;

--- a/src/main/java/appeng/integration/modules/IC2.java
+++ b/src/main/java/appeng/integration/modules/IC2.java
@@ -27,25 +27,41 @@ import ic2.api.energy.tile.IEnergyTile;
 import ic2.api.recipe.RecipeInputItemStack;
 
 import appeng.api.AEApi;
+import appeng.api.IAppEngApi;
 import appeng.api.config.TunnelType;
 import appeng.api.features.IP2PTunnelRegistry;
+import appeng.api.parts.IPartHelper;
+import appeng.helpers.Reflected;
 import appeng.integration.BaseModule;
+import appeng.integration.IntegrationHelper;
+import appeng.integration.IntegrationRegistry;
+import appeng.integration.IntegrationType;
 import appeng.integration.abstraction.IIC2;
 
 
 public class IC2 extends BaseModule implements IIC2
 {
-
+	@Reflected
 	public static IC2 instance;
 
+	@Reflected
 	public IC2()
 	{
-		this.testClassExistence( IEnergyTile.class );
+		IntegrationHelper.testClassExistence( this, ic2.api.energy.tile.IEnergyTile.class );
+		IntegrationHelper.testClassExistence( this, ic2.api.recipe.RecipeInputItemStack.class );
 	}
 
 	@Override
 	public void init()
 	{
+		final IAppEngApi api = AEApi.instance();
+		final IPartHelper partHelper = api.partHelper();
+
+		if( IntegrationRegistry.INSTANCE.isEnabled( IntegrationType.IC2 ) )
+		{
+			partHelper.registerNewLayer( "appeng.parts.layers.LayerIEnergySink", "ic2.api.energy.tile.IEnergySink" );
+			partHelper.registerNewLayer( "appeng.parts.layers.LayerIEnergySource", "ic2.api.energy.tile.IEnergySource" );
+		}
 	}
 
 	@Override

--- a/src/main/java/appeng/integration/modules/ImmibisMicroblocks.java
+++ b/src/main/java/appeng/integration/modules/ImmibisMicroblocks.java
@@ -31,7 +31,6 @@ import net.minecraft.world.World;
 
 import mods.immibis.core.api.multipart.ICoverSystem;
 import mods.immibis.core.api.multipart.IMultipartTile;
-import mods.immibis.core.api.multipart.IPartContainer;
 
 import appeng.api.AEApi;
 import appeng.api.definitions.IBlockDefinition;
@@ -40,6 +39,7 @@ import appeng.api.parts.IPartItem;
 import appeng.core.AELog;
 import appeng.helpers.Reflected;
 import appeng.integration.BaseModule;
+import appeng.integration.IntegrationHelper;
 import appeng.integration.abstraction.IImmibisMicroblocks;
 
 
@@ -53,13 +53,17 @@ public class ImmibisMicroblocks extends BaseModule implements IImmibisMicroblock
 	private Class<?> MicroblockAPIUtils;
 	private Method mergeIntoMicroblockContainer;
 
+	@Reflected
+	public ImmibisMicroblocks()
+	{
+		IntegrationHelper.testClassExistence( this, mods.immibis.core.api.multipart.IMultipartTile.class );
+		IntegrationHelper.testClassExistence( this, mods.immibis.core.api.multipart.ICoverSystem.class );
+		IntegrationHelper.testClassExistence( this, mods.immibis.core.api.multipart.IPartContainer.class );
+	}
+
 	@Override
 	public void init() throws Throwable
 	{
-		this.testClassExistence( IMultipartTile.class );
-		this.testClassExistence( ICoverSystem.class );
-		this.testClassExistence( IPartContainer.class );
-
 		try
 		{
 			this.MicroblockAPIUtils = Class.forName( "mods.immibis.microblocks.api.MicroblockAPIUtils" );

--- a/src/main/java/appeng/integration/modules/InvTweaks.java
+++ b/src/main/java/appeng/integration/modules/InvTweaks.java
@@ -25,16 +25,24 @@ import cpw.mods.fml.common.Loader;
 
 import invtweaks.api.InvTweaksAPI;
 
+import appeng.helpers.Reflected;
 import appeng.integration.BaseModule;
+import appeng.integration.IntegrationHelper;
 import appeng.integration.abstraction.IInvTweaks;
 
 
 public class InvTweaks extends BaseModule implements IInvTweaks
 {
-
+	@Reflected
 	public static InvTweaks instance;
 
 	static InvTweaksAPI api;
+
+	@Reflected
+	public InvTweaks()
+	{
+		IntegrationHelper.testClassExistence( this, invtweaks.api.InvTweaksAPI.class );
+	}
 
 	@Override
 	public void init()

--- a/src/main/java/appeng/integration/modules/MFR.java
+++ b/src/main/java/appeng/integration/modules/MFR.java
@@ -19,30 +19,29 @@
 package appeng.integration.modules;
 
 
-import powercrystals.minefactoryreloaded.api.rednet.connectivity.IRedNetConnection;
-
+import appeng.helpers.Reflected;
 import appeng.integration.BaseModule;
+import appeng.integration.IntegrationHelper;
 
 
 public class MFR extends BaseModule
 {
-
+	@Reflected
 	public static MFR instance;
 
+	@Reflected
 	public MFR()
 	{
-		this.testClassExistence( IRedNetConnection.class );
+		IntegrationHelper.testClassExistence( this, powercrystals.minefactoryreloaded.api.rednet.connectivity.IRedNetConnection.class );
 	}
 
 	@Override
 	public void init() throws Throwable
 	{
-
 	}
 
 	@Override
 	public void postInit()
 	{
-
 	}
 }

--- a/src/main/java/appeng/integration/modules/Mekanism.java
+++ b/src/main/java/appeng/integration/modules/Mekanism.java
@@ -24,25 +24,31 @@ import net.minecraft.nbt.NBTTagCompound;
 
 import cpw.mods.fml.common.event.FMLInterModComms;
 
+import appeng.helpers.Reflected;
 import appeng.integration.BaseModule;
+import appeng.integration.IntegrationHelper;
 import appeng.integration.abstraction.IMekanism;
 
 
 public final class Mekanism extends BaseModule implements IMekanism
 {
-
+	@Reflected
 	public static Mekanism instance;
+
+	@Reflected
+	public Mekanism()
+	{
+		IntegrationHelper.testClassExistence( this, mekanism.api.energy.IStrictEnergyAcceptor.class );
+	}
 
 	@Override
 	public void init() throws Throwable
 	{
-		this.testClassExistence( mekanism.api.energy.IStrictEnergyAcceptor.class );
 	}
 
 	@Override
 	public void postInit()
 	{
-
 	}
 
 	@Override

--- a/src/main/java/appeng/integration/modules/NEI.java
+++ b/src/main/java/appeng/integration/modules/NEI.java
@@ -42,6 +42,7 @@ import appeng.core.AEConfig;
 import appeng.core.features.AEFeature;
 import appeng.helpers.Reflected;
 import appeng.integration.BaseModule;
+import appeng.integration.IntegrationHelper;
 import appeng.integration.abstraction.INEI;
 import appeng.integration.modules.NEIHelpers.NEIAEShapedRecipeHandler;
 import appeng.integration.modules.NEIHelpers.NEIAEShapelessRecipeHandler;
@@ -61,15 +62,19 @@ public class NEI extends BaseModule implements INEI, IContainerTooltipHandler
 	private final Class<?> apiClass;
 
 	// recipe handler...
-	Method registerRecipeHandler;
-	Method registerUsageHandler;
+	private Method registerRecipeHandler;
+	private Method registerUsageHandler;
 
 	@Reflected
 	public NEI() throws ClassNotFoundException
 	{
-		this.testClassExistence( GuiContainerManager.class );
-		this.testClassExistence( codechicken.nei.recipe.ICraftingHandler.class );
-		this.testClassExistence( codechicken.nei.recipe.IUsageHandler.class );
+		IntegrationHelper.testClassExistence( this, codechicken.nei.api.API.class );
+		IntegrationHelper.testClassExistence( this, codechicken.nei.api.IStackPositioner.class );
+		IntegrationHelper.testClassExistence( this, codechicken.nei.guihook.GuiContainerManager.class );
+		IntegrationHelper.testClassExistence( this, codechicken.nei.guihook.IContainerTooltipHandler.class );
+		IntegrationHelper.testClassExistence( this, codechicken.nei.recipe.ICraftingHandler.class );
+		IntegrationHelper.testClassExistence( this, codechicken.nei.recipe.IUsageHandler.class );
+
 		this.apiClass = Class.forName( "codechicken.nei.api.API" );
 	}
 
@@ -96,7 +101,7 @@ public class NEI extends BaseModule implements INEI, IContainerTooltipHandler
 		// crafting terminal...
 		Method registerGuiOverlay = this.apiClass.getDeclaredMethod( "registerGuiOverlay", Class.class, String.class, IStackPositioner.class );
 		Class overlayHandler = Class.forName( "codechicken.nei.api.IOverlayHandler" );
-		Class defaultHandler = NEICraftingHandler.class;
+		Class<NEICraftingHandler> defaultHandler = NEICraftingHandler.class;
 
 		Method registrar = this.apiClass.getDeclaredMethod( "registerGuiOverlayHandler", Class.class, overlayHandler, String.class );
 		registerGuiOverlay.invoke( this.apiClass, GuiCraftingTerm.class, "crafting", new TerminalCraftingSlotFinder() );

--- a/src/main/java/appeng/integration/modules/OpenComputers.java
+++ b/src/main/java/appeng/integration/modules/OpenComputers.java
@@ -22,28 +22,44 @@ package appeng.integration.modules;
 import li.cil.oc.api.Items;
 
 import appeng.api.AEApi;
+import appeng.api.IAppEngApi;
 import appeng.api.config.TunnelType;
 import appeng.api.features.IP2PTunnelRegistry;
+import appeng.api.parts.IPartHelper;
+import appeng.helpers.Reflected;
 import appeng.integration.BaseModule;
+import appeng.integration.IntegrationHelper;
+import appeng.integration.IntegrationRegistry;
+import appeng.integration.IntegrationType;
+
 
 
 public class OpenComputers extends BaseModule
 {
+	@Reflected
 	public static OpenComputers instance;
 
+	@Reflected
 	public OpenComputers()
 	{
-		this.testClassExistence( li.cil.oc.api.Items.class );
-		this.testClassExistence( li.cil.oc.api.Network.class );
-		this.testClassExistence( li.cil.oc.api.network.Environment.class );
-		this.testClassExistence( li.cil.oc.api.network.SidedEnvironment.class );
-		this.testClassExistence( li.cil.oc.api.network.Node.class );
-		this.testClassExistence( li.cil.oc.api.network.Message.class );
+		IntegrationHelper.testClassExistence( this, li.cil.oc.api.Items.class );
+		IntegrationHelper.testClassExistence( this, li.cil.oc.api.Network.class );
+		IntegrationHelper.testClassExistence( this, li.cil.oc.api.network.Environment.class );
+		IntegrationHelper.testClassExistence( this, li.cil.oc.api.network.SidedEnvironment.class );
+		IntegrationHelper.testClassExistence( this, li.cil.oc.api.network.Node.class );
+		IntegrationHelper.testClassExistence( this, li.cil.oc.api.network.Message.class );
 	}
 
 	@Override
 	public void init()
 	{
+		final IAppEngApi api = AEApi.instance();
+		final IPartHelper partHelper = api.partHelper();
+
+		if( IntegrationRegistry.INSTANCE.isEnabled( IntegrationType.OpenComputers ) )
+		{
+			partHelper.registerNewLayer( "appeng.parts.layers.LayerSidedEnvironment", "li.cil.oc.api.network.SidedEnvironment" );
+		}
 	}
 
 	@Override

--- a/src/main/java/appeng/integration/modules/PneumaticCraft.java
+++ b/src/main/java/appeng/integration/modules/PneumaticCraft.java
@@ -31,6 +31,7 @@ import appeng.api.features.IP2PTunnelRegistry;
 import appeng.api.parts.IPartHelper;
 import appeng.helpers.Reflected;
 import appeng.integration.BaseModule;
+import appeng.integration.IntegrationHelper;
 import appeng.integration.IntegrationRegistry;
 import appeng.integration.IntegrationType;
 
@@ -45,10 +46,10 @@ public class PneumaticCraft extends BaseModule
 	@Reflected
 	public PneumaticCraft()
 	{
-		this.testClassExistence( pneumaticCraft.api.block.BlockSupplier.class );
-		this.testClassExistence( pneumaticCraft.api.tileentity.ISidedPneumaticMachine.class );
-		this.testClassExistence( pneumaticCraft.api.tileentity.AirHandlerSupplier.class );
-		this.testClassExistence( pneumaticCraft.api.tileentity.IAirHandler.class );
+		IntegrationHelper.testClassExistence( this, pneumaticCraft.api.block.BlockSupplier.class );
+		IntegrationHelper.testClassExistence( this, pneumaticCraft.api.tileentity.ISidedPneumaticMachine.class );
+		IntegrationHelper.testClassExistence( this, pneumaticCraft.api.tileentity.AirHandlerSupplier.class );
+		IntegrationHelper.testClassExistence( this, pneumaticCraft.api.tileentity.IAirHandler.class );
 	}
 
 	@Override

--- a/src/main/java/appeng/integration/modules/RC.java
+++ b/src/main/java/appeng/integration/modules/RC.java
@@ -24,19 +24,22 @@ import net.minecraft.item.ItemStack;
 import mods.railcraft.api.crafting.IRockCrusherRecipe;
 import mods.railcraft.api.crafting.RailcraftCraftingManager;
 
+import appeng.helpers.Reflected;
 import appeng.integration.BaseModule;
+import appeng.integration.IntegrationHelper;
 import appeng.integration.abstraction.IRC;
 
 
 public class RC extends BaseModule implements IRC
 {
-
+	@Reflected
 	public static RC instance;
 
+	@Reflected
 	public RC()
 	{
-		this.testClassExistence( RailcraftCraftingManager.class );
-		this.testClassExistence( IRockCrusherRecipe.class );
+		IntegrationHelper.testClassExistence( this, mods.railcraft.api.crafting.RailcraftCraftingManager.class );
+		IntegrationHelper.testClassExistence( this, mods.railcraft.api.crafting.IRockCrusherRecipe.class );
 	}
 
 	@Override
@@ -49,13 +52,10 @@ public class RC extends BaseModule implements IRC
 	@Override
 	public void init()
 	{
-		// TODO Auto-generated method stub
-
 	}
 
 	@Override
 	public void postInit()
 	{
-
 	}
 }

--- a/src/main/java/appeng/integration/modules/RF.java
+++ b/src/main/java/appeng/integration/modules/RF.java
@@ -25,9 +25,14 @@ import net.minecraftforge.oredict.OreDictionary;
 import cpw.mods.fml.common.registry.GameRegistry;
 
 import appeng.api.AEApi;
+import appeng.api.IAppEngApi;
 import appeng.api.config.TunnelType;
+import appeng.api.parts.IPartHelper;
 import appeng.helpers.Reflected;
 import appeng.integration.BaseModule;
+import appeng.integration.IntegrationHelper;
+import appeng.integration.IntegrationRegistry;
+import appeng.integration.IntegrationType;
 
 
 public final class RF extends BaseModule
@@ -35,17 +40,25 @@ public final class RF extends BaseModule
 	@Reflected
 	public static RF instance;
 
+	@Reflected
 	public RF()
 	{
-		this.testClassExistence( cofh.api.energy.IEnergyReceiver.class );
-		this.testClassExistence( cofh.api.energy.IEnergyProvider.class );
-		this.testClassExistence( cofh.api.energy.IEnergyHandler.class );
-		this.testClassExistence( cofh.api.energy.IEnergyConnection.class );
+		IntegrationHelper.testClassExistence( this, cofh.api.energy.IEnergyReceiver.class );
+		IntegrationHelper.testClassExistence( this, cofh.api.energy.IEnergyProvider.class );
+		IntegrationHelper.testClassExistence( this, cofh.api.energy.IEnergyHandler.class );
+		IntegrationHelper.testClassExistence( this, cofh.api.energy.IEnergyConnection.class );
 	}
 
 	@Override
 	public void init()
 	{
+		final IAppEngApi api = AEApi.instance();
+		final IPartHelper partHelper = api.partHelper();
+
+		if( IntegrationRegistry.INSTANCE.isEnabled( IntegrationType.RF ) )
+		{
+			partHelper.registerNewLayer( "appeng.parts.layers.LayerIEnergyHandler", "cofh.api.energy.IEnergyReceiver" );
+		}
 	}
 
 	@Override

--- a/src/main/java/appeng/integration/modules/RotaryCraft.java
+++ b/src/main/java/appeng/integration/modules/RotaryCraft.java
@@ -19,28 +19,30 @@
 package appeng.integration.modules;
 
 
+import appeng.helpers.Reflected;
 import appeng.integration.BaseModule;
+import appeng.integration.IntegrationHelper;
 
 
 public class RotaryCraft extends BaseModule
 {
+	@Reflected
 	public static RotaryCraft instance;
 
+	@Reflected
 	public RotaryCraft()
 	{
-		this.testClassExistence( Reika.RotaryCraft.API.Power.AdvancedShaftPowerReceiver.class );
-		this.testClassExistence( Reika.RotaryCraft.API.Interfaces.Transducerable.class );
+		IntegrationHelper.testClassExistence( this, Reika.RotaryCraft.API.Power.AdvancedShaftPowerReceiver.class );
+		IntegrationHelper.testClassExistence( this, Reika.RotaryCraft.API.Interfaces.Transducerable.class );
 	}
 
 	@Override
 	public void init() throws Throwable
 	{
-
 	}
 
 	@Override
 	public void postInit()
 	{
-
 	}
 }

--- a/src/main/java/appeng/integration/modules/Waila.java
+++ b/src/main/java/appeng/integration/modules/Waila.java
@@ -24,7 +24,9 @@ import cpw.mods.fml.common.event.FMLInterModComms;
 import mcp.mobius.waila.api.IWailaDataProvider;
 import mcp.mobius.waila.api.IWailaRegistrar;
 
+import appeng.helpers.Reflected;
 import appeng.integration.BaseModule;
+import appeng.integration.IntegrationHelper;
 import appeng.integration.modules.waila.PartWailaDataProvider;
 import appeng.integration.modules.waila.TileWailaDataProvider;
 import appeng.tile.AEBaseTile;
@@ -32,7 +34,18 @@ import appeng.tile.AEBaseTile;
 
 public class Waila extends BaseModule
 {
+	@Reflected
 	public static Waila instance;
+
+	@Reflected
+	public Waila()
+	{
+		IntegrationHelper.testClassExistence( this, mcp.mobius.waila.api.IWailaDataProvider.class );
+		IntegrationHelper.testClassExistence( this, mcp.mobius.waila.api.IWailaRegistrar.class );
+		IntegrationHelper.testClassExistence( this, mcp.mobius.waila.api.IWailaConfigHandler.class );
+		IntegrationHelper.testClassExistence( this, mcp.mobius.waila.api.IWailaDataAccessor.class );
+		IntegrationHelper.testClassExistence( this, mcp.mobius.waila.api.ITaggedList.class );
+	}
 
 	public static void register( IWailaRegistrar registrar )
 	{
@@ -51,15 +64,11 @@ public class Waila extends BaseModule
 	@Override
 	public void init() throws Throwable
 	{
-		this.testClassExistence( IWailaDataProvider.class );
-		this.testClassExistence( IWailaRegistrar.class );
-
 		FMLInterModComms.sendMessage( "Waila", "register", this.getClass().getName() + ".register" );
 	}
 
 	@Override
 	public void postInit()
 	{
-		// :P
 	}
 }

--- a/src/main/java/appeng/items/tools/ToolNetworkTool.java
+++ b/src/main/java/appeng/items/tools/ToolNetworkTool.java
@@ -48,13 +48,14 @@ import appeng.core.features.AEFeature;
 import appeng.core.sync.GuiBridge;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketClick;
+import appeng.integration.IntegrationType;
 import appeng.items.AEBaseItem;
 import appeng.items.contents.NetworkToolViewer;
 import appeng.transformer.annotations.Integration.Interface;
 import appeng.util.Platform;
 
 
-@Interface( iface = "buildcraft.api.tools.IToolWrench", iname = "BuildCraftCore" )
+@Interface( iface = "buildcraft.api.tools.IToolWrench", iname = IntegrationType.BuildCraftCore )
 public class ToolNetworkTool extends AEBaseItem implements IGuiItem, IAEWrench, IToolWrench
 {
 

--- a/src/main/java/appeng/items/tools/powered/powersink/IC2.java
+++ b/src/main/java/appeng/items/tools/powered/powersink/IC2.java
@@ -29,12 +29,13 @@ import ic2.api.item.IElectricItemManager;
 import ic2.api.item.ISpecialElectricItem;
 
 import appeng.api.config.PowerUnits;
+import appeng.integration.IntegrationType;
 import appeng.transformer.annotations.Integration.Interface;
 import appeng.transformer.annotations.Integration.InterfaceList;
 import appeng.transformer.annotations.Integration.Method;
 
 
-@InterfaceList( value = { @Interface( iface = "ic2.api.item.ISpecialElectricItem", iname = "IC2" ), @Interface( iface = "ic2.api.item.IElectricItemManager", iname = "IC2" ) } )
+@InterfaceList( value = { @Interface( iface = "ic2.api.item.ISpecialElectricItem", iname = IntegrationType.IC2 ), @Interface( iface = "ic2.api.item.IElectricItemManager", iname = IntegrationType.IC2 ) } )
 public abstract class IC2 extends AERootPoweredItem implements IElectricItemManager, ISpecialElectricItem
 {
 	public IC2( double powerCapacity, Optional<String> subName )
@@ -135,7 +136,7 @@ public abstract class IC2 extends AERootPoweredItem implements IElectricItemMana
 	}
 
 	@Override
-	@Method( iname = "IC2" )
+	@Method( iname = IntegrationType.IC2 )
 	public IElectricItemManager getManager( ItemStack itemStack )
 	{
 		return this;

--- a/src/main/java/appeng/items/tools/powered/powersink/RedstoneFlux.java
+++ b/src/main/java/appeng/items/tools/powered/powersink/RedstoneFlux.java
@@ -26,10 +26,11 @@ import net.minecraft.item.ItemStack;
 import cofh.api.energy.IEnergyContainerItem;
 
 import appeng.api.config.PowerUnits;
+import appeng.integration.IntegrationType;
 import appeng.transformer.annotations.Integration.Interface;
 
 
-@Interface( iface = "cofh.api.energy.IEnergyContainerItem", iname = "RFItem" )
+@Interface( iface = "cofh.api.energy.IEnergyContainerItem", iname = IntegrationType.RFItem )
 public abstract class RedstoneFlux extends IC2 implements IEnergyContainerItem
 {
 	public RedstoneFlux( double powerCapacity, Optional<String> subName )

--- a/src/main/java/appeng/items/tools/quartz/ToolQuartzWrench.java
+++ b/src/main/java/appeng/items/tools/quartz/ToolQuartzWrench.java
@@ -34,12 +34,13 @@ import buildcraft.api.tools.IToolWrench;
 import appeng.api.implementations.items.IAEWrench;
 import appeng.api.util.DimensionalCoord;
 import appeng.core.features.AEFeature;
+import appeng.integration.IntegrationType;
 import appeng.items.AEBaseItem;
 import appeng.transformer.annotations.Integration.Interface;
 import appeng.util.Platform;
 
 
-@Interface( iface = "buildcraft.api.tools.IToolWrench", iname = "BuildCraftCore" )
+@Interface( iface = "buildcraft.api.tools.IToolWrench", iname = IntegrationType.BuildCraftCore )
 public class ToolQuartzWrench extends AEBaseItem implements IAEWrench, IToolWrench
 {
 

--- a/src/main/java/appeng/parts/misc/PartStorageBus.java
+++ b/src/main/java/appeng/parts/misc/PartStorageBus.java
@@ -77,6 +77,7 @@ import appeng.core.sync.GuiBridge;
 import appeng.helpers.IInterfaceHost;
 import appeng.helpers.IPriorityHost;
 import appeng.helpers.Reflected;
+import appeng.integration.IntegrationType;
 import appeng.me.GridAccessException;
 import appeng.me.storage.MEInventoryHandler;
 import appeng.me.storage.MEMonitorIInventory;
@@ -90,7 +91,7 @@ import appeng.util.prioitylist.FuzzyPriorityList;
 import appeng.util.prioitylist.PrecisePriorityList;
 
 
-@Interface( iname = "BuildCraftTransport", iface = "buildcraft.api.transport.IPipeConnection" )
+@Interface( iname = IntegrationType.BuildCraftTransport, iface = "buildcraft.api.transport.IPipeConnection" )
 public class PartStorageBus extends PartUpgradeable implements IGridTickable, ICellContainer, IMEMonitorHandlerReceiver<IAEItemStack>, IPipeConnection, IPriorityHost
 {
 	final BaseActionSource mySrc;
@@ -565,7 +566,7 @@ public class PartStorageBus extends PartUpgradeable implements IGridTickable, IC
 	}
 
 	@Override
-	@Method( iname = "BuildCraftTransport" )
+	@Method( iname = IntegrationType.BuildCraftTransport )
 	public ConnectOverride overridePipeConnection( PipeType type, ForgeDirection with )
 	{
 		return type == PipeType.ITEM && with == this.side ? ConnectOverride.CONNECT : ConnectOverride.DISCONNECT;

--- a/src/main/java/appeng/parts/p2p/PartP2PIC2Power.java
+++ b/src/main/java/appeng/parts/p2p/PartP2PIC2Power.java
@@ -32,6 +32,7 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
 import appeng.api.config.PowerUnits;
+import appeng.integration.IntegrationType;
 import appeng.me.GridAccessException;
 import appeng.me.cache.helpers.TunnelCollection;
 import appeng.transformer.annotations.Integration.Interface;
@@ -39,7 +40,7 @@ import appeng.transformer.annotations.Integration.InterfaceList;
 import appeng.util.Platform;
 
 
-@InterfaceList( value = { @Interface( iface = "ic2.api.energy.tile.IEnergySink", iname = "IC2" ), @Interface( iface = "ic2.api.energy.tile.IEnergySource", iname = "IC2" ) } )
+@InterfaceList( value = { @Interface( iface = "ic2.api.energy.tile.IEnergySink", iname = IntegrationType.IC2 ), @Interface( iface = "ic2.api.energy.tile.IEnergySource", iname = IntegrationType.IC2 ) } )
 public class PartP2PIC2Power extends PartP2PTunnel<PartP2PIC2Power> implements ic2.api.energy.tile.IEnergySink, ic2.api.energy.tile.IEnergySource
 {
 

--- a/src/main/java/appeng/parts/p2p/PartP2PItems.java
+++ b/src/main/java/appeng/parts/p2p/PartP2PItems.java
@@ -61,7 +61,7 @@ import appeng.util.inv.WrapperChainedInventory;
 import appeng.util.inv.WrapperMCISidedInventory;
 
 
-@Interface( iface = "buildcraft.api.transport.IPipeConnection", iname = "BuildCraftTransport" )
+@Interface( iface = "buildcraft.api.transport.IPipeConnection", iname = IntegrationType.BuildCraftTransport )
 public class PartP2PItems extends PartP2PTunnel<PartP2PItems> implements IPipeConnection, ISidedInventory, IGridTickable
 {
 
@@ -384,7 +384,7 @@ public class PartP2PItems extends PartP2PTunnel<PartP2PItems> implements IPipeCo
 	}
 
 	@Override
-	@Method( iname = "BuildCraftTransport" )
+	@Method( iname = IntegrationType.BuildCraftTransport )
 	public ConnectOverride overridePipeConnection( PipeType type, ForgeDirection with )
 	{
 		return this.side == with && type == PipeType.ITEM ? ConnectOverride.CONNECT : ConnectOverride.DEFAULT;

--- a/src/main/java/appeng/parts/p2p/PartP2POpenComputers.java
+++ b/src/main/java/appeng/parts/p2p/PartP2POpenComputers.java
@@ -54,7 +54,7 @@ import appeng.transformer.annotations.Integration.InterfaceList;
 import appeng.util.IWorldCallable;
 
 
-@InterfaceList( value = { @Interface( iface = "li.cil.oc.api.network.Environment", iname = "OpenComputers" ), @Interface( iface = "li.cil.oc.api.network.SidedEnvironment", iname = "OpenComputers" ) } )
+@InterfaceList( value = { @Interface( iface = "li.cil.oc.api.network.Environment", iname = IntegrationType.OpenComputers ), @Interface( iface = "li.cil.oc.api.network.SidedEnvironment", iname = IntegrationType.OpenComputers ) } )
 public final class PartP2POpenComputers extends PartP2PTunnel<PartP2POpenComputers> implements IGridTickable, Environment, SidedEnvironment
 {
 	@Nullable

--- a/src/main/java/appeng/parts/p2p/PartP2PPressure.java
+++ b/src/main/java/appeng/parts/p2p/PartP2PPressure.java
@@ -38,11 +38,12 @@ import appeng.api.networking.ticking.IGridTickable;
 import appeng.api.networking.ticking.TickRateModulation;
 import appeng.api.networking.ticking.TickingRequest;
 import appeng.core.settings.TickRates;
+import appeng.integration.IntegrationType;
 import appeng.transformer.annotations.Integration.Interface;
 import appeng.util.Platform;
 
 
-@Interface( iface = "pneumaticCraft.api.tileentity.ISidedPneumaticMachine", iname = "PneumaticCraft" )
+@Interface( iface = "pneumaticCraft.api.tileentity.ISidedPneumaticMachine", iname = IntegrationType.PneumaticCraft )
 public final class PartP2PPressure extends PartP2PTunnel<PartP2PPressure> implements ISidedPneumaticMachine, IGridTickable
 {
 	private static final String PRESSURE_NBT_TAG = "pneumaticCraft";

--- a/src/main/java/appeng/parts/p2p/PartP2PRFPower.java
+++ b/src/main/java/appeng/parts/p2p/PartP2PRFPower.java
@@ -33,6 +33,7 @@ import cpw.mods.fml.relauncher.SideOnly;
 import cofh.api.energy.IEnergyReceiver;
 
 import appeng.api.config.PowerUnits;
+import appeng.integration.IntegrationType;
 import appeng.integration.modules.helpers.NullRFHandler;
 import appeng.me.GridAccessException;
 import appeng.transformer.annotations.Integration.Interface;
@@ -40,7 +41,7 @@ import appeng.transformer.annotations.Integration.InterfaceList;
 import appeng.util.Platform;
 
 
-@InterfaceList( value = { @Interface( iface = "cofh.api.energy.IEnergyReceiver", iname = "RF" ) } )
+@InterfaceList( value = { @Interface( iface = "cofh.api.energy.IEnergyReceiver", iname = IntegrationType.RF ) } )
 public final class PartP2PRFPower extends PartP2PTunnel<PartP2PRFPower> implements IEnergyReceiver
 {
 	private static final ThreadLocal<Stack<PartP2PRFPower>> THREAD_STACK = new ThreadLocal<Stack<PartP2PRFPower>>();

--- a/src/main/java/appeng/tile/powersink/IC2.java
+++ b/src/main/java/appeng/tile/powersink/IC2.java
@@ -34,7 +34,7 @@ import appeng.transformer.annotations.Integration.Interface;
 import appeng.util.Platform;
 
 
-@Interface( iname = "IC2", iface = "ic2.api.energy.tile.IEnergySink" )
+@Interface( iname = IntegrationType.IC2, iface = "ic2.api.energy.tile.IEnergySink" )
 public abstract class IC2 extends AERootPoweredTile implements IEnergySink
 {
 

--- a/src/main/java/appeng/tile/powersink/MekJoules.java
+++ b/src/main/java/appeng/tile/powersink/MekJoules.java
@@ -24,10 +24,11 @@ import net.minecraftforge.common.util.ForgeDirection;
 import mekanism.api.energy.IStrictEnergyAcceptor;
 
 import appeng.api.config.PowerUnits;
+import appeng.integration.IntegrationType;
 import appeng.transformer.annotations.Integration.Interface;
 
 
-@Interface( iname = "Mekanism", iface = "mekanism.api.energy.IStrictEnergyAcceptor" )
+@Interface( iname = IntegrationType.Mekanism, iface = "mekanism.api.energy.IStrictEnergyAcceptor" )
 public abstract class MekJoules extends RedstoneFlux implements IStrictEnergyAcceptor
 {
 

--- a/src/main/java/appeng/tile/powersink/RedstoneFlux.java
+++ b/src/main/java/appeng/tile/powersink/RedstoneFlux.java
@@ -24,10 +24,11 @@ import net.minecraftforge.common.util.ForgeDirection;
 import cofh.api.energy.IEnergyReceiver;
 
 import appeng.api.config.PowerUnits;
+import appeng.integration.IntegrationType;
 import appeng.transformer.annotations.Integration.Interface;
 
 
-@Interface( iname = "RF", iface = "cofh.api.energy.IEnergyReceiver" )
+@Interface( iname = IntegrationType.RF, iface = "cofh.api.energy.IEnergyReceiver" )
 public abstract class RedstoneFlux extends RotaryCraft implements IEnergyReceiver
 {
 	@Override

--- a/src/main/java/appeng/tile/powersink/RotaryCraft.java
+++ b/src/main/java/appeng/tile/powersink/RotaryCraft.java
@@ -28,6 +28,7 @@ import Reika.RotaryCraft.API.Interfaces.Transducerable;
 import Reika.RotaryCraft.API.Power.AdvancedShaftPowerReceiver;
 
 import appeng.api.config.PowerUnits;
+import appeng.integration.IntegrationType;
 import appeng.tile.TileEvent;
 import appeng.tile.events.TileEventType;
 import appeng.transformer.annotations.Integration.Interface;
@@ -35,7 +36,7 @@ import appeng.transformer.annotations.Integration.InterfaceList;
 import appeng.transformer.annotations.Integration.Method;
 
 
-@InterfaceList( value = { @Interface( iname = "RotaryCraft", iface = "Reika.RotaryCraft.API.Power.AdvancedShaftPowerReceiver" ), @Interface( iname = "RotaryCraft", iface = "Reika.RotaryCraft.API.Interfaces.Transducerable" ) } )
+@InterfaceList( value = { @Interface( iname = IntegrationType.RotaryCraft, iface = "Reika.RotaryCraft.API.Power.AdvancedShaftPowerReceiver" ), @Interface( iname = IntegrationType.RotaryCraft, iface = "Reika.RotaryCraft.API.Interfaces.Transducerable" ) } )
 public abstract class RotaryCraft extends IC2 implements AdvancedShaftPowerReceiver, Transducerable
 {
 
@@ -47,7 +48,7 @@ public abstract class RotaryCraft extends IC2 implements AdvancedShaftPowerRecei
 	private long currentPower = 0;
 
 	@TileEvent( TileEventType.TICK )
-	@Method( iname = "RotaryCraft" )
+	@Method( iname = IntegrationType.RotaryCraft )
 	public void Tick_RotaryCraft()
 	{
 		if( this.worldObj != null && !this.worldObj.isRemote && this.currentPower > 0 )

--- a/src/main/java/appeng/transformer/annotations/Integration.java
+++ b/src/main/java/appeng/transformer/annotations/Integration.java
@@ -24,6 +24,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import appeng.integration.IntegrationType;
+
 
 public @interface Integration
 {
@@ -40,13 +42,13 @@ public @interface Integration
 	{
 		String iface();
 
-		String iname();
+		IntegrationType iname();
 	}
 
 	@Retention( RetentionPolicy.RUNTIME )
 	@Target( ElementType.METHOD )
 	@interface Method
 	{
-		String iname();
+		IntegrationType iname();
 	}
 }

--- a/src/main/java/appeng/transformer/asm/ASMIntegration.java
+++ b/src/main/java/appeng/transformer/asm/ASMIntegration.java
@@ -184,11 +184,11 @@ public final class ASMIntegration implements IClassTransformer
 
 		if( an.values.get( 0 ).equals( "iname" ) )
 		{
-			iName = (String) an.values.get( 1 );
+			iName = ( (String[]) an.values.get( 1 ) )[1];
 		}
 		else if( an.values.get( 2 ).equals( "iname" ) )
 		{
-			iName = (String) an.values.get( 3 );
+			iName = ( (String[]) an.values.get( 3 ) )[1];
 		}
 
 		if( iName != null && iFace != null )
@@ -224,7 +224,7 @@ public final class ASMIntegration implements IClassTransformer
 
 		if( an.values.get( 0 ).equals( "iname" ) )
 		{
-			iName = (String) an.values.get( 1 );
+			iName = ( (String[]) an.values.get( 1 ) )[1];
 		}
 
 		if( iName != null )


### PR DESCRIPTION
`@Interface` will now require an `IntegrationType` as `iname` and not a string, thus not longer breaking on internal refactoring.

It might also be an idea to change `iface` to `Class<?>` in a further iteration and handle the potentially thrown exception, this would also allow to already fail at compile time in case of a nonexistent class.

Also moved the registration of layers from the registration into the appropriate `IIntegrationModule`.
As these are called during init and the final class is only assembled during postInit, this will not cause any issue, but better encapsulate it.
`IPartHelper.registerNewLayer` should potentially be changed to accept ´Class<?>´ and not `String`, but this would be a API breaking change.
To ensure typesafety it is possible to pass `Object.class.getName()` for now, the check for being enabled is already based on the existance of these classes and thus will catch any potential exception.

Moved `BaseModule.testClassExistence()` into a static helper as some integrations cannot extend `BaseModule` directly, for example the craftguide integration. This still allows to protect these ones in case of a breaking change of the related mod.
Also moved all checks into the constructor for a consistent approach in all integration modules.

The ASM integration is a bit messy as the annotations are now parsed as `String[]` and with the first element being the enum class and the second the acutal value.
Something similar will apply, when changing `iface` to `Class<?>`, but that is just messy ASM.
