### PR TITLE
Fixes #1601: Do not allow 0 as stacksize for recipes

### DIFF
--- a/src/main/java/appeng/recipes/GroupIngredient.java
+++ b/src/main/java/appeng/recipes/GroupIngredient.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
+import com.google.common.base.Preconditions;
+
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.OreDictionary;
 
@@ -35,16 +37,22 @@ import appeng.api.recipes.IIngredient;
 public class GroupIngredient implements IIngredient
 {
 
-	final String name;
-	final List<IIngredient> ingredients;
-	int qty = 0;
-	ItemStack[] baked;
+	private final String name;
+	private final List<IIngredient> ingredients;
+	private final int qty;
+	private ItemStack[] baked;
 
 	boolean isInside = false;
 
-	public GroupIngredient( String myName, List<IIngredient> ingredients ) throws RecipeError
+	public GroupIngredient( String myName, List<IIngredient> ingredients, int qty ) throws RecipeError
 	{
+		Preconditions.checkNotNull( myName );
+		Preconditions.checkNotNull( ingredients );
+		Preconditions.checkState( !ingredients.isEmpty() );
+		Preconditions.checkState( qty > 0 );
+
 		this.name = myName;
+		this.qty = qty;
 
 		for( IIngredient ingredient : ingredients )
 		{
@@ -59,9 +67,8 @@ public class GroupIngredient implements IIngredient
 
 	public IIngredient copy( int qty ) throws RecipeError
 	{
-		GroupIngredient gi = new GroupIngredient( this.name, this.ingredients );
-		gi.qty = qty;
-		return gi;
+		Preconditions.checkState( qty > 0 );
+		return new GroupIngredient( this.name, this.ingredients, qty );
 	}
 
 	@Override
@@ -144,7 +151,7 @@ public class GroupIngredient implements IIngredient
 	@Override
 	public int getQty()
 	{
-		return 0;
+		return this.qty;
 	}
 
 	@Override

--- a/src/main/java/appeng/recipes/Ingredient.java
+++ b/src/main/java/appeng/recipes/Ingredient.java
@@ -21,6 +21,8 @@ package appeng.recipes;
 
 import java.util.List;
 
+import com.google.common.base.Preconditions;
+
 import net.minecraft.block.Block;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -41,17 +43,19 @@ import appeng.api.recipes.ResolverResultSet;
 public class Ingredient implements IIngredient
 {
 
-	public final boolean isAir;
-
-	public final String nameSpace;
-	public final String itemName;
-	public final int meta;
-	public final int qty;
-	NBTTagCompound nbt = null;
-	ItemStack[] baked;
+	private final boolean isAir;
+	private final String nameSpace;
+	private final String itemName;
+	private final int meta;
+	private final int qty;
+	private NBTTagCompound nbt = null;
+	private ItemStack[] baked;
 
 	public Ingredient( RecipeHandler handler, String input, int qty ) throws RecipeError, MissedIngredientSet
 	{
+		Preconditions.checkNotNull( handler );
+		Preconditions.checkNotNull( input );
+		Preconditions.checkState( qty > 0 );
 
 		// works no matter wat!
 		this.qty = qty;
@@ -134,7 +138,7 @@ public class Ingredient implements IIngredient
 			throw new RecipeError( input + " : Needs at least Namespace and Name." );
 		}
 
-		handler.data.knownItem.add( this.toString() );
+		handler.getData().knownItem.add( this.toString() );
 	}
 
 	@Override

--- a/src/main/java/appeng/recipes/IngredientSet.java
+++ b/src/main/java/appeng/recipes/IngredientSet.java
@@ -22,6 +22,8 @@ package appeng.recipes;
 import java.util.LinkedList;
 import java.util.List;
 
+import com.google.common.base.Preconditions;
+
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.OreDictionary;
 
@@ -34,16 +36,22 @@ import appeng.api.recipes.ResolverResultSet;
 public class IngredientSet implements IIngredient
 {
 
-	final int qty = 0;
-	final String name;
-	final List<ItemStack> items;
-	final boolean isInside = false;
-	ItemStack[] baked;
+	private final int qty;
+	private final String name;
+	private final List<ItemStack> items;
+	private final boolean isInside = false;
+	private ItemStack[] baked;
 
-	public IngredientSet( ResolverResultSet rr )
+	public IngredientSet( ResolverResultSet rr, int qty )
 	{
+		Preconditions.checkNotNull( rr );
+		Preconditions.checkNotNull( rr.name );
+		Preconditions.checkNotNull( rr.results );
+		Preconditions.checkState( qty > 0 );
+
 		this.name = rr.name;
 		this.items = rr.results;
+		this.qty = qty;
 	}
 
 	@Override
@@ -108,7 +116,7 @@ public class IngredientSet implements IIngredient
 	@Override
 	public int getQty()
 	{
-		return 0;
+		return this.qty;
 	}
 
 	@Override

--- a/src/main/java/appeng/recipes/MissedIngredientSet.java
+++ b/src/main/java/appeng/recipes/MissedIngredientSet.java
@@ -26,10 +26,15 @@ public class MissedIngredientSet extends Throwable
 {
 
 	private static final long serialVersionUID = 2672951714376345807L;
-	final ResolverResultSet rrs;
+	private final ResolverResultSet resolverResultSet;
 
 	public MissedIngredientSet( ResolverResultSet ro )
 	{
-		this.rrs = ro;
+		this.resolverResultSet = ro;
+	}
+
+	public ResolverResultSet getResolverResultSet()
+	{
+		return this.resolverResultSet;
 	}
 }

--- a/src/main/java/appeng/recipes/RecipeData.java
+++ b/src/main/java/appeng/recipes/RecipeData.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import appeng.api.recipes.ICraftHandler;
@@ -31,10 +32,10 @@ import appeng.api.recipes.ICraftHandler;
 public class RecipeData
 {
 
-	public final HashMap<String, String> aliases = new HashMap<String, String>();
-	public final HashMap<String, GroupIngredient> groups = new HashMap<String, GroupIngredient>();
+	public final Map<String, String> aliases = new HashMap<String, String>();
+	public final Map<String, GroupIngredient> groups = new HashMap<String, GroupIngredient>();
 
-	public final List<ICraftHandler> Handlers = new LinkedList<ICraftHandler>();
+	public final List<ICraftHandler> handlers = new LinkedList<ICraftHandler>();
 	public final Set<String> knownItem = new HashSet<String>();
 	public boolean crash = true;
 	public boolean exceptions = true;

--- a/src/main/java/appeng/recipes/RecipeHandler.java
+++ b/src/main/java/appeng/recipes/RecipeHandler.java
@@ -34,6 +34,7 @@ import java.util.zip.ZipOutputStream;
 import javax.annotation.Nonnull;
 
 import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.HashMultimap;
 
 import net.minecraft.item.Item;
@@ -74,7 +75,7 @@ import appeng.recipes.handlers.OreRegistration;
  */
 public class RecipeHandler implements IRecipeHandler
 {
-	final RecipeData data;
+	private final RecipeData data;
 	private final List<String> tokens = new LinkedList<String>();
 
 	public RecipeHandler()
@@ -89,12 +90,13 @@ public class RecipeHandler implements IRecipeHandler
 	 */
 	private RecipeHandler( RecipeHandler parent )
 	{
+		Preconditions.checkNotNull( parent );
 		this.data = parent.data;
 	}
 
 	private void addCrafting( ICraftHandler ch )
 	{
-		this.data.Handlers.add( ch );
+		this.data.handlers.add( ch );
 	}
 
 	public String getName( @Nonnull IIngredient i )
@@ -120,6 +122,8 @@ public class RecipeHandler implements IRecipeHandler
 
 	public String getName( ItemStack is ) throws RecipeError
 	{
+		Preconditions.checkNotNull( is );
+
 		UniqueIdentifier id = GameRegistry.findUniqueIdentifierFor( is.getItem() );
 		String realName = id.modId + ':' + id.name;
 
@@ -226,6 +230,8 @@ public class RecipeHandler implements IRecipeHandler
 
 	public String alias( String in )
 	{
+		Preconditions.checkNotNull( in );
+
 		String out = this.data.aliases.get( in );
 
 		if( out != null )
@@ -239,6 +245,9 @@ public class RecipeHandler implements IRecipeHandler
 	@Override
 	public void parseRecipes( IRecipeLoader loader, String path )
 	{
+		Preconditions.checkNotNull( loader );
+		Preconditions.checkNotNull( path );
+
 		try
 		{
 			BufferedReader reader = null;
@@ -370,7 +379,7 @@ public class RecipeHandler implements IRecipeHandler
 		Map<Class, Integer> processed = new HashMap<Class, Integer>();
 		try
 		{
-			for( ICraftHandler ch : this.data.Handlers )
+			for( ICraftHandler ch : this.data.handlers )
 			{
 				try
 				{
@@ -509,7 +518,7 @@ public class RecipeHandler implements IRecipeHandler
 	{
 		List<IWebsiteSerializer> out = new LinkedList<IWebsiteSerializer>();
 
-		for( ICraftHandler ch : this.data.Handlers )
+		for( ICraftHandler ch : this.data.handlers )
 		{
 			try
 			{
@@ -525,6 +534,11 @@ public class RecipeHandler implements IRecipeHandler
 		}
 
 		return out;
+	}
+
+	RecipeData getData()
+	{
+		return this.data;
 	}
 
 	private void processTokens( IRecipeLoader loader, String file, int line ) throws RecipeError
@@ -563,7 +577,7 @@ public class RecipeHandler implements IRecipeHandler
 
 					if( inputs.size() == 1 && inputs.get( 0 ).size() > 0 && post.size() == 1 )
 					{
-						this.data.groups.put( post.get( 0 ), new GroupIngredient( post.get( 0 ), inputs.get( 0 ) ) );
+						this.data.groups.put( post.get( 0 ), new GroupIngredient( post.get( 0 ), inputs.get( 0 ), 1 ) );
 					}
 					else
 					{
@@ -749,7 +763,7 @@ public class RecipeHandler implements IRecipeHandler
 		}
 		catch( MissedIngredientSet grp )
 		{
-			return new IngredientSet( grp.rrs );
+			return new IngredientSet( grp.getResolverResultSet(), qty );
 		}
 	}
 

--- a/src/main/java/appeng/recipes/game/FacadeRecipe.java
+++ b/src/main/java/appeng/recipes/game/FacadeRecipe.java
@@ -38,7 +38,6 @@ import appeng.items.parts.ItemFacade;
 
 public final class FacadeRecipe implements IRecipe
 {
-
 	private final IComparableDefinition anchor;
 	private final Optional<Item> maybeFacade;
 

--- a/src/main/java/appeng/recipes/game/ShapedRecipe.java
+++ b/src/main/java/appeng/recipes/game/ShapedRecipe.java
@@ -36,7 +36,6 @@ import appeng.api.recipes.IIngredient;
 
 public class ShapedRecipe implements IRecipe, IRecipeBakeable
 {
-
 	// Added in for future ease of change, but hard coded for now.
 	private static final int MAX_CRAFT_GRID_WIDTH = 3;
 	private static final int MAX_CRAFT_GRID_HEIGHT = 3;

--- a/src/main/java/appeng/recipes/ores/OreDictionaryHandler.java
+++ b/src/main/java/appeng/recipes/ores/OreDictionaryHandler.java
@@ -37,7 +37,7 @@ public class OreDictionaryHandler
 
 	public static final OreDictionaryHandler INSTANCE = new OreDictionaryHandler();
 
-	private final List<IOreListener> ol = new ArrayList<IOreListener>();
+	private final List<IOreListener> oreListeners = new ArrayList<IOreListener>();
 
 	private boolean enableRebaking = false;
 
@@ -51,7 +51,7 @@ public class OreDictionaryHandler
 
 		if( this.shouldCare( event.Name ) )
 		{
-			for( IOreListener v : this.ol )
+			for( IOreListener v : this.oreListeners )
 			{
 				v.oreRegistered( event.Name, event.Ore );
 			}
@@ -103,7 +103,7 @@ public class OreDictionaryHandler
 	 */
 	public void observe( IOreListener n )
 	{
-		this.ol.add( n );
+		this.oreListeners.add( n );
 
 		// notify the listener of any ore already in existence.
 		for( String name : OreDictionary.getOreNames() )


### PR DESCRIPTION
No longer allow recipes with a stacksize of 0, as it will throw an `ArithmeticException` when using NEI shift-clicking.

Also some general cleanup, including making fields private and adding `Preconditions` to prevent issues showing up in future.


Fixes #1601