### PR TITLE
Closes #1283: Add custom Callable to prevent memory leaks

### DIFF
--- a/src/main/java/appeng/me/GridNode.java
+++ b/src/main/java/appeng/me/GridNode.java
@@ -25,7 +25,6 @@ import java.util.Deque;
 import java.util.EnumSet;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.concurrent.Callable;
 
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
@@ -52,6 +51,7 @@ import appeng.api.util.IReadOnlyCollection;
 import appeng.core.worlddata.WorldData;
 import appeng.hooks.TickHandler;
 import appeng.me.pathfinding.IPathItem;
+import appeng.util.IWorldCallable;
 import appeng.util.ReadOnlyCollection;
 
 
@@ -669,7 +669,7 @@ public class GridNode implements IGridNode, IPathItem
 		return this.lastUsedChannels;
 	}
 
-	private static class MachineSecurityBreak implements Callable<Void>
+	private static class MachineSecurityBreak implements IWorldCallable<Void>
 	{
 		private final GridNode node;
 
@@ -679,7 +679,7 @@ public class GridNode implements IGridNode, IPathItem
 		}
 
 		@Override
-		public Void call() throws Exception
+		public Void call(World world) throws Exception
 		{
 			this.node.getMachine().securityBreak();
 

--- a/src/main/java/appeng/me/cache/helpers/Connections.java
+++ b/src/main/java/appeng/me/cache/helpers/Connections.java
@@ -20,13 +20,15 @@ package appeng.me.cache.helpers;
 
 
 import java.util.HashMap;
-import java.util.concurrent.Callable;
+
+import net.minecraft.world.World;
 
 import appeng.api.networking.IGridNode;
 import appeng.parts.p2p.PartP2PTunnelME;
+import appeng.util.IWorldCallable;
 
 
-public class Connections implements Callable
+public class Connections implements IWorldCallable<Void>
 {
 
 	public final HashMap<IGridNode, TunnelConnection> connections = new HashMap<IGridNode, TunnelConnection>();
@@ -40,7 +42,7 @@ public class Connections implements Callable
 	}
 
 	@Override
-	public Object call() throws Exception
+	public Void call( World world ) throws Exception
 	{
 		this.me.updateConnections( this );
 

--- a/src/main/java/appeng/parts/automation/PartAnnihilationPlane.java
+++ b/src/main/java/appeng/parts/automation/PartAnnihilationPlane.java
@@ -20,7 +20,6 @@ package appeng.parts.automation;
 
 
 import java.util.List;
-import java.util.concurrent.Callable;
 
 import com.google.common.collect.Lists;
 
@@ -34,6 +33,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.IIcon;
+import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
 import net.minecraftforge.common.util.ForgeDirection;
 
@@ -65,11 +65,12 @@ import appeng.hooks.TickHandler;
 import appeng.me.GridAccessException;
 import appeng.parts.PartBasicState;
 import appeng.server.ServerHelper;
+import appeng.util.IWorldCallable;
 import appeng.util.Platform;
 import appeng.util.item.AEItemStack;
 
 
-public class PartAnnihilationPlane extends PartBasicState implements IGridTickable, Callable<TickRateModulation>
+public class PartAnnihilationPlane extends PartBasicState implements IGridTickable, IWorldCallable<TickRateModulation>
 {
 	private final static IIcon SIDE_ICON = CableBusTextures.PartPlaneSides.getIcon();
 	private final static IIcon BACK_ICON = CableBusTextures.PartTransitionPlaneBack.getIcon();
@@ -86,7 +87,7 @@ public class PartAnnihilationPlane extends PartBasicState implements IGridTickab
 	}
 
 	@Override
-	public TickRateModulation call() throws Exception
+	public TickRateModulation call(World world) throws Exception
 	{
 		this.breaking = false;
 		return this.breakBlock( true );

--- a/src/main/java/appeng/parts/p2p/PartP2POpenComputers.java
+++ b/src/main/java/appeng/parts/p2p/PartP2POpenComputers.java
@@ -19,13 +19,12 @@
 package appeng.parts.p2p;
 
 
-import java.util.concurrent.Callable;
-
 import javax.annotation.Nullable;
 
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.IIcon;
+import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import cpw.mods.fml.relauncher.Side;
@@ -52,6 +51,7 @@ import appeng.integration.IntegrationType;
 import appeng.me.GridAccessException;
 import appeng.transformer.annotations.Integration.Interface;
 import appeng.transformer.annotations.Integration.InterfaceList;
+import appeng.util.IWorldCallable;
 
 
 @InterfaceList( value = { @Interface( iface = "li.cil.oc.api.network.Environment", iname = "OpenComputers" ), @Interface( iface = "li.cil.oc.api.network.SidedEnvironment", iname = "OpenComputers" ) } )
@@ -60,7 +60,7 @@ public final class PartP2POpenComputers extends PartP2PTunnel<PartP2POpenCompute
 	@Nullable
 	private final Node node;
 
-	private final Callable<Void> updateCallback;
+	private final IWorldCallable<Void> updateCallback;
 
 	public PartP2POpenComputers( ItemStack is )
 	{
@@ -239,11 +239,11 @@ public final class PartP2POpenComputers extends PartP2PTunnel<PartP2POpenCompute
 		return side == this.side;
 	}
 
-	private final class UpdateCallback implements Callable<Void>
+	private final class UpdateCallback implements IWorldCallable<Void>
 	{
 		@Nullable
 		@Override
-		public Void call() throws Exception
+		public Void call( World world ) throws Exception
 		{
 			PartP2POpenComputers.this.updateConnections();
 

--- a/src/main/java/appeng/tile/spatial/TileSpatialIOPort.java
+++ b/src/main/java/appeng/tile/spatial/TileSpatialIOPort.java
@@ -19,11 +19,10 @@
 package appeng.tile.spatial;
 
 
-import java.util.concurrent.Callable;
-
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import appeng.api.config.Actionable;
@@ -46,10 +45,11 @@ import appeng.tile.events.TileEventType;
 import appeng.tile.grid.AENetworkInvTile;
 import appeng.tile.inventory.AppEngInternalInventory;
 import appeng.tile.inventory.InvOperation;
+import appeng.util.IWorldCallable;
 import appeng.util.Platform;
 
 
-public class TileSpatialIOPort extends AENetworkInvTile implements Callable
+public class TileSpatialIOPort extends AENetworkInvTile implements IWorldCallable<Void>
 {
 
 	final int[] sides = { 0, 1 };
@@ -122,9 +122,8 @@ public class TileSpatialIOPort extends AENetworkInvTile implements Callable
 	}
 
 	@Override
-	public Object call() throws Exception
+	public Void call( World world ) throws Exception
 	{
-
 		ItemStack cell = this.getStackInSlot( 0 );
 		if( this.isSpatialCell( cell ) && this.getStackInSlot( 1 ) == null )
 		{

--- a/src/main/java/appeng/util/IWorldCallable.java
+++ b/src/main/java/appeng/util/IWorldCallable.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of Applied Energistics 2.
- * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
  *
  * Applied Energistics 2 is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -19,31 +19,31 @@
 package appeng.util;
 
 
+import java.util.concurrent.Callable;
+
+import javax.annotation.Nullable;
+
 import net.minecraft.world.World;
 
 
-public class BlockUpdate implements IWorldCallable<Boolean>
+/**
+ * An interface similar to {@link Callable}, but allowing to pass the {@link World} when calling.
+ *
+ * @see Callable
+ * @author yueh
+ * @version rv3
+ * @since rv3
+ */
+public interface IWorldCallable<T>
 {
-
-	final int x;
-	final int y;
-	final int z;
-
-	public BlockUpdate( int x, int y, int z )
-	{
-		this.x = x;
-		this.y = y;
-		this.z = z;
-	}
-
-	@Override
-	public Boolean call( World world ) throws Exception
-	{
-		if( world.blockExists( this.x, this.y, this.z ) )
-		{
-			world.notifyBlocksOfNeighborChange( this.x, this.y, this.z, Platform.AIR_BLOCK );
-		}
-
-		return true;
-	}
+	/**
+	 * Similar to {@link Callable#call()}
+	 *
+	 * @see Callable#call()
+	 * @param world
+	 * @return
+	 * @throws Exception
+	 */
+	@Nullable
+	T call( @Nullable World world ) throws Exception;
 }

--- a/src/main/java/appeng/util/Platform.java
+++ b/src/main/java/appeng/util/Platform.java
@@ -1911,7 +1911,7 @@ public class Platform
 	{
 		if( !worldObj.isRemote )
 		{
-			TickHandler.INSTANCE.addCallable( worldObj, new BlockUpdate( worldObj, xCoord, yCoord, zCoord ) );
+			TickHandler.INSTANCE.addCallable( worldObj, new BlockUpdate( xCoord, yCoord, zCoord ) );
 		}
 	}
 

--- a/src/main/java/appeng/worldgen/MeteoriteWorldGen.java
+++ b/src/main/java/appeng/worldgen/MeteoriteWorldGen.java
@@ -20,7 +20,6 @@ package appeng.worldgen;
 
 
 import java.util.Random;
-import java.util.concurrent.Callable;
 
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
@@ -33,6 +32,7 @@ import appeng.core.AEConfig;
 import appeng.core.features.registries.WorldGenRegistry;
 import appeng.core.worlddata.WorldData;
 import appeng.hooks.TickHandler;
+import appeng.util.IWorldCallable;
 import appeng.util.Platform;
 import appeng.worldgen.meteorite.ChunkOnly;
 
@@ -51,11 +51,11 @@ public final class MeteoriteWorldGen implements IWorldGenerator
 				int z = r.nextInt( 16 ) + ( chunkZ << 4 );
 
 				int depth = 180 + r.nextInt( 20 );
-				TickHandler.INSTANCE.addCallable( w, new MeteoriteSpawn( x, depth, z, w ) );
+				TickHandler.INSTANCE.addCallable( w, new MeteoriteSpawn( x, depth, z ) );
 			}
 			else
 			{
-				TickHandler.INSTANCE.addCallable( w, new MeteoriteSpawn( chunkX << 4, 128, chunkZ << 4, w ) );
+				TickHandler.INSTANCE.addCallable( w, new MeteoriteSpawn( chunkX << 4, 128, chunkZ << 4 ) );
 			}
 		}
 		else
@@ -113,24 +113,22 @@ public final class MeteoriteWorldGen implements IWorldGenerator
 		return WorldData.instance().spawnData().getNearByMeteorites( w.provider.dimensionId, chunkX, chunkZ );
 	}
 
-	class MeteoriteSpawn implements Callable
+	class MeteoriteSpawn implements IWorldCallable<Object>
 	{
 
 		final int x;
 		final int z;
-		final World w;
 		final int depth;
 
-		public MeteoriteSpawn( int x, int depth, int z, World w )
+		public MeteoriteSpawn( int x, int depth, int z )
 		{
 			this.x = x;
 			this.z = z;
-			this.w = w;
 			this.depth = depth;
 		}
 
 		@Override
-		public Object call() throws Exception
+		public Object call( World world ) throws Exception
 		{
 			int chunkX = this.x >> 4;
 			int chunkZ = this.z >> 4;
@@ -138,10 +136,10 @@ public final class MeteoriteWorldGen implements IWorldGenerator
 			double minSqDist = Double.MAX_VALUE;
 
 			// near by meteorites!
-			for( NBTTagCompound data : MeteoriteWorldGen.this.getNearByMeteorites( this.w, chunkX, chunkZ ) )
+			for( NBTTagCompound data : MeteoriteWorldGen.this.getNearByMeteorites( world, chunkX, chunkZ ) )
 			{
 				MeteoritePlacer mp = new MeteoritePlacer();
-				mp.spawnMeteorite( new ChunkOnly( this.w, chunkX, chunkZ ), data );
+				mp.spawnMeteorite( new ChunkOnly( world, chunkX, chunkZ ), data );
 
 				minSqDist = Math.min( minSqDist, mp.getSqDistance( this.x, this.z ) );
 			}
@@ -150,11 +148,11 @@ public final class MeteoriteWorldGen implements IWorldGenerator
 
 			if( minSqDist > AEConfig.instance.minMeteoriteDistanceSq || isCluster )
 			{
-				MeteoriteWorldGen.this.tryMeteorite( this.w, this.depth, this.x, this.z );
+				MeteoriteWorldGen.this.tryMeteorite( world, this.depth, this.x, this.z );
 			}
 
-			WorldData.instance().spawnData().setGenerated( this.w.provider.dimensionId, chunkX, chunkZ );
-			WorldData.instance().compassData().service().updateArea( this.w, chunkX, chunkZ );
+			WorldData.instance().spawnData().setGenerated( world.provider.dimensionId, chunkX, chunkZ );
+			WorldData.instance().compassData().service().updateArea( world, chunkX, chunkZ );
 
 			return null;
 		}


### PR DESCRIPTION
Added `IWorldCallable` with `World` as parameter to replace the generic `Callable`.

Besides `BlockUpdate` and `MeteoriteSpawn` no other class actually needs to access the world passed as argument (or it is already available through being a `TileEntity`).

Closes #1283