### PR TITLE
Fixes #1781: Do not crash after the tileentity was removed

### DIFF
--- a/src/main/java/appeng/parts/automation/PartSharedItemBus.java
+++ b/src/main/java/appeng/parts/automation/PartSharedItemBus.java
@@ -143,11 +143,9 @@ public abstract class PartSharedItemBus extends PartUpgradeable implements IGrid
 	protected boolean canDoBusWork()
 	{
 		final TileEntity self = this.getHost().getTile();
-		final TileEntity target = this.getTileEntity( self, self.xCoord + this.side.offsetX, self.yCoord + this.side.offsetY, self.zCoord + this.side.offsetZ );
-
-		final World world = target.getWorldObj();
-		final int xCoordinate = target.xCoord;
-		final int zCoordinate = target.zCoord;
+		final World world = self.getWorldObj();
+		final int xCoordinate = self.xCoord + this.side.offsetX;
+		final int zCoordinate = self.zCoord + this.side.offsetZ;
 
 		return world != null && world.getChunkProvider().chunkExists( xCoordinate >> 4, zCoordinate >> 4 );
 	}


### PR DESCRIPTION
Just take the the current position and side offset into account and not try to access the adjacent TE.

Fixes #1781