### PR TITLE
Fixes #1786: Locale critical code now uses the english local. Fixes Turkish Problem.

### DIFF
--- a/src/api/java/appeng/api/features/IRecipeHandlerRegistry.java
+++ b/src/api/java/appeng/api/features/IRecipeHandlerRegistry.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2013 AlgorithmX2
+ * Copyright (c) 2013 - 2015 AlgorithmX2
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -24,11 +24,19 @@
 package appeng.api.features;
 
 
+import javax.annotation.Nullable;
+
 import appeng.api.recipes.ICraftHandler;
 import appeng.api.recipes.IRecipeHandler;
 import appeng.api.recipes.ISubItemResolver;
 
 
+/**
+ * @author AlgorithmX2
+ * @author thatsIch
+ * @version rv3 - 10.08.2015
+ * @since rv0
+ */
 public interface IRecipeHandlerRegistry
 {
 
@@ -37,7 +45,7 @@ public interface IRecipeHandlerRegistry
 	 *
 	 * MUST BE CALLED IN PRE-INIT
 	 *
-	 * @param name    name of crafthandler
+	 * @param name name of crafthandler
 	 * @param handler class of crafthandler
 	 */
 	void addNewCraftHandler( String name, Class<? extends ICraftHandler> handler );
@@ -56,6 +64,7 @@ public interface IRecipeHandlerRegistry
 	 *
 	 * @return A recipe handler by name, returns null on failure.
 	 */
+	@Nullable
 	ICraftHandler getCraftHandlerFor( String name );
 
 	/**
@@ -67,9 +76,10 @@ public interface IRecipeHandlerRegistry
 	 * resolve sub items by name.
 	 *
 	 * @param nameSpace namespace of item
-	 * @param itemName  full name of item
+	 * @param itemName full name of item
 	 *
-	 * @return ResolverResult or ResolverResultSet
+	 * @return ResolverResult or ResolverResultSet or null if could not resolve
 	 */
+	@Nullable
 	Object resolveItem( String nameSpace, String itemName );
 }

--- a/src/main/java/appeng/core/IMCHandler.java
+++ b/src/main/java/appeng/core/IMCHandler.java
@@ -20,6 +20,7 @@ package appeng.core;
 
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 import cpw.mods.fml.common.event.FMLInterModComms;
@@ -35,6 +36,10 @@ import appeng.core.api.imc.IMCSpatial;
 
 /**
  * Handles the delegation of the corresponding IMC messages to the suitable IMC processors
+ *
+ * @author thatsIch
+ * @version rv3 - 10.08.2015
+ * @since rv1
  */
 public class IMCHandler
 {
@@ -43,8 +48,7 @@ public class IMCHandler
 	/**
 	 * Contains the processors,
 	 *
-	 * is mutable,
-	 * but write access only by the constructor
+	 * is mutable, but write access only by the constructor
 	 */
 	private final Map<String, IIMCProcessor> processors;
 
@@ -62,13 +66,12 @@ public class IMCHandler
 
 		for( TunnelType type : TunnelType.values() )
 		{
-			this.processors.put( "add-p2p-attunement-" + type.name().replace( '_', '-' ).toLowerCase(), new IMCP2PAttunement() );
+			this.processors.put( "add-p2p-attunement-" + type.name().replace( '_', '-' ).toLowerCase( Locale.ENGLISH ), new IMCP2PAttunement() );
 		}
 	}
 
 	/**
-	 * Tries to find every message matching the internal IMC keys.
-	 * When found the corresponding handler will process the attached message.
+	 * Tries to find every message matching the internal IMC keys. When found the corresponding handler will process the attached message.
 	 *
 	 * @param event Event carrying the identifier and message for the handlers
 	 */
@@ -80,7 +83,7 @@ public class IMCHandler
 
 			try
 			{
-				IIMCProcessor handler = this.processors.get( key );
+				final IIMCProcessor handler = this.processors.get( key );
 				if( handler != null )
 				{
 					handler.process( message );
@@ -90,7 +93,7 @@ public class IMCHandler
 					throw new IllegalStateException( "Invalid IMC Called: " + key );
 				}
 			}
-			catch( Throwable t )
+			catch( Exception t )
 			{
 				AELog.warning( "Problem detected when processing IMC " + key + " from " + message.getSender() );
 				AELog.error( t );

--- a/src/main/java/appeng/core/RecipeLoader.java
+++ b/src/main/java/appeng/core/RecipeLoader.java
@@ -22,7 +22,6 @@ package appeng.core;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
-
 import javax.annotation.Nonnull;
 
 import com.google.common.base.Preconditions;
@@ -70,11 +69,11 @@ public class RecipeLoader implements Runnable
 		final File readmeGenDest = new File( generatedRecipesDir, "README.html" );
 		final File readmeUserDest = new File( userRecipesDir, "README.html" );
 
-        final IRecipeLoader oreDictLoader = new JarLoader("/assets/appliedenergistics2/oredict/");
-        this.handler.parseRecipes(oreDictLoader, "vanilla.oredict" );
-        this.handler.parseRecipes(oreDictLoader, "ae2.oredict" );
+		final IRecipeLoader oreDictLoader = new JarLoader( "/assets/appliedenergistics2/oredict/" );
+		this.handler.parseRecipes( oreDictLoader, "vanilla.oredict" );
+		this.handler.parseRecipes( oreDictLoader, "ae2.oredict" );
 
-        // generates generated and user recipes dir
+		// generates generated and user recipes dir
 		// will clean the generated every time to keep it up to date
 		// copies over the recipes in the jar over to the generated folder
 		// copies over the readmes

--- a/src/main/java/appeng/core/api/imc/IMCP2PAttunement.java
+++ b/src/main/java/appeng/core/api/imc/IMCP2PAttunement.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of Applied Energistics 2.
- * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
  *
  * Applied Energistics 2 is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -31,6 +31,7 @@ package appeng.core.api.imc;
 
 
 import java.util.Arrays;
+import java.util.Locale;
 
 import net.minecraft.item.ItemStack;
 
@@ -47,7 +48,7 @@ public class IMCP2PAttunement implements IIMCProcessor
 	@Override
 	public void process( IMCMessage m )
 	{
-		String key = m.key.substring( "add-p2p-attunement-".length() ).replace( '-', '_' ).toUpperCase();
+		String key = m.key.substring( "add-p2p-attunement-".length() ).replace( '-', '_' ).toUpperCase( Locale.ENGLISH );
 
 		TunnelType type = TunnelType.valueOf( key );
 

--- a/src/main/java/appeng/core/features/registries/RecipeHandlerRegistry.java
+++ b/src/main/java/appeng/core/features/registries/RecipeHandlerRegistry.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of Applied Energistics 2.
- * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
  *
  * Applied Energistics 2 is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -19,8 +19,12 @@
 package appeng.core.features.registries;
 
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
+import java.util.Locale;
+import java.util.Map;
+import javax.annotation.Nullable;
 
 import appeng.api.features.IRecipeHandlerRegistry;
 import appeng.api.recipes.ICraftHandler;
@@ -30,16 +34,21 @@ import appeng.core.AELog;
 import appeng.recipes.RecipeHandler;
 
 
+/**
+ * @author AlgorithmX2
+ * @author thatsIch
+ * @version rv3 - 10.08.2015
+ * @since rv0
+ */
 public class RecipeHandlerRegistry implements IRecipeHandlerRegistry
 {
-
-	final HashMap<String, Class<? extends ICraftHandler>> handlers = new HashMap<String, Class<? extends ICraftHandler>>();
-	final LinkedList<ISubItemResolver> resolvers = new LinkedList<ISubItemResolver>();
+	private final Map<String, Class<? extends ICraftHandler>> handlers = new HashMap<String, Class<? extends ICraftHandler>>( 20 );
+	private final Collection<ISubItemResolver> resolvers = new LinkedList<ISubItemResolver>();
 
 	@Override
 	public void addNewCraftHandler( String name, Class<? extends ICraftHandler> handler )
 	{
-		this.handlers.put( name.toLowerCase(), handler );
+		this.handlers.put( name.toLowerCase( Locale.ENGLISH ), handler );
 	}
 
 	@Override
@@ -48,6 +57,7 @@ public class RecipeHandlerRegistry implements IRecipeHandlerRegistry
 		this.resolvers.add( sir );
 	}
 
+	@Nullable
 	@Override
 	public ICraftHandler getCraftHandlerFor( String name )
 	{
@@ -64,7 +74,9 @@ public class RecipeHandlerRegistry implements IRecipeHandlerRegistry
 		{
 			AELog.severe( "Error Caused when trying to construct " + clz.getName() );
 			AELog.error( e );
+
 			this.handlers.put( name, null ); // clear it..
+
 			return null;
 		}
 	}
@@ -75,6 +87,7 @@ public class RecipeHandlerRegistry implements IRecipeHandlerRegistry
 		return new RecipeHandler();
 	}
 
+	@Nullable
 	@Override
 	public Object resolveItem( String nameSpace, String itemName )
 	{

--- a/src/main/java/appeng/recipes/RecipeHandler.java
+++ b/src/main/java/appeng/recipes/RecipeHandler.java
@@ -26,11 +26,11 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
-
 import javax.annotation.Nonnull;
 
 import com.google.common.base.Optional;
@@ -69,7 +69,7 @@ import appeng.recipes.handlers.OreRegistration;
 /**
  * @author AlgorithmX2
  * @author thatsIch
- * @version rv2
+ * @version rv3 - 10.08.2015
  * @since rv0
  */
 public class RecipeHandler implements IRecipeHandler
@@ -446,7 +446,7 @@ public class RecipeHandler implements IRecipeHandler
 					try
 					{
 
-						Ingredient i = new Ingredient( this, s, 1 );
+						IIngredient i = new Ingredient( this, s, 1 );
 
 						for( ItemStack is : i.getItemStackSet() )
 						{
@@ -541,7 +541,7 @@ public class RecipeHandler implements IRecipeHandler
 			int split = this.tokens.indexOf( "->" );
 			if( split != -1 )
 			{
-				String operation = this.tokens.remove( 0 ).toLowerCase();
+				final String operation = this.tokens.remove( 0 ).toLowerCase( Locale.ENGLISH );
 
 				if( operation.equals( "alias" ) )
 				{
@@ -678,7 +678,7 @@ public class RecipeHandler implements IRecipeHandler
 		this.tokens.clear();
 	}
 
-	private List<List<IIngredient>> parseLines( List<String> subList ) throws RecipeError
+	private List<List<IIngredient>> parseLines( Iterable<String> subList ) throws RecipeError
 	{
 		List<List<IIngredient>> out = new LinkedList<List<IIngredient>>();
 		List<IIngredient> cList = new LinkedList<IIngredient>();
@@ -753,7 +753,7 @@ public class RecipeHandler implements IRecipeHandler
 		}
 	}
 
-	private boolean isNumber( String v )
+	private boolean isNumber( CharSequence v )
 	{
 		if( v.length() <= 0 )
 		{


### PR DESCRIPTION
Applied English Locale where localization is not expected as in internal recipe handling and IMC handling, basically which interacts with public API where we either require to enforce the incoming text with regex ([a-z0-9]) or just expect proper usage of the API, but with just using upper cases in recipe files it would break in Turkish Locale like

ALIAS

another option would have been to use `equalsIgnoreCase` in some cases, but not all applicable