### PR TITLE
Fixed the order craftinglinks are notified for the last item.

### DIFF
--- a/src/main/java/appeng/me/cache/CraftingGridCache.java
+++ b/src/main/java/appeng/me/cache/CraftingGridCache.java
@@ -314,9 +314,9 @@ public class CraftingGridCache implements ICraftingGrid, ICraftingProviderHelper
 			{
 				this.craftingCPUClusters.add( cluster );
 
-				if( cluster.myLastLink != null )
+				if( cluster.getLastCraftingLink() != null )
 				{
-					this.addLink( (CraftingLink) cluster.myLastLink );
+					this.addLink( (CraftingLink) cluster.getLastCraftingLink() );
 				}
 			}
 		}
@@ -641,7 +641,7 @@ public class CraftingGridCache implements ICraftingGrid, ICraftingProviderHelper
 			while( this.iterator.hasNext() && this.cpuCluster == null )
 			{
 				this.cpuCluster = this.iterator.next();
-				if( !this.cpuCluster.isActive() || this.cpuCluster.isDestroyed )
+				if( !this.cpuCluster.isActive() || this.cpuCluster.isDestroyed() )
 				{
 					this.cpuCluster = null;
 				}


### PR DESCRIPTION
Changed the order in which the job is marked as complete and when the last items are inserted into the requesting machine.
See the corresponding issue for a detailed explanation, about why it happens.

`injectItems()` is probably a good candidate for a general refactoring, but the control flow is not trivial and I currently cannot ensure that this will not break it.

Also some general cleanup.

Fixes #1833