### PR TITLE
ItemList refactoring

### DIFF
--- a/src/main/java/appeng/core/api/ApiStorage.java
+++ b/src/main/java/appeng/core/api/ApiStorage.java
@@ -41,6 +41,7 @@ import appeng.util.Platform;
 import appeng.util.item.AEFluidStack;
 import appeng.util.item.AEItemStack;
 import appeng.util.item.ItemList;
+import appeng.util.item.FluidList;
 
 
 public class ApiStorage implements IStorageHelper
@@ -67,13 +68,13 @@ public class ApiStorage implements IStorageHelper
 	@Override
 	public IItemList<IAEItemStack> createItemList()
 	{
-		return new ItemList<IAEItemStack>( IAEItemStack.class );
+		return new ItemList();
 	}
 
 	@Override
 	public IItemList<IAEFluidStack> createFluidList()
 	{
-		return new ItemList<IAEFluidStack>( IAEFluidStack.class );
+		return new FluidList();
 	}
 
 	@Override

--- a/src/main/java/appeng/util/item/FluidList.java
+++ b/src/main/java/appeng/util/item/FluidList.java
@@ -1,0 +1,201 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.util.item;
+
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import appeng.api.config.FuzzyMode;
+import appeng.api.storage.data.IAEFluidStack;
+import appeng.api.storage.data.IItemList;
+
+
+public final class FluidList implements IItemList<IAEFluidStack>
+{
+
+	private final Map<IAEFluidStack, IAEFluidStack> records = new HashMap<IAEFluidStack, IAEFluidStack>();
+
+	@Override
+	public void add( IAEFluidStack option )
+	{
+		if( option == null )
+		{
+			return;
+		}
+
+		final IAEFluidStack st = this.getFluidRecord( option );
+
+		if( st != null )
+		{
+			st.add( option );
+			return;
+		}
+
+		final IAEFluidStack opt = option.copy();
+
+		this.putFluidRecord( opt );
+	}
+
+	@Override
+	public IAEFluidStack findPrecise( IAEFluidStack fluidStack )
+	{
+		if( fluidStack == null )
+		{
+			return null;
+		}
+
+		return this.getFluidRecord( fluidStack );
+	}
+
+	@Override
+	public Collection<IAEFluidStack> findFuzzy( IAEFluidStack filter, FuzzyMode fuzzy )
+	{
+		if( filter == null )
+		{
+			return Collections.emptyList();
+		}
+
+		return Collections.singletonList( this.findPrecise( filter ) );
+	}
+
+	@Override
+	public boolean isEmpty()
+	{
+		return !this.iterator().hasNext();
+	}
+
+	@Override
+	public void addStorage( IAEFluidStack option )
+	{
+		if( option == null )
+		{
+			return;
+		}
+
+		final IAEFluidStack st = this.getFluidRecord( option );
+
+		if( st != null )
+		{
+			st.incStackSize( option.getStackSize() );
+			return;
+		}
+
+		final IAEFluidStack opt = option.copy();
+
+		this.putFluidRecord( opt );
+	}
+
+	/*
+	 * public synchronized void clean() { Iterator<StackType> i = iterator(); while (i.hasNext()) { StackType AEI =
+	 * i.next(); if ( !AEI.isMeaningful() ) i.remove(); } }
+	 */
+
+	@Override
+	public void addCrafting( IAEFluidStack option )
+	{
+		if( option == null )
+		{
+			return;
+		}
+
+		final IAEFluidStack st = this.getFluidRecord( option );
+
+		if( st != null )
+		{
+			st.setCraftable( true );
+			return;
+		}
+
+		final IAEFluidStack opt = option.copy();
+		opt.setStackSize( 0 );
+		opt.setCraftable( true );
+
+		this.putFluidRecord( opt );
+	}
+
+	@Override
+	public void addRequestable( IAEFluidStack option )
+	{
+		if( option == null )
+		{
+			return;
+		}
+
+		final IAEFluidStack st = this.getFluidRecord( option );
+
+		if( st != null )
+		{
+			st.setCountRequestable( st.getCountRequestable() + option.getCountRequestable() );
+			return;
+		}
+
+		final IAEFluidStack opt = option.copy();
+		opt.setStackSize( 0 );
+		opt.setCraftable( false );
+		opt.setCountRequestable( option.getCountRequestable() );
+
+		this.putFluidRecord( opt );
+	}
+
+	@Override
+	public IAEFluidStack getFirstItem()
+	{
+		for( IAEFluidStack stackType : this )
+		{
+			return stackType;
+		}
+
+		return null;
+	}
+
+	@Override
+	public int size()
+	{
+		return this.records.values().size();
+	}
+
+	@Override
+	public Iterator<IAEFluidStack> iterator()
+	{
+		return new MeaningfulFluidIterator<IAEFluidStack>( this.records.values().iterator() );
+	}
+
+	@Override
+	public void resetStatus()
+	{
+		for( IAEFluidStack i : this )
+		{
+			i.reset();
+		}
+	}
+
+	private IAEFluidStack getFluidRecord( IAEFluidStack fluid )
+	{
+		return this.records.get( fluid );
+	}
+
+	private IAEFluidStack putFluidRecord( IAEFluidStack fluid )
+	{
+		return this.records.put( fluid, fluid );
+	}
+}

--- a/src/main/java/appeng/util/item/ItemList.java
+++ b/src/main/java/appeng/util/item/ItemList.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of Applied Energistics 2.
- * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
  *
  * Applied Energistics 2 is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -19,126 +19,83 @@
 package appeng.util.item;
 
 
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
-import java.util.List;
+import java.util.Map;
 import java.util.NavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 
-import com.google.common.collect.Lists;
-
+import net.minecraft.item.Item;
 import net.minecraftforge.oredict.OreDictionary;
 
 import appeng.api.config.FuzzyMode;
-import appeng.api.storage.data.IAEFluidStack;
 import appeng.api.storage.data.IAEItemStack;
-import appeng.api.storage.data.IAEStack;
 import appeng.api.storage.data.IItemList;
 
 
-public final class ItemList<StackType extends IAEStack> implements IItemList<StackType>
+public final class ItemList implements IItemList<IAEItemStack>
 {
 
-	private final NavigableMap<StackType, StackType> records = new ConcurrentSkipListMap<StackType, StackType>();
-	private final Class<? extends IAEStack> clz;
-
-	// private int currentPriority = Integer.MIN_VALUE;
-	public Throwable stacktrace;
-	int iteration = Integer.MIN_VALUE;
-
-	public ItemList( Class<? extends IAEStack> cla )
-	{
-		this.clz = cla;
-	}
+	private final Map<Item, NavigableMap<IAEItemStack, IAEItemStack>> records = new IdentityHashMap<Item, NavigableMap<IAEItemStack, IAEItemStack>>();
 
 	@Override
-	public synchronized void add( StackType option )
+	public void add( IAEItemStack option )
 	{
-		if( this.checkStackType( option ) )
+		if( option == null )
 		{
 			return;
 		}
 
-		StackType st = this.records.get( option );
+		final IAEItemStack st = this.getItemRecord( option.getItem() ).get( option );
 
 		if( st != null )
 		{
-			// st.setPriority( currentPriority );
 			st.add( option );
 			return;
 		}
 
-		StackType opt = (StackType) option.copy();
-		// opt.setPriority( currentPriority );
-		this.records.put( opt, opt );
-	}
+		final IAEItemStack opt = option.copy();
 
-	private boolean checkStackType( StackType st )
-	{
-		if( st == null )
-		{
-			return true;
-		}
-
-		if( !this.clz.isInstance( st ) )
-		{
-			throw new IllegalArgumentException( "WRONG TYPE - got " + st.getClass().getName() + " expected " + this.clz.getName() );
-		}
-
-		return false;
+		this.putItemRecord( opt );
 	}
 
 	@Override
-	public synchronized StackType findPrecise( StackType i )
+	public IAEItemStack findPrecise( IAEItemStack itemStack )
 	{
-		if( this.checkStackType( i ) )
+		if( itemStack == null )
 		{
 			return null;
 		}
 
-		StackType is = this.records.get( i );
-		if( is != null )
-		{
-			return is;
-		}
-
-		return null;
+		return this.getItemRecord( itemStack.getItem() ).get( itemStack );
 	}
 
 	@Override
-	public Collection<StackType> findFuzzy( StackType filter, FuzzyMode fuzzy )
+	public Collection<IAEItemStack> findFuzzy( IAEItemStack filter, FuzzyMode fuzzy )
 	{
-		if( this.checkStackType( filter ) )
+		if( filter == null )
 		{
-			return new ArrayList<StackType>();
+			return Collections.emptyList();
 		}
 
-		if( filter instanceof IAEFluidStack )
-		{
-			List<StackType> result = Lists.newArrayList();
+		final AEItemStack ais = (AEItemStack) filter;
 
-			if( filter.equals( this ) )
-			{
-				result.add( filter );
-			}
-
-			return result;
-		}
-
-		AEItemStack ais = (AEItemStack) filter;
 		if( ais.isOre() )
 		{
-			OreReference or = ais.def.isOre;
+			final OreReference or = ais.def.isOre;
+
 			if( or.getAEEquivalents().size() == 1 )
 			{
-				IAEItemStack is = or.getAEEquivalents().get( 0 );
+				final IAEItemStack is = or.getAEEquivalents().get( 0 );
+
 				return this.findFuzzyDamage( (AEItemStack) is, fuzzy, is.getItemDamage() == OreDictionary.WILDCARD_VALUE );
 			}
 			else
 			{
-				Collection<StackType> output = new LinkedList<StackType>();
+				final Collection<IAEItemStack> output = new LinkedList<IAEItemStack>();
 
 				for( IAEItemStack is : or.getAEEquivalents() )
 				{
@@ -158,123 +115,141 @@ public final class ItemList<StackType extends IAEStack> implements IItemList<Sta
 		return !this.iterator().hasNext();
 	}
 
-	public Collection<StackType> findFuzzyDamage( AEItemStack filter, FuzzyMode fuzzy, boolean ignoreMeta )
-	{
-		StackType low = (StackType) filter.getLow( fuzzy, ignoreMeta );
-		StackType high = (StackType) filter.getHigh( fuzzy, ignoreMeta );
-		return this.records.subMap( low, true, high, true ).descendingMap().values();
-	}
-
 	@Override
-	public synchronized void addStorage( StackType option ) // adds a stack as
-	// stored.
+	public void addStorage( IAEItemStack option )
 	{
-		if( this.checkStackType( option ) )
+		if( option == null )
 		{
 			return;
 		}
 
-		StackType st = this.records.get( option );
+		final IAEItemStack st = this.getItemRecord( option.getItem() ).get( option );
 
 		if( st != null )
 		{
-			// st.setPriority( currentPriority );
 			st.incStackSize( option.getStackSize() );
 			return;
 		}
 
-		StackType opt = (StackType) option.copy();
-		// opt.setPriority( currentPriority );
-		this.records.put( opt, opt );
+		final IAEItemStack opt = option.copy();
+
+		this.putItemRecord( opt );
 	}
 
 	/*
-	 * public synchronized void clean() { Iterator<StackType> i = iterator(); while (i.hasNext()) { StackType AEI =
+	 * public void clean() { Iterator<StackType> i = iterator(); while (i.hasNext()) { StackType AEI =
 	 * i.next(); if ( !AEI.isMeaningful() ) i.remove(); } }
 	 */
 
 	@Override
-	public synchronized void addCrafting( StackType option ) // adds a stack as
-	// craftable.
+	public void addCrafting( IAEItemStack option )
 	{
-		if( this.checkStackType( option ) )
+		if( option == null )
 		{
 			return;
 		}
 
-		StackType st = this.records.get( option );
+		final IAEItemStack st = this.getItemRecord( option.getItem() ).get( option );
 
 		if( st != null )
 		{
-			// st.setPriority( currentPriority );
 			st.setCraftable( true );
 			return;
 		}
 
-		StackType opt = (StackType) option.copy();
-		// opt.setPriority( currentPriority );
+		final IAEItemStack opt = option.copy();
 		opt.setStackSize( 0 );
 		opt.setCraftable( true );
 
-		this.records.put( opt, opt );
+		this.putItemRecord( opt );
 	}
 
 	@Override
-	public synchronized void addRequestable( StackType option ) // adds a stack
-	// as
-	// requestable.
+	public void addRequestable( IAEItemStack option )
 	{
-		if( this.checkStackType( option ) )
+		if( option == null )
 		{
 			return;
 		}
 
-		StackType st = this.records.get( option );
+		final IAEItemStack st = this.getItemRecord( option.getItem() ).get( option );
 
 		if( st != null )
 		{
-			// st.setPriority( currentPriority );
-			( (IAEItemStack) st ).setCountRequestable( st.getCountRequestable() + option.getCountRequestable() );
+			st.setCountRequestable( st.getCountRequestable() + option.getCountRequestable() );
 			return;
 		}
 
-		StackType opt = (StackType) option.copy();
-		// opt.setPriority( currentPriority );
+		final IAEItemStack opt = option.copy();
 		opt.setStackSize( 0 );
 		opt.setCraftable( false );
-		opt.setCountRequestable( opt.getCountRequestable() );
+		opt.setCountRequestable( option.getCountRequestable() );
 
-		this.records.put( opt, opt );
+		this.putItemRecord( opt );
 	}
 
 	@Override
-	public synchronized StackType getFirstItem()
+	public IAEItemStack getFirstItem()
 	{
-		for( StackType stackType : this )
+		for( IAEItemStack stackType : this )
 		{
 			return stackType;
 		}
+
 		return null;
 	}
 
 	@Override
-	public synchronized int size()
+	public int size()
 	{
-		return this.records.values().size();
+		int size = 0;
+
+		for( Map<IAEItemStack, IAEItemStack> element : this.records.values() )
+		{
+			size += element.size();
+		}
+
+		return size;
 	}
 
 	@Override
-	public synchronized Iterator<StackType> iterator()
+	public Iterator<IAEItemStack> iterator()
 	{
-		return new MeaningfulIterator<StackType>( this.records.values().iterator() );
+		return new MeaningfulItemIterator<IAEItemStack>( this.records.values().iterator() );
 	}
 
 	@Override
-	public synchronized void resetStatus()
+	public void resetStatus()
 	{
-		for( StackType i : this )
+		for( IAEItemStack i : this )
 		{
 			i.reset();
 		}
+	}
+
+	private NavigableMap<IAEItemStack, IAEItemStack> getItemRecord( Item item )
+	{
+		NavigableMap<IAEItemStack, IAEItemStack> itemRecords = this.records.get( item );
+
+		if( itemRecords == null )
+		{
+			itemRecords = new ConcurrentSkipListMap<IAEItemStack, IAEItemStack>();
+			this.records.put( item, itemRecords );
+		}
+
+		return itemRecords;
+	}
+
+	private IAEItemStack putItemRecord( IAEItemStack itemStack )
+	{
+		return this.getItemRecord( itemStack.getItem() ).put( itemStack, itemStack );
+	}
+
+	private Collection<IAEItemStack> findFuzzyDamage( AEItemStack filter, FuzzyMode fuzzy, boolean ignoreMeta )
+	{
+		final IAEItemStack low = filter.getLow( fuzzy, ignoreMeta );
+		final IAEItemStack high = filter.getHigh( fuzzy, ignoreMeta );
+
+		return this.getItemRecord( filter.getItem() ).subMap( low, true, high, true ).descendingMap().values();
 	}
 }

--- a/src/main/java/appeng/util/item/MeaningfulFluidIterator.java
+++ b/src/main/java/appeng/util/item/MeaningfulFluidIterator.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of Applied Energistics 2.
- * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
  *
  * Applied Energistics 2 is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -20,17 +20,18 @@ package appeng.util.item;
 
 
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 
 import appeng.api.storage.data.IAEStack;
 
 
-public class MeaningfulIterator<StackType extends IAEStack> implements Iterator<StackType>
+public class MeaningfulFluidIterator<T extends IAEStack> implements Iterator<T>
 {
 
-	private final Iterator<StackType> parent;
-	private StackType next;
+	private final Iterator<T> parent;
+	private T next;
 
-	public MeaningfulIterator( Iterator<StackType> iterator )
+	public MeaningfulFluidIterator( Iterator<T> iterator )
 	{
 		this.parent = iterator;
 	}
@@ -51,12 +52,18 @@ public class MeaningfulIterator<StackType extends IAEStack> implements Iterator<
 			}
 		}
 
+		this.next = null;
 		return false;
 	}
 
 	@Override
-	public StackType next()
+	public T next()
 	{
+		if( this.next == null )
+		{
+			throw new NoSuchElementException();
+		}
+
 		return this.next;
 	}
 

--- a/src/main/java/appeng/util/item/MeaningfulItemIterator.java
+++ b/src/main/java/appeng/util/item/MeaningfulItemIterator.java
@@ -1,0 +1,96 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.util.item;
+
+
+import java.util.Iterator;
+import java.util.NavigableMap;
+import java.util.NoSuchElementException;
+
+import appeng.api.storage.data.IAEItemStack;
+
+
+public class MeaningfulItemIterator<T extends IAEItemStack> implements Iterator<T>
+{
+
+	private final Iterator<NavigableMap<T, T>> parent;
+	private Iterator<T> innerIterater = null;
+	private T next;
+
+	public MeaningfulItemIterator( Iterator<NavigableMap<T, T>> iterator )
+	{
+		this.parent = iterator;
+
+		if( this.parent.hasNext() )
+		{
+			this.innerIterater = this.parent.next().values().iterator();
+		}
+	}
+
+	@Override
+	public boolean hasNext()
+	{
+		if( this.innerIterater == null )
+		{
+			return false;
+		}
+
+		while( this.innerIterater.hasNext() || this.parent.hasNext() )
+		{
+			if( this.innerIterater.hasNext() )
+			{
+				this.next = this.innerIterater.next();
+
+				if( this.next.isMeaningful() )
+				{
+					return true;
+				}
+				else
+				{
+					this.innerIterater.remove(); // self cleaning :3
+				}
+			}
+
+			if( this.parent.hasNext() )
+			{
+				this.innerIterater = this.parent.next().values().iterator();
+			}
+		}
+
+		this.next = null;
+		return false;
+	}
+
+	@Override
+	public T next()
+	{
+		if( this.next == null )
+		{
+			throw new NoSuchElementException();
+		}
+
+		return this.next;
+	}
+
+	@Override
+	public void remove()
+	{
+		this.parent.remove();
+	}
+}


### PR DESCRIPTION
Splitted the ItemList and MeaningfulIterator into an item and fluid version.
Added an IdentityHashMap as additional item layer to the ItemList for faster access.
The FluidList is a copy of the old ItemList.

The general approach is to use a `IdentityHashMap` on the item layer to speed up the access to a single item type. As `Item` is using a flyweight pattern, we can switch a `HashMap` for the slightly faster `IdentityHashMap`.
This actually mimics our intention with the fuzzy sorting, as this is only require on a per `Item` level, not over the whole collection. Thus it replaces the `O(log n)` in a deep tree with an access with `O(1)` and `O(log n)` on a very shallow tree. This also applies to oredict based searching, as this is based on merging different distinct items together into a collection.

It does result in a clear improvement under normal condition (about 50% less cpu consumed). Very high load can still be an issue (moving about 1024 itemtyps/tick through a network). Maybe it results in actually more items moved per tick, but this is really hard to track down as long as it is CPU gated.

The main issue prevent better optimizations is still the `MeaningfulItemIterator`. Due to the change it will now put a bit more load into the system as it needs to handle a second inner collection. But overall it is still a solid improvement. Getting rid of the actual self cleaning and replace it with a more fine grained explicitly cleanup is the main requirement here. Which will most likely require an API break.

Special thanks to @sfPlayer1 for the idea of using a `IdentityHashMap` and split the collection.

