### PR TITLE
Rendering cleanup

### DIFF
--- a/src/main/java/appeng/block/AEBaseBlock.java
+++ b/src/main/java/appeng/block/AEBaseBlock.java
@@ -61,6 +61,7 @@ import appeng.core.features.IAEFeature;
 import appeng.core.features.IFeatureHandler;
 import appeng.helpers.AEGlassMaterial;
 import appeng.helpers.ICustomCollision;
+import appeng.tile.AEBaseTile;
 import appeng.util.LookDirection;
 import appeng.util.Platform;
 
@@ -132,27 +133,21 @@ public abstract class AEBaseBlock extends Block implements IAEFeature
 			return this.renderInfo;
 		}
 
-		try
-		{
-			final BaseBlockRender renderer = this.getRenderer().newInstance();
-			this.renderInfo = new BlockRenderInfo( renderer );
+		final BaseBlockRender<? extends AEBaseBlock, ? extends AEBaseTile> renderer = this.getRenderer();
+		this.renderInfo = new BlockRenderInfo( renderer );
 
-			return this.renderInfo;
-		}
-		catch( final InstantiationException e )
-		{
-			throw new IllegalStateException( "Failed to create a new instance of an illegal class " + this.getRenderer(), e );
-		}
-		catch( final IllegalAccessException e )
-		{
-			throw new IllegalStateException( "Failed to create a new instance of " + this.getRenderer() + " because of permissions.", e );
-		}
+		return this.renderInfo;
 	}
 
+	/**
+	 * Factory method to create a new render instance.
+	 *
+	 * @return the newly created instance.
+	 */
 	@SideOnly( Side.CLIENT )
-	protected Class<? extends BaseBlockRender> getRenderer()
+	protected BaseBlockRender<? extends AEBaseBlock, ? extends AEBaseTile> getRenderer()
 	{
-		return BaseBlockRender.class;
+		return new BaseBlockRender<AEBaseBlock, AEBaseTile>();
 	}
 
 	IIcon unmappedGetIcon( final IBlockAccess w, final int x, final int y, final int z, final int s )

--- a/src/main/java/appeng/block/crafting/BlockCraftingMonitor.java
+++ b/src/main/java/appeng/block/crafting/BlockCraftingMonitor.java
@@ -32,7 +32,6 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
 import appeng.api.AEApi;
-import appeng.client.render.BaseBlockRender;
 import appeng.client.render.blocks.RenderBlockCraftingCPUMonitor;
 import appeng.client.texture.ExtraBlockTextures;
 import appeng.tile.crafting.TileCraftingMonitorTile;
@@ -46,9 +45,10 @@ public class BlockCraftingMonitor extends BlockCraftingUnit
 	}
 
 	@Override
-	protected Class<? extends BaseBlockRender> getRenderer()
+	@SideOnly( Side.CLIENT )
+	protected RenderBlockCraftingCPUMonitor getRenderer()
 	{
-		return RenderBlockCraftingCPUMonitor.class;
+		return new RenderBlockCraftingCPUMonitor();
 	}
 
 	@Override

--- a/src/main/java/appeng/block/crafting/BlockCraftingUnit.java
+++ b/src/main/java/appeng/block/crafting/BlockCraftingUnit.java
@@ -36,7 +36,6 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
 import appeng.block.AEBaseTileBlock;
-import appeng.client.render.BaseBlockRender;
 import appeng.client.render.blocks.RenderBlockCraftingCPU;
 import appeng.client.texture.ExtraBlockTextures;
 import appeng.core.features.AEFeature;
@@ -59,9 +58,10 @@ public class BlockCraftingUnit extends AEBaseTileBlock
 	}
 
 	@Override
-	protected Class<? extends BaseBlockRender> getRenderer()
+	@SideOnly( Side.CLIENT )
+	protected RenderBlockCraftingCPU<? extends BlockCraftingUnit, ? extends TileCraftingTile> getRenderer()
 	{
-		return RenderBlockCraftingCPU.class;
+		return new RenderBlockCraftingCPU<BlockCraftingUnit, TileCraftingTile>();
 	}
 
 	@Override

--- a/src/main/java/appeng/block/crafting/BlockMolecularAssembler.java
+++ b/src/main/java/appeng/block/crafting/BlockMolecularAssembler.java
@@ -30,7 +30,6 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
 import appeng.block.AEBaseTileBlock;
-import appeng.client.render.BaseBlockRender;
 import appeng.client.render.blocks.RenderBlockAssembler;
 import appeng.core.features.AEFeature;
 import appeng.core.sync.GuiBridge;
@@ -68,9 +67,9 @@ public class BlockMolecularAssembler extends AEBaseTileBlock
 
 	@Override
 	@SideOnly( Side.CLIENT )
-	public Class<? extends BaseBlockRender> getRenderer()
+	public RenderBlockAssembler getRenderer()
 	{
-		return RenderBlockAssembler.class;
+		return new RenderBlockAssembler();
 	}
 
 	@Override

--- a/src/main/java/appeng/block/grindstone/BlockCrank.java
+++ b/src/main/java/appeng/block/grindstone/BlockCrank.java
@@ -31,9 +31,11 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.util.FakePlayer;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
 import appeng.api.implementations.tiles.ICrankable;
 import appeng.block.AEBaseTileBlock;
-import appeng.client.render.BaseBlockRender;
 import appeng.client.render.blocks.RenderBlockCrank;
 import appeng.core.features.AEFeature;
 import appeng.core.stats.Stats;
@@ -56,9 +58,10 @@ public class BlockCrank extends AEBaseTileBlock
 	}
 
 	@Override
-	public Class<? extends BaseBlockRender> getRenderer()
+	@SideOnly( Side.CLIENT )
+	public RenderBlockCrank getRenderer()
 	{
-		return RenderBlockCrank.class;
+		return new RenderBlockCrank();
 	}
 
 	@Override

--- a/src/main/java/appeng/block/misc/BlockCharger.java
+++ b/src/main/java/appeng/block/misc/BlockCharger.java
@@ -37,7 +37,6 @@ import cpw.mods.fml.relauncher.SideOnly;
 
 import appeng.api.AEApi;
 import appeng.block.AEBaseTileBlock;
-import appeng.client.render.BaseBlockRender;
 import appeng.client.render.blocks.RenderBlockCharger;
 import appeng.client.render.effects.LightningFX;
 import appeng.core.AEConfig;
@@ -63,9 +62,10 @@ public class BlockCharger extends AEBaseTileBlock implements ICustomCollision
 	}
 
 	@Override
-	protected Class<? extends BaseBlockRender> getRenderer()
+	@SideOnly( Side.CLIENT )
+	protected RenderBlockCharger getRenderer()
 	{
-		return RenderBlockCharger.class;
+		return new RenderBlockCharger();
 	}
 
 	@Override

--- a/src/main/java/appeng/block/misc/BlockInscriber.java
+++ b/src/main/java/appeng/block/misc/BlockInscriber.java
@@ -26,8 +26,10 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
 import appeng.block.AEBaseTileBlock;
-import appeng.client.render.BaseBlockRender;
 import appeng.client.render.blocks.RenderBlockInscriber;
 import appeng.core.features.AEFeature;
 import appeng.core.sync.GuiBridge;
@@ -49,9 +51,10 @@ public class BlockInscriber extends AEBaseTileBlock
 	}
 
 	@Override
-	protected Class<? extends BaseBlockRender> getRenderer()
+	@SideOnly( Side.CLIENT )
+	protected RenderBlockInscriber getRenderer()
 	{
-		return RenderBlockInscriber.class;
+		return new RenderBlockInscriber();
 	}
 
 	@Override

--- a/src/main/java/appeng/block/misc/BlockInterface.java
+++ b/src/main/java/appeng/block/misc/BlockInterface.java
@@ -26,9 +26,11 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
 import appeng.api.util.IOrientable;
 import appeng.block.AEBaseTileBlock;
-import appeng.client.render.BaseBlockRender;
 import appeng.client.render.blocks.RenderBlockInterface;
 import appeng.core.features.AEFeature;
 import appeng.core.sync.GuiBridge;
@@ -48,9 +50,10 @@ public class BlockInterface extends AEBaseTileBlock
 	}
 
 	@Override
-	protected Class<? extends BaseBlockRender> getRenderer()
+	@SideOnly( Side.CLIENT )
+	protected RenderBlockInterface getRenderer()
 	{
-		return RenderBlockInterface.class;
+		return new RenderBlockInterface();
 	}
 
 	@Override

--- a/src/main/java/appeng/block/misc/BlockLightDetector.java
+++ b/src/main/java/appeng/block/misc/BlockLightDetector.java
@@ -91,9 +91,10 @@ public class BlockLightDetector extends AEBaseTileBlock implements IOrientableBl
 	}
 
 	@Override
-	protected Class<? extends RenderQuartzTorch> getRenderer()
+	@SideOnly( Side.CLIENT )
+	protected RenderQuartzTorch getRenderer()
 	{
-		return RenderQuartzTorch.class;
+		return new RenderQuartzTorch();
 	}
 
 	@Override

--- a/src/main/java/appeng/block/misc/BlockPaint.java
+++ b/src/main/java/appeng/block/misc/BlockPaint.java
@@ -37,7 +37,6 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
 import appeng.block.AEBaseTileBlock;
-import appeng.client.render.BaseBlockRender;
 import appeng.client.render.blocks.RenderBlockPaint;
 import appeng.core.features.AEFeature;
 import appeng.tile.misc.TilePaint;
@@ -59,9 +58,10 @@ public class BlockPaint extends AEBaseTileBlock
 	}
 
 	@Override
-	protected Class<? extends BaseBlockRender> getRenderer()
+	@SideOnly( Side.CLIENT )
+	protected RenderBlockPaint getRenderer()
 	{
-		return RenderBlockPaint.class;
+		return new RenderBlockPaint();
 	}
 
 	@Override

--- a/src/main/java/appeng/block/misc/BlockQuartzGrowthAccelerator.java
+++ b/src/main/java/appeng/block/misc/BlockQuartzGrowthAccelerator.java
@@ -33,7 +33,6 @@ import cpw.mods.fml.relauncher.SideOnly;
 
 import appeng.api.util.IOrientableBlock;
 import appeng.block.AEBaseTileBlock;
-import appeng.client.render.BaseBlockRender;
 import appeng.client.render.blocks.RenderBlockQuartzAccelerator;
 import appeng.client.render.effects.LightningFX;
 import appeng.core.AEConfig;
@@ -55,9 +54,10 @@ public class BlockQuartzGrowthAccelerator extends AEBaseTileBlock implements IOr
 	}
 
 	@Override
-	protected Class<? extends BaseBlockRender> getRenderer()
+	@SideOnly( Side.CLIENT )
+	protected RenderBlockQuartzAccelerator getRenderer()
 	{
-		return RenderBlockQuartzAccelerator.class;
+		return new RenderBlockQuartzAccelerator();
 	}
 
 	@Override

--- a/src/main/java/appeng/block/misc/BlockQuartzTorch.java
+++ b/src/main/java/appeng/block/misc/BlockQuartzTorch.java
@@ -39,7 +39,6 @@ import cpw.mods.fml.relauncher.SideOnly;
 import appeng.api.util.IOrientable;
 import appeng.api.util.IOrientableBlock;
 import appeng.block.AEBaseBlock;
-import appeng.client.render.BaseBlockRender;
 import appeng.client.render.blocks.RenderQuartzTorch;
 import appeng.client.render.effects.LightningFX;
 import appeng.core.AEConfig;
@@ -63,9 +62,10 @@ public class BlockQuartzTorch extends AEBaseBlock implements IOrientableBlock, I
 	}
 
 	@Override
-	protected Class<? extends BaseBlockRender> getRenderer()
+	@SideOnly( Side.CLIENT )
+	protected RenderQuartzTorch getRenderer()
 	{
-		return RenderQuartzTorch.class;
+		return new RenderQuartzTorch();
 	}
 
 	@Override

--- a/src/main/java/appeng/block/misc/BlockSecurity.java
+++ b/src/main/java/appeng/block/misc/BlockSecurity.java
@@ -26,8 +26,10 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
 import appeng.block.AEBaseTileBlock;
-import appeng.client.render.BaseBlockRender;
 import appeng.client.render.blocks.RendererSecurity;
 import appeng.core.features.AEFeature;
 import appeng.core.sync.GuiBridge;
@@ -47,9 +49,10 @@ public class BlockSecurity extends AEBaseTileBlock
 	}
 
 	@Override
-	protected Class<? extends BaseBlockRender> getRenderer()
+	@SideOnly( Side.CLIENT )
+	protected RendererSecurity getRenderer()
 	{
-		return RendererSecurity.class;
+		return new RendererSecurity();
 	}
 
 	@Override

--- a/src/main/java/appeng/block/misc/BlockSkyCompass.java
+++ b/src/main/java/appeng/block/misc/BlockSkyCompass.java
@@ -37,7 +37,6 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
 import appeng.block.AEBaseTileBlock;
-import appeng.client.render.BaseBlockRender;
 import appeng.client.render.blocks.RenderBlockSkyCompass;
 import appeng.core.features.AEFeature;
 import appeng.helpers.ICustomCollision;
@@ -57,9 +56,10 @@ public class BlockSkyCompass extends AEBaseTileBlock implements ICustomCollision
 	}
 
 	@Override
-	protected Class<? extends BaseBlockRender> getRenderer()
+	@SideOnly( Side.CLIENT )
+	protected RenderBlockSkyCompass getRenderer()
 	{
-		return RenderBlockSkyCompass.class;
+		return new RenderBlockSkyCompass();
 	}
 
 	@Override

--- a/src/main/java/appeng/block/misc/BlockTinyTNT.java
+++ b/src/main/java/appeng/block/misc/BlockTinyTNT.java
@@ -40,9 +40,10 @@ import net.minecraft.world.Explosion;
 import net.minecraft.world.World;
 
 import cpw.mods.fml.common.registry.EntityRegistry;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 
 import appeng.block.AEBaseBlock;
-import appeng.client.render.BaseBlockRender;
 import appeng.client.render.blocks.RenderTinyTNT;
 import appeng.client.texture.FullIcon;
 import appeng.core.AppEng;
@@ -70,9 +71,10 @@ public class BlockTinyTNT extends AEBaseBlock implements ICustomCollision
 	}
 
 	@Override
-	protected Class<? extends BaseBlockRender> getRenderer()
+	@SideOnly( Side.CLIENT )
+	protected RenderTinyTNT getRenderer()
 	{
-		return RenderTinyTNT.class;
+		return new RenderTinyTNT();
 	}
 
 	@Override

--- a/src/main/java/appeng/block/networking/BlockCableBus.java
+++ b/src/main/java/appeng/block/networking/BlockCableBus.java
@@ -54,7 +54,6 @@ import appeng.api.parts.PartItemStack;
 import appeng.api.parts.SelectedPart;
 import appeng.api.util.AEColor;
 import appeng.block.AEBaseTileBlock;
-import appeng.client.render.BaseBlockRender;
 import appeng.client.render.BusRenderHelper;
 import appeng.client.render.blocks.RendererCableBus;
 import appeng.client.texture.ExtraBlockTextures;
@@ -414,9 +413,10 @@ public class BlockCableBus extends AEBaseTileBlock implements IRedNetConnection
 	}
 
 	@Override
-	protected Class<? extends BaseBlockRender> getRenderer()
+	@SideOnly( Side.CLIENT )
+	protected RendererCableBus getRenderer()
 	{
-		return RendererCableBus.class;
+		return new RendererCableBus();
 	}
 
 	@Override

--- a/src/main/java/appeng/block/networking/BlockController.java
+++ b/src/main/java/appeng/block/networking/BlockController.java
@@ -25,8 +25,10 @@ import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.world.World;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
 import appeng.block.AEBaseTileBlock;
-import appeng.client.render.BaseBlockRender;
 import appeng.client.render.blocks.RenderBlockController;
 import appeng.core.features.AEFeature;
 import appeng.tile.networking.TileController;
@@ -54,8 +56,9 @@ public class BlockController extends AEBaseTileBlock
 	}
 
 	@Override
-	protected Class<? extends BaseBlockRender> getRenderer()
+	@SideOnly( Side.CLIENT )
+	protected RenderBlockController getRenderer()
 	{
-		return RenderBlockController.class;
+		return new RenderBlockController();
 	}
 }

--- a/src/main/java/appeng/block/networking/BlockEnergyCell.java
+++ b/src/main/java/appeng/block/networking/BlockEnergyCell.java
@@ -34,7 +34,6 @@ import cpw.mods.fml.relauncher.SideOnly;
 import appeng.block.AEBaseItemBlock;
 import appeng.block.AEBaseItemBlockChargeable;
 import appeng.block.AEBaseTileBlock;
-import appeng.client.render.BaseBlockRender;
 import appeng.client.render.blocks.RenderBlockEnergyCube;
 import appeng.client.texture.ExtraBlockTextures;
 import appeng.core.features.AEFeature;
@@ -55,9 +54,10 @@ public class BlockEnergyCell extends AEBaseTileBlock
 	}
 
 	@Override
-	protected Class<? extends BaseBlockRender> getRenderer()
+	@SideOnly( Side.CLIENT )
+	protected RenderBlockEnergyCube getRenderer()
 	{
-		return RenderBlockEnergyCube.class;
+		return new RenderBlockEnergyCube();
 	}
 
 	@Override

--- a/src/main/java/appeng/block/networking/BlockWireless.java
+++ b/src/main/java/appeng/block/networking/BlockWireless.java
@@ -29,8 +29,10 @@ import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
 import appeng.block.AEBaseTileBlock;
-import appeng.client.render.BaseBlockRender;
 import appeng.client.render.blocks.RenderBlockWireless;
 import appeng.core.features.AEFeature;
 import appeng.core.sync.GuiBridge;
@@ -54,9 +56,10 @@ public class BlockWireless extends AEBaseTileBlock implements ICustomCollision
 	}
 
 	@Override
-	protected Class<? extends BaseBlockRender> getRenderer()
+	@SideOnly( Side.CLIENT )
+	protected RenderBlockWireless getRenderer()
 	{
-		return RenderBlockWireless.class;
+		return new RenderBlockWireless();
 	}
 
 	@Override

--- a/src/main/java/appeng/block/qnb/BlockQuantumBase.java
+++ b/src/main/java/appeng/block/qnb/BlockQuantumBase.java
@@ -25,6 +25,9 @@ import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.world.World;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
 import appeng.block.AEBaseTileBlock;
 import appeng.client.render.blocks.RenderQNB;
 import appeng.core.features.AEFeature;
@@ -69,9 +72,10 @@ public abstract class BlockQuantumBase extends AEBaseTileBlock implements ICusto
 	}
 
 	@Override
-	protected Class<? extends RenderQNB> getRenderer()
+	@SideOnly( Side.CLIENT )
+	protected RenderQNB getRenderer()
 	{
-		return RenderQNB.class;
+		return new RenderQNB();
 	}
 
 }

--- a/src/main/java/appeng/block/solids/BlockQuartzGlass.java
+++ b/src/main/java/appeng/block/solids/BlockQuartzGlass.java
@@ -28,7 +28,6 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
 import appeng.block.AEBaseBlock;
-import appeng.client.render.BaseBlockRender;
 import appeng.client.render.blocks.RenderQuartzGlass;
 import appeng.core.features.AEFeature;
 import appeng.helpers.AEGlassMaterial;
@@ -46,9 +45,9 @@ public class BlockQuartzGlass extends AEBaseBlock
 
 	@Override
 	@SideOnly( Side.CLIENT )
-	public Class<? extends BaseBlockRender> getRenderer()
+	public RenderQuartzGlass getRenderer()
 	{
-		return RenderQuartzGlass.class;
+		return new RenderQuartzGlass();
 	}
 
 	@Override

--- a/src/main/java/appeng/block/solids/OreQuartz.java
+++ b/src/main/java/appeng/block/solids/OreQuartz.java
@@ -31,10 +31,12 @@ import net.minecraft.util.MathHelper;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
 import appeng.api.AEApi;
 import appeng.api.exceptions.MissingDefinition;
 import appeng.block.AEBaseBlock;
-import appeng.client.render.BaseBlockRender;
 import appeng.client.render.blocks.RenderQuartzOre;
 import appeng.core.features.AEFeature;
 
@@ -57,9 +59,10 @@ public class OreQuartz extends AEBaseBlock
 	}
 
 	@Override
-	protected Class<? extends BaseBlockRender> getRenderer()
+	@SideOnly( Side.CLIENT )
+	protected RenderQuartzOre getRenderer()
 	{
-		return RenderQuartzOre.class;
+		return new RenderQuartzOre();
 	}
 
 	@Override

--- a/src/main/java/appeng/block/spatial/BlockMatrixFrame.java
+++ b/src/main/java/appeng/block/spatial/BlockMatrixFrame.java
@@ -38,7 +38,6 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
 import appeng.block.AEBaseBlock;
-import appeng.client.render.BaseBlockRender;
 import appeng.client.render.blocks.RenderNull;
 import appeng.core.features.AEFeature;
 import appeng.helpers.ICustomCollision;
@@ -58,9 +57,10 @@ public class BlockMatrixFrame extends AEBaseBlock implements ICustomCollision
 	}
 
 	@Override
-	protected Class<? extends BaseBlockRender> getRenderer()
+	@SideOnly( Side.CLIENT )
+	protected RenderNull getRenderer()
 	{
-		return RenderNull.class;
+		return new RenderNull();
 	}
 
 	@Override

--- a/src/main/java/appeng/block/spatial/BlockSpatialPylon.java
+++ b/src/main/java/appeng/block/spatial/BlockSpatialPylon.java
@@ -25,8 +25,10 @@ import net.minecraft.block.Block;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
 import appeng.block.AEBaseTileBlock;
-import appeng.client.render.BaseBlockRender;
 import appeng.client.render.blocks.RenderSpatialPylon;
 import appeng.core.features.AEFeature;
 import appeng.helpers.AEGlassMaterial;
@@ -65,8 +67,9 @@ public class BlockSpatialPylon extends AEBaseTileBlock
 	}
 
 	@Override
-	protected Class<? extends BaseBlockRender> getRenderer()
+	@SideOnly( Side.CLIENT )
+	protected RenderSpatialPylon getRenderer()
 	{
-		return RenderSpatialPylon.class;
+		return new RenderSpatialPylon();
 	}
 }

--- a/src/main/java/appeng/block/storage/BlockChest.java
+++ b/src/main/java/appeng/block/storage/BlockChest.java
@@ -27,10 +27,12 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
 import appeng.api.AEApi;
 import appeng.api.storage.ICellHandler;
 import appeng.block.AEBaseTileBlock;
-import appeng.client.render.BaseBlockRender;
 import appeng.client.render.blocks.RenderMEChest;
 import appeng.core.features.AEFeature;
 import appeng.core.localization.PlayerMessages;
@@ -50,9 +52,10 @@ public class BlockChest extends AEBaseTileBlock
 	}
 
 	@Override
-	protected Class<? extends BaseBlockRender> getRenderer()
+	@SideOnly( Side.CLIENT )
+	protected RenderMEChest getRenderer()
 	{
-		return RenderMEChest.class;
+		return new RenderMEChest();
 	}
 
 	@Override

--- a/src/main/java/appeng/block/storage/BlockDrive.java
+++ b/src/main/java/appeng/block/storage/BlockDrive.java
@@ -26,8 +26,10 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
 import appeng.block.AEBaseTileBlock;
-import appeng.client.render.BaseBlockRender;
 import appeng.client.render.blocks.RenderDrive;
 import appeng.core.features.AEFeature;
 import appeng.core.sync.GuiBridge;
@@ -46,9 +48,10 @@ public class BlockDrive extends AEBaseTileBlock
 	}
 
 	@Override
-	protected Class<? extends BaseBlockRender> getRenderer()
+	@SideOnly( Side.CLIENT )
+	protected RenderDrive getRenderer()
 	{
-		return RenderDrive.class;
+		return new RenderDrive();
 	}
 
 	@Override

--- a/src/main/java/appeng/block/storage/BlockSkyChest.java
+++ b/src/main/java/appeng/block/storage/BlockSkyChest.java
@@ -43,7 +43,6 @@ import cpw.mods.fml.relauncher.SideOnly;
 
 import appeng.api.AEApi;
 import appeng.block.AEBaseTileBlock;
-import appeng.client.render.BaseBlockRender;
 import appeng.client.render.blocks.RenderBlockSkyChest;
 import appeng.core.features.AEFeature;
 import appeng.core.sync.GuiBridge;
@@ -83,9 +82,10 @@ public class BlockSkyChest extends AEBaseTileBlock implements ICustomCollision
 	}
 
 	@Override
-	protected Class<? extends BaseBlockRender> getRenderer()
+	@SideOnly( Side.CLIENT )
+	protected RenderBlockSkyChest getRenderer()
 	{
-		return RenderBlockSkyChest.class;
+		return new RenderBlockSkyChest();
 	}
 
 	@Override

--- a/src/main/java/appeng/client/gui/implementations/GuiCraftConfirm.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiCraftConfirm.java
@@ -383,9 +383,7 @@ public class GuiCraftConfirm extends AEBaseGui
 
 		if( this.tooltip >= 0 && dspToolTip.length() > 0 )
 		{
-			GL11.glPushAttrib( GL11.GL_ALL_ATTRIB_BITS );
 			this.drawTooltip( toolPosX, toolPosY + 10, 0, dspToolTip );
-			GL11.glPopAttrib();
 		}
 	}
 

--- a/src/main/java/appeng/client/gui/implementations/GuiCraftingCPU.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiCraftingCPU.java
@@ -334,9 +334,7 @@ public class GuiCraftingCPU extends AEBaseGui implements ISortSource
 
 		if( this.tooltip >= 0 && dspToolTip.length() > 0 )
 		{
-			GL11.glPushAttrib( GL11.GL_ALL_ATTRIB_BITS );
 			this.drawTooltip( toolPosX, toolPosY + 10, 0, dspToolTip );
-			GL11.glPopAttrib();
 		}
 	}
 

--- a/src/main/java/appeng/client/gui/implementations/GuiNetworkStatus.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiNetworkStatus.java
@@ -202,9 +202,7 @@ public class GuiNetworkStatus extends AEBaseGui implements ISortSource
 
 		if( this.tooltip >= 0 && toolTip.length() > 0 )
 		{
-			GL11.glPushAttrib( GL11.GL_ALL_ATTRIB_BITS );
 			this.drawTooltip( toolPosX, toolPosY + 10, 0, toolTip );
-			GL11.glPopAttrib();
 		}
 	}
 

--- a/src/main/java/appeng/client/render/AppEngRenderItem.java
+++ b/src/main/java/appeng/client/render/AppEngRenderItem.java
@@ -67,17 +67,21 @@ public class AppEngRenderItem extends RenderItem
 				final double health = is.getItem().getDurabilityForDisplay( is );
 				final int j1 = (int) Math.round( 13.0D - health * 13.0D );
 				final int k = (int) Math.round( 255.0D - health * 255.0D );
+
 				GL11.glDisable( GL11.GL_LIGHTING );
 				GL11.glDisable( GL11.GL_DEPTH_TEST );
 				GL11.glDisable( GL11.GL_TEXTURE_2D );
 				GL11.glDisable( GL11.GL_ALPHA_TEST );
 				GL11.glDisable( GL11.GL_BLEND );
+
 				final Tessellator tessellator = Tessellator.instance;
 				final int l = 255 - k << 16 | k << 8;
 				final int i1 = ( 255 - k ) / 4 << 16 | 16128;
+
 				this.renderQuad( tessellator, par4 + 2, par5 + 13, 13, 2, 0 );
 				this.renderQuad( tessellator, par4 + 2, par5 + 13, 12, 1, i1 );
 				this.renderQuad( tessellator, par4 + 2, par5 + 13, j1, 1, l );
+
 				GL11.glEnable( GL11.GL_ALPHA_TEST );
 				GL11.glEnable( GL11.GL_TEXTURE_2D );
 				GL11.glEnable( GL11.GL_LIGHTING );
@@ -88,19 +92,23 @@ public class AppEngRenderItem extends RenderItem
 			if( is.stackSize == 0 )
 			{
 				final String craftLabelText = AEConfig.instance.useTerminalUseLargeFont() ? GuiText.LargeFontCraft.getLocal() : GuiText.SmallFontCraft.getLocal();
+
 				GL11.glDisable( GL11.GL_LIGHTING );
 				GL11.glDisable( GL11.GL_DEPTH_TEST );
 				GL11.glPushMatrix();
 				GL11.glScaled( scaleFactor, scaleFactor, scaleFactor );
+
 				final int X = (int) ( ( (float) par4 + offset + 16.0f - fontRenderer.getStringWidth( craftLabelText ) * scaleFactor ) * inverseScaleFactor );
 				final int Y = (int) ( ( (float) par5 + offset + 16.0f - 7.0f * scaleFactor ) * inverseScaleFactor );
 				fontRenderer.drawStringWithShadow( craftLabelText, X, Y, 16777215 );
+
 				GL11.glPopMatrix();
 				GL11.glEnable( GL11.GL_LIGHTING );
 				GL11.glEnable( GL11.GL_DEPTH_TEST );
 			}
 
 			final long amount = this.aeStack != null ? this.aeStack.getStackSize() : is.stackSize;
+
 			if( amount != 0 )
 			{
 				final String stackSize = this.getToBeRenderedStackSize( amount );
@@ -109,9 +117,11 @@ public class AppEngRenderItem extends RenderItem
 				GL11.glDisable( GL11.GL_DEPTH_TEST );
 				GL11.glPushMatrix();
 				GL11.glScaled( scaleFactor, scaleFactor, scaleFactor );
+
 				final int X = (int) ( ( (float) par4 + offset + 16.0f - fontRenderer.getStringWidth( stackSize ) * scaleFactor ) * inverseScaleFactor );
 				final int Y = (int) ( ( (float) par5 + offset + 16.0f - 7.0f * scaleFactor ) * inverseScaleFactor );
 				fontRenderer.drawStringWithShadow( stackSize, X, Y, 16777215 );
+
 				GL11.glPopMatrix();
 				GL11.glEnable( GL11.GL_LIGHTING );
 				GL11.glEnable( GL11.GL_DEPTH_TEST );

--- a/src/main/java/appeng/client/render/BaseBlockRender.java
+++ b/src/main/java/appeng/client/render/BaseBlockRender.java
@@ -283,8 +283,8 @@ public class BaseBlockRender<B extends AEBaseBlock, T extends AEBaseTile>
 	public void renderInventory( final B block, final ItemStack item, final RenderBlocks renderer, final ItemRenderType type, final Object[] data )
 	{
 		final Tessellator tess = Tessellator.instance;
-
 		final BlockRenderInfo info = block.getRendererInstance();
+
 		if( info.isValid() )
 		{
 			if( block.hasSubtypes() )
@@ -330,8 +330,14 @@ public class BaseBlockRender<B extends AEBaseBlock, T extends AEBaseTile>
 
 	public void renderInvBlock( final EnumSet<ForgeDirection> sides, final B block, final ItemStack item, final Tessellator tess, final int color, final RenderBlocks renderer )
 	{
+		if( block == null )
+		{
+			return;
+		}
+
 		int meta = 0;
-		if( block != null && block.hasSubtypes() && item != null )
+
+		if( block.hasSubtypes() && item != null )
 		{
 			meta = item.getItemDamage();
 		}
@@ -400,6 +406,7 @@ public class BaseBlockRender<B extends AEBaseBlock, T extends AEBaseTile>
 				return o;
 			}
 		}
+
 		return ExtraBlockTextures.getMissing();
 	}
 
@@ -410,6 +417,7 @@ public class BaseBlockRender<B extends AEBaseBlock, T extends AEBaseTile>
 		final boolean o = renderer.renderStandardBlock( block, x, y, z );
 
 		this.postRenderInWorld( renderer );
+
 		return o;
 	}
 
@@ -418,6 +426,7 @@ public class BaseBlockRender<B extends AEBaseBlock, T extends AEBaseTile>
 
 		final BlockRenderInfo info = block.getRendererInstance();
 		final IOrientable te = this.getOrientable( block, world, x, y, z );
+
 		if( te != null )
 		{
 			final ForgeDirection forward = te.getForward();
@@ -450,13 +459,7 @@ public class BaseBlockRender<B extends AEBaseBlock, T extends AEBaseTile>
 		renderer.setRenderBounds( i / 16.0, j / 16.0, k / 16.0, l / 16.0, m / 16.0, n / 16.0 );
 	}
 
-	protected void renderBlockBounds( final RenderBlocks renderer,
-
-			double minX, double minY, double minZ,
-
-			double maxX, double maxY, double maxZ,
-
-			final ForgeDirection x, final ForgeDirection y, final ForgeDirection z )
+	protected void renderBlockBounds( final RenderBlocks renderer, double minX, double minY, double minZ, double maxX, double maxY, double maxZ, final ForgeDirection x, final ForgeDirection y, final ForgeDirection z )
 	{
 		minX /= 16.0;
 		minY /= 16.0;
@@ -763,6 +766,7 @@ public class BaseBlockRender<B extends AEBaseBlock, T extends AEBaseTile>
 		if( itemstack != null )
 		{
 			final EntityItem entityitem = new EntityItem( par1EntityItemFrame.getWorldObj(), 0.0D, 0.0D, 0.0D, itemstack );
+
 			entityitem.getEntityItem().stackSize = 1;
 
 			// set all this stuff and then do shit? meh?

--- a/src/main/java/appeng/client/render/BlockRenderInfo.java
+++ b/src/main/java/appeng/client/render/BlockRenderInfo.java
@@ -22,14 +22,16 @@ package appeng.client.render;
 import net.minecraft.util.IIcon;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import appeng.block.AEBaseBlock;
 import appeng.client.texture.FlippableIcon;
 import appeng.client.texture.TmpFlippableIcon;
+import appeng.tile.AEBaseTile;
 
 
 public class BlockRenderInfo
 {
 
-	private final BaseBlockRender rendererInstance;
+	private final BaseBlockRender<? extends AEBaseBlock, ? extends AEBaseTile> rendererInstance;
 	private final TmpFlippableIcon tmpTopIcon = new TmpFlippableIcon();
 	private final TmpFlippableIcon tmpBottomIcon = new TmpFlippableIcon();
 	private final TmpFlippableIcon tmpSouthIcon = new TmpFlippableIcon();
@@ -44,7 +46,7 @@ public class BlockRenderInfo
 	private FlippableIcon eastIcon = null;
 	private FlippableIcon westIcon = null;
 
-	public BlockRenderInfo( final BaseBlockRender inst )
+	public BlockRenderInfo( final BaseBlockRender<? extends AEBaseBlock, ? extends AEBaseTile> inst )
 	{
 		this.rendererInstance = inst;
 	}

--- a/src/main/java/appeng/client/render/BusRenderHelper.java
+++ b/src/main/java/appeng/client/render/BusRenderHelper.java
@@ -56,7 +56,7 @@ public final class BusRenderHelper implements IPartRenderHelper
 
 	private final BoundBoxCalculator bbc;
 	private final boolean noAlphaPass;
-	private final BaseBlockRender bbr;
+	private final BaseBlockRender<AEBaseBlock, AEBaseTile> bbr;
 	private final Optional<Block> maybeBlock;
 	private final Optional<AEBaseBlock> maybeBaseBlock;
 	private int renderingForPass;

--- a/src/main/java/appeng/client/render/BusRenderer.java
+++ b/src/main/java/appeng/client/render/BusRenderer.java
@@ -74,7 +74,7 @@ public class BusRenderer implements IItemRenderer
 		}
 
 		GL11.glPushMatrix();
-		GL11.glPushAttrib( GL11.GL_ALL_ATTRIB_BITS );
+		GL11.glPushAttrib( GL11.GL_ENABLE_BIT | GL11.GL_COLOR_BUFFER_BIT );
 		GL11.glEnable( GL11.GL_DEPTH_TEST );
 		GL11.glEnable( GL11.GL_TEXTURE_2D );
 		GL11.glEnable( GL11.GL_LIGHTING );
@@ -147,6 +147,7 @@ public class BusRenderer implements IItemRenderer
 		else
 		{
 			final IPart ip = this.getRenderer( item, (IPartItem) item.getItem() );
+
 			if( ip != null )
 			{
 				if( type == ItemRenderType.ENTITY )
@@ -171,6 +172,7 @@ public class BusRenderer implements IItemRenderer
 		final int id = ( Item.getIdFromItem( is.getItem() ) << Platform.DEF_OFFSET ) | is.getItemDamage();
 
 		IPart part = RENDER_PART.get( id );
+
 		if( part == null )
 		{
 			part = c.createPartFromItemStack( is );

--- a/src/main/java/appeng/client/render/CableRenderHelper.java
+++ b/src/main/java/appeng/client/render/CableRenderHelper.java
@@ -85,6 +85,7 @@ public class CableRenderHelper
 			 * snag list of boxes...
 			 */
 			final List<AxisAlignedBB> boxes = new ArrayList<AxisAlignedBB>();
+
 			for( final ForgeDirection s : ForgeDirection.values() )
 			{
 				final IPart part = cableBusContainer.getPart( s );
@@ -120,6 +121,7 @@ public class CableRenderHelper
 			for( final ForgeDirection s : ForgeDirection.VALID_DIRECTIONS )
 			{
 				final IFacadePart fPart = iFacadeContainer.getFacade( s );
+
 				if( fPart != null )
 				{
 					fPart.setThinFacades( useThinFacades );
@@ -214,6 +216,7 @@ public class CableRenderHelper
 		for( final ForgeDirection s : ForgeDirection.values() )
 		{
 			final IPart part = cableBusContainer.getPart( s );
+
 			if( part != null )
 			{
 				final ForgeDirection ax;

--- a/src/main/java/appeng/client/render/ItemRenderer.java
+++ b/src/main/java/appeng/client/render/ItemRenderer.java
@@ -46,7 +46,7 @@ public class ItemRenderer implements IItemRenderer
 	public void renderItem( final ItemRenderType type, final ItemStack item, final Object... data )
 	{
 		GL11.glPushMatrix();
-		GL11.glPushAttrib( GL11.GL_ALL_ATTRIB_BITS );
+		GL11.glPushAttrib( GL11.GL_ENABLE_BIT | GL11.GL_COLOR_BUFFER_BIT );
 		GL11.glEnable( GL11.GL_ALPHA_TEST );
 		GL11.glEnable( GL11.GL_DEPTH_TEST );
 		GL11.glEnable( GL11.GL_BLEND );

--- a/src/main/java/appeng/client/render/RenderBlocksWorkaround.java
+++ b/src/main/java/appeng/client/render/RenderBlocksWorkaround.java
@@ -689,7 +689,6 @@ public class RenderBlocksWorkaround extends RenderBlocks
 
 	private static class LightingCache implements ISimplifiedBundle
 	{
-
 		public final int[] aoXPos;
 		public final int[] aoXNeg;
 		public final int[] aoYPos;

--- a/src/main/java/appeng/client/render/SpatialSkyRender.java
+++ b/src/main/java/appeng/client/render/SpatialSkyRender.java
@@ -55,6 +55,7 @@ public class SpatialSkyRender extends IRenderHandler
 	public void render( final float partialTicks, final WorldClient world, final Minecraft mc )
 	{
 		final long now = System.currentTimeMillis();
+
 		if( now - this.cycle > 2000 )
 		{
 			this.cycle = now;
@@ -67,42 +68,37 @@ public class SpatialSkyRender extends IRenderHandler
 		fade /= 1000;
 		fade = 0.15f * ( 1.0f - Math.abs( ( fade - 1.0f ) * ( fade - 1.0f ) ) );
 
-		GL11.glPushAttrib( GL11.GL_ALL_ATTRIB_BITS );
-
 		GL11.glDisable( GL11.GL_FOG );
 		GL11.glDisable( GL11.GL_ALPHA_TEST );
 		GL11.glDisable( GL11.GL_BLEND );
 		GL11.glDepthMask( false );
 		GL11.glColor4f( 0.0f, 0.0f, 0.0f, 1.0f );
+
 		final Tessellator tessellator = Tessellator.instance;
 
 		for( int i = 0; i < 6; ++i )
 		{
 			GL11.glPushMatrix();
 
-			if( i == 1 )
+			switch( i )
 			{
-				GL11.glRotatef( 90.0F, 1.0F, 0.0F, 0.0F );
-			}
-
-			if( i == 2 )
-			{
-				GL11.glRotatef( -90.0F, 1.0F, 0.0F, 0.0F );
-			}
-
-			if( i == 3 )
-			{
-				GL11.glRotatef( 180.0F, 1.0F, 0.0F, 0.0F );
-			}
-
-			if( i == 4 )
-			{
-				GL11.glRotatef( 90.0F, 0.0F, 0.0F, 1.0F );
-			}
-
-			if( i == 5 )
-			{
-				GL11.glRotatef( -90.0F, 0.0F, 0.0F, 1.0F );
+				case 1:
+					GL11.glRotatef( 90.0F, 1.0F, 0.0F, 0.0F );
+					break;
+				case 2:
+					GL11.glRotatef( -90.0F, 1.0F, 0.0F, 0.0F );
+					break;
+				case 3:
+					GL11.glRotatef( 180.0F, 1.0F, 0.0F, 0.0F );
+					break;
+				case 4:
+					GL11.glRotatef( 90.0F, 0.0F, 0.0F, 1.0F );
+					break;
+				case 5:
+					GL11.glRotatef( -90.0F, 0.0F, 0.0F, 1.0F );
+					break;
+				default:
+					break;
 			}
 
 			tessellator.startDrawingQuads();
@@ -112,30 +108,29 @@ public class SpatialSkyRender extends IRenderHandler
 			tessellator.addVertexWithUV( 100.0D, -100.0D, 100.0D, 16.0D, 16.0D );
 			tessellator.addVertexWithUV( 100.0D, -100.0D, -100.0D, 16.0D, 0.0D );
 			tessellator.draw();
+
 			GL11.glPopMatrix();
 		}
 
-		GL11.glDepthMask( true );
-
 		if( fade > 0.0f )
 		{
-			GL11.glDisable( GL11.GL_FOG );
-			GL11.glDisable( GL11.GL_ALPHA_TEST );
 			GL11.glEnable( GL11.GL_BLEND );
-			GL11.glDepthMask( false );
-			GL11.glEnable( GL11.GL_FOG );
-			GL11.glDisable( GL11.GL_FOG );
-			GL11.glDisable( GL11.GL_ALPHA_TEST );
 			GL11.glDisable( GL11.GL_TEXTURE_2D );
+
 			OpenGlHelper.glBlendFunc( 770, 771, 1, 0 );
 			RenderHelper.disableStandardItemLighting();
-			GL11.glDepthMask( false );
 
+			GL11.glEnable( GL11.GL_TEXTURE_2D );
 			GL11.glColor4f( fade, fade, fade, 1.0f );
 			GL11.glCallList( this.dspList );
+
+			RenderHelper.enableStandardItemLighting();
 		}
 
-		GL11.glPopAttrib();
+		GL11.glEnable( GL11.GL_FOG );
+		GL11.glEnable( GL11.GL_ALPHA_TEST );
+		GL11.glEnable( GL11.GL_BLEND );
+		GL11.glDepthMask( true );
 
 		GL11.glColor4f( 1.0f, 1.0f, 1.0f, 1.0f );
 	}
@@ -159,6 +154,7 @@ public class SpatialSkyRender extends IRenderHandler
 				iX *= dist;
 				iY *= dist;
 				iZ *= dist;
+
 				final double x = iX * 100.0D;
 				final double y = iY * 100.0D;
 				final double z = iZ * 100.0D;
@@ -183,6 +179,7 @@ public class SpatialSkyRender extends IRenderHandler
 					final double d23 = d17 * d12 - d20 * d13;
 					final double d24 = d23 * d9 - d21 * d10;
 					final double d25 = d21 * d9 + d23 * d10;
+
 					tessellator.addVertex( x + d24, y + d22, z + d25 );
 				}
 			}

--- a/src/main/java/appeng/client/render/WorldRender.java
+++ b/src/main/java/appeng/client/render/WorldRender.java
@@ -20,6 +20,7 @@ package appeng.client.render;
 
 
 import java.util.HashMap;
+import java.util.Map;
 
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
@@ -41,7 +42,7 @@ public final class WorldRender implements ISimpleBlockRenderingHandler
 {
 
 	public static final WorldRender INSTANCE = new WorldRender();
-	private final HashMap<AEBaseBlock, BaseBlockRender> blockRenders = new HashMap<AEBaseBlock, BaseBlockRender>();
+	private final Map<AEBaseBlock, BaseBlockRender> blockRenders = new HashMap<AEBaseBlock, BaseBlockRender>();
 	private final int renderID = RenderingRegistry.getNextAvailableRenderId();
 	private final RenderBlocks renderer = new RenderBlocks();
 	private boolean hasError = false;

--- a/src/main/java/appeng/client/render/blocks/RenderBlockAssembler.java
+++ b/src/main/java/appeng/client/render/blocks/RenderBlockAssembler.java
@@ -203,42 +203,48 @@ public class RenderBlockAssembler extends BaseBlockRender<BlockMolecularAssemble
 	{
 		IIcon texture = null;
 
-		block.getRendererInstance().setTemporaryRenderIcon( texture = this.getConnectedCable( world, x, y, z, ForgeDirection.WEST, covered ) );
+		texture = this.getConnectedCable( world, x, y, z, ForgeDirection.WEST, covered );
+		block.getRendererInstance().setTemporaryRenderIcon( texture );
 		if( texture != null )
 		{
 			renderer.setRenderBounds( 0.0D, 0.5D - thickness, 0.5D - thickness, 0.5D - thickness - pull, 0.5D + thickness, 0.5D + thickness );
 			renderer.renderStandardBlock( block, x, y, z );
 		}
 
-		block.getRendererInstance().setTemporaryRenderIcon( texture = this.getConnectedCable( world, x, y, z, ForgeDirection.EAST, covered ) );
+		texture = this.getConnectedCable( world, x, y, z, ForgeDirection.EAST, covered );
+		block.getRendererInstance().setTemporaryRenderIcon( texture );
 		if( texture != null )
 		{
 			renderer.setRenderBounds( 0.5D + thickness + pull, 0.5D - thickness, 0.5D - thickness, 1.0D, 0.5D + thickness, 0.5D + thickness );
 			renderer.renderStandardBlock( block, x, y, z );
 		}
 
-		block.getRendererInstance().setTemporaryRenderIcon( texture = this.getConnectedCable( world, x, y, z, ForgeDirection.NORTH, covered ) );
+		texture = this.getConnectedCable( world, x, y, z, ForgeDirection.NORTH, covered );
+		block.getRendererInstance().setTemporaryRenderIcon( texture );
 		if( texture != null )
 		{
 			renderer.setRenderBounds( 0.5D - thickness, 0.5D - thickness, 0.0D, 0.5D + thickness, 0.5D + thickness, 0.5D - thickness - pull );
 			renderer.renderStandardBlock( block, x, y, z );
 		}
 
-		block.getRendererInstance().setTemporaryRenderIcon( texture = this.getConnectedCable( world, x, y, z, ForgeDirection.SOUTH, covered ) );
+		texture = this.getConnectedCable( world, x, y, z, ForgeDirection.SOUTH, covered );
+		block.getRendererInstance().setTemporaryRenderIcon( texture );
 		if( texture != null )
 		{
 			renderer.setRenderBounds( 0.5D - thickness, 0.5D - thickness, 0.5D + thickness + pull, 0.5D + thickness, 0.5D + thickness, 1.0D );
 			renderer.renderStandardBlock( block, x, y, z );
 		}
 
-		block.getRendererInstance().setTemporaryRenderIcon( texture = this.getConnectedCable( world, x, y, z, ForgeDirection.DOWN, covered ) );
+		texture = this.getConnectedCable( world, x, y, z, ForgeDirection.DOWN, covered );
+		block.getRendererInstance().setTemporaryRenderIcon( texture );
 		if( texture != null )
 		{
 			renderer.setRenderBounds( 0.5D - thickness, 0.0D, 0.5D - thickness, 0.5D + thickness, 0.5D - thickness - pull, 0.5D + thickness );
 			renderer.renderStandardBlock( block, x, y, z );
 		}
 
-		block.getRendererInstance().setTemporaryRenderIcon( texture = this.getConnectedCable( world, x, y, z, ForgeDirection.UP, covered ) );
+		texture = this.getConnectedCable( world, x, y, z, ForgeDirection.UP, covered );
+		block.getRendererInstance().setTemporaryRenderIcon( texture );
 		if( texture != null )
 		{
 			renderer.setRenderBounds( 0.5D - thickness, 0.5D + thickness + pull, 0.5D - thickness, 0.5D + thickness, 1.0D, 0.5D + thickness );
@@ -251,6 +257,7 @@ public class RenderBlockAssembler extends BaseBlockRender<BlockMolecularAssemble
 	private IIcon getConnectedCable( final IBlockAccess world, final int x, final int y, final int z, final ForgeDirection side, final boolean covered )
 	{
 		final int tileYPos = y + side.offsetY;
+
 		if( -1 < tileYPos && tileYPos < 256 )
 		{
 			final TileEntity ne = world.getTileEntity( x + side.offsetX, tileYPos, z + side.offsetZ );
@@ -258,9 +265,11 @@ public class RenderBlockAssembler extends BaseBlockRender<BlockMolecularAssemble
 			{
 				final IPartHost ph = (IPartHost) ne;
 				final IPart pcx = ph.getPart( ForgeDirection.UNKNOWN );
+
 				if( pcx instanceof PartCable )
 				{
 					final PartCable pc = (PartCable) pcx;
+
 					if( pc.isConnected( side.getOpposite() ) )
 					{
 						if( covered )

--- a/src/main/java/appeng/client/render/blocks/RenderBlockCharger.java
+++ b/src/main/java/appeng/client/render/blocks/RenderBlockCharger.java
@@ -124,48 +124,59 @@ public class RenderBlockCharger extends BaseBlockRender<BlockCharger, TileCharge
 	@Override
 	public void renderTile( final BlockCharger block, final TileCharger tile, final Tessellator tess, final double x, final double y, final double z, final float f, final RenderBlocks renderer )
 	{
+		if( tile == null )
+		{
+			return;
+		}
+
 		final ItemStack sis = tile.getStackInSlot( 0 );
 
-		if( sis != null )
+		if( sis == null )
 		{
-			GL11.glPushMatrix();
-			this.applyTESRRotation( x, y, z, tile.getForward(), tile.getUp() );
-
-			try
-			{
-				GL11.glTranslatef( 0.5f, 0.45f, 0.5f );
-				GL11.glScalef( 1.0f / 1.1f, 1.0f / 1.1f, 1.0f / 1.1f );
-				GL11.glScalef( 1.0f, 1.0f, 1.0f );
-
-				final Block blk = Block.getBlockFromItem( sis.getItem() );
-				if( sis.getItemSpriteNumber() == 0 && block != null && RenderBlocks.renderItemIn3d( blk.getRenderType() ) )
-				{
-					GL11.glRotatef( 25.0f, 1.0f, 0.0f, 0.0f );
-					GL11.glRotatef( 15.0f, 0.0f, 1.0f, 0.0f );
-					GL11.glRotatef( 30.0f, 0.0f, 1.0f, 0.0f );
-				}
-
-				// << 20 | light << 4;
-				final int br = tile.getWorldObj().getLightBrightnessForSkyBlocks( tile.xCoord, tile.yCoord, tile.zCoord, 0 );
-				final int var11 = br % 65536;
-				final int var12 = br / 65536;
-
-				OpenGlHelper.setLightmapTextureCoords( OpenGlHelper.lightmapTexUnit, var11, var12 );
-
-				GL11.glColor4f( 1.0F, 1.0F, 1.0F, 1.0F );
-
-				GL11.glDisable( GL11.GL_LIGHTING );
-				GL11.glDisable( GL12.GL_RESCALE_NORMAL );
-				tess.setColorOpaque_F( 1.0f, 1.0f, 1.0f );
-
-				this.doRenderItem( sis, tile );
-			}
-			catch( final Exception err )
-			{
-				AELog.error( err );
-			}
-
-			GL11.glPopMatrix();
+			return;
 		}
+
+		GL11.glPushMatrix();
+		this.applyTESRRotation( x, y, z, tile.getForward(), tile.getUp() );
+
+		try
+		{
+			GL11.glTranslatef( 0.5f, 0.45f, 0.5f );
+			GL11.glScalef( 1.0f / 1.1f, 1.0f / 1.1f, 1.0f / 1.1f );
+			GL11.glScalef( 1.0f, 1.0f, 1.0f );
+
+			final Block blk = Block.getBlockFromItem( sis.getItem() );
+
+			if( sis.getItemSpriteNumber() == 0 && block != null && RenderBlocks.renderItemIn3d( blk.getRenderType() ) )
+			{
+				GL11.glRotatef( 25.0f, 1.0f, 0.0f, 0.0f );
+				GL11.glRotatef( 15.0f, 0.0f, 1.0f, 0.0f );
+				GL11.glRotatef( 30.0f, 0.0f, 1.0f, 0.0f );
+			}
+			final int br = tile.getWorldObj().getLightBrightnessForSkyBlocks( tile.xCoord, tile.yCoord, tile.zCoord, 0 );
+			final int var11 = br % 65536;
+			final int var12 = br / 65536;
+
+			OpenGlHelper.setLightmapTextureCoords( OpenGlHelper.lightmapTexUnit, var11, var12 );
+
+			GL11.glColor4f( 1.0F, 1.0F, 1.0F, 1.0F );
+
+			GL11.glDisable( GL11.GL_LIGHTING );
+			GL11.glDisable( GL12.GL_RESCALE_NORMAL );
+			tess.setColorOpaque_F( 1.0f, 1.0f, 1.0f );
+
+			this.doRenderItem( sis, tile );
+		}
+		catch( final Exception err )
+		{
+			AELog.error( err );
+		}
+		finally
+		{
+			GL11.glEnable( GL12.GL_RESCALE_NORMAL );
+			GL11.glEnable( GL11.GL_LIGHTING );
+		}
+
+		GL11.glPopMatrix();
 	}
 }

--- a/src/main/java/appeng/client/render/blocks/RenderBlockController.java
+++ b/src/main/java/appeng/client/render/blocks/RenderBlockController.java
@@ -124,6 +124,7 @@ public class RenderBlockController extends BaseBlockRender<BlockController, Tile
 		else if( ( xx ? 1 : 0 ) + ( yy ? 1 : 0 ) + ( zz ? 1 : 0 ) >= 2 )
 		{
 			final int v = ( Math.abs( x ) + Math.abs( y ) + Math.abs( z ) ) % 2;
+
 			renderer.uvRotateEast = renderer.uvRotateBottom = renderer.uvRotateNorth = renderer.uvRotateSouth = renderer.uvRotateTop = renderer.uvRotateWest = 0;
 
 			if( v == 0 )
@@ -140,6 +141,7 @@ public class RenderBlockController extends BaseBlockRender<BlockController, Tile
 			if( hasPower )
 			{
 				blk.getRendererInstance().setTemporaryRenderIcon( ExtraBlockTextures.BlockControllerPowered.getIcon() );
+
 				if( isConflict )
 				{
 					lights = ExtraBlockTextures.BlockControllerConflict;
@@ -156,6 +158,7 @@ public class RenderBlockController extends BaseBlockRender<BlockController, Tile
 		}
 
 		final boolean out = renderer.renderStandardBlock( blk, x, y, z );
+
 		if( lights != null )
 		{
 			Tessellator.instance.setColorOpaque_F( 1.0f, 1.0f, 1.0f );

--- a/src/main/java/appeng/client/render/blocks/RenderBlockCraftingCPUMonitor.java
+++ b/src/main/java/appeng/client/render/blocks/RenderBlockCraftingCPUMonitor.java
@@ -68,8 +68,7 @@ public class RenderBlockCraftingCPUMonitor extends RenderBlockCraftingCPU<BlockC
 				tile.setUpdateList( true );
 				tile.setDisplayList( GLAllocation.generateDisplayLists( 1 ) );
 			}
-
-			if( ais != null )
+			else
 			{
 				GL11.glPushMatrix();
 				GL11.glTranslated( x + 0.5, y + 0.5, z + 0.5 );
@@ -97,8 +96,8 @@ public class RenderBlockCraftingCPUMonitor extends RenderBlockCraftingCPU<BlockC
 
 		ForgeDirection walrus = side.offsetY != 0 ? ForgeDirection.SOUTH : ForgeDirection.UP;
 		int spin = 0;
-
 		int max = 5;
+
 		while( walrus != cmt.getUp() && max > 0 )
 		{
 			max--;
@@ -107,50 +106,43 @@ public class RenderBlockCraftingCPUMonitor extends RenderBlockCraftingCPU<BlockC
 		}
 		max--;
 
-		GL11.glPushAttrib( GL11.GL_ALL_ATTRIB_BITS );
 		GL11.glTranslated( side.offsetX * 0.69, side.offsetY * 0.69, side.offsetZ * 0.69 );
 
 		final float scale = 0.7f;
 		GL11.glScalef( scale, scale, scale );
 
-		if( side == ForgeDirection.UP )
+		switch( side )
 		{
-			GL11.glScalef( 1.0f, -1.0f, 1.0f );
-			GL11.glRotatef( 90.0f, 1.0f, 0.0f, 0.0f );
-			GL11.glRotatef( spin * 90.0F, 0, 0, 1 );
+			case UP:
+				GL11.glScalef( 1.0f, -1.0f, 1.0f );
+				GL11.glRotatef( 90.0f, 1.0f, 0.0f, 0.0f );
+				GL11.glRotatef( spin * 90.0F, 0, 0, 1 );
+				break;
+			case DOWN:
+				GL11.glScalef( 1.0f, -1.0f, 1.0f );
+				GL11.glRotatef( -90.0f, 1.0f, 0.0f, 0.0f );
+				GL11.glRotatef( spin * -90.0F, 0, 0, 1 );
+				break;
+			case EAST:
+				GL11.glScalef( -1.0f, -1.0f, -1.0f );
+				GL11.glRotatef( -90.0f, 0.0f, 1.0f, 0.0f );
+				break;
+			case WEST:
+				GL11.glScalef( -1.0f, -1.0f, -1.0f );
+				GL11.glRotatef( 90.0f, 0.0f, 1.0f, 0.0f );
+				break;
+			case NORTH:
+				GL11.glScalef( -1.0f, -1.0f, -1.0f );
+				break;
+			case SOUTH:
+				GL11.glScalef( -1.0f, -1.0f, -1.0f );
+				GL11.glRotatef( 180.0f, 0.0f, 1.0f, 0.0f );
+				break;
+
+			default:
+				break;
 		}
 
-		if( side == ForgeDirection.DOWN )
-		{
-			GL11.glScalef( 1.0f, -1.0f, 1.0f );
-			GL11.glRotatef( -90.0f, 1.0f, 0.0f, 0.0f );
-			GL11.glRotatef( spin * -90.0F, 0, 0, 1 );
-		}
-
-		if( side == ForgeDirection.EAST )
-		{
-			GL11.glScalef( -1.0f, -1.0f, -1.0f );
-			GL11.glRotatef( -90.0f, 0.0f, 1.0f, 0.0f );
-		}
-
-		if( side == ForgeDirection.WEST )
-		{
-			GL11.glScalef( -1.0f, -1.0f, -1.0f );
-			GL11.glRotatef( 90.0f, 0.0f, 1.0f, 0.0f );
-		}
-
-		if( side == ForgeDirection.NORTH )
-		{
-			GL11.glScalef( -1.0f, -1.0f, -1.0f );
-		}
-
-		if( side == ForgeDirection.SOUTH )
-		{
-			GL11.glScalef( -1.0f, -1.0f, -1.0f );
-			GL11.glRotatef( 180.0f, 0.0f, 1.0f, 0.0f );
-		}
-
-		GL11.glPushMatrix();
 		try
 		{
 			final ItemStack sis = ais.getItemStack();
@@ -159,6 +151,7 @@ public class RenderBlockCraftingCPUMonitor extends RenderBlockCraftingCPU<BlockC
 			final int br = 16 << 20 | 16 << 4;
 			final int var11 = br % 65536;
 			final int var12 = br / 65536;
+
 			OpenGlHelper.setLightmapTextureCoords( OpenGlHelper.lightmapTexUnit, var11 * 0.8F, var12 * 0.8F );
 
 			GL11.glColor4f( 1.0F, 1.0F, 1.0F, 1.0F );
@@ -174,8 +167,11 @@ public class RenderBlockCraftingCPUMonitor extends RenderBlockCraftingCPU<BlockC
 		{
 			AELog.error( e );
 		}
-
-		GL11.glPopMatrix();
+		finally
+		{
+			GL11.glEnable( GL12.GL_RESCALE_NORMAL );
+			GL11.glEnable( GL11.GL_LIGHTING );
+		}
 
 		GL11.glTranslatef( 0.0f, 0.14f, -0.24f );
 		GL11.glScalef( 1.0f / 62.0f, 1.0f / 62.0f, 1.0f / 62.0f );
@@ -185,9 +181,8 @@ public class RenderBlockCraftingCPUMonitor extends RenderBlockCraftingCPU<BlockC
 
 		final FontRenderer fr = Minecraft.getMinecraft().fontRenderer;
 		final int width = fr.getStringWidth( renderedStackSize );
+
 		GL11.glTranslatef( -0.5f * width, 0.0f, -1.0f );
 		fr.drawString( renderedStackSize, 0, 0, 0 );
-
-		GL11.glPopAttrib();
 	}
 }

--- a/src/main/java/appeng/client/render/blocks/RenderBlockCrank.java
+++ b/src/main/java/appeng/client/render/blocks/RenderBlockCrank.java
@@ -71,7 +71,6 @@ public class RenderBlockCrank extends BaseBlockRender<BlockCrank, TileCrank>
 		{
 			return;
 		}
-
 		Minecraft.getMinecraft().getTextureManager().bindTexture( TextureMap.locationBlocksTexture );
 		RenderHelper.disableStandardItemLighting();
 
@@ -84,6 +83,7 @@ public class RenderBlockCrank extends BaseBlockRender<BlockCrank, TileCrank>
 			GL11.glShadeModel( GL11.GL_FLAT );
 		}
 
+		GL11.glCullFace( GL11.GL_FRONT );
 		GL11.glColor4f( 1.0f, 1.0f, 1.0f, 1.0f );
 
 		this.applyTESRRotation( x, y, z, tile.getForward(), tile.getUp() );
@@ -107,6 +107,9 @@ public class RenderBlockCrank extends BaseBlockRender<BlockCrank, TileCrank>
 
 		tess.draw();
 		tess.setTranslation( 0, 0, 0 );
+
+		GL11.glCullFace( GL11.GL_BACK );
+
 		RenderHelper.enableStandardItemLighting();
 	}
 }

--- a/src/main/java/appeng/client/render/blocks/RenderBlockEnergyCube.java
+++ b/src/main/java/appeng/client/render/blocks/RenderBlockEnergyCube.java
@@ -67,6 +67,7 @@ public class RenderBlockEnergyCube extends BaseBlockRender<BlockEnergyCell, Tile
 		final int meta = world.getBlockMetadata( x, y, z );
 
 		renderer.overrideBlockTexture = blk.getIcon( 0, meta );
+
 		final boolean out = renderer.renderStandardBlock( blk, x, y, z );
 		renderer.overrideBlockTexture = null;
 

--- a/src/main/java/appeng/client/render/blocks/RenderBlockInscriber.java
+++ b/src/main/java/appeng/client/render/blocks/RenderBlockInscriber.java
@@ -108,13 +108,14 @@ public class RenderBlockInscriber extends BaseBlockRender<BlockInscriber, TileIn
 	@Override
 	public boolean renderInWorld( final BlockInscriber block, final IBlockAccess world, final int x, final int y, final int z, final RenderBlocks renderer )
 	{
-		this.preRenderInWorld( block, world, x, y, z, renderer );
-
 		final IOrientable te = this.getOrientable( block, world, x, y, z );
+
 		if( te == null )
 		{
 			return false;
 		}
+
+		this.preRenderInWorld( block, world, x, y, z, renderer );
 
 		final ForgeDirection fdy = te.getUp();
 		final ForgeDirection fdz = te.getForward();
@@ -278,6 +279,7 @@ public class RenderBlockInscriber extends BaseBlockRender<BlockInscriber, TileIn
 		if( sis != null )
 		{
 			sis = sis.copy();
+
 			GL11.glPushMatrix();
 			// fix to inscriber
 			this.applyTESRRotation( x, y, z, tile.getForward(), tile.getUp() );
@@ -318,6 +320,11 @@ public class RenderBlockInscriber extends BaseBlockRender<BlockInscriber, TileIn
 			catch( final Exception err )
 			{
 				AELog.error( err );
+			}
+			finally
+			{
+				GL11.glEnable( GL11.GL_LIGHTING );
+				GL11.glEnable( GL12.GL_RESCALE_NORMAL );
 			}
 
 			GL11.glPopMatrix();

--- a/src/main/java/appeng/client/render/blocks/RenderBlockInscriber.java
+++ b/src/main/java/appeng/client/render/blocks/RenderBlockInscriber.java
@@ -58,7 +58,6 @@ public class RenderBlockInscriber extends BaseBlockRender<BlockInscriber, TileIn
 {
 	private static final float ITEM_RENDER_SCALE = 1.0f / 1.1f;
 
-
 	public RenderBlockInscriber()
 	{
 		super( true, 30 );
@@ -152,6 +151,8 @@ public class RenderBlockInscriber extends BaseBlockRender<BlockInscriber, TileIn
 	@Override
 	public void renderTile( final BlockInscriber block, final TileInscriber tile, final Tessellator tess, final double x, final double y, final double z, final float f, final RenderBlocks renderer )
 	{
+		// render inscriber
+
 		GL11.glPushMatrix();
 		this.applyTESRRotation( x, y, z, tile.getForward(), tile.getUp() );
 
@@ -224,10 +225,10 @@ public class RenderBlockInscriber extends BaseBlockRender<BlockInscriber, TileIn
 
 		tess.draw();
 
-		GL11.glCullFace( GL11.GL_BACK );
-		GL11.glEnable( GL11.GL_LIGHTING );
-		GL11.glEnable( GL12.GL_RESCALE_NORMAL );
 		GL11.glPopMatrix();
+
+		// render items.
+		GL11.glColor4f( 1.0F, 1.0F, 1.0F, 1.0F );
 
 		int items = 0;
 		if( tile.getStackInSlot( 0 ) != null )
@@ -260,18 +261,14 @@ public class RenderBlockInscriber extends BaseBlockRender<BlockInscriber, TileIn
 		}
 		else
 		{
-			GL11.glColor4f( 1.0F, 1.0F, 1.0F, 1.0F );
-
-			GL11.glDisable( GL11.GL_LIGHTING );
-			GL11.glDisable( GL12.GL_RESCALE_NORMAL );
-
 			this.renderItem( tile.getStackInSlot( 0 ), press, block, tile, tess, x, y, z, f, renderer );
 			this.renderItem( tile.getStackInSlot( 1 ), -press, block, tile, tess, x, y, z, f, renderer );
 			this.renderItem( tile.getStackInSlot( 2 ), 0.0f, block, tile, tess, x, y, z, f, renderer );
-
-			GL11.glEnable( GL11.GL_LIGHTING );
-			GL11.glEnable( GL12.GL_RESCALE_NORMAL );
 		}
+
+		GL11.glEnable( GL11.GL_LIGHTING );
+		GL11.glEnable( GL12.GL_RESCALE_NORMAL );
+		GL11.glCullFace( GL11.GL_BACK );
 	}
 
 	private void renderItem( ItemStack sis, final float o, final AEBaseBlock block, final AEBaseTile tile, final Tessellator tess, final double x, final double y, final double z, final float f, final RenderBlocks renderer )
@@ -291,7 +288,6 @@ public class RenderBlockInscriber extends BaseBlockRender<BlockInscriber, TileIn
 
 				// set scale
 				GL11.glScalef( ITEM_RENDER_SCALE, ITEM_RENDER_SCALE, ITEM_RENDER_SCALE );
-				GL11.glScalef( 1.0f, 1.0f, 1.0f );
 
 				final Block blk = Block.getBlockFromItem( sis.getItem() );
 
@@ -299,12 +295,15 @@ public class RenderBlockInscriber extends BaseBlockRender<BlockInscriber, TileIn
 				if( sis.getItemSpriteNumber() == 0 && block != null && RenderBlocks.renderItemIn3d( blk.getRenderType() ) )
 				{
 					// rotate block in angle to make it more plastic
-					GL11.glRotatef( 25.0f, 1.0f, 0.0f, 0.0f );
-					GL11.glRotatef( 15.0f, 0.0f, 1.0f, 0.0f );
-					GL11.glRotatef( 30.0f, 0.0f, 1.0f, 0.0f );
+					GL11.glRotatef( 22.5f, 1f, 0f, 0f );
+					GL11.glRotatef( -33.75f, 0f, 1f, 0f );
 				}
-
-				GL11.glRotatef( 90.0f, 1, 0, 0 );
+				else
+				{
+					// rotate item to match the inventory icon orientation.
+					GL11.glRotatef( -90.0f, 1f, 0f, 0f );
+					GL11.glRotatef( 180.0f, 0f, 1f, 0f );
+				}
 
 				// << 20 | light << 4;
 				final int br = tile.getWorldObj().getLightBrightnessForSkyBlocks( tile.xCoord, tile.yCoord, tile.zCoord, 0 );
@@ -320,11 +319,6 @@ public class RenderBlockInscriber extends BaseBlockRender<BlockInscriber, TileIn
 			catch( final Exception err )
 			{
 				AELog.error( err );
-			}
-			finally
-			{
-				GL11.glEnable( GL11.GL_LIGHTING );
-				GL11.glEnable( GL12.GL_RESCALE_NORMAL );
 			}
 
 			GL11.glPopMatrix();

--- a/src/main/java/appeng/client/render/blocks/RenderBlockPaint.java
+++ b/src/main/java/appeng/client/render/blocks/RenderBlockPaint.java
@@ -55,6 +55,7 @@ public class RenderBlockPaint extends BaseBlockRender<BlockPaint, TilePaint>
 	{
 		final TilePaint tp = imb.getTileEntity( world, x, y, z );
 		boolean out = false;
+
 		if( tp != null )
 		{
 			// super.renderInWorld( imb, world, x, y, z, renderer );

--- a/src/main/java/appeng/client/render/blocks/RenderBlockQuartzAccelerator.java
+++ b/src/main/java/appeng/client/render/blocks/RenderBlockQuartzAccelerator.java
@@ -42,17 +42,22 @@ public class RenderBlockQuartzAccelerator extends BaseBlockRender<BlockQuartzGro
 	public boolean renderInWorld( final BlockQuartzGrowthAccelerator blk, final IBlockAccess world, final int x, final int y, final int z, final RenderBlocks renderer )
 	{
 		final TileEntity te = world.getTileEntity( x, y, z );
+
 		if( te instanceof TileQuartzGrowthAccelerator )
 		{
-			if( ( (TileQuartzGrowthAccelerator) te ).isPowered() )
+			final TileQuartzGrowthAccelerator tileCGA = (TileQuartzGrowthAccelerator) te;
+
+			if( tileCGA.isPowered() )
 			{
 				final IIcon top_Bottom = ExtraBlockTextures.BlockQuartzGrowthAcceleratorOn.getIcon();
 				final IIcon side = ExtraBlockTextures.BlockQuartzGrowthAcceleratorSideOn.getIcon();
+
 				blk.getRendererInstance().setTemporaryRenderIcons( top_Bottom, top_Bottom, side, side, side, side );
 			}
 		}
 
 		final boolean out = super.renderInWorld( blk, world, x, y, z, renderer );
+
 		blk.getRendererInstance().setTemporaryRenderIcon( null );
 
 		return out;

--- a/src/main/java/appeng/client/render/blocks/RenderBlockSkyChest.java
+++ b/src/main/java/appeng/client/render/blocks/RenderBlockSkyChest.java
@@ -85,12 +85,7 @@ public class RenderBlockSkyChest extends BaseBlockRender<BlockSkyChest, TileSkyC
 	@Override
 	public void renderTile( final BlockSkyChest block, final TileSkyChest skyChest, final Tessellator tess, final double x, final double y, final double z, final float partialTick, final RenderBlocks renderer )
 	{
-		if( skyChest == null )
-		{
-			return;
-		}
-
-		if( !skyChest.hasWorldObj() )
+		if( skyChest == null || !skyChest.hasWorldObj() )
 		{
 			return;
 		}

--- a/src/main/java/appeng/client/render/blocks/RenderBlockSkyCompass.java
+++ b/src/main/java/appeng/client/render/blocks/RenderBlockSkyCompass.java
@@ -43,6 +43,7 @@ import appeng.tile.misc.TileSkyCompass;
 
 public class RenderBlockSkyCompass extends BaseBlockRender<BlockSkyCompass, TileSkyCompass>
 {
+	private static final ResourceLocation TEXTURE_SKY_COMPASS = new ResourceLocation( "appliedenergistics2", "textures/models/compass.png" );
 
 	private final ModelCompass model = new ModelCompass();
 
@@ -57,8 +58,8 @@ public class RenderBlockSkyCompass extends BaseBlockRender<BlockSkyCompass, Tile
 		if( type == ItemRenderType.INVENTORY )
 		{
 			boolean isGood = false;
-
 			final IInventory inv = Minecraft.getMinecraft().thePlayer.inventory;
+
 			for( int x = 0; x < inv.getSizeInventory(); x++ )
 			{
 				if( inv.getStackInSlot( x ) == is )
@@ -76,9 +77,7 @@ public class RenderBlockSkyCompass extends BaseBlockRender<BlockSkyCompass, Tile
 		GL11.glEnable( GL12.GL_RESCALE_NORMAL );
 		GL11.glColor4f( 1.0F, 1.0F, 1.0F, 1.0F );
 
-		final ResourceLocation loc = new ResourceLocation( "appliedenergistics2", "textures/models/compass.png" );
-
-		Minecraft.getMinecraft().getTextureManager().bindTexture( loc );
+		Minecraft.getMinecraft().getTextureManager().bindTexture( TEXTURE_SKY_COMPASS );
 
 		if( type == ItemRenderType.ENTITY )
 		{
@@ -108,6 +107,7 @@ public class RenderBlockSkyCompass extends BaseBlockRender<BlockSkyCompass, Tile
 		}
 
 		long now = System.currentTimeMillis();
+
 		if( type == ItemRenderType.EQUIPPED_FIRST_PERSON || type == ItemRenderType.INVENTORY || type == ItemRenderType.EQUIPPED )
 		{
 			EntityPlayer p = Minecraft.getMinecraft().thePlayer;
@@ -145,12 +145,14 @@ public class RenderBlockSkyCompass extends BaseBlockRender<BlockSkyCompass, Tile
 					{
 						final float offRads = rYaw / 180.0f * (float) Math.PI;
 						final float adjustment = (float) Math.PI * 0.74f;
+
 						this.model.renderAll( (float) this.flipidiy( cr.getRad() + offRads + adjustment ) );
 					}
 					else
 					{
 						final float offRads = rYaw / 180.0f * (float) Math.PI;
 						final float adjustment = (float) Math.PI * -0.74f;
+
 						this.model.renderAll( (float) this.flipidiy( cr.getRad() + offRads + adjustment ) );
 					}
 				}
@@ -194,9 +196,7 @@ public class RenderBlockSkyCompass extends BaseBlockRender<BlockSkyCompass, Tile
 		GL11.glColor4f( 1.0F, 1.0F, 1.0F, 1.0F );
 		GL11.glCullFace( GL11.GL_FRONT );
 
-		final ResourceLocation loc = new ResourceLocation( "appliedenergistics2", "textures/models/compass.png" );
-
-		Minecraft.getMinecraft().getTextureManager().bindTexture( loc );
+		Minecraft.getMinecraft().getTextureManager().bindTexture( TEXTURE_SKY_COMPASS );
 
 		this.applyTESRRotation( x, y, z, skyCompass.getUp(), skyCompass.getForward() );
 
@@ -204,8 +204,8 @@ public class RenderBlockSkyCompass extends BaseBlockRender<BlockSkyCompass, Tile
 		GL11.glTranslatef( 0.5F, -1.5F, -0.5F );
 
 		long now = System.currentTimeMillis();
-
 		CompassResult cr = null;
+
 		if( skyCompass.getForward() == ForgeDirection.UP || skyCompass.getForward() == ForgeDirection.DOWN )
 		{
 			cr = CompassManager.INSTANCE.getCompassDirection( 0, skyCompass.xCoord, skyCompass.yCoord, skyCompass.zCoord );

--- a/src/main/java/appeng/client/render/blocks/RenderBlockWireless.java
+++ b/src/main/java/appeng/client/render/blocks/RenderBlockWireless.java
@@ -64,6 +64,7 @@ public class RenderBlockWireless extends BaseBlockRender<BlockWireless, TileWire
 		this.centerZ = 0;
 		this.hasChan = false;
 		this.hasPower = false;
+
 		final BlockRenderInfo ri = blk.getRendererInstance();
 		final Tessellator tess = Tessellator.instance;
 
@@ -111,6 +112,7 @@ public class RenderBlockWireless extends BaseBlockRender<BlockWireless, TileWire
 	{
 		final TileWireless tw = blk.getTileEntity( world, x, y, z );
 		this.blk = blk;
+
 		if( tw != null )
 		{
 			this.hasChan = ( tw.getClientFlags() & ( TileWireless.POWERED_FLAG | TileWireless.CHANNEL_FLAG ) ) == ( TileWireless.POWERED_FLAG | TileWireless.CHANNEL_FLAG );

--- a/src/main/java/appeng/client/render/blocks/RenderDrive.java
+++ b/src/main/java/appeng/client/render/blocks/RenderDrive.java
@@ -58,15 +58,15 @@ public class RenderDrive extends BaseBlockRender<BlockDrive, TileDrive>
 	public boolean renderInWorld( final BlockDrive imb, final IBlockAccess world, final int x, final int y, final int z, final RenderBlocks renderer )
 	{
 		final TileDrive sp = imb.getTileEntity( world, x, y, z );
-		renderer.setRenderBounds( 0, 0, 0, 1, 1, 1 );
-
 		final ForgeDirection up = sp.getUp();
 		final ForgeDirection forward = sp.getForward();
 		final ForgeDirection west = Platform.crossProduct( forward, up );
 
-		final boolean result = super.renderInWorld( imb, world, x, y, z, renderer );
-		final Tessellator tess = Tessellator.instance;
+		renderer.setRenderBounds( 0, 0, 0, 1, 1, 1 );
 
+		final boolean result = super.renderInWorld( imb, world, x, y, z, renderer );
+
+		final Tessellator tess = Tessellator.instance;
 		final IIcon ico = ExtraBlockTextures.MEStorageCellTextures.getIcon();
 
 		final int b = world.getLightBrightnessForSkyBlocks( x + forward.offsetX, y + forward.offsetY, z + forward.offsetZ, 0 );
@@ -76,6 +76,7 @@ public class RenderDrive extends BaseBlockRender<BlockDrive, TileDrive>
 			for( int xx = 0; xx < 2; xx++ )
 			{
 				final int stat = sp.getCellStatus( yy * 2 + ( 1 - xx ) );
+
 				this.selectFace( renderer, west, up, forward, 2 + xx * 7, 7 + xx * 7, 1 + yy * 3, 3 + yy * 3 );
 
 				int spin = 0;

--- a/src/main/java/appeng/client/render/blocks/RenderMEChest.java
+++ b/src/main/java/appeng/client/render/blocks/RenderMEChest.java
@@ -53,6 +53,7 @@ public class RenderMEChest extends BaseBlockRender<BlockChest, TileChest>
 	public void renderInventory( final BlockChest block, final ItemStack is, final RenderBlocks renderer, final ItemRenderType type, final Object[] obj )
 	{
 		Tessellator.instance.setBrightness( 0 );
+
 		renderer.overrideBlockTexture = ExtraBlockTextures.getMissing();
 		this.renderInvBlock( EnumSet.of( ForgeDirection.SOUTH ), block, is, Tessellator.instance, 0x000000, renderer );
 
@@ -67,12 +68,13 @@ public class RenderMEChest extends BaseBlockRender<BlockChest, TileChest>
 	public boolean renderInWorld( final BlockChest imb, final IBlockAccess world, final int x, final int y, final int z, final RenderBlocks renderer )
 	{
 		final TileChest sp = imb.getTileEntity( world, x, y, z );
-		renderer.setRenderBounds( 0, 0, 0, 1, 1, 1 );
 
 		if( sp == null )
 		{
 			return false;
 		}
+
+		renderer.setRenderBounds( 0, 0, 0, 1, 1, 1 );
 
 		final ForgeDirection up = sp.getUp();
 		final ForgeDirection forward = sp.getForward();
@@ -97,6 +99,7 @@ public class RenderMEChest extends BaseBlockRender<BlockChest, TileChest>
 
 		final int offsetU = -4;
 		final FlippableIcon flippableIcon = new FlippableIcon( new OffsetIcon( ExtraBlockTextures.MEStorageCellTextures.getIcon(), offsetU, offsetV ) );
+
 		if( forward == ForgeDirection.EAST && ( up == ForgeDirection.NORTH || up == ForgeDirection.SOUTH ) )
 		{
 			flippableIcon.setFlip( true, false );
@@ -117,13 +120,6 @@ public class RenderMEChest extends BaseBlockRender<BlockChest, TileChest>
 		{
 			flippableIcon.setFlip( true, false );
 		}
-
-		/*
-		 * 1.7.2
-		 * else if ( forward == ForgeDirection.EAST && up == ForgeDirection.UP ) flippableIcon.setFlip( true, false );
-		 * else if (
-		 * forward == ForgeDirection.NORTH && up == ForgeDirection.UP ) flippableIcon.setFlip( true, false );
-		 */
 
 		this.renderFace( x, y, z, imb, flippableIcon, renderer, forward );
 

--- a/src/main/java/appeng/client/render/blocks/RenderQNB.java
+++ b/src/main/java/appeng/client/render/blocks/RenderQNB.java
@@ -45,14 +45,19 @@ import appeng.tile.qnb.TileQuantumBridge;
 
 public class RenderQNB extends BaseBlockRender<BlockQuantumBase, TileQuantumBridge>
 {
+	private static final float DEFAULT_RENDER_MIN = 2.0f / 16.0f;
+	private static final float DEFAULT_RENDER_MAX = 14.0f / 16.0f;
+
+	private static final float CORNER_POWERED_RENDER_MIN = 3.9f / 16.0f;
+	private static final float CORNER_POWERED_RENDER_MAX = 12.1f / 16.0f;
+
+	private static final float CENTER_POWERED_RENDER_MIN = -0.01f / 16.0f;
+	private static final float CENTER_POWERED_RENDER_MAX = 16.01f / 16.0f;
 
 	@Override
 	public void renderInventory( final BlockQuantumBase block, final ItemStack item, final RenderBlocks renderer, final ItemRenderType type, final Object[] obj )
 	{
-		final float minPx = 2.0f / 16.0f;
-		final float maxPx = 14.0f / 16.0f;
-		renderer.setRenderBounds( minPx, minPx, minPx, maxPx, maxPx, maxPx );
-
+		renderer.setRenderBounds( DEFAULT_RENDER_MIN, DEFAULT_RENDER_MIN, DEFAULT_RENDER_MIN, DEFAULT_RENDER_MAX, DEFAULT_RENDER_MAX, DEFAULT_RENDER_MAX );
 		super.renderInventory( block, item, renderer, type, obj );
 	}
 
@@ -60,6 +65,7 @@ public class RenderQNB extends BaseBlockRender<BlockQuantumBase, TileQuantumBrid
 	public boolean renderInWorld( final BlockQuantumBase block, final IBlockAccess world, final int x, final int y, final int z, final RenderBlocks renderer )
 	{
 		final TileQuantumBridge tqb = block.getTileEntity( world, x, y, z );
+
 		if( tqb == null )
 		{
 			return false;
@@ -86,37 +92,28 @@ public class RenderQNB extends BaseBlockRender<BlockQuantumBase, TileQuantumBrid
 					this.renderCableAt( 0.188D, world, x, y, z, block, renderer, transCoveredCable.getIconIndex( parts.cableCovered().stack( AEColor.Transparent, 1 ) ), 0.1875D, sides );
 				}
 
-				final float renderMin = 2.0f / 16.0f;
-				final float renderMax = 14.0f / 16.0f;
-				renderer.setRenderBounds( renderMin, renderMin, renderMin, renderMax, renderMax, renderMax );
+				renderer.setRenderBounds( DEFAULT_RENDER_MIN, DEFAULT_RENDER_MIN, DEFAULT_RENDER_MIN, DEFAULT_RENDER_MAX, DEFAULT_RENDER_MAX, DEFAULT_RENDER_MAX );
 				renderer.renderStandardBlock( block, x, y, z );
 			}
 			else
 			{
 				if( !tqb.isFormed() )
 				{
-					final float renderMin = 2.0f / 16.0f;
-					final float renderMax = 14.0f / 16.0f;
-					renderer.setRenderBounds( renderMin, renderMin, renderMin, renderMax, renderMax, renderMax );
+					renderer.setRenderBounds( DEFAULT_RENDER_MIN, DEFAULT_RENDER_MIN, DEFAULT_RENDER_MIN, DEFAULT_RENDER_MAX, DEFAULT_RENDER_MAX, DEFAULT_RENDER_MAX );
 					renderer.renderStandardBlock( block, x, y, z );
 				}
 				else if( tqb.isCorner() )
 				{
 					final Item transCoveredCable = parts.cableCovered().item( AEColor.Transparent );
+
 					this.renderCableAt( 0.188D, world, x, y, z, block, renderer, transCoveredCable.getIconIndex( parts.cableCovered().stack( AEColor.Transparent, 1 ) ), 0.05D, tqb.getConnections() );
 
-					float renderMin = 4.0f / 16.0f;
-					float renderMax = 12.0f / 16.0f;
-
-					renderer.setRenderBounds( renderMin, renderMin, renderMin, renderMax, renderMax, renderMax );
+					renderer.setRenderBounds( DEFAULT_RENDER_MIN, DEFAULT_RENDER_MIN, DEFAULT_RENDER_MIN, DEFAULT_RENDER_MAX, DEFAULT_RENDER_MAX, DEFAULT_RENDER_MAX );
 					renderer.renderStandardBlock( block, x, y, z );
 
 					if( tqb.isPowered() )
 					{
-
-						renderMin = 3.9f / 16.0f;
-						renderMax = 12.1f / 16.0f;
-						renderer.setRenderBounds( renderMin, renderMin, renderMin, renderMax, renderMax, renderMax );
+						renderer.setRenderBounds( CORNER_POWERED_RENDER_MIN, CORNER_POWERED_RENDER_MIN, CORNER_POWERED_RENDER_MIN, CORNER_POWERED_RENDER_MAX, CORNER_POWERED_RENDER_MAX, CORNER_POWERED_RENDER_MAX );
 
 						Tessellator.instance.setColorOpaque_F( 1.0F, 1.0F, 1.0F );
 						final int bn = 15;
@@ -129,22 +126,18 @@ public class RenderQNB extends BaseBlockRender<BlockQuantumBase, TileQuantumBrid
 				}
 				else
 				{
-					float renderMin = 2.0f / 16.0f;
-					float renderMax = 14.0f / 16.0f;
-					renderer.setRenderBounds( 0, renderMin, renderMin, 1, renderMax, renderMax );
+					renderer.setRenderBounds( 0, DEFAULT_RENDER_MIN, DEFAULT_RENDER_MIN, 1, DEFAULT_RENDER_MAX, DEFAULT_RENDER_MAX );
 					renderer.renderStandardBlock( block, x, y, z );
 
-					renderer.setRenderBounds( renderMin, 0, renderMin, renderMax, 1, renderMax );
+					renderer.setRenderBounds( DEFAULT_RENDER_MIN, 0, DEFAULT_RENDER_MIN, DEFAULT_RENDER_MAX, 1, DEFAULT_RENDER_MAX );
 					renderer.renderStandardBlock( block, x, y, z );
 
-					renderer.setRenderBounds( renderMin, renderMin, 0, renderMax, renderMax, 1 );
+					renderer.setRenderBounds( DEFAULT_RENDER_MIN, DEFAULT_RENDER_MIN, 0, DEFAULT_RENDER_MAX, DEFAULT_RENDER_MAX, 1 );
 					renderer.renderStandardBlock( block, x, y, z );
 
 					if( tqb.isPowered() )
 					{
-						renderMin = -0.01f / 16.0f;
-						renderMax = 16.01f / 16.0f;
-						renderer.setRenderBounds( renderMin, renderMin, renderMin, renderMax, renderMax, renderMax );
+						renderer.setRenderBounds( CENTER_POWERED_RENDER_MIN, CENTER_POWERED_RENDER_MIN, CENTER_POWERED_RENDER_MIN, CENTER_POWERED_RENDER_MAX, CENTER_POWERED_RENDER_MAX, CENTER_POWERED_RENDER_MAX );
 
 						Tessellator.instance.setColorOpaque_F( 1.0F, 1.0F, 1.0F );
 						final int bn = 15;

--- a/src/main/java/appeng/client/render/blocks/RenderQuartzGlass.java
+++ b/src/main/java/appeng/client/render/blocks/RenderQuartzGlass.java
@@ -38,23 +38,28 @@ import appeng.tile.AEBaseTile;
 public class RenderQuartzGlass extends BaseBlockRender<BlockQuartzGlass, AEBaseTile>
 {
 
-	private static byte[][][] offsets;
+	private static final byte[][][] OFFSETS = generateOffsets();
 
 	public RenderQuartzGlass()
 	{
 		super( false, 0 );
-		if( offsets == null )
+
+	}
+
+	private static byte[][][] generateOffsets()
+	{
+		final Random r = new Random( 924 );
+		final byte[][][] offset = new byte[10][10][10];
+
+		for( int x = 0; x < 10; x++ )
 		{
-			final Random r = new Random( 924 );
-			offsets = new byte[10][10][10];
-			for( int x = 0; x < 10; x++ )
+			for( int y = 0; y < 10; y++ )
 			{
-				for( int y = 0; y < 10; y++ )
-				{
-					r.nextBytes( offsets[x][y] );
-				}
+				r.nextBytes( offset[x][y] );
 			}
 		}
+
+		return offset;
 	}
 
 	@Override
@@ -75,10 +80,10 @@ public class RenderQuartzGlass extends BaseBlockRender<BlockQuartzGlass, AEBaseT
 		final int cy = Math.abs( y % 10 );
 		final int cz = Math.abs( z % 10 );
 
-		final int u = offsets[cx][cy][cz] % 4;
-		final int v = offsets[9 - cx][9 - cy][9 - cz] % 4;
+		final int u = OFFSETS[cx][cy][cz] % 4;
+		final int v = OFFSETS[9 - cx][9 - cy][9 - cz] % 4;
 
-		switch( Math.abs( ( offsets[cx][cy][cz] + ( x + y + z ) ) % 4 ) )
+		switch( Math.abs( ( OFFSETS[cx][cy][cz] + ( x + y + z ) ) % 4 ) )
 		{
 			case 0:
 				renderer.overrideBlockTexture = new OffsetIcon( imb.getIcon( 0, 0 ), u / 2, v / 2 );

--- a/src/main/java/appeng/client/render/blocks/RenderQuartzTorch.java
+++ b/src/main/java/appeng/client/render/blocks/RenderQuartzTorch.java
@@ -99,10 +99,12 @@ public class RenderQuartzTorch extends BaseBlockRender<AEBaseBlock, AEBaseTile>
 	{
 		final IOrientable te = ( (IOrientableBlock) block ).getOrientable( world, x, y, z );
 
-		renderer.renderAllFaces = true;
-		float zOff = 0.0f;
-		float yOff = 0.0f;
 		float xOff = 0.0f;
+		float yOff = 0.0f;
+		float zOff = 0.0f;
+
+		renderer.renderAllFaces = true;
+
 		if( te != null )
 		{
 			final ForgeDirection forward = te.getUp();

--- a/src/main/java/appeng/client/render/blocks/RenderSpatialPylon.java
+++ b/src/main/java/appeng/client/render/blocks/RenderSpatialPylon.java
@@ -66,6 +66,7 @@ public class RenderSpatialPylon extends BaseBlockRender<BlockSpatialPylon, TileS
 			if( ( displayBits & TileSpatialPylon.DISPLAY_Z ) == TileSpatialPylon.DISPLAY_X )
 			{
 				ori = ForgeDirection.EAST;
+
 				if( ( displayBits & TileSpatialPylon.DISPLAY_MIDDLE ) == TileSpatialPylon.DISPLAY_END_MAX )
 				{
 					renderer.uvRotateEast = 1;

--- a/src/main/java/appeng/client/render/blocks/RendererSecurity.java
+++ b/src/main/java/appeng/client/render/blocks/RendererSecurity.java
@@ -70,6 +70,7 @@ public class RendererSecurity extends BaseBlockRender<BlockSecurity, TileSecurit
 		final boolean result = renderer.renderStandardBlock( imb, x, y, z );
 
 		int b = world.getLightBrightnessForSkyBlocks( x + up.offsetX, y + up.offsetY, z + up.offsetZ, 0 );
+
 		if( sp.isActive() )
 		{
 			b = 15 << 20 | 15 << 4;
@@ -82,6 +83,7 @@ public class RendererSecurity extends BaseBlockRender<BlockSecurity, TileSecurit
 		Tessellator.instance.setColorOpaque_I( sp.getColor().whiteVariant );
 		IIcon ico = sp.isActive() ? ExtraBlockTextures.BlockMESecurityOn_Light.getIcon() : ExtraBlockTextures.MEChest.getIcon();
 		this.renderFace( x, y, z, imb, ico, renderer, up );
+
 		if( sp.isActive() )
 		{
 			Tessellator.instance.setColorOpaque_I( sp.getColor().mediumVariant );

--- a/src/main/java/appeng/client/render/effects/AssemblerFX.java
+++ b/src/main/java/appeng/client/render/effects/AssemblerFX.java
@@ -76,6 +76,7 @@ public class AssemblerFX extends EntityFX
 	public void renderParticle( final Tessellator tess, final float l, final float rX, final float rY, final float rZ, final float rYZ, final float rXY )
 	{
 		this.time += l;
+
 		if( this.time > 4.0 )
 		{
 			this.time -= 4.0;

--- a/src/main/java/appeng/client/render/effects/ChargedOreFX.java
+++ b/src/main/java/appeng/client/render/effects/ChargedOreFX.java
@@ -37,10 +37,12 @@ public class ChargedOreFX extends EntityReddustFX
 		int j1 = super.getBrightnessForRender( par1 );
 		j1 = Math.max( j1 >> 20, j1 >> 4 );
 		j1 += 3;
+
 		if( j1 > 15 )
 		{
 			j1 = 15;
 		}
+
 		return j1 << 20 | j1 << 4;
 	}
 }

--- a/src/main/java/appeng/client/render/effects/CraftingFx.java
+++ b/src/main/java/appeng/client/render/effects/CraftingFx.java
@@ -89,6 +89,7 @@ public class CraftingFx extends EntityBreakingFX
 		final int blkX = MathHelper.floor_double( offX );
 		final int blkY = MathHelper.floor_double( offY );
 		final int blkZ = MathHelper.floor_double( offZ );
+
 		if( blkX == this.startBlkX && blkY == this.startBlkY && blkZ == this.startBlkZ )
 		{
 			offX -= interpPosX;

--- a/src/main/java/appeng/client/render/effects/LightningArcFX.java
+++ b/src/main/java/appeng/client/render/effects/LightningArcFX.java
@@ -51,8 +51,8 @@ public class LightningArcFX extends LightningFX
 		final double lastDirectionX = this.rx * i;
 		final double lastDirectionY = this.ry * i;
 		final double lastDirectionZ = this.rz * i;
-
 		final double len = Math.sqrt( lastDirectionX * lastDirectionX + lastDirectionY * lastDirectionY + lastDirectionZ * lastDirectionZ );
+
 		for( int s = 0; s < this.getSteps(); s++ )
 		{
 			final double[][] localSteps = this.getPrecomputedSteps();

--- a/src/main/java/appeng/client/render/effects/LightningFX.java
+++ b/src/main/java/appeng/client/render/effects/LightningFX.java
@@ -31,7 +31,6 @@ import net.minecraft.world.World;
 
 public class LightningFX extends EntityFX
 {
-
 	private static final Random RANDOM_GENERATOR = new Random();
 	private static final int STEPS = 5;
 
@@ -62,6 +61,7 @@ public class LightningFX extends EntityFX
 		double lastDirectionX = ( RANDOM_GENERATOR.nextDouble() - 0.5 ) * 0.9;
 		double lastDirectionY = ( RANDOM_GENERATOR.nextDouble() - 0.5 ) * 0.9;
 		double lastDirectionZ = ( RANDOM_GENERATOR.nextDouble() - 0.5 ) * 0.9;
+
 		for( int s = 0; s < LightningFX.STEPS; s++ )
 		{
 			this.precomputedSteps[s][0] = lastDirectionX = ( lastDirectionX + ( RANDOM_GENERATOR.nextDouble() - 0.5 ) * 0.9 ) / 2.0;
@@ -86,7 +86,9 @@ public class LightningFX extends EntityFX
 	public void renderParticle( final Tessellator tess, final float l, final float rX, final float rY, final float rZ, final float rYZ, final float rXY )
 	{
 		final float j = 1.0f;
+
 		tess.setColorRGBA_F( this.particleRed * j * 0.9f, this.particleGreen * j * 0.95f, this.particleBlue * j, this.particleAlpha );
+
 		if( this.particleAge == 3 )
 		{
 			this.regen();
@@ -190,10 +192,6 @@ public class LightningFX extends EntityFX
 				}
 			}
 		}
-		/*
-		 * GL11.glPushAttrib( GL11.GL_ALL_ATTRIB_BITS ); GL11.glDisable( GL11.GL_CULL_FACE ); tess.draw();
-		 * GL11.glPopAttrib(); tess.startDrawingQuads();
-		 */
 	}
 
 	private void clear()
@@ -210,7 +208,9 @@ public class LightningFX extends EntityFX
 			tess.addVertexWithUV( this.verticesWithUV[0], this.verticesWithUV[1], this.verticesWithUV[2], f6, f8 );
 			tess.addVertexWithUV( b[0], b[1], b[2], f6, f8 );
 		}
+
 		this.hasData = true;
+
 		for( int x = 0; x < 3; x++ )
 		{
 			this.vertices[x] = a[x];

--- a/src/main/java/appeng/client/render/items/ItemEncodedPatternRenderer.java
+++ b/src/main/java/appeng/client/render/items/ItemEncodedPatternRenderer.java
@@ -45,6 +45,7 @@ public class ItemEncodedPatternRenderer implements IItemRenderer
 		if( !this.recursive && type == IItemRenderer.ItemRenderType.INVENTORY && isShiftHeld )
 		{
 			final ItemEncodedPattern iep = (ItemEncodedPattern) item.getItem();
+
 			if( iep.getOutput( item ) != null )
 			{
 				return true;
@@ -66,11 +67,10 @@ public class ItemEncodedPatternRenderer implements IItemRenderer
 		this.recursive = true;
 
 		final ItemEncodedPattern iep = (ItemEncodedPattern) item.getItem();
-
 		final ItemStack is = iep.getOutput( item );
 		final Minecraft mc = Minecraft.getMinecraft();
 
-		GL11.glPushAttrib( GL11.GL_ALL_ATTRIB_BITS );
+		GL11.glPushAttrib( GL11.GL_ENABLE_BIT | GL11.GL_COLOR_BUFFER_BIT );
 		RenderHelper.enableGUIStandardItemLighting();
 		this.ri.renderItemAndEffectIntoGUI( mc.fontRenderer, mc.getTextureManager(), is, 0, 0 );
 		RenderHelper.disableStandardItemLighting();

--- a/src/main/java/appeng/client/render/items/PaintBallRender.java
+++ b/src/main/java/appeng/client/render/items/PaintBallRender.java
@@ -50,8 +50,13 @@ public class PaintBallRender implements IItemRenderer
 	@Override
 	public void renderItem( final ItemRenderType type, final ItemStack item, final Object... data )
 	{
-		IIcon par2Icon = item.getIconIndex();
-		if( item.getItemDamage() >= 20 )
+		final IIcon par2Icon;
+
+		if( item.getItemDamage() < 20 )
+		{
+			par2Icon = item.getIconIndex();
+		}
+		else
 		{
 			par2Icon = ExtraItemTextures.ItemPaintBallShimmer.getIcon();
 		}
@@ -64,8 +69,8 @@ public class PaintBallRender implements IItemRenderer
 		final ItemPaintBall ipb = (ItemPaintBall) item.getItem();
 
 		final Tessellator tessellator = Tessellator.instance;
+
 		GL11.glPushMatrix();
-		GL11.glPushAttrib( GL11.GL_ALL_ATTRIB_BITS );
 
 		final AEColor col = ipb.getColor( item );
 
@@ -122,7 +127,15 @@ public class PaintBallRender implements IItemRenderer
 
 		GL11.glColor4f( 1, 1, 1, 1.0F );
 
-		GL11.glPopAttrib();
+		if( type == ItemRenderType.INVENTORY )
+		{
+			GL11.glDisable( GL11.GL_ALPHA_TEST );
+		}
+		else
+		{
+			GL11.glEnable( GL11.GL_CULL_FACE );
+		}
+
 		GL11.glPopMatrix();
 	}
 }

--- a/src/main/java/appeng/client/render/items/ToolBiometricCardRender.java
+++ b/src/main/java/appeng/client/render/items/ToolBiometricCardRender.java
@@ -60,8 +60,9 @@ public class ToolBiometricCardRender implements IItemRenderer
 		final float f7 = par2Icon.getMaxV();
 
 		final Tessellator tessellator = Tessellator.instance;
+
 		GL11.glPushMatrix();
-		GL11.glPushAttrib( GL11.GL_ALL_ATTRIB_BITS );
+		GL11.glPushAttrib( GL11.GL_ENABLE_BIT | GL11.GL_COLOR_BUFFER_BIT );
 
 		if( type == ItemRenderType.INVENTORY )
 		{
@@ -96,6 +97,7 @@ public class ToolBiometricCardRender implements IItemRenderer
 		final float v = ExtraItemTextures.White.getIcon().getInterpolatedV( 8.1 );
 
 		String username = "";
+
 		if( item.getItem() instanceof IBiometricCard )
 		{
 			final GameProfile gp = ( (IBiometricCard) item.getItem() ).getProfile( item );
@@ -119,6 +121,7 @@ public class ToolBiometricCardRender implements IItemRenderer
 		}
 
 		final float z = 0;
+
 		for( int x = 0; x < 8; x++ )// 8
 		{
 			for( int y = 0; y < 6; y++ )// 6
@@ -150,6 +153,7 @@ public class ToolBiometricCardRender implements IItemRenderer
 				tessellator.addVertexWithUV( x, y + 1, z, u, v );
 			}
 		}
+
 		tessellator.draw();
 
 		GL11.glPopAttrib();

--- a/src/main/java/appeng/client/render/items/ToolColorApplicatorRender.java
+++ b/src/main/java/appeng/client/render/items/ToolColorApplicatorRender.java
@@ -58,8 +58,9 @@ public class ToolColorApplicatorRender implements IItemRenderer
 		float f7 = par2Icon.getMaxV();
 
 		final Tessellator tessellator = Tessellator.instance;
+
 		GL11.glPushMatrix();
-		GL11.glPushAttrib( GL11.GL_ALL_ATTRIB_BITS );
+		GL11.glPushAttrib( GL11.GL_ENABLE_BIT | GL11.GL_COLOR_BUFFER_BIT );
 
 		if( type == ItemRenderType.INVENTORY )
 		{
@@ -106,10 +107,12 @@ public class ToolColorApplicatorRender implements IItemRenderer
 		final IIcon light = ExtraItemTextures.ToolColorApplicatorTip_Light.getIcon();
 
 		GL11.glScalef( 1F / 16F, 1F / 16F, 1F );
+
 		if( type != ItemRenderType.INVENTORY )
 		{
 			GL11.glTranslatef( 2, 0, 0 );
 		}
+
 		GL11.glDisable( GL11.GL_LIGHTING );
 
 		final AEColor col = ( (ToolColorApplicator) item.getItem() ).getActiveColor( item );


### PR DESCRIPTION
Replaces the reflexive instantiation of the Renderes with a factory method.
Some optimizations to the renderers to no longer push the whole OpenGL state to the stack.
General cleanup of duplicate code, etc

For now I did not notice any rendering issues, but I would not exclude that it can happen in some corner cases as it is way less defensive now. Potentially it can now even make bugs in the rendering obvious. Like enabling/disabling already enabled/disabled OpenGL capabilities.