### PR TITLE
Updated the buildscript and dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@
 
 apply plugin: 'forge'
 
+apply from: 'gradle/scripts/repositories.gradle'
 apply from: 'gradle/scripts/dependencies.gradle'
 apply from: 'gradle/scripts/artifacts.gradle'
 apply from: 'gradle/scripts/autoinstallruntime.gradle'

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ forge_version=10.13.4.1448-1.7.10
 #########################################################
 waila_version=1.5.10
 jabba_version=1.2.1a
-enderstorage_version=1.4.7.36
+enderstorage_version=1.4.7.37
 translocator_version=1.1.2.15
 ic2_version=2.2.717
 enderio_version=2.3.0.375_beta
@@ -30,29 +30,20 @@ invtweaks_version=1.58
 # Provided APIs                                         #
 #########################################################
 fmp_version=1.2.0.345
-code_chicken_lib_version=1.1.3.138
-code_chicken_core_version=1.0.7.46
-nei_version=1.0.5.111
-bc_version=7.0.9
-opencomputers_version=1.5.12.26
-pneumaticcraft_version=1.9.15-105
+code_chicken_lib_version=1.1.3.140
+code_chicken_core_version=1.0.7.47
+nei_version=1.0.5.118
+bc_version=7.0.23
+opencomputers_version=1.5.17.33
+pneumaticcraft_version=1.11.7-127
 
 #########################################################
-# Self Compiled APIs                                    #
+# Self Compiled APIs or hosted artifacts                #
 #########################################################
 mekansim_version=8.0.1.198
 rotarycraft_version=V6e
-
-
-#########################################################
-# Self Compiled API Stubs                               #
-# Note: Do not edit these version numbers as they are   #
-# not the version of the mod, but stub code for AE2 to  #
-# compile                                               #
-#########################################################
-api_coloredlightscore_version=1
-api_craftguide_version=1
-api_immibis_version=1
-api_mfr_version=1
-api_railcraft_version=1
-api_rf_version=2
+craftguide_version=1.6.9.0
+immibis_version=59.1.2
+mfr_version=2.8.0-104
+railcraft_version=9.7.0.0
+cofhcore_version=3.0.3-303

--- a/gradle/scripts/autoinstallruntime.gradle
+++ b/gradle/scripts/autoinstallruntime.gradle
@@ -1,12 +1,13 @@
 // searches for NEI and Chicken stuff from compile set
 // and adds them to the mods in run dir
-task copyChicken(type: Copy, dependsOn: "extractUserDev") {
-    from { configurations.compile }
-    include "**/*Chicken*.jar", "**/*NotEnoughItems*.jar"
-    exclude "**/CodeChickenLib*" // because CCC downloads it anyways.. -_-
-    into file(minecraft.runDir + "/mods")
-    mustRunAfter "deobfBinJar"
-    mustRunAfter "repackMinecraft"
-}
-tasks.setupDevWorkspace.dependsOn copyChicken
-tasks.setupDecompWorkspace.dependsOn copyChicken
+// now done by forge, kept for historical reasons
+//task copyChicken(type: Copy, dependsOn: "extractUserDev") {
+//    from { configurations.compile }
+//    include "**/*Chicken*.jar", "**/*NotEnoughItems*.jar"
+//    exclude "**/CodeChickenLib*" // because CCC downloads it anyways.. -_-
+//    into file(minecraft.runDir + "/mods")
+//    mustRunAfter "deobfBinJar"
+//    mustRunAfter "repackMinecraft"
+//}
+//tasks.setupDevWorkspace.dependsOn copyChicken
+//tasks.setupDecompWorkspace.dependsOn copyChicken

--- a/gradle/scripts/dependencies.gradle
+++ b/gradle/scripts/dependencies.gradle
@@ -1,7 +1,7 @@
 
 /*
  * This file is part of Applied Energistics 2.
- * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
  *
  * Applied Energistics 2 is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -16,77 +16,6 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
  */
-
-
-
-repositories {
-    mavenLocal()
-    maven {
-        name "ChickenBones"
-        url "http://chickenbones.net/maven/"
-    }
-
-    maven {
-        name "Mobius"
-        url "http://mobiusstrip.eu/maven"
-    }
-
-    maven {
-        name "FireBall API Depot"
-        url "http://dl.tsr.me/artifactory/libs-release-local"
-    }
-
-    maven {
-        name = "Player"
-        url = "http://maven.ic2.player.to/"
-    }
-
-    maven {
-        name = "Tterrag"
-        url = "http://maven.tterrag.com/"
-    }
-
-    maven  {
-        name = "RX14 Proxy"
-        url = "http://mvn.rx14.co.uk/repo/"
-    }
-
-    maven {
-        name "OpenComputers Repo"
-        url = "http://maven.cil.li/"
-    }
-
-    maven {
-        name = "MM repo"
-        url = "http://maven.k-4u.nl/"
-    }
-
-    ivy {
-        name "BuildCraft"
-        artifactPattern "http://www.mod-buildcraft.com/releases/BuildCraft/[revision]/[module]-[revision]-[classifier].[ext]"
-    }
-
-//  CurseForge DNS for TE is not available or I am just being unlucky, code part can stay since this is applicable to any other curseforge mod though
-//    ivy {
-//        name = "CoFHLib"
-//        artifactPattern "http://addons.cursecdn.com/files/2212/893/[module]-[revision].[ext]"
-//    }
-//
-//    ivy {
-//        name = "CoFHCore"
-//        artifactPattern "http://addons.cursecdn.com/files/2212/895/[module]-[revision].[ext]"
-//    }
-
-//    ivy {
-//        name = "ThermalExpansion"
-//        artifactPattern "http://addons.curse.cursecdn.com/files/2212/446/[module]-[revision].[ext]"
-//    }
-
-//    ivy {
-//        name = "ThermalFoundation"
-//        artifactPattern "http://addons.curse.cursecdn.com/files/2212/444/[module]-[revision].[ext]"
-//    }
-}
 
 configurations {
     mods
@@ -120,20 +49,20 @@ dependencies {
     compile "li.cil.oc:OpenComputers:MC${minecraft_version}-${opencomputers_version}:api"
     compile "net.industrial-craft:industrialcraft-2:${ic2_version}-experimental:api"
     compile "net.mcft.copy.betterstorage:BetterStorage:${minecraft_version}-${betterstorage_version}:api"
+    compile "coloredlightscore:ColoredLightsCore:1.3.7.39:api"
 
     // self compiled APIs
     compile "appeng:Waila:${waila_version}_${minecraft_version}:api"
     compile "appeng:RotaryCraft:${rotarycraft_version}:api"
     compile "appeng:mekanism:${minecraft_version}-${mekansim_version}:api"
     compile "appeng:InventoryTweaks:${invtweaks_version}:api"
+    compile "appeng:immibis-core:${immibis_version}:api"
+    compile "appeng:mfr:${mfr_version}:api"
+    compile "appeng:railcraft:${railcraft_version}:api"
+    compile "appeng:cofhcore:${cofhcore_version}:api"
 
-    // self compiled stubs
-    compile(group: 'api', name: 'coloredlightscore', version: "${api_coloredlightscore_version}")
-    compile(group: 'api', name: 'craftguide', version: "${api_craftguide_version}")
-    compile(group: 'api', name: 'immibis', version: "${api_immibis_version}")
-    compile(group: 'api', name: 'mfr', version: "${api_mfr_version}")
-    compile(group: 'api', name: 'railcraft', version: "${api_railcraft_version}")
-    compile(group: 'api', name: 'rf', version: "${api_rf_version}")
+    // self hosted artifacts
+    compile "uristqwerty:CraftGuide:${craftguide_version}"
 
     testCompile "junit:junit:4.11"
 }

--- a/gradle/scripts/repositories.gradle
+++ b/gradle/scripts/repositories.gradle
@@ -1,0 +1,104 @@
+
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+repositories {
+
+    //// local maven to potentially speedup the dependency lookup
+    mavenLocal()
+
+    //// This repo hosts our self compiled apis or artifacts and acts as proxy to other repos.
+    maven {
+        name "orod maven"
+        url "http://maven.orod.org/repository/internal"
+    }
+
+    //// ivy repos are not an option to proxy throug a maven repo, thus they need be defined here.
+    ivy {
+        name "BuildCraft"
+        artifactPattern "http://www.mod-buildcraft.com/releases/BuildCraft/[revision]/[module]-[revision]-[classifier].[ext]"
+    }
+    
+    //// These repositories are provided via proxy by "orod maven"
+    //// Kept as documentation or in case it is unreachable 
+    //    maven {
+    //        name "ChickenBones"
+    //        url "http://chickenbones.net/maven/"
+    //    }
+    //
+    //    maven {
+    //        name "Mobius"
+    //        url "http://mobiusstrip.eu/maven"
+    //    }
+    //
+    //    maven {
+    //        name "FireBall API Depot"
+    //        url "http://dl.tsr.me/artifactory/libs-release-local"
+    //    }
+    //
+    //    maven {
+    //        name = "Player"
+    //        url = "http://maven.ic2.player.to/"
+    //    }
+    //
+    //    maven {
+    //        name = "Tterrag"
+    //        url = "http://maven.tterrag.com/"
+    //    }
+    //
+    //    maven  {
+    //        name = "RX14 Proxy"
+    //        url = "http://mvn.rx14.co.uk/repo/"
+    //    }
+    //
+    //    maven {
+    //        name "OpenComputers Repo"
+    //        url = "http://maven.cil.li/"
+    //    }
+    //
+    //    maven {
+    //        name = "MM repo"
+    //        url = "http://maven.k-4u.nl/"
+    //    }
+    //
+    //      maven {
+    //        name = "ColoredLights"
+    //        url = "http://coloredlightscore.us.to/maven/clc/"
+    //    }
+
+////  CurseForge DNS for TE is not available or I am just being unlucky, code part can stay since this is applicable to any other curseforge mod though
+//    ivy {
+//        name = "CoFHLib"
+//        artifactPattern "http://addons.cursecdn.com/files/2212/893/[module]-[revision].[ext]"
+//    }
+//
+//    ivy {
+//        name = "CoFHCore"
+//        artifactPattern "http://addons.cursecdn.com/files/2212/895/[module]-[revision].[ext]"
+//    }
+
+//    ivy {
+//        name = "ThermalExpansion"
+//        artifactPattern "http://addons.curse.cursecdn.com/files/2212/446/[module]-[revision].[ext]"
+//    }
+
+//    ivy {
+//        name = "ThermalFoundation"
+//        artifactPattern "http://addons.curse.cursecdn.com/files/2212/444/[module]-[revision].[ext]"
+//    }
+}

--- a/src/main/java/appeng/integration/modules/ImmibisMicroblocks.java
+++ b/src/main/java/appeng/integration/modules/ImmibisMicroblocks.java
@@ -30,7 +30,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 
 import mods.immibis.core.api.multipart.ICoverSystem;
-import mods.immibis.core.api.multipart.IMultipartTile;
+import mods.immibis.core.api.multipart.ICoverableTile;
 
 import appeng.api.AEApi;
 import appeng.api.definitions.IBlockDefinition;
@@ -56,8 +56,8 @@ public class ImmibisMicroblocks implements IImmibisMicroblocks, IIntegrationModu
 	@Reflected
 	public ImmibisMicroblocks()
 	{
-		IntegrationHelper.testClassExistence( this, mods.immibis.core.api.multipart.IMultipartTile.class );
 		IntegrationHelper.testClassExistence( this, mods.immibis.core.api.multipart.ICoverSystem.class );
+		IntegrationHelper.testClassExistence( this, mods.immibis.core.api.multipart.ICoverableTile.class );
 		IntegrationHelper.testClassExistence( this, mods.immibis.core.api.multipart.IPartContainer.class );
 	}
 
@@ -91,7 +91,7 @@ public class ImmibisMicroblocks implements IImmibisMicroblocks, IIntegrationModu
 		final int z = te.zCoord;
 		final boolean isPartItem = player != null && player.getHeldItem() != null && player.getHeldItem().getItem() instanceof IPartItem;
 
-		if( te instanceof IMultipartTile && this.canConvertTiles && isPartItem )
+		if( te instanceof ICoverableTile && this.canConvertTiles && isPartItem )
 		{
 			final IBlockDefinition multiPart = AEApi.instance().definitions().blocks().multiPart();
 			final Optional<Block> maybeMultiPartBlock = multiPart.maybeBlock();
@@ -130,9 +130,9 @@ public class ImmibisMicroblocks implements IImmibisMicroblocks, IIntegrationModu
 	@Override
 	public boolean leaveParts( final TileEntity te )
 	{
-		if( te instanceof IMultipartTile )
+		if( te instanceof ICoverableTile )
 		{
-			final ICoverSystem ci = ( (IMultipartTile) te ).getCoverSystem();
+			final ICoverSystem ci = ( (ICoverableTile) te ).getCoverSystem();
 			if( ci != null )
 			{
 				ci.convertToContainerBlock();


### PR DESCRIPTION
**Only for testing**

It now uses a single maven proxy, but the old repos are still kept as
documentation and new ones should also be documented.
The old ones can potentially be uncommented, it is mostly a question of
how fast the lookups are with multiple repos compared to a single proxy.

Self hosted artifacts or self compiled APIs are now using the actual mod
version they are based on for a better documentation in case of any api
breaking change made by them.

Splitted dependencies and repositories into two files as they are getting
a bit large.

Updating immibis contains a renamed Interface, this is also fixed.