### PR TITLE
Fixes incorrect handling of prioritized inventories

### DIFF
--- a/src/main/java/appeng/me/storage/NetworkInventoryHandler.java
+++ b/src/main/java/appeng/me/storage/NetworkInventoryHandler.java
@@ -113,11 +113,16 @@ public class NetworkInventoryHandler<T extends IAEStack<T>> implements IMEInvent
 				}
 			}
 
+			// We need to ignore prioritized inventories in the second pass. If they were not able to store everything
+			// during the first pass, they will do so in the second, but as this is stateless we will just report twice
+			// the amount of storable items.
+			// ignores craftingcache on the second pass.
 			ii = invList.iterator();
 			while( ii.hasNext() && input != null )
 			{
 				IMEInventoryHandler<T> inv = ii.next();
-				if( inv.validForPass( 2 ) && inv.canAccept( input ) )// ignore crafting on the second pass.
+
+				if( inv.validForPass( 2 ) && inv.canAccept( input ) && !inv.isPrioritized( input ) )
 				{
 					input = inv.injectItems( input, type, src );
 				}

--- a/src/main/java/appeng/parts/automation/PartImportBus.java
+++ b/src/main/java/appeng/parts/automation/PartImportBus.java
@@ -54,6 +54,7 @@ import appeng.me.GridAccessException;
 import appeng.util.InventoryAdaptor;
 import appeng.util.Platform;
 import appeng.util.inv.IInventoryDestination;
+import appeng.util.item.AEItemStack;
 
 
 public class PartImportBus extends PartSharedItemBus implements IInventoryDestination
@@ -238,8 +239,8 @@ public class PartImportBus extends PartSharedItemBus implements IInventoryDestin
 
 	private boolean importStuff( InventoryAdaptor myAdaptor, IAEItemStack whatToImport, IMEMonitor<IAEItemStack> inv, IEnergySource energy, FuzzyMode fzMode )
 	{
-		final int toSend = Math.min( this.itemToSend, 64 );
-		ItemStack newItems;
+		final int toSend = this.calculateMaximumAmountToImport( myAdaptor, whatToImport, inv, fzMode );
+		final ItemStack newItems;
 
 		if( this.getInstalledUpgrades( Upgrades.FUZZY ) > 0 )
 		{
@@ -264,8 +265,8 @@ public class PartImportBus extends PartSharedItemBus implements IInventoryDestin
 				this.lastItemChecked.setStackSize( newItems.stackSize );
 			}
 
-			IAEItemStack failed = Platform.poweredInsert( energy, this.destination, this.lastItemChecked, this.source );
-			// destination.injectItems( lastItemChecked, Actionable.MODULATE );
+			final IAEItemStack failed = Platform.poweredInsert( energy, this.destination, this.lastItemChecked, this.source );
+
 			if( failed != null )
 			{
 				myAdaptor.addItems( failed.getItemStack() );
@@ -282,6 +283,41 @@ public class PartImportBus extends PartSharedItemBus implements IInventoryDestin
 		}
 
 		return false;
+	}
+
+	private int calculateMaximumAmountToImport( InventoryAdaptor myAdaptor, IAEItemStack whatToImport, IMEMonitor<IAEItemStack> inv, FuzzyMode fzMode )
+	{
+		final int toSend = Math.min( this.itemToSend, 64 );
+		final ItemStack simResult;
+		final IAEItemStack itemAmountNotStorable;
+		final ItemStack itemStackToImport;
+
+		if( whatToImport == null )
+		{
+			itemStackToImport = null;
+		}
+		else
+		{
+			itemStackToImport = whatToImport.getItemStack();
+		}
+
+		if( this.getInstalledUpgrades( Upgrades.FUZZY ) > 0 )
+		{
+			simResult = myAdaptor.simulateSimilarRemove( toSend, itemStackToImport, fzMode, this.configDestination( inv ) );
+			itemAmountNotStorable = this.destination.injectItems( AEItemStack.create( simResult ), Actionable.SIMULATE, this.source );
+		}
+		else
+		{
+			simResult = myAdaptor.simulateRemove( toSend, itemStackToImport, this.configDestination( inv ) );
+			itemAmountNotStorable = this.destination.injectItems( AEItemStack.create( simResult ), Actionable.SIMULATE, this.source );
+		}
+
+		if( itemAmountNotStorable != null )
+		{
+			return (int) Math.min( simResult.stackSize - itemAmountNotStorable.getStackSize(), toSend );
+		}
+
+		return toSend;
 	}
 
 	private IInventoryDestination configDestination( IMEMonitor<IAEItemStack> itemInventory )


### PR DESCRIPTION
Prioritized inventories are not longer used twice for storing leftover
items and thus finally reporting twice the amount of storable items when
they are the only possible option to store something.

Also fixes import buses now respecting the amount of storable items inside
the network instead of trying to place the exported items back and failing
on any restricted inventory, potentially voiding the overflow.

Fixes #1892