### PR TITLE
Fixes #1905: Export bus now considers failed crafting requests

### DIFF
--- a/src/main/java/appeng/helpers/MultiCraftingTracker.java
+++ b/src/main/java/appeng/helpers/MultiCraftingTracker.java
@@ -35,18 +35,18 @@ import appeng.api.networking.crafting.ICraftingLink;
 import appeng.api.networking.crafting.ICraftingRequester;
 import appeng.api.networking.security.BaseActionSource;
 import appeng.api.storage.data.IAEItemStack;
-import appeng.parts.automation.NonNullArrayIterator;
 import appeng.util.InventoryAdaptor;
 
 
 public class MultiCraftingTracker
 {
 
-	final int size;
-	final ICraftingRequester owner;
+	private final int size;
+	private final ICraftingRequester owner;
 
-	Future<ICraftingJob>[] jobs = null;
-	ICraftingLink[] links = null;
+	private Future<ICraftingJob>[] jobs = null;
+	private ICraftingLink[] links = null;
+	private int failedCraftingAttempts = 0;
 
 	public MultiCraftingTracker( ICraftingRequester o, int size )
 	{
@@ -54,11 +54,17 @@ public class MultiCraftingTracker
 		this.size = size;
 	}
 
+	public int getFailedCraftingAttempts()
+	{
+		return failedCraftingAttempts;
+	}
+
 	public void readFromNBT( NBTTagCompound extra )
 	{
 		for( int x = 0; x < this.size; x++ )
 		{
-			NBTTagCompound link = extra.getCompoundTag( "links-" + x );
+			final NBTTagCompound link = extra.getCompoundTag( "links-" + x );
+
 			if( link != null && !link.hasNoTags() )
 			{
 				this.setLink( x, AEApi.instance().storage().loadCraftingLink( link, this.owner ) );
@@ -66,65 +72,27 @@ public class MultiCraftingTracker
 		}
 	}
 
-	void setLink( int slot, ICraftingLink l )
-	{
-		if( this.links == null )
-		{
-			this.links = new ICraftingLink[this.size];
-		}
-
-		this.links[slot] = l;
-
-		boolean hasStuff = false;
-		for( int x = 0; x < this.links.length; x++ )
-		{
-			ICraftingLink g = this.links[x];
-
-			if( g == null || g.isCanceled() || g.isDone() )
-			{
-				this.links[x] = null;
-			}
-			else
-			{
-				hasStuff = true;
-			}
-		}
-
-		if( !hasStuff )
-		{
-			this.links = null;
-		}
-	}
-
 	public void writeToNBT( NBTTagCompound extra )
 	{
 		for( int x = 0; x < this.size; x++ )
 		{
-			ICraftingLink link = this.getLink( x );
+			final ICraftingLink link = this.getLink( x );
+
 			if( link != null )
 			{
-				NBTTagCompound ln = new NBTTagCompound();
+				final NBTTagCompound ln = new NBTTagCompound();
 				link.writeToNBT( ln );
 				extra.setTag( "links-" + x, ln );
 			}
 		}
 	}
 
-	ICraftingLink getLink( int slot )
-	{
-		if( this.links == null )
-		{
-			return null;
-		}
-
-		return this.links[slot];
-	}
-
 	public boolean handleCrafting( int x, long itemToCraft, IAEItemStack ais, InventoryAdaptor d, World w, IGrid g, ICraftingGrid cg, BaseActionSource mySrc )
 	{
 		if( ais != null && d.simulateAdd( ais.getItemStack() ) == null )
 		{
-			Future<ICraftingJob> craftingJob = this.getJob( x );
+			final Future<ICraftingJob> craftingJob = this.getJob( x );
+
 			if( this.getLink( x ) != null )
 			{
 				return false;
@@ -132,6 +100,7 @@ public class MultiCraftingTracker
 			else if( craftingJob != null )
 			{
 				ICraftingJob job = null;
+
 				try
 				{
 					if( craftingJob.isDone() )
@@ -141,8 +110,20 @@ public class MultiCraftingTracker
 
 					if( job != null )
 					{
+						final ICraftingLink link = cg.submitJob( job, this.owner, null, false, mySrc );
+
 						this.setJob( x, null );
-						this.setLink( x, cg.submitJob( job, this.owner, null, false, mySrc ) );
+
+						if( link != null )
+						{
+							this.failedCraftingAttempts = Math.max( 0, this.failedCraftingAttempts - 1 );
+
+							this.setLink( x, link );
+						}
+						else
+						{
+							this.failedCraftingAttempts = Math.min( 10, this.failedCraftingAttempts + 1 );
+						}
 						return true;
 					}
 				}
@@ -159,47 +140,14 @@ public class MultiCraftingTracker
 			{
 				if( this.getLink( x ) == null )
 				{
-					IAEItemStack aisC = ais.copy();
+					final IAEItemStack aisC = ais.copy();
 					aisC.setStackSize( itemToCraft );
+
 					this.setJob( x, cg.beginCraftingJob( w, g, mySrc, aisC, null ) );
 				}
 			}
 		}
 		return false;
-	}
-
-	Future<ICraftingJob> getJob( int slot )
-	{
-		if( this.jobs == null )
-		{
-			return null;
-		}
-
-		return this.jobs[slot];
-	}
-
-	void setJob( int slot, Future<ICraftingJob> l )
-	{
-		if( this.jobs == null )
-		{
-			this.jobs = new Future[this.size];
-		}
-
-		this.jobs[slot] = l;
-
-		boolean hasStuff = false;
-		for( Future<ICraftingJob> job : this.jobs )
-		{
-			if( job != null )
-			{
-				hasStuff = true;
-			}
-		}
-
-		if( !hasStuff )
-		{
-			this.jobs = null;
-		}
 	}
 
 	public ImmutableSet<ICraftingLink> getRequestedJobs()
@@ -209,7 +157,7 @@ public class MultiCraftingTracker
 			return ImmutableSet.of();
 		}
 
-		return ImmutableSet.copyOf( new NonNullArrayIterator( this.links ) );
+		return ImmutableSet.copyOf( new NonNullArrayIterator<ICraftingLink>( this.links ) );
 	}
 
 	public void jobStateChange( ICraftingLink link )
@@ -275,5 +223,80 @@ public class MultiCraftingTracker
 	public boolean isBusy( int slot )
 	{
 		return this.getLink( slot ) != null || this.getJob( slot ) != null;
+	}
+
+	private ICraftingLink getLink( int slot )
+	{
+		if( this.links == null )
+		{
+			return null;
+		}
+
+		return this.links[slot];
+	}
+
+	private void setLink( int slot, ICraftingLink l )
+	{
+		if( this.links == null )
+		{
+			this.links = new ICraftingLink[this.size];
+		}
+
+		this.links[slot] = l;
+
+		boolean hasStuff = false;
+		for( int x = 0; x < this.links.length; x++ )
+		{
+			final ICraftingLink g = this.links[x];
+
+			if( g == null || g.isCanceled() || g.isDone() )
+			{
+				this.links[x] = null;
+			}
+			else
+			{
+				hasStuff = true;
+			}
+		}
+
+		if( !hasStuff )
+		{
+			this.links = null;
+		}
+	}
+
+	private Future<ICraftingJob> getJob( int slot )
+	{
+		if( this.jobs == null )
+		{
+			return null;
+		}
+
+		return this.jobs[slot];
+	}
+
+	private void setJob( int slot, Future<ICraftingJob> l )
+	{
+		if( this.jobs == null )
+		{
+			this.jobs = new Future[this.size];
+		}
+
+		this.jobs[slot] = l;
+
+		boolean hasStuff = false;
+
+		for( Future<ICraftingJob> job : this.jobs )
+		{
+			if( job != null )
+			{
+				hasStuff = true;
+			}
+		}
+
+		if( !hasStuff )
+		{
+			this.jobs = null;
+		}
 	}
 }

--- a/src/main/java/appeng/helpers/NonNullArrayIterator.java
+++ b/src/main/java/appeng/helpers/NonNullArrayIterator.java
@@ -16,7 +16,7 @@
  * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
  */
 
-package appeng.parts.automation;
+package appeng.helpers;
 
 
 import java.util.Iterator;
@@ -27,8 +27,8 @@ import scala.NotImplementedError;
 public class NonNullArrayIterator<E> implements Iterator<E>
 {
 
-	final E[] g;
-	int offset = 0;
+	private final E[] g;
+	private int offset = 0;
 
 	public NonNullArrayIterator( E[] o )
 	{
@@ -49,8 +49,9 @@ public class NonNullArrayIterator<E> implements Iterator<E>
 	@Override
 	public E next()
 	{
-		E result = this.g[this.offset];
+		final E result = this.g[this.offset];
 		this.offset++;
+
 		return result;
 	}
 

--- a/src/main/java/appeng/parts/automation/PartExportBus.java
+++ b/src/main/java/appeng/parts/automation/PartExportBus.java
@@ -176,6 +176,13 @@ public class PartExportBus extends PartSharedItemBus implements ICraftingRequest
 			// :P
 		}
 
+		final int failedAttempts = this.craftingTracker.getFailedCraftingAttempts();
+
+		if( this.isCraftingEnabled() && failedAttempts > 0 )
+		{
+			return this.getFailedCraftingPenalty( failedAttempts );
+		}
+
 		return this.didSomething ? TickRateModulation.FASTER : TickRateModulation.SLOWER;
 	}
 
@@ -380,5 +387,19 @@ public class PartExportBus extends PartSharedItemBus implements ICraftingRequest
 		{
 			this.nextSlot = ( this.nextSlot + x ) % this.availableSlots();
 		}
+	}
+
+	private TickRateModulation getFailedCraftingPenalty( int failedAttempts )
+	{
+		if( failedAttempts > 5 )
+		{
+			return TickRateModulation.SLOWER;
+		}
+		else if( failedAttempts > 1 )
+		{
+			return TickRateModulation.SAME;
+		}
+
+		return TickRateModulation.FASTER;
 	}
 }


### PR DESCRIPTION
The export bus will now no longer speed up, if more than 1 of the last
crafting requests failed and slow down, if more then 5 failed.

Some code cleanup and moved the custom iterator into the helper package
as it is clearly related to the craftingtracker and not the export bus.

Fixes #1905