### PR TITLE
Fixes #1932: Better VersionChecker exception handling

### DIFF
--- a/src/main/java/appeng/services/VersionChecker.java
+++ b/src/main/java/appeng/services/VersionChecker.java
@@ -21,6 +21,10 @@ package appeng.services;
 
 import java.util.Date;
 
+import javax.annotation.Nonnull;
+
+import com.google.common.base.Preconditions;
+
 import net.minecraft.nbt.NBTTagCompound;
 
 import cpw.mods.fml.common.Loader;
@@ -66,30 +70,40 @@ public final class VersionChecker implements Runnable
 	private static final int MS_TO_SEC = 1000;
 	private final VersionCheckerConfig config;
 
-	public VersionChecker( final VersionCheckerConfig config )
+	public VersionChecker( @Nonnull final VersionCheckerConfig config )
 	{
+		Preconditions.checkNotNull( config );
+
 		this.config = config;
 	}
 
 	@Override
 	public void run()
 	{
-		Thread.yield();
+		try
+		{
+			Thread.yield();
 
-		// persist the config
-		this.config.save();
+			// persist the config
+			this.config.save();
 
-		// retrieve data
-		final String rawLastCheck = this.config.lastCheck();
+			// retrieve data
+			final String rawLastCheck = this.config.lastCheck();
 
-		// process data
-		final long lastCheck = Long.parseLong( rawLastCheck );
-		final Date now = new Date();
-		final long nowInMs = now.getTime();
-		final long intervalInMs = this.config.interval() * SEC_TO_HOUR * MS_TO_SEC;
-		final long lastAfterInterval = lastCheck + intervalInMs;
+			// process data
+			final long lastCheck = Long.parseLong( rawLastCheck );
+			final Date now = new Date();
+			final long nowInMs = now.getTime();
+			final long intervalInMs = this.config.interval() * SEC_TO_HOUR * MS_TO_SEC;
+			final long lastAfterInterval = lastCheck + intervalInMs;
 
-		this.processInterval( nowInMs, lastAfterInterval );
+			this.processInterval( nowInMs, lastAfterInterval );
+		}
+		catch( Exception exception )
+		{
+			// Log any unhandled exception to prevent the JVM from reporting them as unhandled.
+			AELog.error( exception );
+		}
 
 		AELog.info( "Stopping AE2 VersionChecker" );
 	}
@@ -127,7 +141,7 @@ public final class VersionChecker implements Runnable
 	 * @param modVersion version of mod
 	 * @param githubRelease release retrieved through github
 	 */
-	private void processVersions( final Version modVersion, final FormattedRelease githubRelease )
+	private void processVersions( @Nonnull final Version modVersion, @Nonnull final FormattedRelease githubRelease )
 	{
 		final Version githubVersion = githubRelease.version();
 		final String modFormatted = modVersion.formatted();
@@ -162,7 +176,7 @@ public final class VersionChecker implements Runnable
 	 * @param ghFormatted retrieved github version formatted as rv2-beta-8
 	 * @param changelog retrieved github changelog
 	 */
-	private void interactWithVersionCheckerMod( final String modFormatted, final String ghFormatted, final String changelog )
+	private void interactWithVersionCheckerMod( @Nonnull final String modFormatted, @Nonnull final String ghFormatted, @Nonnull final String changelog )
 	{
 		if( Loader.isModLoaded( "VersionChecker" ) )
 		{

--- a/src/main/java/appeng/services/version/BaseVersion.java
+++ b/src/main/java/appeng/services/version/BaseVersion.java
@@ -1,5 +1,28 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
 
 package appeng.services.version;
+
+
+import javax.annotation.Nonnegative;
+import javax.annotation.Nonnull;
+
+import com.google.common.base.Preconditions;
 
 
 /**
@@ -9,8 +32,11 @@ package appeng.services.version;
  */
 public abstract class BaseVersion implements Version
 {
+	@Nonnegative
 	private final int revision;
+	@Nonnull
 	private final Channel channel;
+	@Nonnegative
 	private final int build;
 
 	/**
@@ -20,10 +46,11 @@ public abstract class BaseVersion implements Version
 	 *
 	 * @throws AssertionError if assertion are enabled and revision or build are not natural numbers
 	 */
-	public BaseVersion( final int revision, final Channel channel, final int build )
+	public BaseVersion( @Nonnegative final int revision, @Nonnull final Channel channel, @Nonnegative final int build )
 	{
-		assert revision >= 0;
-		assert build >= 0;
+		Preconditions.checkArgument( revision >= 0 );
+		Preconditions.checkNotNull( channel );
+		Preconditions.checkArgument( build >= 0 );
 
 		this.revision = revision;
 		this.channel = channel;
@@ -58,7 +85,7 @@ public abstract class BaseVersion implements Version
 	public final int hashCode()
 	{
 		int result = this.revision;
-		result = 31 * result + ( this.channel != null ? this.channel.hashCode() : 0 );
+		result = 31 * result + this.channel.hashCode();
 		result = 31 * result + this.build;
 		return result;
 	}

--- a/src/main/java/appeng/services/version/MissingVersion.java
+++ b/src/main/java/appeng/services/version/MissingVersion.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
 
 package appeng.services.version;
 

--- a/src/main/java/appeng/services/version/ModVersionFetcher.java
+++ b/src/main/java/appeng/services/version/ModVersionFetcher.java
@@ -1,5 +1,28 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
 
 package appeng.services.version;
+
+
+import javax.annotation.Nonnull;
+
+import appeng.core.AELog;
+import appeng.services.version.exceptions.VersionCheckerException;
 
 
 /**
@@ -9,10 +32,14 @@ package appeng.services.version;
  */
 public final class ModVersionFetcher implements VersionFetcher
 {
+	private static final Version EXCEPTIONAL_VERSION = new MissingVersion();
+
+	@Nonnull
 	private final String rawModVersion;
+	@Nonnull
 	private final VersionParser parser;
 
-	public ModVersionFetcher( final String rawModVersion, final VersionParser parser )
+	public ModVersionFetcher( @Nonnull final String rawModVersion, @Nonnull final VersionParser parser )
 	{
 		this.rawModVersion = rawModVersion;
 		this.parser = parser;
@@ -21,7 +48,8 @@ public final class ModVersionFetcher implements VersionFetcher
 	/**
 	 * Parses only, if not checked in developer environment or in a pull request
 	 *
-	 * @return {@link DoNotCheckVersion} if in developer environment or pull request, else the parsed {@link Version}
+	 * @return {@link DoNotCheckVersion} if in developer environment or pull request, {@link MissingVersion} in case of
+	 * a parser exception or else the parsed {@link Version}.
 	 */
 	@Override
 	public Version get()
@@ -30,11 +58,18 @@ public final class ModVersionFetcher implements VersionFetcher
 		{
 			return new DoNotCheckVersion();
 		}
-		else
+
+		try
 		{
 			final Version version = this.parser.parse( this.rawModVersion );
 
 			return version;
+		}
+		catch( final VersionCheckerException e )
+		{
+			AELog.error( e );
+
+			return EXCEPTIONAL_VERSION;
 		}
 	}
 }

--- a/src/main/java/appeng/services/version/VersionCheckerConfig.java
+++ b/src/main/java/appeng/services/version/VersionCheckerConfig.java
@@ -22,6 +22,10 @@ package appeng.services.version;
 import java.io.File;
 import java.util.Date;
 
+import javax.annotation.Nonnull;
+
+import com.google.common.base.Preconditions;
+
 import net.minecraftforge.common.config.Configuration;
 
 
@@ -34,13 +38,16 @@ public final class VersionCheckerConfig
 	private static final int MIN_INTERVAL_HOURS = 0;
 	private static final int MAX_INTERVAL_HOURS = 7 * 24;
 
+	@Nonnull
 	private final Configuration config;
 
 	private final boolean isEnabled;
 
+	@Nonnull
 	private final String lastCheck;
 	private final int interval;
 
+	@Nonnull
 	private final String level;
 
 	private final boolean shouldNotifyPlayer;
@@ -49,8 +56,11 @@ public final class VersionCheckerConfig
 	/**
 	 * @param file requires fully qualified file in which the config is saved
 	 */
-	public VersionCheckerConfig( final File file )
+	public VersionCheckerConfig( @Nonnull final File file )
 	{
+		Preconditions.checkNotNull( file );
+		Preconditions.checkState( file.isFile() );
+
 		this.config = new Configuration( file );
 
 		// initializes default values by caching

--- a/src/main/java/appeng/services/version/VersionFetcher.java
+++ b/src/main/java/appeng/services/version/VersionFetcher.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
 
 package appeng.services.version;
 

--- a/src/main/java/appeng/services/version/exceptions/InvalidBuildException.java
+++ b/src/main/java/appeng/services/version/exceptions/InvalidBuildException.java
@@ -16,42 +16,18 @@
  * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
  */
 
-package appeng.services.version;
-
-
-import javax.annotation.Nonnegative;
-import javax.annotation.Nonnull;
+package appeng.services.version.exceptions;
 
 
 /**
- * AE prints version like rv2-beta-8
- * GitHub prints version like rv2.beta.8
+ * Indicates a invalid build number, which is any string except a natural number.
  */
-public final class DefaultVersion extends BaseVersion
+public class InvalidBuildException extends VersionCheckerException
 {
-	/**
-	 * @param revision natural number
-	 * @param channel either alpha, beta or release
-	 * @param build natural number
-	 */
-	public DefaultVersion( @Nonnegative final int revision, @Nonnull final Channel channel, @Nonnegative final int build )
+	private static final long serialVersionUID = 3015432444672364991L;
+
+	public InvalidBuildException()
 	{
-		super( revision, channel, build );
-	}
-
-	@Override
-	public boolean isNewerAs( final Version maybeOlder )
-	{
-		if( this.revision() > maybeOlder.revision() )
-		{
-			return true;
-		}
-
-		if( this.channel().compareTo( maybeOlder.channel() ) > 0 )
-		{
-			return true;
-		}
-
-		return this.build() > maybeOlder.build();
+		super( "Invalid Build: Needs to be a natural number." );
 	}
 }

--- a/src/main/java/appeng/services/version/exceptions/InvalidChannelException.java
+++ b/src/main/java/appeng/services/version/exceptions/InvalidChannelException.java
@@ -16,42 +16,21 @@
  * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
  */
 
-package appeng.services.version;
+package appeng.services.version.exceptions;
 
 
-import javax.annotation.Nonnegative;
-import javax.annotation.Nonnull;
+import appeng.services.version.Channel;
 
 
 /**
- * AE prints version like rv2-beta-8
- * GitHub prints version like rv2.beta.8
+ * Indicates an invalid {@link Channel} value.
  */
-public final class DefaultVersion extends BaseVersion
+public class InvalidChannelException extends VersionCheckerException
 {
-	/**
-	 * @param revision natural number
-	 * @param channel either alpha, beta or release
-	 * @param build natural number
-	 */
-	public DefaultVersion( @Nonnegative final int revision, @Nonnull final Channel channel, @Nonnegative final int build )
+	private static final long serialVersionUID = -1306378515002341620L;
+
+	public InvalidChannelException()
 	{
-		super( revision, channel, build );
-	}
-
-	@Override
-	public boolean isNewerAs( final Version maybeOlder )
-	{
-		if( this.revision() > maybeOlder.revision() )
-		{
-			return true;
-		}
-
-		if( this.channel().compareTo( maybeOlder.channel() ) > 0 )
-		{
-			return true;
-		}
-
-		return this.build() > maybeOlder.build();
+		super( "Invalid Channel: Needs to be one of the following values; alpha, beta, or stable." );
 	}
 }

--- a/src/main/java/appeng/services/version/exceptions/InvalidRevisionException.java
+++ b/src/main/java/appeng/services/version/exceptions/InvalidRevisionException.java
@@ -16,42 +16,19 @@
  * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
  */
 
-package appeng.services.version;
-
-
-import javax.annotation.Nonnegative;
-import javax.annotation.Nonnull;
+package appeng.services.version.exceptions;
 
 
 /**
- * AE prints version like rv2-beta-8
- * GitHub prints version like rv2.beta.8
+ * Indicates a invalid revision, which does not match the pattern "rv" followed by a natural number.
  */
-public final class DefaultVersion extends BaseVersion
+public class InvalidRevisionException extends VersionCheckerException
 {
-	/**
-	 * @param revision natural number
-	 * @param channel either alpha, beta or release
-	 * @param build natural number
-	 */
-	public DefaultVersion( @Nonnegative final int revision, @Nonnull final Channel channel, @Nonnegative final int build )
+
+	private static final long serialVersionUID = 4828906902143875942L;
+
+	public InvalidRevisionException()
 	{
-		super( revision, channel, build );
-	}
-
-	@Override
-	public boolean isNewerAs( final Version maybeOlder )
-	{
-		if( this.revision() > maybeOlder.revision() )
-		{
-			return true;
-		}
-
-		if( this.channel().compareTo( maybeOlder.channel() ) > 0 )
-		{
-			return true;
-		}
-
-		return this.build() > maybeOlder.build();
+		super( "Invalid Revision: Needs to be 'rv' followd by a natural number." );
 	}
 }

--- a/src/main/java/appeng/services/version/exceptions/InvalidVersionException.java
+++ b/src/main/java/appeng/services/version/exceptions/InvalidVersionException.java
@@ -16,42 +16,19 @@
  * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
  */
 
-package appeng.services.version;
-
-
-import javax.annotation.Nonnegative;
-import javax.annotation.Nonnull;
+package appeng.services.version.exceptions;
 
 
 /**
- * AE prints version like rv2-beta-8
- * GitHub prints version like rv2.beta.8
+ * Indicates an invalid version, which does not consists of 3 parts matching /(rv\d+)-(alpha|beta|stable)-(b\d+)/.
  */
-public final class DefaultVersion extends BaseVersion
+public class InvalidVersionException extends VersionCheckerException
 {
-	/**
-	 * @param revision natural number
-	 * @param channel either alpha, beta or release
-	 * @param build natural number
-	 */
-	public DefaultVersion( @Nonnegative final int revision, @Nonnull final Channel channel, @Nonnegative final int build )
+
+	private static final long serialVersionUID = 4828906902143875942L;
+
+	public InvalidVersionException()
 	{
-		super( revision, channel, build );
-	}
-
-	@Override
-	public boolean isNewerAs( final Version maybeOlder )
-	{
-		if( this.revision() > maybeOlder.revision() )
-		{
-			return true;
-		}
-
-		if( this.channel().compareTo( maybeOlder.channel() ) > 0 )
-		{
-			return true;
-		}
-
-		return this.build() > maybeOlder.build();
+		super( "Invalid Version Format: Need to consist of exactly 3 parts separated by a dash." );
 	}
 }

--- a/src/main/java/appeng/services/version/exceptions/MissingSeparatorException.java
+++ b/src/main/java/appeng/services/version/exceptions/MissingSeparatorException.java
@@ -16,42 +16,20 @@
  * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
  */
 
-package appeng.services.version;
-
-
-import javax.annotation.Nonnegative;
-import javax.annotation.Nonnull;
+package appeng.services.version.exceptions;
 
 
 /**
- * AE prints version like rv2-beta-8
- * GitHub prints version like rv2.beta.8
+ * Indicates a version without a valid separator.
+ *
+ * Valid separators are a dash ("-") or dot (".")
  */
-public final class DefaultVersion extends BaseVersion
+public class MissingSeparatorException extends VersionCheckerException
 {
-	/**
-	 * @param revision natural number
-	 * @param channel either alpha, beta or release
-	 * @param build natural number
-	 */
-	public DefaultVersion( @Nonnegative final int revision, @Nonnull final Channel channel, @Nonnegative final int build )
+	private static final long serialVersionUID = 8366370192017020750L;
+
+	public MissingSeparatorException()
 	{
-		super( revision, channel, build );
-	}
-
-	@Override
-	public boolean isNewerAs( final Version maybeOlder )
-	{
-		if( this.revision() > maybeOlder.revision() )
-		{
-			return true;
-		}
-
-		if( this.channel().compareTo( maybeOlder.channel() ) > 0 )
-		{
-			return true;
-		}
-
-		return this.build() > maybeOlder.build();
+		super( "Invalid Revision: Needs to match 'rv' followed by a natural number." );
 	}
 }

--- a/src/main/java/appeng/services/version/exceptions/VersionCheckerException.java
+++ b/src/main/java/appeng/services/version/exceptions/VersionCheckerException.java
@@ -16,42 +16,21 @@
  * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
  */
 
-package appeng.services.version;
+package appeng.services.version.exceptions;
 
 
-import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
 
 
 /**
- * AE prints version like rv2-beta-8
- * GitHub prints version like rv2.beta.8
+ * A super class for any exception thrown by the version checker for easier handling.
  */
-public final class DefaultVersion extends BaseVersion
+public class VersionCheckerException extends Exception
 {
-	/**
-	 * @param revision natural number
-	 * @param channel either alpha, beta or release
-	 * @param build natural number
-	 */
-	public DefaultVersion( @Nonnegative final int revision, @Nonnull final Channel channel, @Nonnegative final int build )
+	private static final long serialVersionUID = 4582501864800542884L;
+
+	public VersionCheckerException( @Nonnull String string )
 	{
-		super( revision, channel, build );
-	}
-
-	@Override
-	public boolean isNewerAs( final Version maybeOlder )
-	{
-		if( this.revision() > maybeOlder.revision() )
-		{
-			return true;
-		}
-
-		if( this.channel().compareTo( maybeOlder.channel() ) > 0 )
-		{
-			return true;
-		}
-
-		return this.build() > maybeOlder.build();
+		super( string );
 	}
 }

--- a/src/main/java/appeng/services/version/github/DefaultFormattedRelease.java
+++ b/src/main/java/appeng/services/version/github/DefaultFormattedRelease.java
@@ -1,6 +1,25 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
 
 package appeng.services.version.github;
 
+
+import javax.annotation.Nonnull;
 
 import appeng.services.version.Version;
 
@@ -10,10 +29,12 @@ import appeng.services.version.Version;
  */
 public final class DefaultFormattedRelease implements FormattedRelease
 {
+	@Nonnull
 	private final Version version;
+	@Nonnull
 	private final String changelog;
 
-	public DefaultFormattedRelease( final Version version, final String changelog )
+	public DefaultFormattedRelease( @Nonnull final Version version, @Nonnull final String changelog )
 	{
 		this.version = version;
 		this.changelog = changelog;

--- a/src/main/java/appeng/services/version/github/FormattedRelease.java
+++ b/src/main/java/appeng/services/version/github/FormattedRelease.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
 
 package appeng.services.version.github;
 

--- a/src/main/java/appeng/services/version/github/MissingFormattedRelease.java
+++ b/src/main/java/appeng/services/version/github/MissingFormattedRelease.java
@@ -1,6 +1,25 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
 
 package appeng.services.version.github;
 
+
+import javax.annotation.Nonnull;
 
 import appeng.services.version.MissingVersion;
 import appeng.services.version.Version;
@@ -11,6 +30,7 @@ import appeng.services.version.Version;
  */
 public final class MissingFormattedRelease implements FormattedRelease
 {
+	@Nonnull
 	private final Version version;
 
 	public MissingFormattedRelease()

--- a/src/main/java/appeng/services/version/github/Release.java
+++ b/src/main/java/appeng/services/version/github/Release.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
 
 package appeng.services.version.github;
 

--- a/src/main/java/appeng/services/version/github/ReleaseFetcher.java
+++ b/src/main/java/appeng/services/version/github/ReleaseFetcher.java
@@ -1,11 +1,31 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
 
 package appeng.services.version.github;
 
 
 import java.io.IOException;
 import java.lang.reflect.Type;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
+
+import javax.annotation.Nonnull;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
@@ -17,6 +37,7 @@ import appeng.services.version.Channel;
 import appeng.services.version.Version;
 import appeng.services.version.VersionCheckerConfig;
 import appeng.services.version.VersionParser;
+import appeng.services.version.exceptions.VersionCheckerException;
 
 
 public final class ReleaseFetcher
@@ -24,10 +45,12 @@ public final class ReleaseFetcher
 	private static final String GITHUB_RELEASES_URL = "https://api.github.com/repos/AppliedEnergistics/Applied-Energistics-2/releases";
 	private static final FormattedRelease EXCEPTIONAL_RELEASE = new MissingFormattedRelease();
 
+	@Nonnull
 	private final VersionCheckerConfig config;
+	@Nonnull
 	private final VersionParser parser;
 
-	public ReleaseFetcher( final VersionCheckerConfig config, final VersionParser parser )
+	public ReleaseFetcher( @Nonnull final VersionCheckerConfig config, @Nonnull final VersionParser parser )
 	{
 		this.config = config;
 		this.parser = parser;
@@ -50,12 +73,20 @@ public final class ReleaseFetcher
 
 			return latestFitRelease;
 		}
-		catch( final Exception e )
+		catch( final VersionCheckerException e )
 		{
 			AELog.error( e );
-
-			return EXCEPTIONAL_RELEASE;
 		}
+		catch( MalformedURLException e )
+		{
+			AELog.error( e );
+		}
+		catch( IOException e )
+		{
+			AELog.error( e );
+		}
+
+		return EXCEPTIONAL_RELEASE;
 	}
 
 	private String getRawReleases( final URL url ) throws IOException
@@ -63,7 +94,7 @@ public final class ReleaseFetcher
 		return IOUtils.toString( url );
 	}
 
-	private FormattedRelease getLatestFitRelease( final Iterable<Release> releases )
+	private FormattedRelease getLatestFitRelease( final Iterable<Release> releases ) throws VersionCheckerException
 	{
 		final String levelInConfig = this.config.level();
 		final Channel level = Channel.valueOf( levelInConfig );

--- a/src/test/java/appeng/services/version/VersionParserTest.java
+++ b/src/test/java/appeng/services/version/VersionParserTest.java
@@ -1,7 +1,15 @@
+
 package appeng.services.version;
 
 
 import org.junit.Test;
+
+import appeng.services.version.exceptions.InvalidBuildException;
+import appeng.services.version.exceptions.InvalidChannelException;
+import appeng.services.version.exceptions.InvalidRevisionException;
+import appeng.services.version.exceptions.InvalidVersionException;
+import appeng.services.version.exceptions.MissingSeparatorException;
+import appeng.services.version.exceptions.VersionCheckerException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -21,6 +29,8 @@ public final class VersionParserTest
 	private static final String MOD_INVALID_REVISION = "2-beta-8";
 	private static final String MOD_INVALID_CHANNEL = "rv2-gamma-8";
 	private static final String MOD_INVALID_BUILD = "rv2-beta-b8";
+	private static final String GENERIC_MISSING_SEPARATOR = "foobar";
+	private static final String GENERIC_INVALID_VERSION = "foo-bar";
 
 	private static final DefaultVersion VERSION = new DefaultVersion( 2, Channel.Beta, 8 );
 
@@ -32,7 +42,7 @@ public final class VersionParserTest
 	}
 
 	@Test
-	public void testSameParsedGitHub()
+	public void testSameParsedGitHub() throws VersionCheckerException
 	{
 		final Version version = this.parser.parse( GITHUB_VERSION );
 
@@ -40,50 +50,62 @@ public final class VersionParserTest
 	}
 
 	@Test
-	public void testParseGitHub()
+	public void testParseGitHub() throws VersionCheckerException
 	{
 		assertTrue( this.parser.parse( GITHUB_VERSION ).equals( VERSION ) );
 	}
 
-	@Test( expected = AssertionError.class )
-	public void parseGH_InvalidRevision()
+	@Test( expected = InvalidRevisionException.class )
+	public void parseGH_InvalidRevision() throws VersionCheckerException
 	{
 		assertFalse( this.parser.parse( GITHUB_INVALID_REVISION ).equals( VERSION ) );
 	}
 
-	@Test( expected = AssertionError.class )
-	public void parseGH_InvalidChannel()
+	@Test( expected = InvalidChannelException.class )
+	public void parseGH_InvalidChannel() throws VersionCheckerException
 	{
 		assertFalse( this.parser.parse( GITHUB_INVALID_CHANNEL ).equals( VERSION ) );
 	}
 
-	@Test( expected = AssertionError.class )
-	public void parseGH_InvalidBuild()
+	@Test( expected = InvalidBuildException.class )
+	public void parseGH_InvalidBuild() throws VersionCheckerException
 	{
 		assertFalse( this.parser.parse( GITHUB_INVALID_BUILD ).equals( VERSION ) );
 	}
 
 	@Test
-	public void testParseMod()
+	public void testParseMod() throws VersionCheckerException
 	{
 		assertTrue( this.parser.parse( MOD_VERSION ).equals( VERSION ) );
 	}
 
-	@Test( expected = AssertionError.class )
-	public void parseMod_InvalidRevision()
+	@Test( expected = InvalidRevisionException.class )
+	public void parseMod_InvalidRevision() throws VersionCheckerException
 	{
 		assertFalse( this.parser.parse( MOD_INVALID_REVISION ).equals( VERSION ) );
 	}
 
-	@Test( expected = AssertionError.class )
-	public void parseMod_InvalidChannel()
+	@Test( expected = InvalidChannelException.class )
+	public void parseMod_InvalidChannel() throws VersionCheckerException
 	{
 		assertFalse( this.parser.parse( MOD_INVALID_CHANNEL ).equals( VERSION ) );
 	}
 
-	@Test( expected = AssertionError.class )
-	public void parseMod_InvalidBuild()
+	@Test( expected = InvalidBuildException.class )
+	public void parseMod_InvalidBuild() throws VersionCheckerException
 	{
 		assertFalse( this.parser.parse( MOD_INVALID_BUILD ).equals( VERSION ) );
+	}
+
+	@Test( expected = MissingSeparatorException.class )
+	public void parseGeneric_MissingSeparator() throws VersionCheckerException
+	{
+		assertFalse( this.parser.parse( GENERIC_MISSING_SEPARATOR ).equals( VERSION ) );
+	}
+
+	@Test( expected = InvalidVersionException.class )
+	public void parseGeneric_InvalidVersion() throws VersionCheckerException
+	{
+		assertFalse( this.parser.parse( GENERIC_INVALID_VERSION ).equals( VERSION ) );
 	}
 }


### PR DESCRIPTION
ModVersionFetcher will now return a MissingVersion in case of an exception
instead of letting it propagate upwards.

Also added a generic try/catch to the VersionChecker itself, just in case
any unchecked exception might be triggered inside the thread and at least
not logged correctly.