### PR TITLE
Add config to adjust valid meteorite spawn blocks

### DIFF
--- a/src/main/java/appeng/core/AEConfig.java
+++ b/src/main/java/appeng/core/AEConfig.java
@@ -99,6 +99,7 @@ public final class AEConfig extends Configuration implements IConfigurableObject
 	public double meteoriteClusterChance = 0.1;
 	public double meteoriteSpawnChance = 0.3;
 	public int[] meteoriteDimensionWhitelist = { 0 };
+	public String[] meteoriteValidSpawnBlocks = new String[] {};
 	public int craftingCalculationTimePerTick = 5;
 	PowerUnits selectedPowerUnit = PowerUnits.AE;
 	private double WirelessBaseCost = 8;
@@ -143,6 +144,7 @@ public final class AEConfig extends Configuration implements IConfigurableObject
 		this.meteoriteClusterChance = this.get( "worldGen", "meteoriteClusterChance", this.meteoriteClusterChance ).getDouble( this.meteoriteClusterChance );
 		this.meteoriteSpawnChance = this.get( "worldGen", "meteoriteSpawnChance", this.meteoriteSpawnChance ).getDouble( this.meteoriteSpawnChance );
 		this.meteoriteDimensionWhitelist = this.get( "worldGen", "meteoriteDimensionWhitelist", this.meteoriteDimensionWhitelist ).getIntList();
+		this.meteoriteValidSpawnBlocks = this.get( "worldGen", "meteoriteValidSpawnBlocks", this.meteoriteValidSpawnBlocks ).getStringList();
 
 		this.quartzOresPerCluster = this.get( "worldGen", "quartzOresPerCluster", this.quartzOresPerCluster ).getInt( this.quartzOresPerCluster );
 		this.quartzOresClusterAmount = this.get( "worldGen", "quartzOresClusterAmount", this.quartzOresClusterAmount ).getInt( this.quartzOresClusterAmount );

--- a/src/main/java/appeng/worldgen/MeteoritePlacer.java
+++ b/src/main/java/appeng/worldgen/MeteoritePlacer.java
@@ -91,7 +91,18 @@ public final class MeteoritePlacer
 		this.validSpawn.add( Blocks.ice );
 		this.validSpawn.add( Blocks.snow );
 		this.validSpawn.add( Blocks.stained_hardened_clay );
+		
+		for( final String name : AEConfig.instance.meteoriteValidSpawnBlocks )
+		{
+			Block block = Block.getBlockFromName( name );
+			
+			if( block != null )
+			{
+				this.validSpawn.add( block );
+			}
+		}
 
+		
 		for( final Block skyStoneBlock : this.skyStoneDefinition.maybeBlock().asSet() )
 		{
 			this.invalidSpawn.add( skyStoneBlock );


### PR DESCRIPTION
This adds a configuration option to add to the list of valid spawn blocks for meteorites.

Example usage:
```
worldgen {
    S:meteoriteValidSpawnBlocks <
        minecraft:wool
    >
}
```