### PR TITLE
Fixes #1983: WorldData cleared too early when still needed.

### DIFF
--- a/src/main/java/appeng/core/AppEng.java
+++ b/src/main/java/appeng/core/AppEng.java
@@ -21,6 +21,7 @@ package appeng.core;
 
 import java.io.File;
 import java.util.concurrent.TimeUnit;
+
 import javax.annotation.Nonnull;
 
 import com.google.common.base.Stopwatch;
@@ -37,6 +38,7 @@ import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.common.event.FMLServerAboutToStartEvent;
 import cpw.mods.fml.common.event.FMLServerStartingEvent;
+import cpw.mods.fml.common.event.FMLServerStoppedEvent;
 import cpw.mods.fml.common.event.FMLServerStoppingEvent;
 import cpw.mods.fml.common.network.NetworkRegistry;
 
@@ -233,6 +235,12 @@ public final class AppEng
 	private void serverStopping( final FMLServerStoppingEvent event )
 	{
 		WorldData.instance().onServerStopping();
+	}
+
+	@EventHandler
+	private void serverStopped( final FMLServerStoppedEvent event )
+	{
+		WorldData.instance().onServerStoppped();
 		TickHandler.INSTANCE.shutdown();
 	}
 

--- a/src/main/java/appeng/core/worlddata/IWorldData.java
+++ b/src/main/java/appeng/core/worlddata/IWorldData.java
@@ -24,12 +24,14 @@ import javax.annotation.Nonnull;
 
 /**
  * @author thatsIch
- * @version rv3 - 30.05.2015
+ * @version rv3 - 02.11.2015
  * @since rv3 30.05.2015
  */
 public interface IWorldData
 {
 	void onServerStopping();
+
+	void onServerStoppped();
 
 	@Nonnull
 	IWorldGridStorageData storageData();

--- a/src/main/java/appeng/core/worlddata/WorldData.java
+++ b/src/main/java/appeng/core/worlddata/WorldData.java
@@ -45,7 +45,7 @@ import appeng.services.compass.CompassThreadFactory;
  * different worlds.
  *
  * @author thatsIch
- * @version rv3 - 30.05.2015
+ * @version rv3 - 02.11.2015
  * @since rv3 30.05.2015
  */
 public final class WorldData implements IWorldData
@@ -162,15 +162,18 @@ public final class WorldData implements IWorldData
 	@Override
 	public void onServerStopping()
 	{
-		Preconditions.checkNotNull( instance );
-
 		for( final IOnWorldStoppable stoppable : this.stoppables )
 		{
 			stoppable.onWorldStop();
 		}
+	}
+
+	@Override
+	public void onServerStoppped()
+	{
+		Preconditions.checkNotNull( instance );
 
 		this.stoppables.clear();
-
 		instance = null;
 	}
 


### PR DESCRIPTION
The `WorldData` instance is removed too early during the server stop and not once the server is actually stopped.
This results in interdimensional networks to not be saved correctly as they no longer can access the `StorageData` to determine their grid.

Moved the cleanup to `FMLServerStoppedEvent` stage and extended the interface for `IWorldData` to contain a method this stage.