### PR TITLE
Backport some 1.8 cleanups

### DIFF
--- a/src/main/java/appeng/tile/crafting/TileMolecularAssembler.java
+++ b/src/main/java/appeng/tile/crafting/TileMolecularAssembler.java
@@ -102,7 +102,7 @@ public class TileMolecularAssembler extends AENetworkInvTile implements IUpgrade
 		this.settings = new ConfigManager( this );
 		this.settings.registerSetting( Settings.REDSTONE_CONTROLLED, RedstoneMode.IGNORE );
 		this.inv.setMaxStackSize( 1 );
-		this.getGridProxy().setIdlePowerUsage( 0.0 );
+		this.getProxy().setIdlePowerUsage( 0.0 );
 		this.upgrades = new DefinitionUpgradeInventory( assembler, this, this.getUpgradeSlots() );
 		this.craftingInv = new InventoryCrafting( new ContainerNull(), 3, 3 );
 	}
@@ -152,11 +152,11 @@ public class TileMolecularAssembler extends AENetworkInvTile implements IUpgrade
 			{
 				if( this.isAwake )
 				{
-					this.getGridProxy().getTick().wakeDevice( this.getGridProxy().getNode() );
+					this.getProxy().getTick().wakeDevice( this.getProxy().getNode() );
 				}
 				else
 				{
-					this.getGridProxy().getTick().sleepDevice( this.getGridProxy().getNode() );
+					this.getProxy().getTick().sleepDevice( this.getProxy().getNode() );
 				}
 			}
 			catch( final GridAccessException e )
@@ -553,7 +553,7 @@ public class TileMolecularAssembler extends AENetworkInvTile implements IUpgrade
 	{
 		try
 		{
-			return (int) ( this.getGridProxy().getEnergy().extractAEPower( ticksPassed * bonusValue * acceleratorTax, Actionable.MODULATE, PowerMultiplier.CONFIG ) / acceleratorTax );
+			return (int) ( this.getProxy().getEnergy().extractAEPower( ticksPassed * bonusValue * acceleratorTax, Actionable.MODULATE, PowerMultiplier.CONFIG ) / acceleratorTax );
 		}
 		catch( final GridAccessException e )
 		{
@@ -629,7 +629,7 @@ public class TileMolecularAssembler extends AENetworkInvTile implements IUpgrade
 
 		try
 		{
-			newState = this.getGridProxy().isActive() && this.getGridProxy().getEnergy().extractAEPower( 1, Actionable.SIMULATE, PowerMultiplier.CONFIG ) > 0.0001;
+			newState = this.getProxy().isActive() && this.getProxy().getEnergy().extractAEPower( 1, Actionable.SIMULATE, PowerMultiplier.CONFIG ) > 0.0001;
 		}
 		catch( final GridAccessException ignored )
 		{

--- a/src/main/java/appeng/tile/grid/AENetworkInvTile.java
+++ b/src/main/java/appeng/tile/grid/AENetworkInvTile.java
@@ -39,19 +39,19 @@ public abstract class AENetworkInvTile extends AEBaseInvTile implements IActionH
 	@TileEvent( TileEventType.WORLD_NBT_READ )
 	public void readFromNBT_AENetwork( final NBTTagCompound data )
 	{
-		this.getGridProxy().readFromNBT( data );
+		this.getProxy().readFromNBT( data );
 	}
 
 	@TileEvent( TileEventType.WORLD_NBT_WRITE )
 	public void writeToNBT_AENetwork( final NBTTagCompound data )
 	{
-		this.getGridProxy().writeToNBT( data );
+		this.getProxy().writeToNBT( data );
 	}
 
 	@Override
 	public AENetworkProxy getProxy()
 	{
-		return this.getGridProxy();
+		return this.gridProxy;
 	}
 
 	@Override
@@ -63,45 +63,40 @@ public abstract class AENetworkInvTile extends AEBaseInvTile implements IActionH
 	@Override
 	public IGridNode getGridNode( final ForgeDirection dir )
 	{
-		return this.getGridProxy().getNode();
+		return this.getProxy().getNode();
 	}
 
 	@Override
 	public void onChunkUnload()
 	{
 		super.onChunkUnload();
-		this.getGridProxy().onChunkUnload();
+		this.getProxy().onChunkUnload();
 	}
 
 	@Override
 	public void onReady()
 	{
 		super.onReady();
-		this.getGridProxy().onReady();
+		this.getProxy().onReady();
 	}
 
 	@Override
 	public void invalidate()
 	{
 		super.invalidate();
-		this.getGridProxy().invalidate();
+		this.getProxy().invalidate();
 	}
 
 	@Override
 	public void validate()
 	{
 		super.validate();
-		this.getGridProxy().validate();
+		this.getProxy().validate();
 	}
 
 	@Override
 	public IGridNode getActionableNode()
 	{
-		return this.getGridProxy().getNode();
-	}
-
-	public AENetworkProxy getGridProxy()
-	{
-		return this.gridProxy;
+		return this.getProxy().getNode();
 	}
 }

--- a/src/main/java/appeng/tile/misc/TileInterface.java
+++ b/src/main/java/appeng/tile/misc/TileInterface.java
@@ -67,7 +67,7 @@ import appeng.util.inv.IInventoryDestination;
 public class TileInterface extends AENetworkInvTile implements IGridTickable, ITileStorageMonitorable, IStorageMonitorable, IInventoryDestination, IInterfaceHost, IPriorityHost
 {
 
-	private final DualityInterface duality = new DualityInterface( this.getGridProxy(), this );
+	private final DualityInterface duality = new DualityInterface( this.getProxy(), this );
 	private ForgeDirection pointAt = ForgeDirection.UNKNOWN;
 
 	@MENetworkEventSubscribe
@@ -115,7 +115,7 @@ public class TileInterface extends AENetworkInvTile implements IGridTickable, IT
 			this.setOrientation( this.pointAt.offsetY != 0 ? ForgeDirection.SOUTH : ForgeDirection.UP, this.pointAt.getOpposite() );
 		}
 
-		this.getGridProxy().setValidSides( EnumSet.complementOf( EnumSet.of( this.pointAt ) ) );
+		this.getProxy().setValidSides( EnumSet.complementOf( EnumSet.of( this.pointAt ) ) );
 		this.markForUpdate();
 		this.markDirty();
 	}
@@ -141,7 +141,7 @@ public class TileInterface extends AENetworkInvTile implements IGridTickable, IT
 	@Override
 	public void onReady()
 	{
-		this.getGridProxy().setValidSides( EnumSet.complementOf( EnumSet.of( this.pointAt ) ) );
+		this.getProxy().setValidSides( EnumSet.complementOf( EnumSet.of( this.pointAt ) ) );
 		super.onReady();
 		this.duality.initialize();
 	}

--- a/src/main/java/appeng/tile/misc/TileVibrationChamber.java
+++ b/src/main/java/appeng/tile/misc/TileVibrationChamber.java
@@ -66,8 +66,8 @@ public class TileVibrationChamber extends AENetworkInvTile implements IGridTicka
 
 	public TileVibrationChamber()
 	{
-		this.getGridProxy().setIdlePowerUsage( 0 );
-		this.getGridProxy().setFlags();
+		this.getProxy().setIdlePowerUsage( 0 );
+		this.getProxy().setFlags();
 	}
 
 	@Override
@@ -131,7 +131,7 @@ public class TileVibrationChamber extends AENetworkInvTile implements IGridTicka
 			{
 				try
 				{
-					this.getGridProxy().getTick().wakeDevice( this.getGridProxy().getNode() );
+					this.getProxy().getTick().wakeDevice( this.getProxy().getNode() );
 				}
 				catch( final GridAccessException e )
 				{
@@ -213,7 +213,7 @@ public class TileVibrationChamber extends AENetworkInvTile implements IGridTicka
 
 		try
 		{
-			final IEnergyGrid grid = this.getGridProxy().getEnergy();
+			final IEnergyGrid grid = this.getProxy().getEnergy();
 			final double newPower = timePassed * POWER_PER_TICK;
 			final double overFlow = grid.injectPower( newPower, Actionable.SIMULATE );
 
@@ -275,7 +275,7 @@ public class TileVibrationChamber extends AENetworkInvTile implements IGridTicka
 		{
 			try
 			{
-				this.getGridProxy().getTick().wakeDevice( this.getGridProxy().getNode() );
+				this.getProxy().getTick().wakeDevice( this.getProxy().getNode() );
 			}
 			catch( final GridAccessException e )
 			{

--- a/src/main/java/appeng/tile/networking/TileWireless.java
+++ b/src/main/java/appeng/tile/networking/TileWireless.java
@@ -60,15 +60,15 @@ public class TileWireless extends AENetworkInvTile implements IWirelessAccessPoi
 
 	public TileWireless()
 	{
-		this.getGridProxy().setFlags( GridFlags.REQUIRE_CHANNEL );
-		this.getGridProxy().setValidSides( EnumSet.noneOf( ForgeDirection.class ) );
+		this.getProxy().setFlags( GridFlags.REQUIRE_CHANNEL );
+		this.getProxy().setValidSides( EnumSet.noneOf( ForgeDirection.class ) );
 	}
 
 	@Override
 	public void setOrientation( final ForgeDirection inForward, final ForgeDirection inUp )
 	{
 		super.setOrientation( inForward, inUp );
-		this.getGridProxy().setValidSides( EnumSet.of( this.getForward().getOpposite() ) );
+		this.getProxy().setValidSides( EnumSet.of( this.getForward().getOpposite() ) );
 	}
 
 	@MENetworkEventSubscribe
@@ -99,12 +99,12 @@ public class TileWireless extends AENetworkInvTile implements IWirelessAccessPoi
 
 		try
 		{
-			if( this.getGridProxy().getEnergy().isNetworkPowered() )
+			if( this.getProxy().getEnergy().isNetworkPowered() )
 			{
 				this.setClientFlags( this.getClientFlags() | POWERED_FLAG );
 			}
 
-			if( this.getGridProxy().getNode().meetsChannelRequirements() )
+			if( this.getProxy().getNode().meetsChannelRequirements() )
 			{
 				this.setClientFlags( this.getClientFlags() | CHANNEL_FLAG );
 			}
@@ -162,7 +162,7 @@ public class TileWireless extends AENetworkInvTile implements IWirelessAccessPoi
 
 	private void updatePower()
 	{
-		this.getGridProxy().setIdlePowerUsage( AEConfig.instance.wireless_getPowerDrain( this.getBoosters() ) );
+		this.getProxy().setIdlePowerUsage( AEConfig.instance.wireless_getPowerDrain( this.getBoosters() ) );
 	}
 
 	private int getBoosters()
@@ -191,7 +191,7 @@ public class TileWireless extends AENetworkInvTile implements IWirelessAccessPoi
 			return this.isPowered() && ( CHANNEL_FLAG == ( this.getClientFlags() & CHANNEL_FLAG ) );
 		}
 
-		return this.getGridProxy().isActive();
+		return this.getProxy().isActive();
 	}
 
 	@Override
@@ -199,7 +199,7 @@ public class TileWireless extends AENetworkInvTile implements IWirelessAccessPoi
 	{
 		try
 		{
-			return this.getGridProxy().getGrid();
+			return this.getProxy().getGrid();
 		}
 		catch( final GridAccessException e )
 		{

--- a/src/main/java/appeng/tile/qnb/TileQuantumBridge.java
+++ b/src/main/java/appeng/tile/qnb/TileQuantumBridge.java
@@ -68,9 +68,9 @@ public class TileQuantumBridge extends AENetworkInvTile implements IAEMultiBlock
 
 	public TileQuantumBridge()
 	{
-		this.getGridProxy().setValidSides( EnumSet.noneOf( ForgeDirection.class ) );
-		this.getGridProxy().setFlags( GridFlags.DENSE_CAPACITY );
-		this.getGridProxy().setIdlePowerUsage( 22 );
+		this.getProxy().setValidSides( EnumSet.noneOf( ForgeDirection.class ) );
+		this.getProxy().setFlags( GridFlags.DENSE_CAPACITY );
+		this.getProxy().setIdlePowerUsage( 22 );
 		this.internalInventory.setMaxStackSize( 1 );
 	}
 
@@ -98,7 +98,7 @@ public class TileQuantumBridge extends AENetworkInvTile implements IAEMultiBlock
 			out |= this.hasSingularity;
 		}
 
-		if( this.getGridProxy().isActive() && this.constructed != -1 )
+		if( this.getProxy().isActive() && this.constructed != -1 )
 		{
 			out |= this.powered;
 		}
@@ -177,7 +177,7 @@ public class TileQuantumBridge extends AENetworkInvTile implements IAEMultiBlock
 		{
 			final ItemStack linkStack = maybeLinkStack.get();
 
-			this.getGridProxy().setVisualRepresentation( linkStack );
+			this.getProxy().setVisualRepresentation( linkStack );
 		}
 	}
 
@@ -205,7 +205,7 @@ public class TileQuantumBridge extends AENetworkInvTile implements IAEMultiBlock
 
 		if( affectWorld )
 		{
-			this.getGridProxy().setValidSides( EnumSet.noneOf( ForgeDirection.class ) );
+			this.getProxy().setValidSides( EnumSet.noneOf( ForgeDirection.class ) );
 		}
 	}
 
@@ -235,11 +235,11 @@ public class TileQuantumBridge extends AENetworkInvTile implements IAEMultiBlock
 
 			if( this.isCorner() || this.isCenter() )
 			{
-				this.getGridProxy().setValidSides( this.getConnections() );
+				this.getProxy().setValidSides( this.getConnections() );
 			}
 			else
 			{
-				this.getGridProxy().setValidSides( EnumSet.allOf( ForgeDirection.class ) );
+				this.getProxy().setValidSides( EnumSet.allOf( ForgeDirection.class ) );
 			}
 		}
 	}
@@ -288,7 +288,7 @@ public class TileQuantumBridge extends AENetworkInvTile implements IAEMultiBlock
 
 		try
 		{
-			return this.getGridProxy().getEnergy().isNetworkPowered();
+			return this.getProxy().getEnergy().isNetworkPowered();
 		}
 		catch( final GridAccessException e )
 		{

--- a/src/main/java/appeng/tile/spatial/TileSpatialIOPort.java
+++ b/src/main/java/appeng/tile/spatial/TileSpatialIOPort.java
@@ -58,7 +58,7 @@ public class TileSpatialIOPort extends AENetworkInvTile implements IWorldCallabl
 
 	public TileSpatialIOPort()
 	{
-		this.getGridProxy().setFlags( GridFlags.REQUIRE_CHANNEL );
+		this.getProxy().setFlags( GridFlags.REQUIRE_CHANNEL );
 	}
 
 	@TileEvent( TileEventType.WORLD_NBT_WRITE )
@@ -127,8 +127,8 @@ public class TileSpatialIOPort extends AENetworkInvTile implements IWorldCallabl
 		final ItemStack cell = this.getStackInSlot( 0 );
 		if( this.isSpatialCell( cell ) && this.getStackInSlot( 1 ) == null )
 		{
-			final IGrid gi = this.getGridProxy().getGrid();
-			final IEnergyGrid energy = this.getGridProxy().getEnergy();
+			final IGrid gi = this.getProxy().getGrid();
+			final IEnergyGrid energy = this.getProxy().getEnergy();
 
 			final ISpatialStorageCell sc = (ISpatialStorageCell) cell.getItem();
 

--- a/src/main/java/appeng/tile/storage/TileDrive.java
+++ b/src/main/java/appeng/tile/storage/TileDrive.java
@@ -78,7 +78,7 @@ public class TileDrive extends AENetworkInvTile implements IChestOrDrive, IPrior
 	public TileDrive()
 	{
 		this.mySrc = new MachineSource( this );
-		this.getGridProxy().setFlags( GridFlags.REQUIRE_CHANNEL );
+		this.getProxy().setFlags( GridFlags.REQUIRE_CHANNEL );
 	}
 
 	@TileEvent( TileEventType.NETWORK_WRITE )
@@ -93,7 +93,7 @@ public class TileDrive extends AENetworkInvTile implements IChestOrDrive, IPrior
 			this.state &= 0x24924924; // just keep the blinks...
 		}
 
-		if( this.getGridProxy().isActive() )
+		if( this.getProxy().isActive() )
 		{
 			this.state |= 0x80000000;
 		}
@@ -160,7 +160,7 @@ public class TileDrive extends AENetworkInvTile implements IChestOrDrive, IPrior
 			return ( this.state & 0x80000000 ) == 0x80000000;
 		}
 
-		return this.getGridProxy().isActive();
+		return this.getProxy().isActive();
 	}
 
 	@Override
@@ -205,7 +205,7 @@ public class TileDrive extends AENetworkInvTile implements IChestOrDrive, IPrior
 
 	private void recalculateDisplay()
 	{
-		final boolean currentActive = this.getGridProxy().isActive();
+		final boolean currentActive = this.getProxy().isActive();
 		if( currentActive )
 		{
 			this.state |= 0x80000000;
@@ -220,7 +220,7 @@ public class TileDrive extends AENetworkInvTile implements IChestOrDrive, IPrior
 			this.wasActive = currentActive;
 			try
 			{
-				this.getGridProxy().getGrid().postEvent( new MENetworkCellArrayUpdate() );
+				this.getProxy().getGrid().postEvent( new MENetworkCellArrayUpdate() );
 			}
 			catch( final GridAccessException e )
 			{
@@ -281,9 +281,9 @@ public class TileDrive extends AENetworkInvTile implements IChestOrDrive, IPrior
 
 		try
 		{
-			this.getGridProxy().getGrid().postEvent( new MENetworkCellArrayUpdate() );
+			this.getProxy().getGrid().postEvent( new MENetworkCellArrayUpdate() );
 
-			final IStorageGrid gs = this.getGridProxy().getStorage();
+			final IStorageGrid gs = this.getProxy().getStorage();
 			Platform.postChanges( gs, removed, added, this.mySrc );
 		}
 		catch( final GridAccessException ignored )
@@ -349,7 +349,7 @@ public class TileDrive extends AENetworkInvTile implements IChestOrDrive, IPrior
 				}
 			}
 
-			this.getGridProxy().setIdlePowerUsage( power );
+			this.getProxy().setIdlePowerUsage( power );
 
 			this.isCached = true;
 		}
@@ -365,7 +365,7 @@ public class TileDrive extends AENetworkInvTile implements IChestOrDrive, IPrior
 	@Override
 	public List<IMEInventoryHandler> getCellArray( final StorageChannel channel )
 	{
-		if( this.getGridProxy().isActive() )
+		if( this.getProxy().isActive() )
 		{
 			this.updateState();
 			return (List) ( channel == StorageChannel.ITEMS ? this.items : this.fluids );
@@ -390,7 +390,7 @@ public class TileDrive extends AENetworkInvTile implements IChestOrDrive, IPrior
 
 		try
 		{
-			this.getGridProxy().getGrid().postEvent( new MENetworkCellArrayUpdate() );
+			this.getProxy().getGrid().postEvent( new MENetworkCellArrayUpdate() );
 		}
 		catch( final GridAccessException e )
 		{

--- a/src/main/java/appeng/tile/storage/TileIOPort.java
+++ b/src/main/java/appeng/tile/storage/TileIOPort.java
@@ -106,7 +106,7 @@ public class TileIOPort extends AENetworkInvTile implements IUpgradeableHost, IC
 	@Reflected
 	public TileIOPort()
 	{
-		this.getGridProxy().setFlags( GridFlags.REQUIRE_CHANNEL );
+		this.getProxy().setFlags( GridFlags.REQUIRE_CHANNEL );
 		this.manager = new ConfigManager( this );
 		this.manager.registerSetting( Settings.REDSTONE_CONTROLLED, RedstoneMode.IGNORE );
 		this.manager.registerSetting( Settings.FULLNESS_MODE, FullnessMode.EMPTY );
@@ -158,11 +158,11 @@ public class TileIOPort extends AENetworkInvTile implements IUpgradeableHost, IC
 		{
 			if( this.hasWork() )
 			{
-				this.getGridProxy().getTick().wakeDevice( this.getGridProxy().getNode() );
+				this.getProxy().getTick().wakeDevice( this.getProxy().getNode() );
 			}
 			else
 			{
-				this.getGridProxy().getTick().sleepDevice( this.getGridProxy().getNode() );
+				this.getProxy().getTick().sleepDevice( this.getProxy().getNode() );
 			}
 		}
 		catch( final GridAccessException e )
@@ -313,7 +313,7 @@ public class TileIOPort extends AENetworkInvTile implements IUpgradeableHost, IC
 	@Override
 	public TickRateModulation tickingRequest( final IGridNode node, final int ticksSinceLastCall )
 	{
-		if( !this.getGridProxy().isActive() )
+		if( !this.getProxy().isActive() )
 		{
 			return TickRateModulation.IDLE;
 		}
@@ -335,9 +335,9 @@ public class TileIOPort extends AENetworkInvTile implements IUpgradeableHost, IC
 
 		try
 		{
-			final IMEInventory<IAEItemStack> itemNet = this.getGridProxy().getStorage().getItemInventory();
-			final IMEInventory<IAEFluidStack> fluidNet = this.getGridProxy().getStorage().getFluidInventory();
-			final IEnergySource energy = this.getGridProxy().getEnergy();
+			final IMEInventory<IAEItemStack> itemNet = this.getProxy().getStorage().getItemInventory();
+			final IMEInventory<IAEFluidStack> fluidNet = this.getProxy().getStorage().getFluidInventory();
+			final IEnergySource energy = this.getProxy().getEnergy();
 			for( int x = 0; x < 6; x++ )
 			{
 				final ItemStack is = this.cells.getStackInSlot( x );


### PR DESCRIPTION
Removed the duplicate getter for `AENetworkProxy` in `AENetworkInvTile` which is already implemented for `IGridProxyable`.