### PR TITLE
Fixes #2099: No neighbor update of Pressure P2P before IAirHandler is validated.

### DIFF
--- a/src/main/java/appeng/parts/p2p/PartP2PPressure.java
+++ b/src/main/java/appeng/parts/p2p/PartP2PPressure.java
@@ -58,6 +58,7 @@ public final class PartP2PPressure extends PartP2PTunnel<PartP2PPressure> implem
 	@Nonnull
 	private final IAirHandler handler;
 	private boolean isConnected = false;
+	private boolean isValid = false;
 
 	public PartP2PPressure( final ItemStack is )
 	{
@@ -87,14 +88,20 @@ public final class PartP2PPressure extends PartP2PTunnel<PartP2PPressure> implem
 	public void onNeighborChanged()
 	{
 		super.onNeighborChanged();
-		this.getInternalHandler().onNeighborChange();
+
+		if( this.isValid )
+		{
+			this.getInternalHandler().onNeighborChange();
+		}
 	}
 
 	@Override
 	public void addToWorld()
 	{
 		super.addToWorld();
+
 		this.getInternalHandler().validateI( this.getTile() );
+		this.isValid = true;
 	}
 
 	@Override
@@ -102,6 +109,7 @@ public final class PartP2PPressure extends PartP2PTunnel<PartP2PPressure> implem
 	{
 		super.removeFromWorld();
 
+		this.isValid = false;
 		if( this.isOutput() && this.getInput() != null )
 		{
 			this.getInternalHandler().removeConnection( this.getInput().getInternalHandler() );


### PR DESCRIPTION
The internal `IAirHandler` needs to be validated with `validateI(TileEntity)` before we can forward a neighbor update.

Currently there is no way to determine it by using the `IAirHandler` itself, so we need to keep track of it on your side for now.

Fixes #2099