### PR TITLE
(Issue #21) Implement Logistics pipes integration

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -42,6 +42,7 @@ pneumaticcraft_version=1.9.15-105
 #########################################################
 mekansim_version=8.0.1.198
 rotarycraft_version=V6e
+logisticspipes_version=0.9-stable
 
 
 #########################################################

--- a/gradle/scripts/dependencies.gradle
+++ b/gradle/scripts/dependencies.gradle
@@ -126,6 +126,7 @@ dependencies {
     compile "appeng:RotaryCraft:${rotarycraft_version}:api"
     compile "appeng:mekanism:${minecraft_version}-${mekansim_version}:api"
     compile "appeng:InventoryTweaks:${invtweaks_version}:api"
+    compile "appeng:logistics-pipes-api:${logisticspipes_version}"
 
     // self compiled stubs
     compile(group: 'api', name: 'coloredlightscore', version: "${api_coloredlightscore_version}")

--- a/src/api/java/appeng/api/networking/crafting/ICraftingGrid.java
+++ b/src/api/java/appeng/api/networking/crafting/ICraftingGrid.java
@@ -96,6 +96,13 @@ public interface ICraftingGrid extends IGridCache
 	boolean canEmitFor( IAEItemStack what );
 
 	/**
+	 * @param what to be requested item
+	 *
+	 * @return true if the item can be requested via an interface with external crafting or storage
+	 */
+	boolean canRequestFor( IAEItemStack what );
+
+	/**
 	 * is this item being crafted?
 	 *
 	 * @param aeStackInSlot item being crafted

--- a/src/api/java/appeng/api/networking/crafting/ICraftingJob.java
+++ b/src/api/java/appeng/api/networking/crafting/ICraftingJob.java
@@ -54,4 +54,10 @@ public interface ICraftingJob
 	 * @return the final output of the job.
 	 */
 	IAEItemStack getOutput();
+
+	/**
+	 * @return if this job can be fulfilled via an external request
+	 */
+	boolean isExternalRequest();
+
 }

--- a/src/api/java/appeng/api/networking/crafting/ICraftingMedium.java
+++ b/src/api/java/appeng/api/networking/crafting/ICraftingMedium.java
@@ -26,6 +26,9 @@ package appeng.api.networking.crafting;
 
 import net.minecraft.inventory.InventoryCrafting;
 
+import appeng.api.config.Actionable;
+import appeng.api.storage.data.IAEItemStack;
+
 
 /**
  * A place to send Items for crafting purposes, this is considered part of AE's External crafting system.
@@ -48,4 +51,13 @@ public interface ICraftingMedium
 	 * @return if this is false, the crafting engine will refuse to send new jobs to this medium.
 	 */
 	boolean isBusy();
+
+	/**
+	 * instruct a medium to request an item from external crafting or storage
+	 * @param item item to request
+	 * @param mode simulate or perform request
+	 *
+	 * @return if request was successful
+	 */
+	boolean pushRequest( IAEItemStack item, Actionable mode );
 }

--- a/src/api/java/appeng/api/networking/crafting/ICraftingProviderHelper.java
+++ b/src/api/java/appeng/api/networking/crafting/ICraftingProviderHelper.java
@@ -42,4 +42,9 @@ public interface ICraftingProviderHelper
 	 * Set an item can Emitable
 	 */
 	void setEmitable( IAEItemStack what );
+
+	/**
+	 * Set an item as requestable via external crafting or storage
+	 */
+	void addRequestOption( ICraftingMedium medium, IAEItemStack is );
 }

--- a/src/api/java/appeng/api/storage/IExternalStorageRegistry.java
+++ b/src/api/java/appeng/api/storage/IExternalStorageRegistry.java
@@ -38,7 +38,6 @@ import appeng.api.networking.security.BaseActionSource;
  */
 public interface IExternalStorageRegistry
 {
-
 	/**
 	 * A registry for StorageBus interactions
 	 *
@@ -55,4 +54,21 @@ public interface IExternalStorageRegistry
 	 * @return the handler for a given tile / forge direction
 	 */
 	IExternalStorageHandler getHandler( TileEntity te, ForgeDirection opposite, StorageChannel channel, BaseActionSource mySrc );
+
+	/**
+	 * A registry for Interface interactions
+	 *
+	 * @param esh storage handler
+	 */
+	void addInterfaceExternalStorage( IExternalStorageHandler esh );
+
+	/**
+	 * @param te       tile entity
+	 * @param opposite direction
+	 * @param channel  channel
+	 * @param mySrc    source
+	 *
+	 * @return the handler for a given tile / forge direction from interface registry
+	 */
+	IExternalStorageHandler getInterfaceHandler( TileEntity te, ForgeDirection opposite, StorageChannel channel, BaseActionSource mySrc );
 }

--- a/src/main/java/appeng/block/misc/BlockInterface.java
+++ b/src/main/java/appeng/block/misc/BlockInterface.java
@@ -21,6 +21,7 @@ package appeng.block.misc;
 
 import java.util.EnumSet;
 
+import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.world.World;
@@ -34,6 +35,7 @@ import appeng.block.AEBaseTileBlock;
 import appeng.client.render.blocks.RenderBlockInterface;
 import appeng.core.features.AEFeature;
 import appeng.core.sync.GuiBridge;
+import appeng.tile.AEBaseTile;
 import appeng.tile.misc.TileInterface;
 import appeng.util.Platform;
 
@@ -88,6 +90,17 @@ public class BlockInterface extends AEBaseTileBlock
 		if( rotatable instanceof TileInterface )
 		{
 			( (TileInterface) rotatable ).setSide( axis );
+		}
+	}
+
+	@Override
+	public void onNeighborBlockChange( final World w, final int x, final int y, final int z, final Block neighbor )
+	{
+		final AEBaseTile tile = this.getTileEntity( w, x, y, z );
+		if( tile instanceof TileInterface )
+		{
+			final TileInterface iface = (TileInterface) tile;
+			iface.onNeighborChanged();
 		}
 	}
 }

--- a/src/main/java/appeng/client/render/AppEngRenderItem.java
+++ b/src/main/java/appeng/client/render/AppEngRenderItem.java
@@ -89,7 +89,9 @@ public class AppEngRenderItem extends RenderItem
 				GL11.glColor4f( 1.0F, 1.0F, 1.0F, 1.0F );
 			}
 
-			if( is.stackSize == 0 )
+			final long requestable = this.aeStack != null ? this.aeStack.getCountRequestable() : 0;
+
+			if( is.stackSize == 0 && requestable == 0 )
 			{
 				final String craftLabelText = AEConfig.instance.useTerminalUseLargeFont() ? GuiText.LargeFontCraft.getLocal() : GuiText.SmallFontCraft.getLocal();
 

--- a/src/main/java/appeng/container/implementations/ContainerCraftConfirm.java
+++ b/src/main/java/appeng/container/implementations/ContainerCraftConfirm.java
@@ -180,6 +180,10 @@ public class ContainerCraftConfirm extends AEBaseContainer
 		}
 
 		this.setNoCPU( this.cpus.isEmpty() );
+		if( this.result != null && this.result.isExternalRequest() )
+		{
+			this.setNoCPU( false );
+		}
 
 		super.detectAndSendChanges();
 
@@ -350,7 +354,7 @@ public class ContainerCraftConfirm extends AEBaseContainer
 			final ICraftingGrid cc = this.getGrid().getCache( ICraftingGrid.class );
 			final ICraftingLink g = cc.submitJob( this.result, null, this.getSelectedCpu() == -1 ? null : this.cpus.get( this.getSelectedCpu() ).getCpu(), true, this.getActionSrc() );
 			this.setAutoStart( false );
-			if( g != null && originalGui != null && this.getOpenContext() != null )
+			if( ( g != null || this.result.isExternalRequest() ) && originalGui != null && this.getOpenContext() != null )
 			{
 				NetworkHandler.instance.sendTo( new PacketSwitchGuis( originalGui ), (EntityPlayerMP) this.getInventoryPlayer().player );
 

--- a/src/main/java/appeng/core/features/registries/ExternalStorageRegistry.java
+++ b/src/main/java/appeng/core/features/registries/ExternalStorageRegistry.java
@@ -36,11 +36,13 @@ public class ExternalStorageRegistry implements IExternalStorageRegistry
 {
 
 	private final List<IExternalStorageHandler> Handlers;
+	private final List<IExternalStorageHandler> interfaceHandlers;
 	private final ExternalIInv lastHandler = new ExternalIInv();
 
 	public ExternalStorageRegistry()
 	{
 		this.Handlers = new ArrayList<IExternalStorageHandler>();
+		this.interfaceHandlers = new ArrayList<IExternalStorageHandler>();
 	}
 
 	@Override
@@ -63,6 +65,26 @@ public class ExternalStorageRegistry implements IExternalStorageRegistry
 		if( this.lastHandler.canHandle( te, d, chan, mySrc ) )
 		{
 			return this.lastHandler;
+		}
+
+		return null;
+	}
+
+	@Override
+	public void addInterfaceExternalStorage( final IExternalStorageHandler esh )
+	{
+		this.interfaceHandlers.add( esh );
+	}
+
+	@Override
+	public IExternalStorageHandler getInterfaceHandler( final TileEntity te, final ForgeDirection d, final StorageChannel chan, final BaseActionSource mySrc )
+	{
+		for( final IExternalStorageHandler x : this.interfaceHandlers )
+		{
+			if( x.canHandle( te, d, chan, mySrc ) )
+			{
+				return x;
+			}
 		}
 
 		return null;

--- a/src/main/java/appeng/crafting/CraftingJob.java
+++ b/src/main/java/appeng/crafting/CraftingJob.java
@@ -64,6 +64,7 @@ public class CraftingJob implements Runnable, ICraftingJob
 	private CraftingTreeNode tree;
 	private final IAEItemStack output;
 	private boolean simulate = false;
+	private boolean externalRequest = false;
 	private MECraftingInventory availableCheck;
 	private long bytes = 0;
 	private final BaseActionSource actionSrc;
@@ -297,6 +298,17 @@ public class CraftingJob implements Runnable, ICraftingJob
 	public IAEItemStack getOutput()
 	{
 		return this.output;
+	}
+
+	@Override
+	public boolean isExternalRequest()
+	{
+		return this.externalRequest;
+	}
+
+	public void setExternalRequest( final boolean externalRequest )
+	{
+		this.externalRequest = externalRequest;
 	}
 
 	public boolean isDone()

--- a/src/main/java/appeng/integration/IntegrationType.java
+++ b/src/main/java/appeng/integration/IntegrationType.java
@@ -27,6 +27,8 @@ public enum IntegrationType
 
 	RC( IntegrationSide.BOTH, "Railcraft", "Railcraft" ),
 
+	LogisticsPipes( IntegrationSide.BOTH, "Logistics Pipes", "LogisticsPipes" ),
+
 	BuildCraftCore( IntegrationSide.BOTH, "BuildCraft Core", "BuildCraft|Core" ),
 
 	BuildCraftTransport( IntegrationSide.BOTH, "BuildCraft Transport", "BuildCraft|Transport" ),

--- a/src/main/java/appeng/integration/abstraction/ILP.java
+++ b/src/main/java/appeng/integration/abstraction/ILP.java
@@ -24,6 +24,7 @@ import java.util.List;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 
+import appeng.api.config.Actionable;
 import appeng.api.storage.IMEInventory;
 
 
@@ -36,7 +37,7 @@ public interface ILP
 
 	boolean isRequestPipe( TileEntity te );
 
-	List<ItemStack> performRequest( TileEntity te, ItemStack wanted );
+	List<ItemStack> performRequest( TileEntity te, ItemStack wanted, Actionable mode );
 
 	IMEInventory getInv( TileEntity te );
 

--- a/src/main/java/appeng/integration/modules/LogisticsPipes.java
+++ b/src/main/java/appeng/integration/modules/LogisticsPipes.java
@@ -1,0 +1,156 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.integration.modules;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+
+import logisticspipes.api.ILPPipe;
+import logisticspipes.api.ILPPipeTile;
+import logisticspipes.api.IRequestAPI;
+import logisticspipes.api.IRequestAPI.SimulationResult;
+import logisticspipes.api.IRoutedPowerProvider;
+
+import appeng.api.AEApi;
+import appeng.api.config.Actionable;
+import appeng.api.storage.IMEInventory;
+import appeng.helpers.Reflected;
+import appeng.integration.IIntegrationModule;
+import appeng.integration.IntegrationHelper;
+import appeng.integration.abstraction.ILP;
+import appeng.integration.modules.helpers.LPInventory;
+import appeng.integration.modules.helpers.LPStorageHandler;
+
+
+public final class LogisticsPipes implements ILP, IIntegrationModule
+{
+	@Reflected
+	public static LogisticsPipes instance;
+
+	public LogisticsPipes()
+	{
+		IntegrationHelper.testClassExistence( this, logisticspipes.api.ILPPipe.class );
+		IntegrationHelper.testClassExistence( this, logisticspipes.api.ILPPipeTile.class );
+		IntegrationHelper.testClassExistence( this, logisticspipes.api.IRequestAPI.class );
+	}
+
+	@Override
+	public void init() throws Throwable
+	{
+		AEApi.instance().registries().externalStorage().addInterfaceExternalStorage( new LPStorageHandler() );
+	}
+
+	@Override
+	public void postInit()
+	{
+	}
+
+	@Override
+	public List<ItemStack> getCraftedItems( final TileEntity te )
+	{
+		if( isRequestPipe( te ) )
+		{
+			final IRequestAPI pipe = (IRequestAPI) ( (ILPPipeTile) te ).getLPPipe();
+			return pipe.getCraftedItems();
+		}
+
+		return new ArrayList<ItemStack>();
+	}
+
+	@Override
+	public List<ItemStack> getProvidedItems( final TileEntity te )
+	{
+		if( isRequestPipe( te ) )
+		{
+			final IRequestAPI pipe = (IRequestAPI) ( (ILPPipeTile) te ).getLPPipe();
+			return pipe.getProvidedItems();
+		}
+
+		return new ArrayList<ItemStack>();
+	}
+
+	@Override
+	public boolean isRequestPipe( final TileEntity te )
+	{
+		return te instanceof ILPPipeTile && ( (ILPPipeTile) te ).getLPPipe() instanceof IRequestAPI;
+	}
+
+	@Override
+	public List<ItemStack> performRequest( final TileEntity te, final ItemStack wanted, final Actionable mode )
+	{
+		if( isRequestPipe( te ) )
+		{
+			final IRequestAPI pipe = (IRequestAPI) ( (ILPPipeTile) te ).getLPPipe();
+			if( mode == Actionable.MODULATE )
+			{
+				return pipe.performRequest( wanted );
+			}
+			else if( mode == Actionable.SIMULATE )
+			{
+				final SimulationResult sim = pipe.simulateRequest( wanted );
+				return sim.missing;
+			}
+		}
+
+		return null;
+	}
+
+	@Override
+	public IMEInventory getInv( final TileEntity te )
+	{
+		return new LPInventory( te );
+	}
+
+	@Override
+	public Object getGetPowerPipe( final TileEntity te )
+	{
+		if( te instanceof ILPPipeTile )
+		{
+			final ILPPipe pipe = ( (ILPPipeTile) te ).getLPPipe();
+			if( pipe instanceof IRoutedPowerProvider )
+			{
+				return (IRoutedPowerProvider) pipe;
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public boolean isPowerSource( final TileEntity tt )
+	{
+		return tt instanceof IRoutedPowerProvider;
+	}
+
+	@Override
+	public boolean canUseEnergy( final Object pp, final int ceil, final List<Object> providersToIgnore )
+	{
+		return ( (IRoutedPowerProvider) pp ).canUseEnergy( ceil, providersToIgnore );
+	}
+
+	@Override
+	public boolean useEnergy( final Object pp, final int ceil, final List<Object> providersToIgnore )
+	{
+		return ( (IRoutedPowerProvider) pp ).useEnergy( ceil, providersToIgnore );
+	}
+
+}

--- a/src/main/java/appeng/integration/modules/helpers/LPInventory.java
+++ b/src/main/java/appeng/integration/modules/helpers/LPInventory.java
@@ -1,0 +1,102 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.integration.modules.helpers;
+
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+
+import appeng.api.config.Actionable;
+import appeng.api.networking.security.BaseActionSource;
+import appeng.api.storage.IMEInventory;
+import appeng.api.storage.StorageChannel;
+import appeng.api.storage.data.IAEItemStack;
+import appeng.api.storage.data.IItemList;
+import appeng.integration.modules.LogisticsPipes;
+import appeng.util.item.AEItemStack;
+
+
+public final class LPInventory implements IMEInventory<IAEItemStack>
+{
+
+	private final TileEntity pipe;
+
+	public LPInventory( final TileEntity te )
+	{
+		this.pipe = te;
+	}
+
+	@Override
+	public IAEItemStack injectItems( final IAEItemStack input, final Actionable type, final BaseActionSource src )
+	{
+		return input;
+	}
+
+	@Override
+	public IAEItemStack extractItems( final IAEItemStack request, final Actionable mode, final BaseActionSource src )
+	{
+		return null;
+	}
+
+	@Override
+	public IItemList<IAEItemStack> getAvailableItems( final IItemList<IAEItemStack> out )
+	{
+		for( final ItemStack is : LogisticsPipes.instance.getProvidedItems( this.pipe ) )
+		{
+			for( final IAEItemStack l : out )
+			{
+				if( l.equals( is ) )
+				{
+					l.incCountRequestable( is.stackSize );
+					break;
+				}
+			}
+			final AEItemStack x = AEItemStack.create( is );
+			x.setStackSize( 0 );
+			x.setCountRequestable( is.stackSize );
+			out.add( x );
+		}
+
+		for( final ItemStack is : LogisticsPipes.instance.getCraftedItems( this.pipe ) )
+		{
+			for( final IAEItemStack l : out )
+			{
+				if( l.equals( is ) )
+				{
+					l.setCraftable( true );
+					break;
+				}
+			}
+
+			final AEItemStack x = AEItemStack.create( is );
+			x.setStackSize( 0 );
+			x.setCraftable( true );
+			out.add( x );
+		}
+
+		return out;
+	}
+
+	@Override
+	public StorageChannel getChannel()
+	{
+		return StorageChannel.ITEMS;
+	}
+
+}

--- a/src/main/java/appeng/integration/modules/helpers/LPStorageHandler.java
+++ b/src/main/java/appeng/integration/modules/helpers/LPStorageHandler.java
@@ -1,0 +1,54 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.integration.modules.helpers;
+
+
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.util.ForgeDirection;
+
+import appeng.api.networking.security.BaseActionSource;
+import appeng.api.storage.IExternalStorageHandler;
+import appeng.api.storage.IMEInventory;
+import appeng.api.storage.StorageChannel;
+import appeng.integration.modules.LogisticsPipes;
+import appeng.me.storage.MEMonitorIInventory;
+import appeng.util.inv.IMEAdaptor;
+
+
+public final class LPStorageHandler implements IExternalStorageHandler
+{
+
+	@Override
+	public boolean canHandle( final TileEntity te, final ForgeDirection d, final StorageChannel channel, final BaseActionSource mySrc )
+	{
+		return channel == StorageChannel.ITEMS && LogisticsPipes.instance.isRequestPipe( te );
+	}
+
+	@Override
+	public IMEInventory getInventory( final TileEntity te, final ForgeDirection d, final StorageChannel channel, final BaseActionSource src )
+	{
+		if( channel == StorageChannel.ITEMS && LogisticsPipes.instance.isRequestPipe( te ) )
+		{
+			return new MEMonitorIInventory( new IMEAdaptor( LogisticsPipes.instance.getInv( te ), src ) );
+		}
+
+		return null;
+	}
+
+}

--- a/src/main/java/appeng/parts/automation/PartLevelEmitter.java
+++ b/src/main/java/appeng/parts/automation/PartLevelEmitter.java
@@ -38,6 +38,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
+import appeng.api.config.Actionable;
 import appeng.api.config.FuzzyMode;
 import appeng.api.config.LevelType;
 import appeng.api.config.RedstoneMode;
@@ -744,5 +745,11 @@ public class PartLevelEmitter extends PartUpgradeable implements IEnergyWatcherH
 				}
 			}
 		}
+	}
+
+	@Override
+	public boolean pushRequest( final IAEItemStack item, final Actionable mode )
+	{
+		return false;
 	}
 }

--- a/src/main/java/appeng/parts/misc/PartInterface.java
+++ b/src/main/java/appeng/parts/misc/PartInterface.java
@@ -424,4 +424,16 @@ public class PartInterface extends PartBasicState implements IGridTickable, ISto
 	{
 		this.duality.setPriority( newValue );
 	}
+
+	@Override
+	public void onNeighborChanged()
+	{
+		this.duality.onNeighborChanged();
+	}
+
+	@Override
+	public boolean pushRequest( final IAEItemStack item, final Actionable mode )
+	{
+		return this.duality.pushRequest( item, mode );
+	}
 }

--- a/src/main/java/appeng/tile/misc/TileInterface.java
+++ b/src/main/java/appeng/tile/misc/TileInterface.java
@@ -323,4 +323,15 @@ public class TileInterface extends AENetworkInvTile implements IGridTickable, IT
 	{
 		this.duality.setPriority( newValue );
 	}
+
+	public void onNeighborChanged()
+	{
+		this.duality.onNeighborChanged();
+	}
+
+	@Override
+	public boolean pushRequest( final IAEItemStack item, final Actionable mode )
+	{
+		return this.duality.pushRequest( item, mode );
+	}
 }

--- a/src/main/java/appeng/util/item/AEStack.java
+++ b/src/main/java/appeng/util/item/AEStack.java
@@ -109,7 +109,7 @@ public abstract class AEStack<StackType extends IAEStack> implements IAEStack<St
 	@Override
 	public boolean isMeaningful()
 	{
-		return this.stackSize != 0 || this.countRequestable > 0 || this.isCraftable;
+		return this.stackSize != 0 || this.countRequestable != 0 || this.isCraftable;
 	}
 
 	@Override


### PR DESCRIPTION
So this is a pretty big patch, based on the ideas for changing ME interfaces from @thatsIch's branch

- LP item requests act like crafting requests, but bypasses the crafting CPU unless the item is an input to an AE2 crafting recipe.
  (This should be trivial to change to require a crafting cpu for all LP requests if decided)
- Most of the external storage handler code for the interface is based on storage bus code, except it supports multiple handlers per block side
- Export busses and ME interfaces require crafting cards to export items from LP
- Partial LP requests aren't allowed, so if an export bus has acceleration cards, it will only export if it can fulfill the request
- Nothing involving LP power was integrated

Code changes that probably need special attention:
- MEMonitorIInventory changes, especially involving the onTick code to detect item changes for requestables/craftables
- DualityInterface supporting all sides for inventory handlers. Doesn't seem like an issue unless multiple large LP networks were connected to one interface. Could be
  easily changed to only support one per ME interface though
- CraftingTree/Grid/CPU additions, tried to avoid touching anything important since I didn't fully understand how everything worked, but definitely needs thorough review
- AEStack::isMeaningful change for requestable items. I didn't look into the impact this would have, since countRequestable isn't used much and it's really only for a minor reason
  (so the requestable item tooltips update in terminals for decreasing items)

Known issues
- Provider pipes could cause an infinite loop of provided->requestable->provided, but luckily LP only reports items with stacksizes right now
- Provider pipes could result in items being shown as requestable after all of an item that only existed in ae2 storage is pulled out,
  closing and re-opening the terminal refreshes that though
- LP requestables are visible on subnets, but not requestable (LP craftables are not visible)

I'm completely unfamiliar with gradle and forge mod dependencies, so I copied the logistics pipes dependecy info from @thatsIch's branch in order to build cleanly

Obviously this will need thorough testing with large scale builds, but all of my little test setups work
My testing was done with:
Forge 1.7.10-10.13.4.1448-1.7.10, Buildcraft 7.0.9, Logistics Pipes 0.9.3.126
Forge 1.7.10-10.13.4.1614-1.7.10, Buildcraft 7.1.16, Logistics Pipes 0.9.3.126