### PR TITLE
Split DummyModContainer from IFMLLoadingPlugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Providing as many details as possible does help us to find and resolve the issue
   - Eclipse: execute `gradlew eclipse`
 5. For add-on developer: Core-Mod Detection
   - In order to have FML detect AE from your dev environment, add the following VM Option to your run profile
-  - `-Dfml.coreMods.load=appeng.transformer.AppEngCore`
+  - `-Dfml.coreMods.load=appeng.transformer.AppEngCoreMod`
 
 ## Contribution
 

--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ jar {
 }
 
 minecraft {
-    coreMod = "appeng.transformer.AppEngCore"
+    coreMod = "appeng.transformer.AppEngCoreMod"
 
     version = minecraft_version + "-" + forge_version
 

--- a/src/main/java/appeng/transformer/AppEngCore.java
+++ b/src/main/java/appeng/transformer/AppEngCore.java
@@ -18,11 +18,6 @@
 
 package appeng.transformer;
 
-
-import java.util.Map;
-
-import javax.annotation.Nullable;
-
 import com.google.common.eventbus.EventBus;
 
 import net.minecraftforge.fml.common.DummyModContainer;
@@ -31,14 +26,11 @@ import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.ModMetadata;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.relauncher.FMLRelaunchLog;
-import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin;
-import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin.MCVersion;
 
 import appeng.core.AEConfig;
 
 
-@MCVersion( "1.10.2" )
-public final class AppEngCore extends DummyModContainer implements IFMLLoadingPlugin
+public final class AppEngCore extends DummyModContainer
 {
 	private final ModMetadata metadata = new ModMetadata();
 
@@ -61,36 +53,6 @@ public final class AppEngCore extends DummyModContainer implements IFMLLoadingPl
 	{
 	}
 
-	@Override
-	public String[] getASMTransformerClass()
-	{
-		return new String[] { "appeng.transformer.asm.ASMIntegration" };
-	}
-
-	@Override
-	public String getModContainerClass()
-	{
-		return "appeng.transformer.AppEngCore";
-	}
-
-	@Nullable
-	@Override
-	public String getSetupClass()
-	{
-		return null;
-	}
-
-	@Override
-	public void injectData( final Map<String, Object> data )
-	{
-
-	}
-
-	@Override
-	public String getAccessTransformerClass()
-	{
-		return "appeng.transformer.asm.ASMTweaker";
-	}
 
 	@Override
 	public ModMetadata getMetadata()

--- a/src/main/java/appeng/transformer/AppEngCoreMod.java
+++ b/src/main/java/appeng/transformer/AppEngCoreMod.java
@@ -1,0 +1,62 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.transformer;
+
+import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin;
+
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+@IFMLLoadingPlugin.MCVersion( "1.10.2" )
+public class AppEngCoreMod implements IFMLLoadingPlugin
+{
+
+	@Override
+	public String[] getASMTransformerClass()
+	{
+		return new String[] { "appeng.transformer.asm.ASMIntegration" };
+	}
+
+	@Override
+	public String getModContainerClass()
+	{
+		return "appeng.transformer.AppEngCore";
+	}
+
+	@Nullable
+	@Override
+	public String getSetupClass()
+	{
+		return null;
+	}
+
+	@Override
+	public void injectData( final Map<String, Object> data )
+	{
+
+	}
+
+	@Override
+	public String getAccessTransformerClass()
+	{
+		return "appeng.transformer.asm.ASMTweaker";
+	}
+
+}


### PR DESCRIPTION
This is the necessary (and tested) changes to fix #2482.

What is happening otherwise is that `ModMetadata` is being class loaded before other `IFMLLoadingPlugin`s are able to register their necessary transformers. This specifically fixes SpongePowered/SpongeForge#966.