### PR TITLE
Fixes issues with lightmap information on Quads (Fixes #2502)

### DIFF
--- a/src/main/java/appeng/client/ClientHelper.java
+++ b/src/main/java/appeng/client/ClientHelper.java
@@ -39,7 +39,9 @@ import net.minecraftforge.client.event.MouseEvent;
 import net.minecraftforge.client.event.RenderLivingEvent;
 import net.minecraftforge.client.event.TextureStitchEvent;
 import net.minecraftforge.client.model.ModelLoaderRegistry;
+import net.minecraftforge.common.ForgeModContainer;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.client.FMLClientHandler;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
 import appeng.api.parts.CableRenderMode;
@@ -79,7 +81,11 @@ public class ClientHelper extends ServerHelper
 	public void preinit()
 	{
 		MinecraftForge.EVENT_BUS.register( this );
-		ModelLoaderRegistry.registerLoader( UVLModelLoader.INSTANCE );
+		// Do not register the Fullbright hacks if Optifine is present or if the Forge lighting is disabled
+		if( !FMLClientHandler.instance().hasOptifine() && ForgeModContainer.forgeLightPipelineEnabled )
+		{
+			ModelLoaderRegistry.registerLoader( UVLModelLoader.INSTANCE );
+		}
 	}
 
 	@Override

--- a/src/main/java/appeng/client/render/VertexFormats.java
+++ b/src/main/java/appeng/client/render/VertexFormats.java
@@ -1,0 +1,68 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.client.render;
+
+
+import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
+import net.minecraft.client.renderer.vertex.VertexFormat;
+import net.minecraftforge.common.ForgeModContainer;
+import net.minecraftforge.fml.client.FMLClientHandler;
+
+
+/**
+ * Utility for managing extended Vertex Formats without having to re-clone existing vertex formats over and over again.
+ */
+public final class VertexFormats
+{
+
+	// Standard item format extended with lightmap coordinates
+	private static final VertexFormat itemFormatWithLightMap = new VertexFormat( DefaultVertexFormats.ITEM ).addElement( DefaultVertexFormats.TEX_2S );
+
+	private VertexFormats() {
+	}
+
+	public static VertexFormat getFormatWithLightMap( VertexFormat format )
+	{
+		// Do not use this when Optifine is present or if the vanilla lighting pipeline is used
+		if( FMLClientHandler.instance().hasOptifine() || !ForgeModContainer.forgeLightPipelineEnabled )
+		{
+			return format;
+		}
+
+		VertexFormat result;
+		if( format == DefaultVertexFormats.BLOCK )
+		{
+			result = DefaultVertexFormats.BLOCK;
+		}
+		else if( format == DefaultVertexFormats.ITEM )
+		{
+			result = itemFormatWithLightMap;
+		}
+		else if( !format.hasUvOffset( 1 ) )
+		{
+			result = new VertexFormat( format );
+			result.addElement( DefaultVertexFormats.TEX_2S );
+		}
+		else
+		{
+			result = format; // Already has the needed UV, so keep it
+		}
+		return result;
+	}
+}

--- a/src/main/java/appeng/client/render/cablebus/CubeBuilder.java
+++ b/src/main/java/appeng/client/render/cablebus/CubeBuilder.java
@@ -35,6 +35,8 @@ import net.minecraft.client.renderer.vertex.VertexFormatElement;
 import net.minecraft.util.EnumFacing;
 import net.minecraftforge.client.model.pipeline.UnpackedBakedQuad;
 
+import appeng.client.render.VertexFormats;
+
 
 /**
  * Builds the quads for a cube.
@@ -84,7 +86,7 @@ public class CubeBuilder
 		if( renderFullBright )
 		{
 			savedFormat = format;
-			format = DefaultVertexFormats.BLOCK;
+			format = VertexFormats.getFormatWithLightMap( format );
 		}
 
 		for( EnumFacing face : drawFaces )

--- a/src/main/java/appeng/client/render/model/UVLModelLoader.java
+++ b/src/main/java/appeng/client/render/model/UVLModelLoader.java
@@ -64,7 +64,6 @@ import net.minecraft.client.renderer.block.model.ItemTransformVec3f;
 import net.minecraft.client.renderer.block.model.ModelBakery;
 import net.minecraft.client.renderer.block.model.ModelBlock;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
-import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.client.renderer.vertex.VertexFormat;
 import net.minecraft.client.resources.IResource;
 import net.minecraft.client.resources.IResourceManager;
@@ -80,6 +79,8 @@ import net.minecraftforge.client.model.pipeline.VertexLighterFlat;
 import net.minecraftforge.common.model.IModelState;
 import net.minecraftforge.common.model.ITransformation;
 import net.minecraftforge.fml.relauncher.ReflectionHelper;
+
+import appeng.client.render.VertexFormats;
 
 
 public enum UVLModelLoader implements ICustomModelLoader
@@ -335,7 +336,8 @@ public enum UVLModelLoader implements ICustomModelLoader
 				Pair<Float, Float> brightness = uvlightmap.get( face );
 				if( brightness != null )
 				{
-					UnpackedBakedQuad.Builder builder = new UnpackedBakedQuad.Builder( DefaultVertexFormats.BLOCK );
+					VertexFormat newFormat = VertexFormats.getFormatWithLightMap( quad.getFormat() );
+					UnpackedBakedQuad.Builder builder = new UnpackedBakedQuad.Builder( newFormat );
 					VertexLighterFlat trans = new VertexLighterFlat( Minecraft.getMinecraft().getBlockColors() ){
 
 						@Override


### PR DESCRIPTION
This reverts back to the old way of extending the vertex format with the necessary vertex element for lightmap data, if fullbright quads are enabled. Instead of then enabling the extended vertex format for Optifine, it is disabled if Optifine is detected. 

Since the root cause is actually that the Vanilla lighting pipeline doesn't support such Vertex Formats, we disable it also if the Forge lighting pipeline is disabled.

This also relates to #2489.