### PR TITLE
Add Config to Remove Crashing Items from Storage Cells

### DIFF
--- a/src/main/java/appeng/core/AEConfig.java
+++ b/src/main/java/appeng/core/AEConfig.java
@@ -88,6 +88,7 @@ public final class AEConfig extends Configuration implements IConfigurableObject
 	public boolean enableEffects = true;
 	public boolean useLargeFonts = false;
 	public boolean useColoredCraftingStatus;
+	public boolean removeCrashingItemsOnLoad = false;
 	public int wirelessTerminalBattery = 1600000;
 	public int entropyManipulatorBattery = 200000;
 	public int matterCannonBattery = 200000;
@@ -125,6 +126,8 @@ public final class AEConfig extends Configuration implements IConfigurableObject
 
 		CondenserOutput.MATTER_BALLS.requiredPower = this.get( "Condenser", "MatterBalls", 256 ).getInt( 256 );
 		CondenserOutput.SINGULARITY.requiredPower = this.get( "Condenser", "Singularity", 256000 ).getInt( 256000 );
+
+		this.removeCrashingItemsOnLoad = this.get( "general", "removeCrashingItemsOnLoad", false, "Will auto-remove items that crash when being loaded from storage. This will destroy those items instead of crashing the game!" ).getBoolean();
 
 		this.grinderOres = this.get( "GrindStone", "grinderOres", this.grinderOres ).getStringList();
 		this.oreDoublePercentage = this.get( "GrindStone", "oreDoublePercentage", this.oreDoublePercentage ).getDouble( this.oreDoublePercentage );

--- a/src/main/java/appeng/me/storage/CellInventory.java
+++ b/src/main/java/appeng/me/storage/CellInventory.java
@@ -444,67 +444,58 @@ public class CellInventory implements ICellInventory
 
 		final int types = (int) this.getStoredItemTypes();
 
-		for( int x = 0; x < types; x++ )
+		for( int slot = 0; slot < types; slot++ )
 		{
-			// Get the item NBT, which can crash if someone daft stored something other than a compound NBT with the same key in our cell
-			final NBTTagCompound compoundTag;
-			try
-			{
-				compoundTag = this.tagCompound.getCompoundTag( itemSlots[x] );
-			}
-			catch( Throwable ex )
-			{
-				if( AEConfig.instance.removeCrashingItemsOnLoad )
-				{
-					AELog.warn( ex, "Removing item from storage cell slot " + itemSlots[x] + " because it's NBT could not be loaded." );
-					continue;
-				}
-				throw ex;
-			}
-
-			// Now load the item stack
-			final ItemStack t;
-			try
-			{
-				t = ItemStack.loadItemStackFromNBT( compoundTag );
-				if( t == null )
-				{
-					AELog.warn( "Removing item " + compoundTag + " from storage cell because the associated item type couldn't be found." );
-					continue;
-				}
-			}
-			catch( Throwable ex )
-			{
-				if( AEConfig.instance.removeCrashingItemsOnLoad )
-				{
-					AELog.warn( ex, "Removing item " + compoundTag + " from storage cell because loading the ItemStack crashed." );
-					continue;
-				}
-				throw ex;
-			}
-
-			t.stackSize = this.tagCompound.getInteger( itemSlotCount[x] );
-
-			if( t.stackSize > 0 )
-			{
-				try
-				{
-					this.cellItems.add( AEItemStack.create( t ) );
-				}
-				catch( Throwable ex )
-				{
-					if( AEConfig.instance.removeCrashingItemsOnLoad )
-					{
-						AELog.warn( ex, "Removing item " + t + " from storage cell because processing the loaded item crashed." );
-						continue;
-					}
-					throw ex;
-				}
-			}
-
+			NBTTagCompound compoundTag = this.tagCompound.getCompoundTag( itemSlots[slot] );
+			int stackSize = this.tagCompound.getInteger( itemSlotCount[slot] );
+			loadCellItem( compoundTag, stackSize );
 		}
 
 		// cellItems.clean();
+	}
+
+	private void loadCellItem( NBTTagCompound compoundTag, int stackSize )
+	{
+
+		// Now load the item stack
+		final ItemStack t;
+		try
+		{
+			t = ItemStack.loadItemStackFromNBT( compoundTag );
+			if( t == null )
+			{
+				AELog.warn( "Removing item " + compoundTag + " from storage cell because the associated item type couldn't be found." );
+				return;
+			}
+		}
+		catch( Throwable ex )
+		{
+			if( AEConfig.instance.removeCrashingItemsOnLoad )
+			{
+				AELog.warn( ex, "Removing item " + compoundTag + " from storage cell because loading the ItemStack crashed." );
+				return;
+			}
+			throw ex;
+		}
+
+		t.stackSize = stackSize;
+
+		if( t.stackSize > 0 )
+		{
+			try
+			{
+				this.cellItems.add( AEItemStack.create( t ) );
+			}
+			catch( Throwable ex )
+			{
+				if( AEConfig.instance.removeCrashingItemsOnLoad )
+				{
+					AELog.warn( ex, "Removing item " + t + " from storage cell because processing the loaded item crashed." );
+					return;
+				}
+				throw ex;
+			}
+		}
 	}
 
 	@Override

--- a/src/main/java/appeng/me/storage/CellInventory.java
+++ b/src/main/java/appeng/me/storage/CellInventory.java
@@ -41,6 +41,8 @@ import appeng.api.storage.ISaveProvider;
 import appeng.api.storage.StorageChannel;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.api.storage.data.IItemList;
+import appeng.core.AEConfig;
+import appeng.core.AELog;
 import appeng.util.Platform;
 import appeng.util.item.AEItemStack;
 
@@ -444,16 +446,62 @@ public class CellInventory implements ICellInventory
 
 		for( int x = 0; x < types; x++ )
 		{
-			final ItemStack t = ItemStack.loadItemStackFromNBT( this.tagCompound.getCompoundTag( itemSlots[x] ) );
-			if( t != null )
+			// Get the item NBT, which can crash if someone daft stored something other than a compound NBT with the same key in our cell
+			final NBTTagCompound compoundTag;
+			try
 			{
-				t.stackSize = this.tagCompound.getInteger( itemSlotCount[x] );
+				compoundTag = this.tagCompound.getCompoundTag( itemSlots[x] );
+			}
+			catch( Throwable ex )
+			{
+				if( AEConfig.instance.removeCrashingItemsOnLoad )
+				{
+					AELog.warn( ex, "Removing item from storage cell slot " + itemSlots[x] + " because it's NBT could not be loaded." );
+					continue;
+				}
+				throw ex;
+			}
 
-				if( t.stackSize > 0 )
+			// Now load the item stack
+			final ItemStack t;
+			try
+			{
+				t = ItemStack.loadItemStackFromNBT( compoundTag );
+				if( t == null )
+				{
+					AELog.warn( "Removing item " + compoundTag + " from storage cell because the associated item type couldn't be found." );
+					continue;
+				}
+			}
+			catch( Throwable ex )
+			{
+				if( AEConfig.instance.removeCrashingItemsOnLoad )
+				{
+					AELog.warn( ex, "Removing item " + compoundTag + " from storage cell because loading the ItemStack crashed." );
+					continue;
+				}
+				throw ex;
+			}
+
+			t.stackSize = this.tagCompound.getInteger( itemSlotCount[x] );
+
+			if( t.stackSize > 0 )
+			{
+				try
 				{
 					this.cellItems.add( AEItemStack.create( t ) );
 				}
+				catch( Throwable ex )
+				{
+					if( AEConfig.instance.removeCrashingItemsOnLoad )
+					{
+						AELog.warn( ex, "Removing item " + t + " from storage cell because processing the loaded item crashed." );
+						continue;
+					}
+					throw ex;
+				}
 			}
+
 		}
 
 		// cellItems.clean();


### PR DESCRIPTION
Added a configuration option to enable players to recover their world if any of their items in storage cause crashes on load.