### PR TITLE
Fixes #2575: Removed ITickable from AEBaseTile

### DIFF
--- a/src/main/java/appeng/core/settings/TickRates.java
+++ b/src/main/java/appeng/core/settings/TickRates.java
@@ -37,6 +37,8 @@ public enum TickRates
 
 	Inscriber( 1, 1 ),
 
+	Charger( 10, 120 ),
+
 	IOPort( 1, 5 ),
 
 	VibrationChamber( 10, 40 ),

--- a/src/main/java/appeng/debug/TileChunkLoader.java
+++ b/src/main/java/appeng/debug/TileChunkLoader.java
@@ -34,8 +34,6 @@ import net.minecraftforge.fml.common.FMLCommonHandler;
 import appeng.core.AELog;
 import appeng.core.AppEng;
 import appeng.tile.AEBaseTile;
-import appeng.tile.TileEvent;
-import appeng.tile.events.TileEventType;
 import appeng.util.Platform;
 
 
@@ -45,8 +43,8 @@ public class TileChunkLoader extends AEBaseTile implements ITickable
 	private boolean requestTicket = true;
 	private Ticket ct = null;
 
-	@TileEvent( TileEventType.TICK )
-	public void onTickEvent()
+	@Override
+	public void update()
 	{
 		if( this.requestTicket )
 		{

--- a/src/main/java/appeng/debug/TileCubeGenerator.java
+++ b/src/main/java/appeng/debug/TileCubeGenerator.java
@@ -30,8 +30,6 @@ import net.minecraft.util.text.TextComponentString;
 
 import appeng.core.CommonHelper;
 import appeng.tile.AEBaseTile;
-import appeng.tile.TileEvent;
-import appeng.tile.events.TileEventType;
 import appeng.util.Platform;
 
 
@@ -43,8 +41,8 @@ public class TileCubeGenerator extends AEBaseTile implements ITickable
 	private int countdown = 20 * 10;
 	private EntityPlayer who = null;
 
-	@TileEvent( TileEventType.TICK )
-	public void onTickEvent()
+	@Override
+	public void update()
 	{
 		if( this.is != null && Platform.isServer() )
 		{

--- a/src/main/java/appeng/tile/AEBaseTile.java
+++ b/src/main/java/appeng/tile/AEBaseTile.java
@@ -43,7 +43,6 @@ import net.minecraft.network.NetworkManager;
 import net.minecraft.network.play.server.SPacketUpdateTileEntity;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
-import net.minecraft.util.ITickable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
@@ -63,7 +62,7 @@ import appeng.util.Platform;
 import appeng.util.SettingsFrom;
 
 
-public class AEBaseTile extends TileEntity implements ITickable, IOrientable, ICommonTile, ICustomNameObject
+public class AEBaseTile extends TileEntity implements IOrientable, ICommonTile, ICustomNameObject
 {
 
 	private static final ThreadLocal<WeakReference<AEBaseTile>> DROP_NO_ITEMS = new ThreadLocal<WeakReference<AEBaseTile>>();
@@ -117,14 +116,15 @@ public class AEBaseTile extends TileEntity implements ITickable, IOrientable, IC
 	}
 
 	@Nonnull
-	public IBlockState getBlockState(){
+	public IBlockState getBlockState()
+	{
 		if( state == null )
 		{
 			state = worldObj.getBlockState( getPos() );
 		}
 		return state;
 	}
-	
+
 	/**
 	 * for dormant chunk cache.
 	 */
@@ -195,15 +195,6 @@ public class AEBaseTile extends TileEntity implements ITickable, IOrientable, IC
 	}
 
 	@Override
-	public final void update()
-	{
-		for( final AETileEventHandler h : this.getHandlerListFor( TileEventType.TICK ) )
-		{
-			h.tick( this );
-		}
-	}
-	
-	@Override
 	public SPacketUpdateTileEntity getUpdatePacket()
 	{
 		return new SPacketUpdateTileEntity( this.pos, 64, getUpdateTag() );
@@ -271,7 +262,8 @@ public class AEBaseTile extends TileEntity implements ITickable, IOrientable, IC
 	{
 		final NBTTagCompound data = writeUpdateData();
 
-		if (data == null) {
+		if( data == null )
+		{
 			return new NBTTagCompound();
 		}
 

--- a/src/main/java/appeng/tile/events/TileEventType.java
+++ b/src/main/java/appeng/tile/events/TileEventType.java
@@ -21,11 +21,6 @@ package appeng.tile.events;
 
 public enum TileEventType
 {
-	/**
-	 * Requires ITickable, this makes the tile entity tick in 1.8
-	 */
-	TICK,
-
 	WORLD_NBT_READ, WORLD_NBT_WRITE,
 
 	/**

--- a/src/main/java/appeng/tile/grindstone/TileCrank.java
+++ b/src/main/java/appeng/tile/grindstone/TileCrank.java
@@ -53,8 +53,8 @@ public class TileCrank extends AEBaseTile implements ICustomCollision, ITickable
 	private int hits = 0;
 	private int rotation = 0;
 
-	@TileEvent( TileEventType.TICK )
-	public void Tick_TileCrank()
+	@Override
+	public void update()
 	{
 		if( this.rotation > 0 )
 		{

--- a/src/main/java/appeng/tile/misc/TileLightDetector.java
+++ b/src/main/java/appeng/tile/misc/TileLightDetector.java
@@ -22,8 +22,6 @@ package appeng.tile.misc;
 import net.minecraft.util.ITickable;
 
 import appeng.tile.AEBaseTile;
-import appeng.tile.TileEvent;
-import appeng.tile.events.TileEventType;
 import appeng.util.Platform;
 
 
@@ -38,8 +36,8 @@ public class TileLightDetector extends AEBaseTile implements ITickable
 		return this.lastLight > 0;
 	}
 
-	@TileEvent( TileEventType.TICK )
-	public void Tick_TileLightDetector()
+	@Override
+	public void update()
 	{
 		this.lastCheck++;
 		if( this.lastCheck > 30 )

--- a/src/main/java/appeng/tile/qnb/TileQuantumBridge.java
+++ b/src/main/java/appeng/tile/qnb/TileQuantumBridge.java
@@ -75,8 +75,8 @@ public class TileQuantumBridge extends AENetworkInvTile implements IAEMultiBlock
 		this.internalInventory.setMaxStackSize( 1 );
 	}
 
-	@TileEvent( TileEventType.TICK )
-	public void onTickEvent()
+	@Override
+	public void update()
 	{
 		if( this.updateStatus )
 		{

--- a/src/main/java/appeng/tile/storage/TileChest.java
+++ b/src/main/java/appeng/tile/storage/TileChest.java
@@ -367,8 +367,8 @@ public class TileChest extends AENetworkPowerTile implements IMEChest, IFluidHan
 		return super.extractAEPower( amt - stash, mode ) + stash;
 	}
 
-	@TileEvent( TileEventType.TICK )
-	public void Tick_TileChest()
+	@Override
+	public void update()
 	{
 		if( this.worldObj.isRemote )
 		{

--- a/src/main/java/appeng/tile/storage/TileSkyChest.java
+++ b/src/main/java/appeng/tile/storage/TileSkyChest.java
@@ -26,6 +26,7 @@ import net.minecraft.init.SoundEvents;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.ITickable;
 import net.minecraft.util.SoundCategory;
 
 import appeng.tile.AEBaseInvTile;
@@ -35,10 +36,46 @@ import appeng.tile.inventory.AppEngInternalInventory;
 import appeng.tile.inventory.InvOperation;
 
 
-public class TileSkyChest extends AEBaseInvTile
+public class TileSkyChest extends AEBaseInvTile implements ITickable
 {
 
-	private final int[] sides = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35 };
+	private final int[] sides = {
+			0,
+			1,
+			2,
+			3,
+			4,
+			5,
+			6,
+			7,
+			8,
+			9,
+			10,
+			11,
+			12,
+			13,
+			14,
+			15,
+			16,
+			17,
+			18,
+			19,
+			20,
+			21,
+			22,
+			23,
+			24,
+			25,
+			26,
+			27,
+			28,
+			29,
+			30,
+			31,
+			32,
+			33,
+			34,
+			35 };
 	private final AppEngInternalInventory inv = new AppEngInternalInventory( this, 9 * 4 );
 	// server
 	private int numPlayersUsing;
@@ -126,8 +163,8 @@ public class TileSkyChest extends AEBaseInvTile
 		}
 	}
 
-	@TileEvent( TileEventType.TICK )
-	public void tick()
+	@Override
+	public void update()
 	{
 		int i = this.pos.getX();
 		int j = this.pos.getY();


### PR DESCRIPTION
Removed TileEventType.TICK, use ITickable when really needed.
The few tiles needing to tick and are not a grid tile now implement ITickable.
Charger is no longer implementing ITickable.