### PR TITLE
Refactored GrinderRegistry.

### DIFF
--- a/src/api/java/appeng/api/features/IGrinderRecipe.java
+++ b/src/api/java/appeng/api/features/IGrinderRecipe.java
@@ -24,13 +24,17 @@
 package appeng.api.features;
 
 
+import java.util.Optional;
+
+import javax.annotation.Nonnull;
+
 import net.minecraft.item.ItemStack;
 
 
 /**
  * Registration Records for {@link IGrinderRegistry}
  */
-public interface IGrinderEntry
+public interface IGrinderRecipe
 {
 
 	/**
@@ -38,65 +42,39 @@ public interface IGrinderEntry
 	 *
 	 * @return input that the grinder will accept.
 	 */
+	@Nonnull
 	ItemStack getInput();
 
 	/**
-	 * lets you change the grinder recipe by changing its input.
-	 *
-	 * @param input input item
-	 */
-	void setInput( ItemStack input );
-
-	/**
 	 * gets the current output
 	 *
 	 * @return output that the grinder will produce
 	 */
+	@Nonnull
 	ItemStack getOutput();
 
 	/**
-	 * allows you to change the output.
+	 * gets the current output
 	 *
-	 * @param output output item
+	 * @return output that the grinder will produce
 	 */
-	void setOutput( ItemStack output );
+	@Nonnull
+	Optional<ItemStack> getOptionalOutput();
 
 	/**
 	 * gets the current output
 	 *
 	 * @return output that the grinder will produce
 	 */
-	ItemStack getOptionalOutput();
-
-	/**
-	 * gets the current output
-	 *
-	 * @return output that the grinder will produce
-	 */
-	ItemStack getSecondOptionalOutput();
-
-	/**
-	 * stack, and 0.0-1.0 chance that it will be generated.
-	 *
-	 * @param output output item
-	 * @param chance generation chance
-	 */
-	void setOptionalOutput( ItemStack output, float chance );
+	Optional<ItemStack> getSecondOptionalOutput();
 
 	/**
 	 * 0.0 - 1.0 the chance that the optional output will be generated.
 	 *
 	 * @return chance of optional output
 	 */
+	@Nonnull
 	float getOptionalChance();
-
-	/**
-	 * stack, and 0.0-1.0 chance that it will be generated.
-	 *
-	 * @param output second optional output item
-	 * @param chance second optional output chance
-	 */
-	void setSecondOptionalOutput( ItemStack output, float chance );
 
 	/**
 	 * 0.0 - 1.0 the chance that the optional output will be generated.
@@ -106,16 +84,10 @@ public interface IGrinderEntry
 	float getSecondOptionalChance();
 
 	/**
-	 * Energy cost, in turns.
+	 * Amount of turns required to process the item.
 	 *
 	 * @return number of turns it takes to produce the output from the input.
 	 */
-	int getEnergyCost();
+	int getRequiredTurns();
 
-	/**
-	 * Allows you to adjust the number of turns
-	 *
-	 * @param c number of turns to produce output.
-	 */
-	void setEnergyCost( int c );
 }

--- a/src/api/java/appeng/api/features/IGrinderRegistry.java
+++ b/src/api/java/appeng/api/features/IGrinderRegistry.java
@@ -24,7 +24,10 @@
 package appeng.api.features;
 
 
-import java.util.List;
+import java.util.Collection;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import net.minecraft.item.ItemStack;
 
@@ -36,51 +39,90 @@ public interface IGrinderRegistry
 {
 
 	/**
-	 * Current list of registered recipes, you can modify this if you want too.
+	 * An immutable list of the currently registered recipes.
 	 *
 	 * @return currentlyRegisteredRecipes
 	 */
-	List<IGrinderEntry> getRecipes();
+	@Nonnull
+	Collection<IGrinderRecipe> getRecipes();
 
 	/**
-	 * add a new recipe the easy way, in &#8594; out, how many turns., duplicates will not be added.
+	 * Add a new recipe with a single input and output and how many turns it requires.
+	 * 
+	 * Will ignore duplicate recipes with the same input item.
 	 *
-	 * @param in input
-	 * @param out output
-	 * @param turns amount of turns to turn the input into the output
+	 * @param in The {@link ItemStack} to grind.
+	 * @param out The {@link ItemStack} to output.
+	 * @param turns Amount of turns to turn the input into the output, with turns > 0.
 	 */
-	void addRecipe( ItemStack in, ItemStack out, int turns );
+	void addRecipe( @Nonnull ItemStack in, @Nonnull ItemStack out, int turns );
+
+	/**
+	 * Add a new recipe with an input, output and a single optional output.
+	 * 
+	 * Will ignore duplicate recipes with the same input item.
+	 *
+	 * @param in The {@link ItemStack} to grind.
+	 * @param out The {@link ItemStack} to output.
+	 * @param optional The optional {@link ItemStack} to output of a certain chance.
+	 * @param chance Chance to get the optional output within 0.0 - 1.0
+	 * @param turns Amount of turns to turn the input into the output, with turns > 0.
+	 */
+	void addRecipe( @Nonnull ItemStack in, @Nonnull ItemStack out, @Nonnull ItemStack optional, float chance, int turns );
 
 	/**
 	 * add a new recipe with optional outputs, duplicates will not be added.
+	 * 
+	 * Will ignore duplicate recipes with the same input item.
 	 *
-	 * @param in input
-	 * @param out output
-	 * @param optional optional output
-	 * @param chance chance to get the optional output within 0.0 - 1.0
-	 * @param turns amount of turns to turn the input into the outputs
-	 */
-	void addRecipe( ItemStack in, ItemStack out, ItemStack optional, float chance, int turns );
-
-	/**
-	 * add a new recipe with optional outputs, duplicates will not be added.
-	 *
-	 * @param in input
-	 * @param out output
-	 * @param optional optional output
-	 * @param chance chance to get the optional output within 0.0 - 1.0
-	 * @param optional2 second optional output
+	 * @param in The {@link ItemStack} to grind.
+	 * @param out The {@link ItemStack} to output.
+	 * @param optional The first optional {@link ItemStack} to output of a certain chance.
+	 * @param chance Chance to get the first optional output within 0.0 - 1.0
+	 * @param optional2 The second optional {@link ItemStack} to output of a certain chance.
 	 * @param chance2 chance to get the second optional output within 0.0 - 1.0
-	 * @param turns amount of turns to turn the input into the outputs
+	 * @param turns Amount of turns to turn the input into the output, with turns > 0.
+	 * 
 	 */
-	void addRecipe( ItemStack in, ItemStack out, ItemStack optional, float chance, ItemStack optional2, float chance2, int turns );
+	void addRecipe( @Nonnull ItemStack in, @Nonnull ItemStack out, @Nonnull ItemStack optional, float chance, @Nonnull ItemStack optional2, float chance2, int turns );
+
+	/**
+	 * Remove the specific from the recipe list.
+	 * 
+	 * @param recipe The recipe to be removed.
+	 * @return true, if it was removed
+	 */
+	boolean removeRecipe( @Nonnull IGrinderRecipe recipe );
 
 	/**
 	 * Searches for a recipe for a given input, and returns it.
 	 *
-	 * @param input input
+	 * @param input The {@link ItemStack} to be grinded.
 	 *
 	 * @return identified recipe or null
 	 */
-	IGrinderEntry getRecipeForInput( ItemStack input );
+	@Nullable
+	IGrinderRecipe getRecipeForInput( @Nonnull ItemStack input );
+
+	/**
+	 * Allows do add a custom ratio from an ore to dust when being grinded.
+	 * 
+	 * The default ratio is 1 ore to 2 dusts.
+	 * 
+	 * These have to be added before any recipe is registered. Otherwise it will use the default value.
+	 * 
+	 * @param oredictName The name of the ore;
+	 * @param ratio The amount, must be > 0;
+	 */
+	void addDustRatio( @Nonnull String oredictName, int ratio );
+
+	/**
+	 * Remove a custom ratio for a specific ore name.
+	 * 
+	 * Will use the default of 2 value afterwards.
+	 * 
+	 * @param oredictName The name of the ore;
+	 */
+	boolean removeDustRatio( @Nonnull String oredictName );
+
 }

--- a/src/main/java/appeng/core/AEConfig.java
+++ b/src/main/java/appeng/core/AEConfig.java
@@ -24,7 +24,10 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Stream;
+
+import com.google.common.collect.Sets;
 
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.config.Configuration;
@@ -99,6 +102,7 @@ public final class AEConfig extends Configuration implements IConfigurableObject
 
 	// Grindstone
 	private String[] grinderOres = Stream.of( ORES_VANILLA, ORES_AE, ORES_COMMON, ORES_MISC ).flatMap( Stream::of ).toArray( String[]::new );
+	private Set<String> grinderBlackList;
 	private double oreDoublePercentage = 90.0;
 
 	// Batteries
@@ -153,8 +157,16 @@ public final class AEConfig extends Configuration implements IConfigurableObject
 		this.removeCrashingItemsOnLoad = this.get( "general", "removeCrashingItemsOnLoad", false,
 				"Will auto-remove items that crash when being loaded from storage. This will destroy those items instead of crashing the game!" ).getBoolean();
 
-		this.grinderOres = this.get( "GrindStone", "grinderOres", this.grinderOres ).getStringList();
-		this.oreDoublePercentage = this.get( "GrindStone", "oreDoublePercentage", this.oreDoublePercentage ).getDouble( this.oreDoublePercentage );
+		this.setCategoryComment( "GrindStone",
+				"Creates recipe of the following pattern automatically: '1 oreTYPE => 2 dustTYPE' and '(1 ingotTYPE or 1 crystalTYPE or 1 gemTYPE) => 1 dustTYPE'" );
+		this.grinderOres = this.get( "GrindStone", "grinderOres", this.grinderOres, "The list of types to handle. Specify without a prefix like ore or dust." )
+				.getStringList();
+		this.grinderBlackList = Sets.newHashSet(
+				this.get( "GrindStone", "blacklist", new String[] {}, "Blacklists the exact oredict name from being handled by any recipe." )
+						.getStringList() );
+		this.oreDoublePercentage = this
+				.get( "GrindStone", "oreDoublePercentage", this.oreDoublePercentage, "Chance to actually get an output with stacksize > 1." )
+				.getDouble( this.oreDoublePercentage );
 
 		this.settings.registerSetting( Settings.SEARCH_TOOLTIPS, YesNo.YES );
 		this.settings.registerSetting( Settings.TERMINAL_STYLE, TerminalStyle.TALL );
@@ -630,6 +642,11 @@ public final class AEConfig extends Configuration implements IConfigurableObject
 	public String[] getGrinderOres()
 	{
 		return grinderOres;
+	}
+
+	public Set<String> getGrinderBlackList()
+	{
+		return this.grinderBlackList;
 	}
 
 	public double getOreDoublePercentage()

--- a/src/main/java/appeng/core/AELog.java
+++ b/src/main/java/appeng/core/AELog.java
@@ -290,11 +290,11 @@ public final class AELog
 	 *
 	 * @param message String to be logged
 	 */
-	public static void grinder( @Nonnull final String message )
+	public static void grinder( @Nonnull final String message, final Object... params )
 	{
 		if( AEConfig.instance().isFeatureEnabled( AEFeature.GRINDER_LOGGING ) )
 		{
-			log( Level.DEBUG, "grinder: " + message );
+			log( Level.DEBUG, "grinder: " + message, params );
 		}
 	}
 

--- a/src/main/java/appeng/core/features/registries/GrinderRecipeManager.java
+++ b/src/main/java/appeng/core/features/registries/GrinderRecipeManager.java
@@ -194,7 +194,8 @@ public final class GrinderRecipeManager implements IGrinderRegistry, IOreListene
 	@Override
 	public void oreRegistered( final String name, final ItemStack item )
 	{
-		if( !AEConfig.instance().getGrinderBlackList().contains( name ) && ( name.startsWith( "ore" ) || name.startsWith( "crystal" ) || name.startsWith( "gem" ) || name.startsWith( "ingot" ) || name.startsWith( "dust" ) ) )
+		if( !AEConfig.instance().getGrinderBlackList().contains( name ) && ( name.startsWith( "ore" ) || name.startsWith( "crystal" ) || name
+				.startsWith( "gem" ) || name.startsWith( "ingot" ) || name.startsWith( "dust" ) ) )
 		{
 			for( final String ore : AEConfig.instance().getGrinderOres() )
 			{
@@ -339,7 +340,7 @@ public final class GrinderRecipeManager implements IGrinderRegistry, IOreListene
 		private final Item item;
 		private final int damage;
 
-		public CacheKey( ItemStack input )
+		CacheKey( ItemStack input )
 		{
 			Preconditions.checkNotNull( input );
 			Preconditions.checkNotNull( input.getItem() );
@@ -380,7 +381,9 @@ public final class GrinderRecipeManager implements IGrinderRegistry, IOreListene
 			if( item == null )
 			{
 				if( other.item != null )
+				{
 					return false;
+				}
 			}
 			else if( item != other.item )
 			{

--- a/src/main/java/appeng/core/features/registries/GrinderRecipeManager.java
+++ b/src/main/java/appeng/core/features/registries/GrinderRecipeManager.java
@@ -161,8 +161,12 @@ public final class GrinderRecipeManager implements IGrinderRegistry, IOreListene
 
 		final IGrinderRecipe recipe = this.recipes.get( new CacheKey( input ) );
 
-		this.log( "Recipe for '%1$s' found '%2$s'", input.getUnlocalizedName(), Platform.getItemDisplayName( recipe.getOutput() ) );
+		if( recipe == null )
+		{
+			return null;
+		}
 
+		this.log( "Recipe for '%1$s' found '%2$s'", input.getUnlocalizedName(), Platform.getItemDisplayName( recipe.getOutput() ) );
 		return recipe;
 	}
 
@@ -190,7 +194,7 @@ public final class GrinderRecipeManager implements IGrinderRegistry, IOreListene
 	@Override
 	public void oreRegistered( final String name, final ItemStack item )
 	{
-		if( name.startsWith( "ore" ) || name.startsWith( "crystal" ) || name.startsWith( "gem" ) || name.startsWith( "ingot" ) || name.startsWith( "dust" ) )
+		if( !AEConfig.instance().getGrinderBlackList().contains( name ) && ( name.startsWith( "ore" ) || name.startsWith( "crystal" ) || name.startsWith( "gem" ) || name.startsWith( "ingot" ) || name.startsWith( "dust" ) ) )
 		{
 			for( final String ore : AEConfig.instance().getGrinderOres() )
 			{

--- a/src/main/java/appeng/core/features/registries/entries/AppEngGrinderRecipe.java
+++ b/src/main/java/appeng/core/features/registries/entries/AppEngGrinderRecipe.java
@@ -19,55 +19,49 @@
 package appeng.core.features.registries.entries;
 
 
+import java.util.Optional;
+
 import net.minecraft.item.ItemStack;
 
-import appeng.api.features.IGrinderEntry;
+import appeng.api.features.IGrinderRecipe;
 
 
-public class AppEngGrinderRecipe implements IGrinderEntry
+public class AppEngGrinderRecipe implements IGrinderRecipe
 {
 
-	private ItemStack in;
-	private ItemStack out;
+	private final ItemStack in;
+	private final ItemStack out;
 
-	private float optionalChance;
-	private ItemStack optionalOutput;
+	private final float optionalChance;
+	private final Optional<ItemStack> optionalOutput;
 
-	private float optionalChance2;
-	private ItemStack optionalOutput2;
+	private final float optionalChance2;
+	private final Optional<ItemStack> optionalOutput2;
 
-	private int energy;
+	private final int turns;
 
-	public AppEngGrinderRecipe( final ItemStack a, final ItemStack b, final int cost )
+	public AppEngGrinderRecipe( final ItemStack input, final ItemStack output, final int cost )
 	{
-		this.in = a;
-		this.out = b;
-		this.energy = cost;
+		this( input, output, null, null, 0, 0, cost );
 	}
 
-	public AppEngGrinderRecipe( final ItemStack a, final ItemStack b, final ItemStack c, final float chance, final int cost )
+	public AppEngGrinderRecipe( final ItemStack input, final ItemStack output, final ItemStack optional, final float chance, final int cost )
 	{
-		this.in = a;
-		this.out = b;
-
-		this.optionalOutput = c;
-		this.optionalChance = chance;
-
-		this.energy = cost;
+		this( input, output, optional, null, chance, 0, cost );
 	}
 
-	public AppEngGrinderRecipe( final ItemStack a, final ItemStack b, final ItemStack c, final ItemStack d, final float chance, final float chance2, final int cost )
+	public AppEngGrinderRecipe( final ItemStack input, final ItemStack output, final ItemStack optional1, final ItemStack optional2, final float chance1, final float chance2, final int cost )
 	{
-		this.in = a;
-		this.out = b;
+		this.in = input;
+		this.out = output;
 
-		this.optionalOutput = c;
-		this.optionalChance = chance;
+		this.optionalOutput = Optional.ofNullable( optional1 );
+		this.optionalChance = chance1;
 
-		this.optionalOutput2 = d;
+		this.optionalOutput2 = Optional.ofNullable( optional2 );
 		this.optionalChance2 = chance2;
 
-		this.energy = cost;
+		this.turns = cost;
 	}
 
 	@Override
@@ -77,40 +71,21 @@ public class AppEngGrinderRecipe implements IGrinderEntry
 	}
 
 	@Override
-	public void setInput( final ItemStack i )
-	{
-		this.in = i.copy();
-	}
-
-	@Override
 	public ItemStack getOutput()
 	{
 		return this.out;
 	}
 
 	@Override
-	public void setOutput( final ItemStack o )
-	{
-		this.out = o.copy();
-	}
-
-	@Override
-	public ItemStack getOptionalOutput()
+	public Optional<ItemStack> getOptionalOutput()
 	{
 		return this.optionalOutput;
 	}
 
 	@Override
-	public ItemStack getSecondOptionalOutput()
+	public Optional<ItemStack> getSecondOptionalOutput()
 	{
 		return this.optionalOutput2;
-	}
-
-	@Override
-	public void setOptionalOutput( final ItemStack output, final float chance )
-	{
-		this.optionalOutput = output.copy();
-		this.optionalChance = chance;
 	}
 
 	@Override
@@ -120,27 +95,14 @@ public class AppEngGrinderRecipe implements IGrinderEntry
 	}
 
 	@Override
-	public void setSecondOptionalOutput( final ItemStack output, final float chance )
-	{
-		this.optionalChance2 = chance;
-		this.optionalOutput2 = output.copy();
-	}
-
-	@Override
 	public float getSecondOptionalChance()
 	{
 		return this.optionalChance2;
 	}
 
 	@Override
-	public int getEnergyCost()
+	public int getRequiredTurns()
 	{
-		return this.energy;
-	}
-
-	@Override
-	public void setEnergyCost( final int c )
-	{
-		this.energy = c;
+		return this.turns;
 	}
 }

--- a/src/main/java/appeng/integration/modules/jei/GrinderRecipeHandler.java
+++ b/src/main/java/appeng/integration/modules/jei/GrinderRecipeHandler.java
@@ -22,16 +22,16 @@ package appeng.integration.modules.jei;
 import mezz.jei.api.recipe.IRecipeHandler;
 import mezz.jei.api.recipe.IRecipeWrapper;
 
-import appeng.api.features.IGrinderEntry;
+import appeng.api.features.IGrinderRecipe;
 
 
-class GrinderRecipeHandler implements IRecipeHandler<IGrinderEntry>
+class GrinderRecipeHandler implements IRecipeHandler<IGrinderRecipe>
 {
 
 	@Override
-	public Class<IGrinderEntry> getRecipeClass()
+	public Class<IGrinderRecipe> getRecipeClass()
 	{
-		return IGrinderEntry.class;
+		return IGrinderRecipe.class;
 	}
 
 	@Override
@@ -41,19 +41,19 @@ class GrinderRecipeHandler implements IRecipeHandler<IGrinderEntry>
 	}
 
 	@Override
-	public String getRecipeCategoryUid( IGrinderEntry recipe )
+	public String getRecipeCategoryUid( IGrinderRecipe recipe )
 	{
 		return GrinderRecipeCategory.UID;
 	}
 
 	@Override
-	public IRecipeWrapper getRecipeWrapper( IGrinderEntry recipe )
+	public IRecipeWrapper getRecipeWrapper( IGrinderRecipe recipe )
 	{
 		return new GrinderRecipeWrapper( recipe );
 	}
 
 	@Override
-	public boolean isRecipeValid( IGrinderEntry recipe )
+	public boolean isRecipeValid( IGrinderRecipe recipe )
 	{
 		return true;
 	}

--- a/src/main/java/appeng/integration/modules/jei/GrinderRecipeWrapper.java
+++ b/src/main/java/appeng/integration/modules/jei/GrinderRecipeWrapper.java
@@ -31,15 +31,15 @@ import net.minecraft.item.ItemStack;
 import mezz.jei.api.ingredients.IIngredients;
 import mezz.jei.api.recipe.BlankRecipeWrapper;
 
-import appeng.api.features.IGrinderEntry;
+import appeng.api.features.IGrinderRecipe;
 
 
 class GrinderRecipeWrapper extends BlankRecipeWrapper
 {
 
-	private final IGrinderEntry recipe;
+	private final IGrinderRecipe recipe;
 
-	GrinderRecipeWrapper( IGrinderEntry recipe )
+	GrinderRecipeWrapper( IGrinderRecipe recipe )
 	{
 		this.recipe = recipe;
 	}
@@ -50,14 +50,8 @@ class GrinderRecipeWrapper extends BlankRecipeWrapper
 		ingredients.setInput( ItemStack.class, recipe.getInput() );
 		List<ItemStack> outputs = new ArrayList<>( 3 );
 		outputs.add( recipe.getOutput() );
-		if( recipe.getOptionalOutput() != null )
-		{
-			outputs.add( recipe.getOptionalOutput() );
-		}
-		if( recipe.getSecondOptionalOutput() != null )
-		{
-			outputs.add( recipe.getSecondOptionalOutput() );
-		}
+		recipe.getOptionalOutput().ifPresent( itemStack -> outputs.add( itemStack ) );
+		recipe.getSecondOptionalOutput().ifPresent( itemStack -> outputs.add( itemStack ) );
 		ingredients.setOutputs( ItemStack.class, outputs );
 	}
 

--- a/src/main/java/appeng/integration/modules/jei/GrinderRecipeWrapper.java
+++ b/src/main/java/appeng/integration/modules/jei/GrinderRecipeWrapper.java
@@ -50,8 +50,8 @@ class GrinderRecipeWrapper extends BlankRecipeWrapper
 		ingredients.setInput( ItemStack.class, recipe.getInput() );
 		List<ItemStack> outputs = new ArrayList<>( 3 );
 		outputs.add( recipe.getOutput() );
-		recipe.getOptionalOutput().ifPresent( itemStack -> outputs.add( itemStack ) );
-		recipe.getSecondOptionalOutput().ifPresent( itemStack -> outputs.add( itemStack ) );
+		recipe.getOptionalOutput().ifPresent( outputs::add );
+		recipe.getSecondOptionalOutput().ifPresent( outputs::add );
 		ingredients.setOutputs( ItemStack.class, outputs );
 	}
 

--- a/src/main/java/appeng/integration/modules/jei/JEIPlugin.java
+++ b/src/main/java/appeng/integration/modules/jei/JEIPlugin.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Optional;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -70,8 +71,10 @@ public class JEIPlugin extends BlankModPlugin
 		registerDescriptions( definitions, registry );
 
 		// Allow recipe transfer from JEI to crafting and pattern terminal
-		registry.getRecipeTransferRegistry().addRecipeTransferHandler( new RecipeTransferHandler<>( ContainerCraftingTerm.class ), VanillaRecipeCategoryUid.CRAFTING );
-		registry.getRecipeTransferRegistry().addRecipeTransferHandler( new RecipeTransferHandler<>( ContainerPatternTerm.class ), VanillaRecipeCategoryUid.CRAFTING );
+		registry.getRecipeTransferRegistry().addRecipeTransferHandler( new RecipeTransferHandler<>( ContainerCraftingTerm.class ),
+				VanillaRecipeCategoryUid.CRAFTING );
+		registry.getRecipeTransferRegistry().addRecipeTransferHandler( new RecipeTransferHandler<>( ContainerPatternTerm.class ),
+				VanillaRecipeCategoryUid.CRAFTING );
 	}
 
 	private void registerDescriptions( IDefinitions definitions, IModRegistry registry )
@@ -130,7 +133,7 @@ public class JEIPlugin extends BlankModPlugin
 			return;
 		}
 
-		registry.addRecipes( AEApi.instance().registries().grinder().getRecipes() );
+		registry.addRecipes( Lists.newArrayList( AEApi.instance().registries().grinder().getRecipes() ) );
 		registry.addRecipeHandlers( new GrinderRecipeHandler() );
 		registry.addRecipeCategories( new GrinderRecipeCategory( registry.getJeiHelpers().getGuiHelper() ) );
 		registry.addRecipeCategoryCraftingItem( grindstone, GrinderRecipeCategory.UID );

--- a/src/main/java/appeng/tile/grindstone/TileGrinder.java
+++ b/src/main/java/appeng/tile/grindstone/TileGrinder.java
@@ -28,7 +28,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
 
 import appeng.api.AEApi;
-import appeng.api.features.IGrinderEntry;
+import appeng.api.features.IGrinderRecipe;
 import appeng.api.implementations.tiles.ICrankable;
 import appeng.tile.AEBaseInvTile;
 import appeng.tile.inventory.AppEngInternalInventory;
@@ -108,7 +108,7 @@ public class TileGrinder extends AEBaseInvTile implements ICrankable
 					continue;
 				}
 
-				final IGrinderEntry r = AEApi.instance().registries().grinder().getRecipeForInput( item );
+				final IGrinderRecipe r = AEApi.instance().registries().grinder().getRecipeForInput( item );
 				if( r != null )
 				{
 					if( item.stackSize >= r.getInput().stackSize )
@@ -144,10 +144,10 @@ public class TileGrinder extends AEBaseInvTile implements ICrankable
 		this.points++;
 
 		final ItemStack processing = this.getStackInSlot( 6 );
-		final IGrinderEntry r = AEApi.instance().registries().grinder().getRecipeForInput( processing );
+		final IGrinderRecipe r = AEApi.instance().registries().grinder().getRecipeForInput( processing );
 		if( r != null )
 		{
-			if( r.getEnergyCost() > this.points )
+			if( r.getRequiredTurns() > this.points )
 			{
 				return;
 			}
@@ -157,17 +157,25 @@ public class TileGrinder extends AEBaseInvTile implements ICrankable
 
 			this.addItem( sia, r.getOutput() );
 
-			float chance = ( Platform.getRandomInt() % 2000 ) / 2000.0f;
-			if( chance <= r.getOptionalChance() )
+			r.getOptionalOutput().ifPresent( itemStack ->
 			{
-				this.addItem( sia, r.getOptionalOutput() );
-			}
+				final float chance = ( Platform.getRandomInt() % 2000 ) / 2000.0f;
 
-			chance = ( Platform.getRandomInt() % 2000 ) / 2000.0f;
-			if( chance <= r.getSecondOptionalChance() )
+				if( chance <= r.getOptionalChance() )
+				{
+					this.addItem( sia, itemStack );
+				}
+			} );
+
+			r.getSecondOptionalOutput().ifPresent( itemStack ->
 			{
-				this.addItem( sia, r.getSecondOptionalOutput() );
-			}
+				final float chance = ( Platform.getRandomInt() % 2000 ) / 2000.0f;
+
+				if( chance <= r.getSecondOptionalChance() )
+				{
+					this.addItem( sia, itemStack );
+				}
+			} );
 
 			this.setInventorySlotContents( 6, null );
 		}


### PR DESCRIPTION
~~**Waiting on config PR for further features.**~~

Changed IGrinderRegistry#getRecipes to return an unmodifiable collection.
Added a way to remove recipes explicitly instead the internal list.
Added a cache to lookup recipes instead of iterating a list.
Added an option to define custom ore to dust ratios.

Renamed IGrinderEntry to IGrinderRecipe
Made IGrindRecipe immutable for easy caching.

Improved GrinderLogging and Exception Handling
JEI Workaround as it expects a List instead Collection.