### PR TITLE
Odd animation breaking

### DIFF
--- a/src/main/java/appeng/items/tools/powered/ToolPortableCell.java
+++ b/src/main/java/appeng/items/tools/powered/ToolPortableCell.java
@@ -186,4 +186,9 @@ public class ToolPortableCell extends AEBasePoweredItem implements IStorageCell,
 	{
 		return new PortableCellViewer( is, pos.getX() );
 	}
+
+	@Override
+	public boolean shouldCauseReequipAnimation(ItemStack oldStack, ItemStack newStack, boolean slotChanged) {
+	        return slotChanged;
+	}
 }

--- a/src/main/java/appeng/items/tools/powered/ToolPortableCell.java
+++ b/src/main/java/appeng/items/tools/powered/ToolPortableCell.java
@@ -188,7 +188,8 @@ public class ToolPortableCell extends AEBasePoweredItem implements IStorageCell,
 	}
 
 	@Override
-	public boolean shouldCauseReequipAnimation(ItemStack oldStack, ItemStack newStack, boolean slotChanged) {
+	public boolean shouldCauseReequipAnimation( ItemStack oldStack, ItemStack newStack, boolean slotChanged ) 
+	{
 	        return slotChanged;
 	}
 }

--- a/src/main/java/appeng/items/tools/powered/ToolWirelessTerminal.java
+++ b/src/main/java/appeng/items/tools/powered/ToolWirelessTerminal.java
@@ -150,4 +150,9 @@ public class ToolWirelessTerminal extends AEBasePoweredItem implements IWireless
 		tag.setString( "encryptionKey", encKey );
 		tag.setString( "name", name );
 	}
+
+        @Override
+        public boolean shouldCauseReequipAnimation(ItemStack oldStack, ItemStack newStack, boolean slotChanged) {
+	        return slotChanged;
+        }
 }

--- a/src/main/java/appeng/items/tools/powered/ToolWirelessTerminal.java
+++ b/src/main/java/appeng/items/tools/powered/ToolWirelessTerminal.java
@@ -152,7 +152,8 @@ public class ToolWirelessTerminal extends AEBasePoweredItem implements IWireless
 	}
 
         @Override
-        public boolean shouldCauseReequipAnimation(ItemStack oldStack, ItemStack newStack, boolean slotChanged) {
+        public boolean shouldCauseReequipAnimation( ItemStack oldStack, ItemStack newStack, boolean slotChanged ) 
+	{
 	        return slotChanged;
         }
 }


### PR DESCRIPTION
This is a simple fix for the Wireless Terminal and Portable Cell to stop them from doing the re-equip animation when in use.