### PR TITLE
Fixes #2750: Added missing RF Integration Modules.

### DIFF
--- a/src/main/java/appeng/core/AELog.java
+++ b/src/main/java/appeng/core/AELog.java
@@ -307,7 +307,7 @@ public final class AELog
 	{
 		if( AEConfig.instance().isFeatureEnabled( AEFeature.INTEGRATION_LOGGING ) )
 		{
-			debug( exception );
+			error( exception );
 		}
 	}
 

--- a/src/main/java/appeng/integration/IntegrationNode.java
+++ b/src/main/java/appeng/integration/IntegrationNode.java
@@ -25,9 +25,6 @@ import net.minecraftforge.fml.common.ModAPIManager;
 import appeng.api.exceptions.ModNotInstalled;
 import appeng.core.AEConfig;
 import appeng.core.AELog;
-import appeng.integration.modules.ic2.IC2Module;
-import appeng.integration.modules.jei.JEIModule;
-import appeng.integration.modules.waila.WailaModule;
 
 
 final class IntegrationNode
@@ -80,7 +77,8 @@ final class IntegrationNode
 						final ModAPIManager apiManager = ModAPIManager.INSTANCE;
 						boolean enabled = this.modID == null || Loader.isModLoaded( this.modID ) || apiManager.hasAPI( this.modID );
 
-						AEConfig.instance().addCustomCategoryComment( "ModIntegration", "Valid Values are 'AUTO', 'ON', or 'OFF' - defaults to 'AUTO' ; Suggested that you leave this alone unless your experiencing an issue, or wish to disable the integration for a reason." );
+						AEConfig.instance().addCustomCategoryComment( "ModIntegration",
+								"Valid Values are 'AUTO', 'ON', or 'OFF' - defaults to 'AUTO' ; Suggested that you leave this alone unless your experiencing an issue, or wish to disable the integration for a reason." );
 						final String mode = AEConfig.instance().get( "ModIntegration", this.displayName.replace( " ", "" ), "AUTO" ).getString();
 
 						if( mode.toUpperCase().equals( "ON" ) )

--- a/src/main/java/appeng/integration/IntegrationType.java
+++ b/src/main/java/appeng/integration/IntegrationType.java
@@ -98,9 +98,7 @@ public enum IntegrationType
 
 	public IIntegrationModule createInstance()
 	{
-		return new IIntegrationModule()
-		{
-		};
+		throw new UnsupportedOperationException( "Missing integration module for type '" + this.name() + "'." );
 	}
 
 }

--- a/src/main/java/appeng/integration/IntegrationType.java
+++ b/src/main/java/appeng/integration/IntegrationType.java
@@ -98,7 +98,7 @@ public enum IntegrationType
 
 	public IIntegrationModule createInstance()
 	{
-		throw new UnsupportedOperationException( "Missing integration module for type '" + this.name() + "'." );
+		throw new MissingIntegrationModuleException( this.name() );
 	}
 
 }

--- a/src/main/java/appeng/integration/IntegrationType.java
+++ b/src/main/java/appeng/integration/IntegrationType.java
@@ -21,6 +21,8 @@ package appeng.integration;
 
 import appeng.integration.modules.ic2.IC2Module;
 import appeng.integration.modules.jei.JEIModule;
+import appeng.integration.modules.rf.RFItemModule;
+import appeng.integration.modules.rf.RFTileModule;
 import appeng.integration.modules.theoneprobe.TheOneProbeModule;
 import appeng.integration.modules.waila.WailaModule;
 
@@ -36,13 +38,25 @@ public enum IntegrationType
 		}
 	},
 
-	RC( IntegrationSide.BOTH, "Railcraft", "Railcraft" ),
+	RF( IntegrationSide.BOTH, "RedstoneFlux Power - Tiles", "CoFHAPI" )
+	{
 
-	RF( IntegrationSide.BOTH, "RedstoneFlux Power - Tiles", "CoFHAPI" ),
+		@Override
+		public IIntegrationModule createInstance()
+		{
+			return new RFTileModule();
+		}
+	},
 
-	RFItem( IntegrationSide.BOTH, "RedstoneFlux Power - Items", "CoFHAPI" ),
+	RFItem( IntegrationSide.BOTH, "RedstoneFlux Power - Items", "CoFHAPI" )
+	{
 
-	MFR( IntegrationSide.BOTH, "Mine Factory Reloaded", "MineFactoryReloaded" ),
+		@Override
+		public IIntegrationModule createInstance()
+		{
+			return new RFItemModule();
+		}
+	},
 
 	Waila( IntegrationSide.BOTH, "Waila", "Waila" )
 	{
@@ -53,8 +67,6 @@ public enum IntegrationType
 		}
 	},
 
-	InvTweaks( IntegrationSide.CLIENT, "Inventory Tweaks", "inventorytweaks" ),
-
 	JEI( IntegrationSide.CLIENT, "Just Enough Items", "JEI" )
 	{
 		@Override
@@ -63,10 +75,6 @@ public enum IntegrationType
 			return Integrations.setJei( new JEIModule() );
 		}
 	},
-
-	Mekanism( IntegrationSide.BOTH, "Mekanism", "Mekanism" ),
-
-	OpenComputers( IntegrationSide.BOTH, "OpenComputers", "OpenComputers" ),
 
 	THE_ONE_PROBE( IntegrationSide.BOTH, "TheOneProbe", "theoneprobe" )
 	{
@@ -90,7 +98,9 @@ public enum IntegrationType
 
 	public IIntegrationModule createInstance()
 	{
-		throw new UnsupportedOperationException();
+		return new IIntegrationModule()
+		{
+		};
 	}
 
 }

--- a/src/main/java/appeng/integration/MissingIntegrationModuleException.java
+++ b/src/main/java/appeng/integration/MissingIntegrationModuleException.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of Applied Energistics 2.
- * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
  *
  * Applied Energistics 2 is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -19,34 +19,14 @@
 package appeng.integration;
 
 
-import static org.junit.Assert.assertNotNull;
-
-import org.junit.Test;
-
-
-public class IntegrationTypeTest
+public class MissingIntegrationModuleException extends RuntimeException
 {
 
-	@Test
-	public void testCreateInstanceWithoutExceptions()
+	public MissingIntegrationModuleException( String name )
 	{
-		for( IntegrationType type : IntegrationType.values() )
-		{
-			try
-			{
-				assertNotNull( type.createInstance() );
-			}
-			// We actually only care about this specific type not being thrown.
-			catch( MissingIntegrationModuleException e )
-			{
-				throw e;
-			}
-			// Throw everything else away as these might be caused due to missing dependencies during testing.
-			catch( Throwable e )
-			{
-				// ignore
-			}
-		}
+		super( "Missing integration module for type '" + name + "'." );
 	}
+
+	private static final long serialVersionUID = 1927357647297008228L;
 
 }

--- a/src/main/java/appeng/integration/MissingIntegrationModuleException.java
+++ b/src/main/java/appeng/integration/MissingIntegrationModuleException.java
@@ -22,11 +22,11 @@ package appeng.integration;
 public class MissingIntegrationModuleException extends RuntimeException
 {
 
+	private static final long serialVersionUID = 1927357647297008228L;
+
 	public MissingIntegrationModuleException( String name )
 	{
 		super( "Missing integration module for type '" + name + "'." );
 	}
-
-	private static final long serialVersionUID = 1927357647297008228L;
 
 }

--- a/src/main/java/appeng/integration/modules/rf/RFItemModule.java
+++ b/src/main/java/appeng/integration/modules/rf/RFItemModule.java
@@ -1,0 +1,32 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.integration.modules.rf;
+
+
+import appeng.integration.IIntegrationModule;
+import appeng.integration.IntegrationHelper;
+
+
+public class RFItemModule implements IIntegrationModule
+{
+	public RFItemModule()
+	{
+		IntegrationHelper.testClassExistence( this, cofh.api.energy.IEnergyContainerItem.class );
+	}
+}

--- a/src/main/java/appeng/integration/modules/rf/RFTileModule.java
+++ b/src/main/java/appeng/integration/modules/rf/RFTileModule.java
@@ -1,0 +1,32 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.integration.modules.rf;
+
+
+import appeng.integration.IIntegrationModule;
+import appeng.integration.IntegrationHelper;
+
+
+public class RFTileModule implements IIntegrationModule
+{
+	public RFTileModule()
+	{
+		IntegrationHelper.testClassExistence( this, cofh.api.energy.IEnergyReceiver.class );
+	}
+}

--- a/src/test/java/appeng/integration/IntegrationTypeTest.java
+++ b/src/test/java/appeng/integration/IntegrationTypeTest.java
@@ -1,0 +1,39 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.integration;
+
+
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+
+
+public class IntegrationTypeTest
+{
+
+	@Test
+	public void testCreateInstanceWithoutExceptions()
+	{
+		for( IntegrationType type : IntegrationType.values() )
+		{
+			assertNotNull( type.createInstance() );
+		}
+	}
+
+}


### PR DESCRIPTION
Readded the integration modules for both RF integrations.
These are necessary to correctly enable RF support as well as act as fallback to disable it automatically on missing interfaces.
Removed superfluous integration types.