### PR TITLE
Only send filter to jei when it's changed.

### DIFF
--- a/src/main/java/appeng/client/me/ItemRepo.java
+++ b/src/main/java/appeng/client/me/ItemRepo.java
@@ -60,6 +60,7 @@ public class ItemRepo
 	private IPartitionList<IAEItemStack> myPartitionList;
 	private String innerSearch = "";
 	private boolean hasPower;
+	private String lastJEIFilter = "";
 
 	public ItemRepo( final IScrollSource src, final ISortSource sortSrc )
 	{
@@ -244,7 +245,11 @@ public class ItemRepo
 
 	private void updateJEI( String filter )
 	{
-		Integrations.jei().setSearchText( filter );
+		if( !filter.equals( lastJEIFilter ) )
+		{
+			lastJEIFilter = filter;
+			Integrations.jei().setSearchText( filter );
+		}
 	}
 
 	public int size()


### PR DESCRIPTION
Current JEI synchronization resets the search and page anytime the monitor is updated. This changes that to act more like the old NEI sync.

[Video of current functionality.](https://youtu.be/Nyy3LAbKE0k)