### PR TITLE
Added Support for CoFH Wrench API (IToolHammer)

### DIFF
--- a/src/main/java/appeng/integration/IntegrationType.java
+++ b/src/main/java/appeng/integration/IntegrationType.java
@@ -38,7 +38,7 @@ public enum IntegrationType
 		}
 	},
 
-	RF( IntegrationSide.BOTH, "RedstoneFlux Power - Tiles", "CoFHAPI" )
+	RF( IntegrationSide.BOTH, "RedstoneFlux Power - Tiles", "cofhapi" )
 	{
 
 		@Override
@@ -48,7 +48,7 @@ public enum IntegrationType
 		}
 	},
 
-	RFItem( IntegrationSide.BOTH, "RedstoneFlux Power - Items", "CoFHAPI" )
+	RFItem( IntegrationSide.BOTH, "RedstoneFlux Power - Items", "cofhapi" )
 	{
 
 		@Override

--- a/src/main/java/appeng/util/Platform.java
+++ b/src/main/java/appeng/util/Platform.java
@@ -80,6 +80,8 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.oredict.OreDictionary;
 
+import cofh.api.item.IToolHammer;
+
 import appeng.api.AEApi;
 import appeng.api.config.AccessRestriction;
 import appeng.api.config.Actionable;
@@ -803,7 +805,20 @@ public class Platform
 			{ // explodes without BC
 
 			}
-
+			
+			// CoFH Wrench Support
+            try {
+                if( eq.getItem() instanceof IToolHammer )
+                {
+                    IToolHammer wrench = (IToolHammer) eq.getItem();
+                    return wrench.isUsable( eq, player, pos );
+                }
+            }
+            catch( final Throwable ignore )
+            {
+            
+            }
+            
 			if( eq.getItem() instanceof IAEWrench )
 			{
 				final IAEWrench wrench = (IAEWrench) eq.getItem();

--- a/src/thirdparty/java/cofh/api/CoFHAPIProps.java
+++ b/src/thirdparty/java/cofh/api/CoFHAPIProps.java
@@ -6,6 +6,6 @@ public class CoFHAPIProps {
 
 	}
 
-	public static final String VERSION = "1.8.9R1.2.0B1";
+	public static final String VERSION = "1.7.0";
 
 }

--- a/src/thirdparty/java/cofh/api/energy/EnergyStorage.java
+++ b/src/thirdparty/java/cofh/api/energy/EnergyStorage.java
@@ -6,7 +6,6 @@ import net.minecraft.nbt.NBTTagCompound;
  * Reference implementation of {@link IEnergyStorage}. Use/extend this or implement your own.
  *
  * @author King Lemming
- *
  */
 public class EnergyStorage implements IEnergyStorage {
 
@@ -91,10 +90,7 @@ public class EnergyStorage implements IEnergyStorage {
 	}
 
 	/**
-	 * This function is included to allow for server to client sync. Do not call this externally to the containing Tile Entity, as not all IEnergyHandlers
-	 * are guaranteed to have it.
-	 *
-	 * @param energy
+	 * This function is included to allow for server to client sync. Do not call this externally to the containing Tile Entity, as not all IEnergyHandlers are guaranteed to have it.
 	 */
 	public void setEnergyStored(int energy) {
 
@@ -108,10 +104,7 @@ public class EnergyStorage implements IEnergyStorage {
 	}
 
 	/**
-	 * This function is included to allow the containing tile to directly and efficiently modify the energy contained in the EnergyStorage. Do not rely on this
-	 * externally, as not all IEnergyHandlers are guaranteed to have it.
-	 *
-	 * @param energy
+	 * This function is included to allow the containing tile to directly and efficiently modify the energy contained in the EnergyStorage. Do not rely on this externally, as not all IEnergyHandlers are guaranteed to have it.
 	 */
 	public void modifyEnergyStored(int energy) {
 

--- a/src/thirdparty/java/cofh/api/energy/IEnergyConnection.java
+++ b/src/thirdparty/java/cofh/api/energy/IEnergyConnection.java
@@ -2,15 +2,13 @@ package cofh.api.energy;
 
 import net.minecraft.util.EnumFacing;
 
-
 /**
  * Implement this interface on TileEntities which should connect to energy transportation blocks. This is intended for blocks which generate energy but do not
  * accept it; otherwise just use IEnergyHandler.
- * <p>
+ *
  * Note that {@link IEnergyHandler} is an extension of this.
  *
  * @author King Lemming
- *
  */
 public interface IEnergyConnection {
 

--- a/src/thirdparty/java/cofh/api/energy/IEnergyContainerItem.java
+++ b/src/thirdparty/java/cofh/api/energy/IEnergyContainerItem.java
@@ -4,23 +4,19 @@ import net.minecraft.item.ItemStack;
 
 /**
  * Implement this interface on Item classes that support external manipulation of their internal energy storages.
- * <p>
+ *
  * A reference implementation is provided {@link ItemEnergyContainer}.
  *
  * @author King Lemming
- *
  */
 public interface IEnergyContainerItem {
 
 	/**
 	 * Adds energy to a container item. Returns the quantity of energy that was accepted. This should always return 0 if the item cannot be externally charged.
 	 *
-	 * @param container
-	 *            ItemStack to be charged.
-	 * @param maxReceive
-	 *            Maximum amount of energy to be sent into the item.
-	 * @param simulate
-	 *            If TRUE, the charge will only be simulated.
+	 * @param container  ItemStack to be charged.
+	 * @param maxReceive Maximum amount of energy to be sent into the item.
+	 * @param simulate   If TRUE, the charge will only be simulated.
 	 * @return Amount of energy that was (or would have been, if simulated) received by the item.
 	 */
 	int receiveEnergy(ItemStack container, int maxReceive, boolean simulate);
@@ -29,12 +25,9 @@ public interface IEnergyContainerItem {
 	 * Removes energy from a container item. Returns the quantity of energy that was removed. This should always return 0 if the item cannot be externally
 	 * discharged.
 	 *
-	 * @param container
-	 *            ItemStack to be discharged.
-	 * @param maxExtract
-	 *            Maximum amount of energy to be extracted from the item.
-	 * @param simulate
-	 *            If TRUE, the discharge will only be simulated.
+	 * @param container  ItemStack to be discharged.
+	 * @param maxExtract Maximum amount of energy to be extracted from the item.
+	 * @param simulate   If TRUE, the discharge will only be simulated.
 	 * @return Amount of energy that was (or would have been, if simulated) extracted from the item.
 	 */
 	int extractEnergy(ItemStack container, int maxExtract, boolean simulate);

--- a/src/thirdparty/java/cofh/api/energy/IEnergyHandler.java
+++ b/src/thirdparty/java/cofh/api/energy/IEnergyHandler.java
@@ -4,13 +4,12 @@ import net.minecraft.util.EnumFacing;
 
 /**
  * Implement this interface on Tile Entities which should handle energy, generally storing it in one or more internal {@link IEnergyStorage} objects.
- * <p>
+ *
  * A reference implementation is provided {@link TileEnergyHandler}.
- * <p>
+ *
  * Note that {@link IEnergyReceiver} and {@link IEnergyProvider} are extensions of this.
  *
  * @author King Lemming
- *
  */
 public interface IEnergyHandler extends IEnergyConnection {
 

--- a/src/thirdparty/java/cofh/api/energy/IEnergyProvider.java
+++ b/src/thirdparty/java/cofh/api/energy/IEnergyProvider.java
@@ -2,26 +2,21 @@ package cofh.api.energy;
 
 import net.minecraft.util.EnumFacing;
 
-
 /**
  * Implement this interface on Tile Entities which should provide energy, generally storing it in one or more internal {@link IEnergyStorage} objects.
- * <p>
+ *
  * A reference implementation is provided {@link TileEnergyHandler}.
  *
  * @author King Lemming
- *
  */
 public interface IEnergyProvider extends IEnergyHandler {
 
 	/**
 	 * Remove energy from an IEnergyProvider, internal distribution is left entirely to the IEnergyProvider.
 	 *
-	 * @param from
-	 *            Orientation the energy is extracted from.
-	 * @param maxExtract
-	 *            Maximum amount of energy to extract.
-	 * @param simulate
-	 *            If TRUE, the extraction will only be simulated.
+	 * @param from       Orientation the energy is extracted from.
+	 * @param maxExtract Maximum amount of energy to extract.
+	 * @param simulate   If TRUE, the extraction will only be simulated.
 	 * @return Amount of energy that was (or would have been, if simulated) extracted.
 	 */
 	int extractEnergy(EnumFacing from, int maxExtract, boolean simulate);

--- a/src/thirdparty/java/cofh/api/energy/IEnergyReceiver.java
+++ b/src/thirdparty/java/cofh/api/energy/IEnergyReceiver.java
@@ -2,26 +2,21 @@ package cofh.api.energy;
 
 import net.minecraft.util.EnumFacing;
 
-
 /**
  * Implement this interface on Tile Entities which should receive energy, generally storing it in one or more internal {@link IEnergyStorage} objects.
- * <p>
+ *
  * A reference implementation is provided {@link TileEnergyHandler}.
  *
  * @author King Lemming
- *
  */
 public interface IEnergyReceiver extends IEnergyHandler {
 
 	/**
 	 * Add energy to an IEnergyReceiver, internal distribution is left entirely to the IEnergyReceiver.
 	 *
-	 * @param from
-	 *            Orientation the energy is received from.
-	 * @param maxReceive
-	 *            Maximum amount of energy to receive.
-	 * @param simulate
-	 *            If TRUE, the charge will only be simulated.
+	 * @param from       Orientation the energy is received from.
+	 * @param maxReceive Maximum amount of energy to receive.
+	 * @param simulate   If TRUE, the charge will only be simulated.
 	 * @return Amount of energy that was (or would have been, if simulated) received.
 	 */
 	int receiveEnergy(EnumFacing from, int maxReceive, boolean simulate);

--- a/src/thirdparty/java/cofh/api/energy/IEnergyStorage.java
+++ b/src/thirdparty/java/cofh/api/energy/IEnergyStorage.java
@@ -3,21 +3,18 @@ package cofh.api.energy;
 /**
  * An energy storage is the unit of interaction with Energy inventories.<br>
  * This is not to be implemented on TileEntities. This is for internal use only.
- * <p>
+ *
  * A reference implementation can be found at {@link EnergyStorage}.
  *
  * @author King Lemming
- *
  */
 public interface IEnergyStorage {
 
 	/**
 	 * Adds energy to the storage. Returns quantity of energy that was accepted.
 	 *
-	 * @param maxReceive
-	 *            Maximum amount of energy to be inserted.
-	 * @param simulate
-	 *            If TRUE, the insertion will only be simulated.
+	 * @param maxReceive Maximum amount of energy to be inserted.
+	 * @param simulate   If TRUE, the insertion will only be simulated.
 	 * @return Amount of energy that was (or would have been, if simulated) accepted by the storage.
 	 */
 	int receiveEnergy(int maxReceive, boolean simulate);
@@ -25,10 +22,8 @@ public interface IEnergyStorage {
 	/**
 	 * Removes energy from the storage. Returns quantity of energy that was removed.
 	 *
-	 * @param maxExtract
-	 *            Maximum amount of energy to be extracted.
-	 * @param simulate
-	 *            If TRUE, the extraction will only be simulated.
+	 * @param maxExtract Maximum amount of energy to be extracted.
+	 * @param simulate   If TRUE, the extraction will only be simulated.
 	 * @return Amount of energy that was (or would have been, if simulated) extracted from the storage.
 	 */
 	int extractEnergy(int maxExtract, boolean simulate);

--- a/src/thirdparty/java/cofh/api/energy/IEnergyTransport.java
+++ b/src/thirdparty/java/cofh/api/energy/IEnergyTransport.java
@@ -1,0 +1,106 @@
+package cofh.api.energy;
+
+import net.minecraft.util.EnumFacing;
+
+/**
+ * Implement this interface on Tile Entities which transport energy.
+ *
+ * This is used to "negotiate" connection types between two separate IEnergyTransports, allowing users to set flow direction and allowing for networks Of
+ * IEnergyTransports to intelligently transfer energy to other networks.
+ */
+public interface IEnergyTransport extends IEnergyProvider, IEnergyReceiver {
+
+	/**
+	 * The type of interface for a given side of a {@link IEnergyTransport}.
+	 *
+	 * Values are:
+	 * {@link #SEND} for sending only
+	 * {@link #RECEIVE} for receiving only
+	 * {@link #BALANCE} for sending and receiving, and the default state
+	 */
+	enum InterfaceType {
+		/**
+		 * Indicates that this {@link IEnergyTransport} is only sending power on this side.
+		 */
+		SEND, /**
+		 * Indicates that this {@link IEnergyTransport} is only receiving power on this side.
+		 */
+		RECEIVE, /**
+		 * Indicates that this {@link IEnergyTransport} wants to balance power between itself and the
+		 * senders/receivers on this side. This is the default state.
+		 * To block any connection, use {@link IEnergyConnection#canConnectEnergy}
+		 *
+		 * IEnergyTransport based senders should check that the total power in the destination IEnergyTransport is less than the power in themselves before sending.
+		 *
+		 * Active IEnergyTransport receivers (i.e., those that call {@link IEnergyProvider#extractEnergy}) should check that they contain less power than the
+		 * source IEnergyTransport.
+		 */
+		BALANCE;
+
+		/**
+		 * Returns the opposite state to this InterfaceType.
+		 *
+		 * {@link #BALANCE} is considered its own opposite.
+		 * {@link #SEND} is the opposite of {@link #RECEIVE} and visa versa.
+		 */
+		public InterfaceType getOpposite() {
+
+			return this == BALANCE ? BALANCE : this == SEND ? RECEIVE : SEND;
+		}
+
+		/**
+		 * Returns the next InterfaceType as described in {@link IEnergyTransport#getTransportState}
+		 */
+		public InterfaceType rotate() {
+
+			return rotate(true);
+		}
+
+		/**
+		 * Returns the next InterfaceType as described in {@link IEnergyTransport#getTransportState}
+		 *
+		 * @param forward Whether to step in the order specified by {@link IEnergyTransport#getTransportState} (<tt>true</tt>) or to step in the opposite direction
+		 */
+		public InterfaceType rotate(boolean forward) {
+
+			if (forward) {
+				return this == BALANCE ? RECEIVE : this == RECEIVE ? SEND : BALANCE;
+			} else {
+				return this == BALANCE ? SEND : this == SEND ? RECEIVE : BALANCE;
+			}
+		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 * This method <b>cannot</b> be a no-op for IEnergyTransport.
+	 */
+	@Override
+	int getEnergyStored(EnumFacing from);
+
+	/**
+	 * Indicates to other IEnergyTransports the state of the given side. See {@link InterfaceType} for details.
+	 *
+	 * For clarity of state tracking, on a tile update from another IEnergyTransport, if its mode has changed from the opposite of your own mode on that side, you
+	 * should change your mode to the opposite of its mode.
+	 *
+	 * When the user alters your mode and your state is:
+	 * BALANCE, your mode should change to {@link InterfaceType#RECEIVE}.
+	 * RECEIVE, your mode should change to {@link InterfaceType#SEND}.
+	 * SEND, your mode should change to {@link InterfaceType#BALANCE}.
+	 * This is not required, but will be easier for users.
+	 *
+	 * @return The type of connection to establish on this side. <b>null is NOT a valid value.</b>
+	 */
+	InterfaceType getTransportState(EnumFacing from);
+
+	/**
+	 * This method is provided primarily for the purposes of automation tools, and should not need to be called by another IEnergyTransport.
+	 *
+	 * Calls to this method may fail if this IEnergyTransport has been secured by a user.
+	 *
+	 * @return Whether or not state was successfully altered.
+	 */
+	boolean setTransportState(InterfaceType state, EnumFacing from);
+
+}

--- a/src/thirdparty/java/cofh/api/energy/ItemEnergyContainer.java
+++ b/src/thirdparty/java/cofh/api/energy/ItemEnergyContainer.java
@@ -8,7 +8,6 @@ import net.minecraft.nbt.NBTTagCompound;
  * Reference implementation of {@link IEnergyContainerItem}. Use/extend this or implement your own.
  *
  * @author King Lemming
- *
  */
 public class ItemEnergyContainer extends Item implements IEnergyContainerItem {
 
@@ -43,20 +42,20 @@ public class ItemEnergyContainer extends Item implements IEnergyContainerItem {
 		return this;
 	}
 
-	public ItemEnergyContainer  setMaxTransfer(int maxTransfer) {
+	public ItemEnergyContainer setMaxTransfer(int maxTransfer) {
 
 		setMaxReceive(maxTransfer);
 		setMaxExtract(maxTransfer);
 		return this;
 	}
 
-	public ItemEnergyContainer  setMaxReceive(int maxReceive) {
+	public ItemEnergyContainer setMaxReceive(int maxReceive) {
 
 		this.maxReceive = maxReceive;
 		return this;
 	}
 
-	public ItemEnergyContainer  setMaxExtract(int maxExtract) {
+	public ItemEnergyContainer setMaxExtract(int maxExtract) {
 
 		this.maxExtract = maxExtract;
 		return this;

--- a/src/thirdparty/java/cofh/api/energy/TileEnergyHandler.java
+++ b/src/thirdparty/java/cofh/api/energy/TileEnergyHandler.java
@@ -6,11 +6,10 @@ import net.minecraft.util.EnumFacing;
 
 /**
  * Reference implementation of {@link IEnergyReceiver} and {@link IEnergyProvider}. Use/extend this or implement your own.
- * 
+ *
  * This class is really meant to summarize how each interface is properly used.
  *
  * @author King Lemming
- *
  */
 public class TileEnergyHandler extends TileEntity implements IEnergyReceiver, IEnergyProvider {
 

--- a/src/thirdparty/java/cofh/api/item/IAugmentItem.java
+++ b/src/thirdparty/java/cofh/api/item/IAugmentItem.java
@@ -1,0 +1,36 @@
+package cofh.api.item;
+
+import net.minecraft.item.ItemStack;
+
+public interface IAugmentItem {
+
+	/**
+	 * Enum for Augment Types.
+	 *
+	 * BASIC - Standard augment, can have multiple.
+	 * ADVANCED - Rare augment, multiples may or may not be allowed.
+	 * MODE - Changes functionality greatly. Only allow one.
+	 * ENDER - Integration with Ender Frequencies.
+	 * CREATIVE - Super-powerful augments which cannot normally be obtained.
+	 */
+	enum AugmentType {
+		BASIC, ADVANCED, MODE, ENDER, CREATIVE
+	}
+
+	/**
+	 * Get the Augment Type for a given Augment.
+	 *
+	 * @param stack ItemStack representing the Augment.
+	 * @return Augment Type of the stack.
+	 */
+	AugmentType getAugmentType(ItemStack stack);
+
+	/**
+	 * Get the Augment Identifier for a given Augment. This is simply a string with some description of what the Augment does. Individual
+	 *
+	 * @param stack ItemStack representing the Augment.
+	 * @return Augment Type of the stack.
+	 */
+	String getAugmentIdentifier(ItemStack stack);
+
+}

--- a/src/thirdparty/java/cofh/api/item/IInventoryContainerItem.java
+++ b/src/thirdparty/java/cofh/api/item/IInventoryContainerItem.java
@@ -1,0 +1,17 @@
+package cofh.api.item;
+
+import net.minecraft.item.ItemStack;
+
+/**
+ * Implement this interface on Item classes that are themselves inventories.
+ *
+ * @author King Lemming
+ */
+public interface IInventoryContainerItem {
+
+	/**
+	 * Get the size of this inventory of this container item.
+	 */
+	int getSizeInventory(ItemStack container);
+
+}

--- a/src/thirdparty/java/cofh/api/item/IMultiModeItem.java
+++ b/src/thirdparty/java/cofh/api/item/IMultiModeItem.java
@@ -1,0 +1,51 @@
+package cofh.api.item;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+
+/**
+ * Implement this interface on Item classes which have multiple modes - what that means is completely up to you. This just provides a uniform way of dealing
+ * with them.
+ *
+ * @author King Lemming
+ */
+public interface IMultiModeItem {
+
+	/**
+	 * Get the current mode of an item.
+	 */
+	int getMode(ItemStack stack);
+
+	/**
+	 * Attempt to set the empowered state of the item.
+	 *
+	 * @param stack ItemStack to set the mode on.
+	 * @param mode  Desired mode.
+	 * @return TRUE if the operation was successful, FALSE if it was not.
+	 */
+	boolean setMode(ItemStack stack, int mode);
+
+	/**
+	 * Increment the current mode of an item.
+	 */
+	boolean incrMode(ItemStack stack);
+
+	/**
+	 * Decrement the current mode of an item.
+	 */
+	boolean decrMode(ItemStack stack);
+
+	/**
+	 * Returns the number of possible modes.
+	 */
+	int getNumModes(ItemStack stack);
+
+	/**
+	 * Callback method for reacting to a state change. Useful in KeyBinding handlers.
+	 *
+	 * @param player Player holding the item, if applicable.
+	 * @param stack  The item being held.
+	 */
+	void onModeChange(EntityPlayer player, ItemStack stack);
+
+}

--- a/src/thirdparty/java/cofh/api/item/IToolHammer.java
+++ b/src/thirdparty/java/cofh/api/item/IToolHammer.java
@@ -1,0 +1,51 @@
+package cofh.api.item;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.BlockPos;
+
+/**
+ * Implement this interface on subclasses of Item to have that item work as a tool for CoFH mods.
+ */
+public interface IToolHammer {
+
+	/**
+	 * Called to ensure that the tool can be used on a block.
+	 *
+	 * @param item The ItemStack for the tool. Not required to match equipped item (e.g., multi-tools that contain other tools).
+	 * @param user The entity using the tool.
+	 * @param pos  Coordinates of the block.
+	 * @return True if this tool can be used.
+	 */
+	boolean isUsable(ItemStack item, EntityLivingBase user, BlockPos pos);
+
+	/**
+	 * Called to ensure that the tool can be used on an entity.
+	 *
+	 * @param item   The ItemStack for the tool. Not required to match equipped item (e.g., multi-tools that contain other tools).
+	 * @param user   The entity using the tool.
+	 * @param entity The entity the tool is being used on.
+	 * @return True if this tool can be used.
+	 */
+	boolean isUsable(ItemStack item, EntityLivingBase user, Entity entity);
+
+	/**
+	 * Callback for when the tool has been used reactively.
+	 *
+	 * @param item The ItemStack for the tool. Not required to match equipped item (e.g., multi-tools that contain other tools).
+	 * @param user The entity using the tool.
+	 * @param pos  Coordinates of the block.
+	 */
+	void toolUsed(ItemStack item, EntityLivingBase user, BlockPos pos);
+
+	/**
+	 * Callback for when the tool has been used reactively.
+	 *
+	 * @param item   The ItemStack for the tool. Not required to match equipped item (e.g., multi-tools that contain other tools).
+	 * @param user   The entity using the tool.
+	 * @param entity The entity the tool is being used on.
+	 */
+	void toolUsed(ItemStack item, EntityLivingBase user, Entity entity);
+
+}

--- a/src/thirdparty/java/cofh/api/item/IUpgradeItem.java
+++ b/src/thirdparty/java/cofh/api/item/IUpgradeItem.java
@@ -1,0 +1,30 @@
+package cofh.api.item;
+
+import net.minecraft.item.ItemStack;
+
+public interface IUpgradeItem {
+
+	/**
+	 * Enum for Upgrade Types - there aren't many.
+	 */
+	enum UpgradeType {
+		INCREMENTAL, FULL, CREATIVE
+	}
+
+	/**
+	 * Get the Upgrade Type for a given Upgrade.
+	 *
+	 * @param stack ItemStack representing the Upgrade.
+	 * @return Upgrade Type of the stack.
+	 */
+	UpgradeType getUpgradeType(ItemStack stack);
+
+	/**
+	 * Get the Upgrade Level for a given Upgrade.
+	 *
+	 * @param stack ItemStack representing the Upgrade.
+	 * @return Upgrade Level of the stack; -1 for a Creative Upgrade.
+	 */
+	int getUpgradeLevel(ItemStack stack);
+
+}

--- a/src/thirdparty/java/cofh/api/item/package-info.java
+++ b/src/thirdparty/java/cofh/api/item/package-info.java
@@ -2,8 +2,8 @@
  * (C) 2014-2017 Team CoFH / CoFH / Cult of the Full Hub
  * http://www.teamcofh.com
  */
-@API (apiVersion = CoFHAPIProps.VERSION, owner = "cofhapi", provides = "cofhapi|energy")
-package cofh.api.energy;
+@API (apiVersion = CoFHAPIProps.VERSION, owner = "cofhapi", provides = "cofhapi|item")
+package cofh.api.item;
 
 import cofh.api.CoFHAPIProps;
 import net.minecraftforge.fml.common.API;

--- a/src/thirdparty/java/cofh/api/package-info.java
+++ b/src/thirdparty/java/cofh/api/package-info.java
@@ -1,9 +1,8 @@
 /**
- * (C) 2014-2016 Team CoFH / CoFH / Cult of the Full Hub
+ * (C) 2014-2017 Team CoFH / CoFH / Cult of the Full Hub
  * http://www.teamcofh.com
  */
-@API(apiVersion = CoFHAPIProps.VERSION, owner = "CoFHLib", provides = "CoFHAPI")
+@API (apiVersion = CoFHAPIProps.VERSION, owner = "cofhlib", provides = "cofhapi")
 package cofh.api;
 
 import net.minecraftforge.fml.common.API;
-


### PR DESCRIPTION
As 1.10 has dropped Buildcraft's Wrench API (as there is no BC for 1.10 this seems logical :) )
In Result of this there is no support for CoFH's Wrench API, Which was in Previous AE Versions as CoFH's Wrench API Implmeneted also Buildcraft's Interface.

Therefore i added direct Support for CoFHLib's Wrench Interface this will also result in a lot of other Mods such as EnderIO's YetaWrench will work on AE2 Tiles.


