### PR TITLE
Improve behaviour of stacks that have 0 stackSize and non-zero requestable count

### DIFF
--- a/src/main/java/appeng/client/gui/AEBaseGui.java
+++ b/src/main/java/appeng/client/gui/AEBaseGui.java
@@ -453,7 +453,7 @@ public abstract class AEBaseGui extends GuiContainer
 					action = ( mouseButton == 1 ) ? InventoryAction.SPLIT_OR_PLACE_SINGLE : InventoryAction.PICKUP_OR_SET_DOWN;
 					stack = ( (SlotME) slot ).getAEStack();
 
-					if( stack != null && action == InventoryAction.PICKUP_OR_SET_DOWN && stack.getStackSize() == 0 && player.inventory.getItemStack() == null )
+					if( stack != null && action == InventoryAction.PICKUP_OR_SET_DOWN && stack.getStackSize() == 0 && player.inventory.getItemStack() == null && stack.getCountRequestable() == 0 )
 					{
 						action = InventoryAction.AUTO_CRAFT;
 					}

--- a/src/main/java/appeng/client/render/StackSizeRenderer.java
+++ b/src/main/java/appeng/client/render/StackSizeRenderer.java
@@ -53,7 +53,7 @@ public class StackSizeRenderer
 			final boolean unicodeFlag = fontRenderer.getUnicodeFlag();
 			fontRenderer.setUnicodeFlag( false );
 
-			if( is.stackSize == 0 )
+			if( is.stackSize == 0 && ( aeStack == null || aeStack.getCountRequestable() == 0 ) )
 			{
 				final String craftLabelText = AEConfig.instance().useTerminalUseLargeFont() ? GuiText.LargeFontCraft.getLocal() : GuiText.SmallFontCraft.getLocal();
 				GlStateManager.disableLighting();

--- a/src/main/java/appeng/crafting/MECraftingInventory.java
+++ b/src/main/java/appeng/crafting/MECraftingInventory.java
@@ -95,6 +95,13 @@ public class MECraftingInventory implements IMEInventory<IAEItemStack>
 		}
 
 		this.localCache = this.target.getAvailableItems( new ItemListIgnoreCrafting<>( AEApi.instance().storage().createItemList() ) );
+		for( IAEItemStack is : this.localCache )
+		{
+			if( is.getCountRequestable() > 0 )
+			{
+				is.incStackSize( is.getCountRequestable() );
+			}
+		}
 
 		this.par = parent;
 	}
@@ -134,8 +141,13 @@ public class MECraftingInventory implements IMEInventory<IAEItemStack>
 		}
 
 		this.localCache = new ItemListIgnoreCrafting<>( AEApi.instance().storage().createItemList() );
-		for( final IAEItemStack is : target.getStorageList() )
+		for( IAEItemStack is : target.getStorageList() )
 		{
+			if( is.getCountRequestable() > 0 )
+			{
+				is = is.copy();
+				is.incStackSize( is.getCountRequestable() );
+			}
 			this.localCache.add( target.extractItems( is, Actionable.SIMULATE, src ) );
 		}
 
@@ -177,6 +189,13 @@ public class MECraftingInventory implements IMEInventory<IAEItemStack>
 		}
 
 		this.localCache = target.getAvailableItems( AEApi.instance().storage().createItemList() );
+		for( IAEItemStack is : this.localCache )
+		{
+			if(is.getCountRequestable() > 0)
+			{
+				is.incStackSize( is.getCountRequestable() );
+			}
+		}
 		this.par = null;
 	}
 


### PR DESCRIPTION
**Preface:** I'm not 100% sure if this is how requestable stacks are supposed to work; there did not seem to be much that actually uses requestable stacks - something to do with power usage? In my addon mod I've been using them for items that don't technically "exist" until they are created (on extraction); they are items that should not (for example) be transferred by the IO Port to/from Item Cells.

Without these changes such stacks appear as craftable in the ME Terminal, but are unable to proceed past the Craft Confirm GUI, and also unable to be used in autocrafting.

With these changes the ME Terminal will not display Craft text when requestable count > 0. Stacks with 0 stack size and requestable count > 0 will display no number in the slot. Crafting calculation can successfully use the requestable stacks as if they existed.