### PR TITLE
Fixes #2679: Correct UVs for East, North and Down.

### DIFF
--- a/src/main/java/appeng/client/render/cablebus/CubeBuilder.java
+++ b/src/main/java/appeng/client/render/cablebus/CubeBuilder.java
@@ -212,9 +212,9 @@ public class CubeBuilder
 		{
 			case DOWN:
 				uv.u1 = texture.getInterpolatedU( x1 * 16 );
-				uv.v1 = texture.getInterpolatedV( z1 * 16 );
+				uv.v1 = texture.getInterpolatedV( 16 - z1 * 16 );
 				uv.u2 = texture.getInterpolatedU( x2 * 16 );
-				uv.v2 = texture.getInterpolatedV( z2 * 16 );
+				uv.v2 = texture.getInterpolatedV( 16 - z2 * 16 );
 				break;
 			case UP:
 				uv.u1 = texture.getInterpolatedU( x1 * 16 );
@@ -223,9 +223,9 @@ public class CubeBuilder
 				uv.v2 = texture.getInterpolatedV( z2 * 16 );
 				break;
 			case NORTH:
-				uv.u1 = texture.getInterpolatedU( x1 * 16 );
+				uv.u1 = texture.getInterpolatedU( 16 - x1 * 16 );
 				uv.v1 = texture.getInterpolatedV( 16 - y1 * 16 );
-				uv.u2 = texture.getInterpolatedU( x2 * 16 );
+				uv.u2 = texture.getInterpolatedU( 16 - x2 * 16 );
 				uv.v2 = texture.getInterpolatedV( 16 - y2 * 16 );
 				break;
 			case SOUTH:
@@ -241,9 +241,9 @@ public class CubeBuilder
 				uv.v2 = texture.getInterpolatedV( 16 - y2 * 16 );
 				break;
 			case EAST:
-				uv.u1 = texture.getInterpolatedU( z2 * 16 );
+				uv.u1 = texture.getInterpolatedU( 16 - z2 * 16 );
 				uv.v1 = texture.getInterpolatedV( 16 - y1 * 16 );
-				uv.u2 = texture.getInterpolatedU( z1 * 16 );
+				uv.u2 = texture.getInterpolatedU( 16 - z1 * 16 );
 				uv.v2 = texture.getInterpolatedV( 16 - y2 * 16 );
 				break;
 		}


### PR DESCRIPTION
(#2679) Fix for facades rendering in the wrong direction.

Changed default UVs in CubeBuilder to match original textures. Tested all directions of facades and other items that are using the CubeBuilder. Moved from fix in 1.10 branch (#2940) to master and tested.