### PR TITLE
Fixes PatternTerminal clearing crafting slot on tried crafting

### DIFF
--- a/src/main/java/appeng/container/implementations/ContainerPatternTerm.java
+++ b/src/main/java/appeng/container/implementations/ContainerPatternTerm.java
@@ -499,6 +499,11 @@ public class ContainerPatternTerm extends ContainerMEMonitorable implements IAEA
 			}
 			this.detectAndSendChanges();
 		}
+
+		if( s == this.craftSlot && Platform.isClient() )
+		{
+			this.getAndUpdateOutput();
+		}
 	}
 
 	public void clear()


### PR DESCRIPTION
The ME Pattern Terminal recipe output gets cleared when you can't craft
the item. To fix that, I call getAndUpdateOutput() in the
ContainerPatternTerm::onSlotChange, when it seems appropriate.

This is a continuation and split of https://github.com/GuntherDW/Applied-Energistics-2/pull/10

This is the part, which is "probably safe"