### PR TITLE
Fixes PatternTerminal crafting issue

### DIFF
--- a/src/main/java/appeng/container/implementations/ContainerPatternTerm.java
+++ b/src/main/java/appeng/container/implementations/ContainerPatternTerm.java
@@ -29,6 +29,7 @@ import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.IContainerListener;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.inventory.InventoryCraftResult;
 import net.minecraft.inventory.Slot;
 import net.minecraft.inventory.SlotCrafting;
 import net.minecraft.item.ItemStack;
@@ -59,7 +60,6 @@ import appeng.core.sync.packets.PacketPatternSlot;
 import appeng.helpers.IContainerCraftingPacket;
 import appeng.items.storage.ItemViewCell;
 import appeng.parts.reporting.PartPatternTerminal;
-import appeng.tile.inventory.AppEngInternalInventory;
 import appeng.tile.inventory.IAEAppEngInventory;
 import appeng.tile.inventory.InvOperation;
 import appeng.util.InventoryAdaptor;
@@ -72,7 +72,7 @@ public class ContainerPatternTerm extends ContainerMEMonitorable implements IAEA
 {
 
 	private final PartPatternTerminal patternTerminal;
-	private final AppEngInternalInventory cOut = new AppEngInternalInventory( null, 1 );
+	private final InventoryCraftResult cOut = new InventoryCraftResult();
 	private final IInventory crafting;
 	private final SlotFakeCraftingMatrix[] craftingSlots = new SlotFakeCraftingMatrix[9];
 	private final OptionalSlotFake[] outputSlots = new OptionalSlotFake[3];
@@ -415,6 +415,7 @@ public class ContainerPatternTerm extends ContainerMEMonitorable implements IAEA
 
 			if( rr == r && Platform.itemComparisons().isSameItem( rr.getCraftingResult( real ), is ) )
 			{
+				this.cOut.setRecipeUsed(rr);
 				final SlotCrafting sc = new SlotCrafting( p, real, this.cOut, 0, 0, 0 );
 				sc.onTake( p, is );
 


### PR DESCRIPTION
The pattern terminal doesn't craft at all. The problem is that `SlotCrafting::onTake` internally expects the inventory to be castable to `InventoryCraftResult`. However, it gets passed an `AppEngInternalInventory`. This replaces the `AppEngInternalInventory `with the vanilla class `InventoryCraftResult`.

This is a continuation and split of https://github.com/GuntherDW/Applied-Energistics-2/pull/10

This contains the **dangerous as well as a breaking** part.
TL;DR Some other mod may change the `InventoryCraftResult` class in a way that it doesn't respect the used fake items, potentially causing a dupe bug in AE2.