### PR TITLE
Changed IPart#onNeighborChanged() to add vanilla arguments

### DIFF
--- a/src/api/java/appeng/api/parts/IPart.java
+++ b/src/api/java/appeng/api/parts/IPart.java
@@ -42,6 +42,7 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fml.relauncher.Side;
@@ -129,7 +130,7 @@ public interface IPart extends IBoxProvider, ICustomCableConnection
 	/**
 	 * a block around the bus's host has been changed.
 	 */
-	void onNeighborChanged();
+	void onNeighborChanged( IBlockAccess w, BlockPos pos, BlockPos neighbor );
 
 	/**
 	 * @return output redstone on facing side

--- a/src/main/java/appeng/block/networking/BlockCableBus.java
+++ b/src/main/java/appeng/block/networking/BlockCableBus.java
@@ -131,7 +131,7 @@ public class BlockCableBus extends AEBaseTileBlock
 	@Override
 	public void onNeighborChange( final IBlockAccess w, final BlockPos pos, final BlockPos neighbor )
 	{
-		this.cb( w, pos ).onNeighborChanged();
+		this.cb( w, pos ).onNeighborChanged( w, pos, neighbor );
 	}
 
 	@Override
@@ -336,7 +336,7 @@ public class BlockCableBus extends AEBaseTileBlock
 	{
 		if( Platform.isServer() )
 		{
-			this.cb( world, pos ).onNeighborChanged();
+			this.cb( world, pos ).onNeighborChanged( world, pos, fromPos );
 		}
 	}
 

--- a/src/main/java/appeng/parts/AEBasePart.java
+++ b/src/main/java/appeng/parts/AEBasePart.java
@@ -41,6 +41,7 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -221,7 +222,7 @@ public abstract class AEBasePart implements IPart, IGridProxyable, IActionHost, 
 	}
 
 	@Override
-	public void onNeighborChanged()
+	public void onNeighborChanged( IBlockAccess w, BlockPos pos, BlockPos neighbor )
 	{
 
 	}

--- a/src/main/java/appeng/parts/CableBusContainer.java
+++ b/src/main/java/appeng/parts/CableBusContainer.java
@@ -823,7 +823,7 @@ public class CableBusContainer extends CableBusStorage implements AEMultiTile, I
 	}
 
 	@Override
-	public void onNeighborChanged()
+	public void onNeighborChanged( IBlockAccess w, BlockPos pos, BlockPos neighbor )
 	{
 		this.hasRedstone = YesNo.UNDECIDED;
 
@@ -832,7 +832,7 @@ public class CableBusContainer extends CableBusStorage implements AEMultiTile, I
 			final IPart part = this.getPart( s );
 			if( part != null )
 			{
-				part.onNeighborChanged();
+				part.onNeighborChanged( w, pos, neighbor );
 			}
 		}
 	}

--- a/src/main/java/appeng/parts/ICableBusContainer.java
+++ b/src/main/java/appeng/parts/ICableBusContainer.java
@@ -29,6 +29,7 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -51,7 +52,7 @@ public interface ICableBusContainer
 
 	boolean activate( EntityPlayer player, EnumHand hand, Vec3d vecFromPool );
 
-	void onNeighborChanged();
+	void onNeighborChanged( IBlockAccess w, BlockPos pos, BlockPos neighbor );
 
 	boolean isSolidOnSide( EnumFacing side );
 

--- a/src/main/java/appeng/parts/NullCableBusContainer.java
+++ b/src/main/java/appeng/parts/NullCableBusContainer.java
@@ -29,6 +29,7 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
 import appeng.api.parts.SelectedPart;
@@ -70,7 +71,7 @@ public class NullCableBusContainer implements ICableBusContainer
 	}
 
 	@Override
-	public void onNeighborChanged()
+	public void onNeighborChanged( IBlockAccess w, BlockPos pos, BlockPos neighbor )
 	{
 
 	}

--- a/src/main/java/appeng/parts/automation/PartAnnihilationPlane.java
+++ b/src/main/java/appeng/parts/automation/PartAnnihilationPlane.java
@@ -33,6 +33,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
 
@@ -212,16 +213,11 @@ public class PartAnnihilationPlane extends PartBasicState implements IGridTickab
 	}
 
 	@Override
-	public void onNeighborChanged()
+	public void onNeighborChanged( IBlockAccess w, BlockPos pos, BlockPos neighbor )
 	{
-		this.isAccepting = true;
-		try
+		if( pos.offset( this.getSide().getFacing() ).equals( neighbor ) )
 		{
-			this.getProxy().getTick().alertDevice( this.getProxy().getNode() );
-		}
-		catch( final GridAccessException e )
-		{
-			// :P
+			this.refresh();
 		}
 	}
 
@@ -419,7 +415,7 @@ public class PartAnnihilationPlane extends PartBasicState implements IGridTickab
 	@MENetworkEventSubscribe
 	public void chanRender( final MENetworkChannelsChanged c )
 	{
-		this.onNeighborChanged();
+		this.refresh();
 		this.getHost().markForUpdate();
 	}
 
@@ -427,7 +423,7 @@ public class PartAnnihilationPlane extends PartBasicState implements IGridTickab
 	@MENetworkEventSubscribe
 	public void powerRender( final MENetworkPowerStatusChange c )
 	{
-		this.onNeighborChanged();
+		this.refresh();
 		this.getHost().markForUpdate();
 	}
 
@@ -592,6 +588,20 @@ public class PartAnnihilationPlane extends PartBasicState implements IGridTickab
 		{
 			final IAEItemStack overflow = this.storeItemStack( snaggedItem );
 			this.spawnOverflow( overflow );
+		}
+	}
+
+	private void refresh()
+	{
+		this.isAccepting = true;
+
+		try
+		{
+			this.getProxy().getTick().alertDevice( this.getProxy().getNode() );
+		}
+		catch( final GridAccessException e )
+		{
+			// :P
 		}
 	}
 

--- a/src/main/java/appeng/parts/automation/PartFormationPlane.java
+++ b/src/main/java/appeng/parts/automation/PartFormationPlane.java
@@ -38,6 +38,7 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
 import net.minecraft.world.chunk.Chunk;
@@ -347,15 +348,17 @@ public class PartFormationPlane extends PartUpgradeable implements ICellContaine
 	}
 
 	@Override
-	public void onNeighborChanged()
+	public void onNeighborChanged( IBlockAccess w, BlockPos pos, BlockPos neighbor )
 	{
-		final TileEntity te = this.getHost().getTile();
-		final World w = te.getWorld();
-		final AEPartLocation side = this.getSide();
+		if( pos.offset( this.getSide().getFacing() ).equals( neighbor ) )
+		{
+			final TileEntity te = this.getHost().getTile();
+			final AEPartLocation side = this.getSide();
 
-		final BlockPos tePos = te.getPos().offset( side.getFacing() );
+			final BlockPos tePos = te.getPos().offset( side.getFacing() );
 
-		this.blocked = !w.getBlockState( tePos ).getBlock().isReplaceable( w, tePos );
+			this.blocked = !w.getBlockState( tePos ).getBlock().isReplaceable( w, tePos );
+		}
 	}
 
 	@Override

--- a/src/main/java/appeng/parts/automation/PartSharedItemBus.java
+++ b/src/main/java/appeng/parts/automation/PartSharedItemBus.java
@@ -22,6 +22,7 @@ package appeng.parts.automation;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.items.IItemHandler;
 
@@ -80,15 +81,18 @@ public abstract class PartSharedItemBus extends PartUpgradeable implements IGrid
 	}
 
 	@Override
-	public void onNeighborChanged()
+	public void onNeighborChanged( IBlockAccess w, BlockPos pos, BlockPos neighbor )
 	{
-		this.updateState();
-		if( this.lastRedstone != this.getHost().hasRedstone( this.getSide() ) )
+		if( pos.offset( this.getSide().getFacing() ).equals( neighbor ) )
 		{
-			this.lastRedstone = !this.lastRedstone;
-			if( this.lastRedstone && this.getRSMode() == RedstoneMode.SIGNAL_PULSE )
+			this.updateState();
+			if( this.lastRedstone != this.getHost().hasRedstone( this.getSide() ) )
 			{
-				this.doBusWork();
+				this.lastRedstone = !this.lastRedstone;
+				if( this.lastRedstone && this.getRSMode() == RedstoneMode.SIGNAL_PULSE )
+				{
+					this.doBusWork();
+				}
 			}
 		}
 	}

--- a/src/main/java/appeng/parts/misc/PartCableAnchor.java
+++ b/src/main/java/appeng/parts/misc/PartCableAnchor.java
@@ -35,6 +35,7 @@ import net.minecraft.util.EnumHand;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
 import appeng.api.networking.IGridNode;
@@ -131,7 +132,7 @@ public class PartCableAnchor implements IPart
 	}
 
 	@Override
-	public void onNeighborChanged()
+	public void onNeighborChanged( IBlockAccess w, BlockPos pos, BlockPos neighbor )
 	{
 
 	}

--- a/src/main/java/appeng/parts/misc/PartStorageBus.java
+++ b/src/main/java/appeng/parts/misc/PartStorageBus.java
@@ -30,7 +30,9 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
 
@@ -278,9 +280,12 @@ public class PartStorageBus extends PartUpgradeable implements IGridTickable, IC
 	}
 
 	@Override
-	public void onNeighborChanged()
+	public void onNeighborChanged( IBlockAccess w, BlockPos pos, BlockPos neighbor )
 	{
-		this.resetCache( false );
+		if( pos.offset( this.getSide().getFacing() ).equals( neighbor ) )
+		{
+			this.resetCache( false );
+		}
 	}
 
 	@Override

--- a/src/main/java/appeng/parts/misc/PartToggleBus.java
+++ b/src/main/java/appeng/parts/misc/PartToggleBus.java
@@ -29,6 +29,8 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockAccess;
 
 import appeng.api.AEApi;
 import appeng.api.exceptions.FailedConnection;
@@ -122,7 +124,7 @@ public class PartToggleBus extends PartBasicState
 	}
 
 	@Override
-	public void onNeighborChanged()
+	public void onNeighborChanged( IBlockAccess w, BlockPos pos, BlockPos neighbor )
 	{
 		final boolean oldHasRedstone = this.hasRedstone;
 		this.hasRedstone = this.getHost().hasRedstone( this.getSide() );

--- a/src/main/java/appeng/parts/p2p/PartP2PFEPower.java
+++ b/src/main/java/appeng/parts/p2p/PartP2PFEPower.java
@@ -27,6 +27,7 @@ import javax.annotation.Nullable;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.energy.IEnergyStorage;
 
@@ -73,9 +74,9 @@ public class PartP2PFEPower extends PartP2PTunnel<PartP2PFEPower> implements IEn
 	}
 
 	@Override
-	public void onNeighborChanged()
+	public void onNeighborChanged( IBlockAccess w, BlockPos pos, BlockPos neighbor )
 	{
-		super.onNeighborChanged();
+		super.onNeighborChanged( w, pos, neighbor );
 
 		this.cachedTarget = false;
 	}

--- a/src/main/java/appeng/parts/p2p/PartP2PFluids.java
+++ b/src/main/java/appeng/parts/p2p/PartP2PFluids.java
@@ -26,6 +26,8 @@ import java.util.List;
 
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
@@ -74,7 +76,7 @@ public class PartP2PFluids extends PartP2PTunnel<PartP2PFluids> implements IFlui
 	}
 
 	@Override
-	public void onNeighborChanged()
+	public void onNeighborChanged( IBlockAccess w, BlockPos pos, BlockPos neighbor )
 	{
 		this.cachedTank = null;
 

--- a/src/main/java/appeng/parts/p2p/PartP2PItems.java
+++ b/src/main/java/appeng/parts/p2p/PartP2PItems.java
@@ -25,6 +25,8 @@ import java.util.List;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
@@ -69,7 +71,7 @@ public class PartP2PItems extends PartP2PTunnel<PartP2PItems> implements IItemHa
 	}
 
 	@Override
-	public void onNeighborChanged()
+	public void onNeighborChanged( IBlockAccess w, BlockPos pos, BlockPos neighbor )
 	{
 		this.cachedInv = null;
 		final PartP2PItems input = this.getInput();

--- a/src/main/java/appeng/parts/p2p/PartP2PLight.java
+++ b/src/main/java/appeng/parts/p2p/PartP2PLight.java
@@ -27,6 +27,8 @@ import io.netty.buffer.ByteBuf;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
 import appeng.api.networking.IGridNode;
@@ -122,7 +124,7 @@ public class PartP2PLight extends PartP2PTunnel<PartP2PLight> implements IGridTi
 	}
 
 	@Override
-	public void onNeighborChanged()
+	public void onNeighborChanged( IBlockAccess w, BlockPos pos, BlockPos neighbor )
 	{
 		this.opacity = -1;
 

--- a/src/main/java/appeng/parts/p2p/PartP2PRFPower.java
+++ b/src/main/java/appeng/parts/p2p/PartP2PRFPower.java
@@ -25,6 +25,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockAccess;
 
 import cofh.redstoneflux.api.IEnergyReceiver;
 
@@ -71,9 +72,9 @@ public final class PartP2PRFPower extends PartP2PTunnel<PartP2PRFPower> implemen
 	}
 
 	@Override
-	public void onNeighborChanged()
+	public void onNeighborChanged( IBlockAccess w, BlockPos pos, BlockPos neighbor )
 	{
-		super.onNeighborChanged();
+		super.onNeighborChanged( w, pos, neighbor );
 
 		this.cachedTarget = false;
 	}

--- a/src/main/java/appeng/parts/p2p/PartP2PRedstone.java
+++ b/src/main/java/appeng/parts/p2p/PartP2PRedstone.java
@@ -28,6 +28,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
 import appeng.api.networking.events.MENetworkBootingStatusChange;
@@ -148,7 +149,7 @@ public class PartP2PRedstone extends PartP2PTunnel<PartP2PRedstone>
 	}
 
 	@Override
-	public void onNeighborChanged()
+	public void onNeighborChanged( IBlockAccess w, BlockPos pos, BlockPos neighbor )
 	{
 		if( !this.isOutput() )
 		{

--- a/src/main/java/appeng/parts/reporting/AbstractPartReporting.java
+++ b/src/main/java/appeng/parts/reporting/AbstractPartReporting.java
@@ -28,8 +28,10 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumHand;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.IBlockAccess;
 
 import appeng.api.implementations.IPowerChannelState;
 import appeng.api.implementations.parts.IPartMonitor;
@@ -113,7 +115,7 @@ public abstract class AbstractPartReporting extends AEBasePart implements IPartM
 	}
 
 	@Override
-	public void onNeighborChanged()
+	public void onNeighborChanged( IBlockAccess w, BlockPos pos, BlockPos neighbor )
 	{
 		this.opacity = -1;
 		this.getHost().markForUpdate();


### PR DESCRIPTION
Allows more precise checks to limit an update to the facing side.