### PR TITLE
Adds improved tooltip to invalid encodedPattern

### DIFF
--- a/src/main/java/appeng/client/render/crafting/ItemEncodedPatternBakedModel.java
+++ b/src/main/java/appeng/client/render/crafting/ItemEncodedPatternBakedModel.java
@@ -227,7 +227,7 @@ class ItemEncodedPatternBakedModel implements IBakedModel
 			{
 				ItemEncodedPattern iep = (ItemEncodedPattern) stack.getItem();
 				ItemStack output = iep.getOutput( stack );
-				if( output != null && !output.isEmpty() )
+				if( !output.isEmpty() )
 				{
 					IBakedModel realModel = Minecraft.getMinecraft().getRenderItem().getItemModelMesher().getItemModel( output );
 					// Give the item model a chance to handle the overrides as well

--- a/src/main/java/appeng/client/render/crafting/ItemEncodedPatternBakedModel.java
+++ b/src/main/java/appeng/client/render/crafting/ItemEncodedPatternBakedModel.java
@@ -227,7 +227,7 @@ class ItemEncodedPatternBakedModel implements IBakedModel
 			{
 				ItemEncodedPattern iep = (ItemEncodedPattern) stack.getItem();
 				ItemStack output = iep.getOutput( stack );
-				if( output != null )
+				if( output != null && !output.isEmpty() )
 				{
 					IBakedModel realModel = Minecraft.getMinecraft().getRenderItem().getItemModelMesher().getItemModel( output );
 					// Give the item model a chance to handle the overrides as well

--- a/src/main/java/appeng/helpers/IPatternIngredient.java
+++ b/src/main/java/appeng/helpers/IPatternIngredient.java
@@ -1,0 +1,6 @@
+package appeng.helpers;
+
+
+public interface IPatternIngredient
+{
+}

--- a/src/main/java/appeng/helpers/IPatternIngredient.java
+++ b/src/main/java/appeng/helpers/IPatternIngredient.java
@@ -1,6 +1,0 @@
-package appeng.helpers;
-
-
-public interface IPatternIngredient
-{
-}

--- a/src/main/java/appeng/helpers/InvalidPatternHelper.java
+++ b/src/main/java/appeng/helpers/InvalidPatternHelper.java
@@ -1,0 +1,113 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2017, tyra314, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.helpers;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
+import net.minecraft.util.text.TextFormatting;
+import net.minecraft.world.World;
+
+import appeng.util.Platform;
+
+
+public class InvalidPatternHelper
+{
+
+	private final List<String> outputs = new ArrayList<>();
+	private final List<String> inputs = new ArrayList<>();
+	private final boolean isCrafting;
+	private final boolean canSubstitute;
+
+	public InvalidPatternHelper( final ItemStack is, final World w )
+	{
+		final NBTTagCompound encodedValue = is.getTagCompound();
+
+		if( encodedValue == null )
+		{
+			throw new IllegalArgumentException( "No pattern here!" );
+		}
+
+		final NBTTagList inTag = encodedValue.getTagList( "in", 10 );
+		final NBTTagList outTag = encodedValue.getTagList( "out", 10 );
+		this.isCrafting = encodedValue.getBoolean( "crafting" );
+
+		this.canSubstitute = this.isCrafting && encodedValue.getBoolean( "substitute" );
+
+		for( int i = 0; i < outTag.tagCount(); i++ )
+		{
+			NBTTagCompound out = outTag.getCompoundTagAt( i );
+
+			ItemStack stack = new ItemStack( out );
+			if( stack.isEmpty() )
+			{
+				outputs.add( TextFormatting.RED + String.valueOf( out.getByte( "Count" ) ) + ' ' + out.getString( "id" ) + '@' + String.valueOf( Math.max( 0, out.getShort( "Damage" ) ) ) );
+			}
+			else
+			{
+				outputs.add( String.valueOf( stack.getCount() ) + ' ' + Platform.getItemDisplayName( stack ) );
+			}
+		}
+
+		for( int i = 0; i < inTag.tagCount(); i++ )
+		{
+			NBTTagCompound in = inTag.getCompoundTagAt( i );
+
+			// skip empty slots in the crafting grid
+			if( in.hasNoTags() )
+			{
+				continue;
+			}
+
+			ItemStack stack = new ItemStack( in );
+			if( stack.isEmpty() )
+			{
+				inputs.add( TextFormatting.RED + String.valueOf( in.getByte( "Count" ) ) + ' ' + in.getString( "id" ) + '@' + String.valueOf( Math.max( 0, in.getShort( "Damage" ) ) ) );
+			}
+			else
+			{
+				inputs.add( String.valueOf( stack.getCount() ) + ' ' + Platform.getItemDisplayName( stack ) );
+			}
+		}
+	}
+
+	public List<String> getOutputs()
+	{
+		return this.outputs;
+	}
+
+	public List<String> getInputs()
+	{
+		return this.inputs;
+	}
+
+	public boolean isCraftable()
+	{
+		return this.isCrafting;
+	}
+
+	public boolean canSubstitute()
+	{
+		return this.canSubstitute;
+	}
+}

--- a/src/main/java/appeng/helpers/InvalidPatternHelper.java
+++ b/src/main/java/appeng/helpers/InvalidPatternHelper.java
@@ -132,7 +132,7 @@ public class InvalidPatternHelper
 			return isValid() ? stack.getCount() : count;
 		}
 
-		public ItemStack getItem() throws IllegalArgumentException
+		public ItemStack getItem()
 		{
 			if( !isValid() )
 			{

--- a/src/main/java/appeng/helpers/PatternHelper.java
+++ b/src/main/java/appeng/helpers/PatternHelper.java
@@ -85,7 +85,13 @@ public class PatternHelper implements ICraftingPatternDetails, Comparable<Patter
 
 		for( int x = 0; x < inTag.tagCount(); x++ )
 		{
-			final ItemStack gs = new ItemStack( inTag.getCompoundTagAt( x ) );
+			NBTTagCompound ingredient = inTag.getCompoundTagAt( x );
+			final ItemStack gs = new ItemStack( ingredient );
+
+			if (!ingredient.hasNoTags() && gs.isEmpty())
+			{
+				throw new IllegalArgumentException( "No pattern here!" );
+			}
 
 			this.crafting.setInventorySlotContents( x, gs );
 
@@ -119,7 +125,13 @@ public class PatternHelper implements ICraftingPatternDetails, Comparable<Patter
 
 			for( int x = 0; x < outTag.tagCount(); x++ )
 			{
-				final ItemStack gs = new ItemStack( outTag.getCompoundTagAt( x ) );
+				NBTTagCompound resultItemTag = outTag.getCompoundTagAt( x );
+				final ItemStack gs = new ItemStack( resultItemTag );
+
+				if (!resultItemTag.hasNoTags() && gs.isEmpty())
+				{
+					throw new IllegalArgumentException( "No pattern here!" );
+				}
 
 				if( !gs.isEmpty() )
 				{

--- a/src/main/java/appeng/helpers/PatternHelper.java
+++ b/src/main/java/appeng/helpers/PatternHelper.java
@@ -88,7 +88,7 @@ public class PatternHelper implements ICraftingPatternDetails, Comparable<Patter
 			NBTTagCompound ingredient = inTag.getCompoundTagAt( x );
 			final ItemStack gs = new ItemStack( ingredient );
 
-			if (!ingredient.hasNoTags() && gs.isEmpty())
+			if( !ingredient.hasNoTags() && gs.isEmpty() )
 			{
 				throw new IllegalArgumentException( "No pattern here!" );
 			}
@@ -128,7 +128,7 @@ public class PatternHelper implements ICraftingPatternDetails, Comparable<Patter
 				NBTTagCompound resultItemTag = outTag.getCompoundTagAt( x );
 				final ItemStack gs = new ItemStack( resultItemTag );
 
-				if (!resultItemTag.hasNoTags() && gs.isEmpty())
+				if( !resultItemTag.hasNoTags() && gs.isEmpty() )
 				{
 					throw new IllegalArgumentException( "No pattern here!" );
 				}

--- a/src/main/java/appeng/items/misc/ItemEncodedPattern.java
+++ b/src/main/java/appeng/items/misc/ItemEncodedPattern.java
@@ -147,6 +147,11 @@ public class ItemEncodedPattern extends AEBaseItem implements ICraftingPatternIt
 			return;
 		}
 
+		if( stack.hasDisplayName() )
+		{
+			stack.removeSubCompound( "display" );
+		}
+
 		final boolean isCrafting = details.isCraftable();
 		final boolean substitute = details.canSubstitute();
 

--- a/src/main/java/appeng/items/misc/ItemEncodedPattern.java
+++ b/src/main/java/appeng/items/misc/ItemEncodedPattern.java
@@ -113,23 +113,23 @@ public class ItemEncodedPattern extends AEBaseItem implements ICraftingPatternIt
 
 			try
 			{
-				InvalidPatternHelper invalid = new InvalidPatternHelper( stack, world );
+				InvalidPatternHelper invalid = new InvalidPatternHelper( stack );
 
 				final String label = ( invalid.isCraftable() ? GuiText.Crafts.getLocal() : GuiText.Creates.getLocal() ) + ": ";
 				final String and = ' ' + GuiText.And.getLocal() + ' ';
 				final String with = GuiText.With.getLocal() + ": ";
 
 				boolean first = true;
-				for( final String output : invalid.getOutputs() )
+				for( final InvalidPatternHelper.PatternIngredient output : invalid.getOutputs() )
 				{
-					lines.add( ( first ? label : and ) + output );
+					lines.add( ( first ? label : and ) + output.getFormattedToolTip() );
 					first = false;
 				}
 
 				first = true;
-				for( final String input : invalid.getInputs() )
+				for( final InvalidPatternHelper.PatternIngredient input : invalid.getInputs() )
 				{
-					lines.add( ( first ? with : and ) + input);
+					lines.add( ( first ? with : and ) + input.getFormattedToolTip() );
 					first = false;
 				}
 

--- a/src/main/java/appeng/items/misc/ItemEncodedPattern.java
+++ b/src/main/java/appeng/items/misc/ItemEncodedPattern.java
@@ -43,6 +43,7 @@ import appeng.api.networking.crafting.ICraftingPatternDetails;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.core.AppEng;
 import appeng.core.localization.GuiText;
+import appeng.helpers.InvalidPatternHelper;
 import appeng.helpers.PatternHelper;
 import appeng.items.AEBaseItem;
 import appeng.util.Platform;
@@ -109,6 +110,42 @@ public class ItemEncodedPattern extends AEBaseItem implements ICraftingPatternIt
 		if( details == null )
 		{
 			lines.add( TextFormatting.RED + GuiText.InvalidPattern.getLocal() );
+
+			try
+			{
+				InvalidPatternHelper invalid = new InvalidPatternHelper( stack, world );
+
+				final String label = ( invalid.isCraftable() ? GuiText.Crafts.getLocal() : GuiText.Creates.getLocal() ) + ": ";
+				final String and = ' ' + GuiText.And.getLocal() + ' ';
+				final String with = GuiText.With.getLocal() + ": ";
+
+				boolean first = true;
+				for( final String output : invalid.getOutputs() )
+				{
+					lines.add( ( first ? label : and ) + output );
+					first = false;
+				}
+
+				first = true;
+				for( final String input : invalid.getInputs() )
+				{
+					lines.add( ( first ? with : and ) + input);
+					first = false;
+				}
+
+				if( invalid.isCraftable() )
+				{
+					final String substitutionLabel = GuiText.Substitute.getLocal() + " ";
+					final String canSubstitute = invalid.canSubstitute() ? GuiText.Yes.getLocal() : GuiText.No.getLocal();
+
+					lines.add( substitutionLabel + canSubstitute );
+				}
+			}
+			catch( IllegalArgumentException e )
+			{
+				// at least we tried
+			}
+
 			return;
 		}
 

--- a/src/main/java/appeng/items/misc/ItemEncodedPattern.java
+++ b/src/main/java/appeng/items/misc/ItemEncodedPattern.java
@@ -109,7 +109,12 @@ public class ItemEncodedPattern extends AEBaseItem implements ICraftingPatternIt
 
 		if( details == null )
 		{
-			lines.add( TextFormatting.RED + GuiText.InvalidPattern.getLocal() );
+			if( !stack.hasTagCompound() )
+			{
+				return;
+			}
+
+			stack.setStackDisplayName( TextFormatting.RED + GuiText.InvalidPattern.getLocal() );
 
 			try
 			{

--- a/src/main/java/appeng/items/misc/ItemEncodedPattern.java
+++ b/src/main/java/appeng/items/misc/ItemEncodedPattern.java
@@ -116,39 +116,32 @@ public class ItemEncodedPattern extends AEBaseItem implements ICraftingPatternIt
 
 			stack.setStackDisplayName( TextFormatting.RED + GuiText.InvalidPattern.getLocal() );
 
-			try
+			InvalidPatternHelper invalid = new InvalidPatternHelper( stack );
+
+			final String label = ( invalid.isCraftable() ? GuiText.Crafts.getLocal() : GuiText.Creates.getLocal() ) + ": ";
+			final String and = ' ' + GuiText.And.getLocal() + ' ';
+			final String with = GuiText.With.getLocal() + ": ";
+
+			boolean first = true;
+			for( final InvalidPatternHelper.PatternIngredient output : invalid.getOutputs() )
 			{
-				InvalidPatternHelper invalid = new InvalidPatternHelper( stack );
-
-				final String label = ( invalid.isCraftable() ? GuiText.Crafts.getLocal() : GuiText.Creates.getLocal() ) + ": ";
-				final String and = ' ' + GuiText.And.getLocal() + ' ';
-				final String with = GuiText.With.getLocal() + ": ";
-
-				boolean first = true;
-				for( final InvalidPatternHelper.PatternIngredient output : invalid.getOutputs() )
-				{
-					lines.add( ( first ? label : and ) + output.getFormattedToolTip() );
-					first = false;
-				}
-
-				first = true;
-				for( final InvalidPatternHelper.PatternIngredient input : invalid.getInputs() )
-				{
-					lines.add( ( first ? with : and ) + input.getFormattedToolTip() );
-					first = false;
-				}
-
-				if( invalid.isCraftable() )
-				{
-					final String substitutionLabel = GuiText.Substitute.getLocal() + " ";
-					final String canSubstitute = invalid.canSubstitute() ? GuiText.Yes.getLocal() : GuiText.No.getLocal();
-
-					lines.add( substitutionLabel + canSubstitute );
-				}
+				lines.add( ( first ? label : and ) + output.getFormattedToolTip() );
+				first = false;
 			}
-			catch( IllegalArgumentException e )
+
+			first = true;
+			for( final InvalidPatternHelper.PatternIngredient input : invalid.getInputs() )
 			{
-				// at least we tried
+				lines.add( ( first ? with : and ) + input.getFormattedToolTip() );
+				first = false;
+			}
+
+			if( invalid.isCraftable() )
+			{
+				final String substitutionLabel = GuiText.Substitute.getLocal() + " ";
+				final String canSubstitute = invalid.canSubstitute() ? GuiText.Yes.getLocal() : GuiText.No.getLocal();
+
+				lines.add( substitutionLabel + canSubstitute );
 			}
 
 			return;


### PR DESCRIPTION
This fixes #415, my personal biggest and longest standing issue with AE2. Invalid Patterns give absolutely no clue, what they have been about, or what they were used before. In a perfect world, this wouldn't be needed, but in reality, we have to deal with a changing item set in worlds. 

While adding those tooltips, I stumbled upon an issue in the `PatternHelper`. In processing patterns, invalid `ItemStacks `are ignored and treated as `ItemStack.EMPTY`, this results in an invalid pattern, which is (at least) shown as a valid one.

What this PR does, is trying and guessing, what the pattern has been about and adding this as tooltip. This is, how it looks like for a crafting recipes:

![2017-07-30_12 39 37](https://user-images.githubusercontent.com/16997177/28752674-5c02cc42-7525-11e7-8e4d-af9328d96dd3.png)

And for a process recipe:

![2017-07-30_12 39 36](https://user-images.githubusercontent.com/16997177/28752677-6ec12310-7525-11e7-9252-274d4d907134.png)

However, while the functionality is there, I'm not entirely satisfied with the code and like to get some feedback about the code and if this is going into the right direction.

There a few issues I see right now. First of all, so much code duplication. Further, in the case of a item, which can't be loaded from the `NBTCompound`, I try to at least get some output string by hardcoding, how an `ItemStack `is serialized interally, this may become an issue in the future. And last but not least, when you hold shift, you get to see those standard invalid block texture, instead of the encodedPattern:

![2017-07-30_12 30 29](https://user-images.githubusercontent.com/16997177/28752709-44ec930c-7526-11e7-8c31-9a3bf750226c.png)

ps: What format should the file header of the newly added class have?