### PR TITLE
Color code tooltip for memory cards (Part of #2978 and #2674)

### DIFF
--- a/src/main/java/appeng/integration/modules/waila/part/P2PStateWailaDataProvider.java
+++ b/src/main/java/appeng/integration/modules/waila/part/P2PStateWailaDataProvider.java
@@ -21,12 +21,16 @@ package appeng.integration.modules.waila.part;
 
 import java.util.List;
 
+import appeng.api.util.AEColor;
+import appeng.util.Platform;
 import com.google.common.collect.Iterators;
 
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.text.TextFormatting;
+import net.minecraft.util.text.translation.I18n;
 import net.minecraft.world.World;
 
 import mcp.mobius.waila.api.IWailaConfigHandler;
@@ -87,6 +91,8 @@ public final class P2PStateWailaDataProvider extends BasePartWailaDataProvider
 					}
 				}
 			}
+
+			currentToolTip.add( getFrequency( (PartP2PTunnel) part ) );
 		}
 
 		return currentToolTip;
@@ -153,6 +159,22 @@ public final class P2PStateWailaDataProvider extends BasePartWailaDataProvider
 		{
 			return String.format( WailaText.P2PInputManyOutputs.getLocal(), outputs );
 		}
+	}
+
+	private static String getFrequency( PartP2PTunnel tunnel )
+	{
+		AEColor[] colors = Platform.p2p().toColors( tunnel.getFrequency() );
+
+		StringBuilder result = new StringBuilder();
+
+		result.append( I18n.translateToLocalFormatted( "gui.tooltips.appliedenergistics2.P2PFrequency", result.toString() ) );
+
+		for( int i = 0; i < 4; i++ )
+		{
+			result.append( TextFormatting.fromColorIndex( colors[i].dye.getDyeDamage() ) ).append(String.format("%X", colors[i].ordinal()));
+		}
+
+		return result.toString();
 	}
 
 }

--- a/src/main/java/appeng/items/tools/ToolMemoryCard.java
+++ b/src/main/java/appeng/items/tools/ToolMemoryCard.java
@@ -73,7 +73,7 @@ public class ToolMemoryCard extends AEBaseItem implements IMemoryCard
 
 			for( int i = 0; i < 4; i++ )
 			{
-				result.append( TextFormatting.fromColorIndex( colors[i].dye.getDyeDamage() ) ).append( TextFormatting.OBFUSCATED ).append( "##" );
+				result.append( TextFormatting.fromColorIndex( colors[i].dye.getDyeDamage() ) ).append(String.format("%X", colors[i].ordinal()));
 			}
 
 			lines.add( I18n.translateToLocalFormatted( "gui.tooltips.appliedenergistics2.P2PFrequency", result.toString() ) );

--- a/src/main/java/appeng/items/tools/ToolMemoryCard.java
+++ b/src/main/java/appeng/items/tools/ToolMemoryCard.java
@@ -29,6 +29,7 @@ import net.minecraft.util.EnumActionResult;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.text.TextFormatting;
 import net.minecraft.util.text.translation.I18n;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
@@ -37,6 +38,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 
 import appeng.api.implementations.items.IMemoryCard;
 import appeng.api.implementations.items.MemoryCardMessages;
+import appeng.api.util.AEColor;
 import appeng.core.localization.GuiText;
 import appeng.core.localization.PlayerMessages;
 import appeng.items.AEBaseItem;
@@ -60,6 +62,21 @@ public class ToolMemoryCard extends AEBaseItem implements IMemoryCard
 		if( data.hasKey( "tooltip" ) )
 		{
 			lines.add( I18n.translateToLocal( this.getLocalizedName( data.getString( "tooltip" ) + ".name", data.getString( "tooltip" ) ) ) );
+		}
+
+		if( data.hasKey( "freq" ) )
+		{
+			final short freq = data.getShort( "freq" );
+			AEColor[] colors = Platform.p2p().toColors( freq );
+
+			StringBuilder result = new StringBuilder();
+
+			for( int i = 0; i < 4; i++ )
+			{
+				result.append( TextFormatting.fromColorIndex( colors[i].dye.getDyeDamage() ) ).append( TextFormatting.OBFUSCATED ).append( "##" );
+			}
+
+			lines.add( I18n.translateToLocalFormatted( "gui.tooltips.appliedenergistics2.P2PFrequency", result.toString() ) );
 		}
 	}
 

--- a/src/main/resources/assets/appliedenergistics2/lang/de_de.lang
+++ b/src/main/resources/assets/appliedenergistics2/lang/de_de.lang
@@ -323,6 +323,7 @@ gui.tooltips.appliedenergistics2.SchedulingModeRoundRobin=Exportiere im Round-Ro
 gui.tooltips.appliedenergistics2.SchedulingModeRandom=Exportiere im Zufallsmodus.
 gui.tooltips.appliedenergistics2.ItemsStored=Items gespeichert: %s
 gui.tooltips.appliedenergistics2.ItemsRequestable=Anfragbare Items: %s
+gui.tooltips.appliedenergistics2.P2PFrequency=Frequenz: %s
 
 // Units
 gui.appliedenergistics2.units.appliedenergstics=AE

--- a/src/main/resources/assets/appliedenergistics2/lang/en_us.lang
+++ b/src/main/resources/assets/appliedenergistics2/lang/en_us.lang
@@ -335,6 +335,7 @@ gui.tooltips.appliedenergistics2.FilterModeKeep=Restore previous search filter.
 gui.tooltips.appliedenergistics2.FilterModeClear=Clear on each opening.
 gui.tooltips.appliedenergistics2.ItemsStored=Items Stored: %s
 gui.tooltips.appliedenergistics2.ItemsRequestable=Items Requestable: %s
+gui.tooltips.appliedenergistics2.P2PFrequency=Frequency: %s
 
 // Units
 gui.appliedenergistics2.units.appliedenergstics=AE


### PR DESCRIPTION
This adds a simple tool tip representing the stored P2P frequency of a memory card.
This is part of #2674 and #2978.

What I haven't dealt with yet, is a colorblind mode. In #2674, it was suggested to use a distinct symbol for each color. According to [this](https://gaming.stackexchange.com/questions/103304/allowed-symbols-characters-in-minecraft-chat), there aren't that much supported characters, so we may simply use the RBG hexadecimal representation. However, a colorblind mode should be separated from the normal mode, as it might be hard to read symbols in colors too.

My current solution uses two `TextFormatting.OBFUSCATED` characters per color and looks like thi:.
![2017-08-06_12 40 12](https://user-images.githubusercontent.com/16997177/29002625-e809c764-7aa6-11e7-839b-65796d59feee.png)

Though, some colors are hard to see. But I don't think it is a big issue, as the only information conveyed is the color itself.
![2017-08-06_12 42 07](https://user-images.githubusercontent.com/16997177/29002626-e9c5ea38-7aa6-11e7-950d-febe7d4f2c65.png)

Note: This adds a new `I18n` entry, which has to be translated in other languages as well.
