### PR TITLE
Fixes #3024: Crash on recipe lookup for disabled features

### DIFF
--- a/src/main/java/appeng/recipes/RecipeHandler.java
+++ b/src/main/java/appeng/recipes/RecipeHandler.java
@@ -30,7 +30,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
-import java.util.function.BooleanSupplier;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -38,15 +37,10 @@ import javax.annotation.Nonnull;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.HashMultimap;
-import com.google.gson.JsonObject;
 
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.JsonUtils;
 import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.common.crafting.IConditionFactory;
-import net.minecraftforge.common.crafting.IIngredientFactory;
-import net.minecraftforge.common.crafting.JsonContext;
 import net.minecraftforge.fml.common.LoaderState;
 
 import appeng.api.AEApi;
@@ -61,11 +55,8 @@ import appeng.api.recipes.ICraftHandler;
 import appeng.api.recipes.IIngredient;
 import appeng.api.recipes.IRecipeHandler;
 import appeng.api.recipes.IRecipeLoader;
-import appeng.api.recipes.ResolverResult;
-import appeng.api.recipes.ResolverResultSet;
 import appeng.core.AEConfig;
 import appeng.core.AELog;
-import appeng.core.Api;
 import appeng.core.AppEng;
 import appeng.core.features.AEFeature;
 import appeng.items.materials.ItemMaterial;
@@ -773,48 +764,6 @@ public class RecipeHandler implements IRecipeHandler
 		}
 
 		return true;
-	}
-
-	public static class MaterialExists implements IConditionFactory
-	{
-		@Override
-		public BooleanSupplier parse( JsonContext jsonContext, JsonObject jsonObject )
-		{
-			String material = JsonUtils.getString( jsonObject, "material" );
-			Object result = (Object) Api.INSTANCE.registries().recipes().resolveItem( AppEng.MOD_ID, material );
-			return () -> result != null;
-
-		}
-	}
-
-	public static class PartFactory implements IIngredientFactory
-	{
-
-		@Nonnull
-		@Override
-		public net.minecraft.item.crafting.Ingredient parse( JsonContext context, JsonObject json )
-		{
-			String partName = json.get( "part" ).getAsString();
-			Object result = (Object) Api.INSTANCE.registries().recipes().resolveItem( AppEng.MOD_ID, partName );
-			if( result instanceof ResolverResultSet )
-			{
-				ResolverResultSet resolverResultSet = (ResolverResultSet) result;
-				return net.minecraft.item.crafting.Ingredient
-						.fromStacks( resolverResultSet.results.toArray( new ItemStack[resolverResultSet.results.size()] ) );
-			}
-			else if( result instanceof ResolverResult )
-			{
-				ResolverResult resolverResult = (ResolverResult) result;
-
-				Item item = Item.getByNameOrId( AppEng.MOD_ID + ":" + resolverResult.itemName );
-				ItemStack itemStack = new ItemStack( item, 1, resolverResult.damageValue, resolverResult.compound );
-
-				return net.minecraft.item.crafting.Ingredient.fromStacks( itemStack );
-			}
-
-			AELog.warn( "Looking for ingredient with name '" + partName + "' ended up with a null item!" );
-			return net.minecraft.item.crafting.Ingredient.EMPTY;
-		}
 	}
 
 }

--- a/src/main/java/appeng/recipes/factories/conditions/Features.java
+++ b/src/main/java/appeng/recipes/factories/conditions/Features.java
@@ -1,0 +1,67 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.recipes.factories.conditions;
+
+
+import java.util.Locale;
+import java.util.function.BooleanSupplier;
+import java.util.stream.Stream;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+import net.minecraft.util.JsonUtils;
+import net.minecraftforge.common.crafting.IConditionFactory;
+import net.minecraftforge.common.crafting.JsonContext;
+
+import appeng.core.AEConfig;
+import appeng.core.features.AEFeature;
+
+
+public class Features implements IConditionFactory
+{
+	private static final String JSON_FEATURES_KEY = "features";
+
+	@Override
+	public BooleanSupplier parse( JsonContext jsonContext, JsonObject jsonObject )
+	{
+		final boolean result;
+
+		if( JsonUtils.isJsonArray( jsonObject, JSON_FEATURES_KEY ) )
+		{
+			final JsonArray features = JsonUtils.getJsonArray( jsonObject, JSON_FEATURES_KEY );
+
+			result = Stream.of( features )
+					.allMatch( p -> AEConfig.instance().isFeatureEnabled( AEFeature.valueOf( p.getAsString().toUpperCase( Locale.ENGLISH ) ) ) );
+		}
+		else if( JsonUtils.isString( jsonObject, JSON_FEATURES_KEY ) )
+		{
+			final String featureName = JsonUtils.getString( jsonObject, JSON_FEATURES_KEY ).toUpperCase( Locale.ENGLISH );
+			final AEFeature feature = AEFeature.valueOf( featureName );
+
+			result = AEConfig.instance().isFeatureEnabled( feature );
+		}
+		else
+		{
+			result = false;
+		}
+
+		return () -> result;
+	}
+}

--- a/src/main/java/appeng/recipes/factories/conditions/MaterialExists.java
+++ b/src/main/java/appeng/recipes/factories/conditions/MaterialExists.java
@@ -33,15 +33,26 @@ import appeng.core.AppEng;
 
 public class MaterialExists implements IConditionFactory
 {
-	private static final String JSON_FEATURES_KEY = "material";
+	private static final String JSON_MATERIAL_KEY = "material";
 
 	@Override
 	public BooleanSupplier parse( JsonContext jsonContext, JsonObject jsonObject )
 	{
-		final String material = JsonUtils.getString( jsonObject, JSON_FEATURES_KEY );
-		final Object result = Api.INSTANCE.registries().recipes().resolveItem( AppEng.MOD_ID, material );
+		final boolean result;
 
-		return () -> result != null;
+		if( JsonUtils.isString( jsonObject, JSON_MATERIAL_KEY ) )
+		{
+			final String material = JsonUtils.getString( jsonObject, JSON_MATERIAL_KEY );
+			final Object item = Api.INSTANCE.registries().recipes().resolveItem( AppEng.MOD_ID, material );
+
+			result = item != null;
+		}
+		else
+		{
+			result = false;
+		}
+
+		return () -> result;
 
 	}
 }

--- a/src/main/java/appeng/recipes/factories/conditions/MaterialExists.java
+++ b/src/main/java/appeng/recipes/factories/conditions/MaterialExists.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.recipes.factories.conditions;
+
+
+import java.util.function.BooleanSupplier;
+
+import com.google.gson.JsonObject;
+
+import net.minecraft.util.JsonUtils;
+import net.minecraftforge.common.crafting.IConditionFactory;
+import net.minecraftforge.common.crafting.JsonContext;
+
+import appeng.core.Api;
+import appeng.core.AppEng;
+
+
+public class MaterialExists implements IConditionFactory
+{
+	private static final String JSON_FEATURES_KEY = "material";
+
+	@Override
+	public BooleanSupplier parse( JsonContext jsonContext, JsonObject jsonObject )
+	{
+		final String material = JsonUtils.getString( jsonObject, JSON_FEATURES_KEY );
+		final Object result = Api.INSTANCE.registries().recipes().resolveItem( AppEng.MOD_ID, material );
+
+		return () -> result != null;
+
+	}
+}

--- a/src/main/java/appeng/recipes/factories/ingredients/PartIngredientFactory.java
+++ b/src/main/java/appeng/recipes/factories/ingredients/PartIngredientFactory.java
@@ -1,0 +1,68 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.recipes.factories.ingredients;
+
+
+import javax.annotation.Nonnull;
+
+import com.google.gson.JsonObject;
+
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.common.crafting.IIngredientFactory;
+import net.minecraftforge.common.crafting.JsonContext;
+
+import appeng.api.recipes.ResolverResult;
+import appeng.api.recipes.ResolverResultSet;
+import appeng.core.AELog;
+import appeng.core.Api;
+import appeng.core.AppEng;
+
+
+public class PartIngredientFactory implements IIngredientFactory
+{
+
+	@Nonnull
+	@Override
+	public net.minecraft.item.crafting.Ingredient parse( JsonContext context, JsonObject json )
+	{
+		final String partName = json.get( "part" ).getAsString();
+		final Object result = Api.INSTANCE.registries().recipes().resolveItem( AppEng.MOD_ID, partName );
+
+		if( result instanceof ResolverResultSet )
+		{
+			final ResolverResultSet resolverResultSet = (ResolverResultSet) result;
+
+			return net.minecraft.item.crafting.Ingredient
+					.fromStacks( resolverResultSet.results.toArray( new ItemStack[resolverResultSet.results.size()] ) );
+		}
+		else if( result instanceof ResolverResult )
+		{
+			final ResolverResult resolverResult = (ResolverResult) result;
+
+			final Item item = Item.getByNameOrId( AppEng.MOD_ID + ":" + resolverResult.itemName );
+			final ItemStack itemStack = new ItemStack( item, 1, resolverResult.damageValue, resolverResult.compound );
+
+			return net.minecraft.item.crafting.Ingredient.fromStacks( itemStack );
+		}
+
+		AELog.warn( "Looking for ingredient with name '" + partName + "' ended up with a null item!" );
+		return net.minecraft.item.crafting.Ingredient.EMPTY;
+	}
+}

--- a/src/main/java/appeng/recipes/factories/recipes/PartRecipeFactory.java
+++ b/src/main/java/appeng/recipes/factories/recipes/PartRecipeFactory.java
@@ -16,7 +16,7 @@
  * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
  */
 
-package appeng.recipes.helpers;
+package appeng.recipes.factories.recipes;
 
 
 import com.google.gson.JsonObject;
@@ -30,6 +30,8 @@ import net.minecraftforge.common.crafting.IRecipeFactory;
 import net.minecraftforge.common.crafting.JsonContext;
 
 import appeng.core.AppEng;
+import appeng.recipes.helpers.PartShapedCraftingFactory;
+import appeng.recipes.helpers.PartShapelessCraftingFactory;
 
 
 /**

--- a/src/main/resources/assets/appliedenergistics2/recipes/_constants.json
+++ b/src/main/resources/assets/appliedenergistics2/recipes/_constants.json
@@ -1,6 +1,12 @@
 [
   {
     "name": "appliedenergistics2:interface",
+    "conditions": [
+      {
+        "type": "appliedenergistics2:features",
+        "features": ["interface"]
+      }
+    ],
     "ingredient": [
       {
         "item": "appliedenergistics2:interface"
@@ -13,6 +19,12 @@
   },
   {
     "name": "appliedenergistics2:knife",
+    "conditions": [
+      {
+        "type": "appliedenergistics2:features",
+        "features": "quartz_knife"
+      }
+    ],
     "ingredient": [
       {
         "item": "appliedenergistics2:certus_quartz_cutting_knife",
@@ -26,6 +38,12 @@
   },
   {
     "name": "appliedenergistics2:wrench",
+    "conditions": [
+      {
+        "type": "appliedenergistics2:features",
+        "features": ["quartz_wrench"]
+      }
+    ],
     "ingredient": [
       {
         "item": "appliedenergistics2:certus_quartz_wrench"

--- a/src/main/resources/assets/appliedenergistics2/recipes/_factories.json
+++ b/src/main/resources/assets/appliedenergistics2/recipes/_factories.json
@@ -1,12 +1,13 @@
  {
   "conditions": {
-   "material_exists": "appeng.recipes.RecipeHandler$MaterialExists"
+   "material_exists": "appeng.recipes.factories.conditions.MaterialExists",
+   "features": "appeng.recipes.factories.conditions.Features"
   },
   "ingredients": {
-   "part": "appeng.recipes.RecipeHandler$PartFactory"
+   "part": "appeng.recipes.factories.ingredients.PartIngredientFactory"
   },
   "recipes": {
-    "part_shaped": "appeng.recipes.helpers.PartRecipeFactory",
-    "part_shapeless": "appeng.recipes.helpers.PartRecipeFactory"
+    "part_shaped": "appeng.recipes.factories.recipes.PartRecipeFactory",
+    "part_shapeless": "appeng.recipes.factories.recipes.PartRecipeFactory"
   }
 }


### PR DESCRIPTION
Adds a new recipe condition for a single AEFeature or a list of them.
Moved the factories to their own package, in preparation of phasing out the old recipe handling.