### PR TITLE
Performance improvements for the energygrid

### DIFF
--- a/src/api/java/appeng/api/networking/energy/IEnergyGridProvider.java
+++ b/src/api/java/appeng/api/networking/energy/IEnergyGridProvider.java
@@ -24,6 +24,7 @@
 package appeng.api.networking.energy;
 
 
+import java.util.Collection;
 import java.util.Set;
 
 import appeng.api.config.Actionable;
@@ -37,15 +38,30 @@ public interface IEnergyGridProvider
 	/**
 	 * internal use only
 	 */
-	double extractAEPower( double amt, Actionable mode, Set<IEnergyGrid> seen );
+	Collection<IEnergyGridProvider> providers();
 
 	/**
 	 * internal use only
 	 */
-	double injectAEPower( double amt, Actionable mode, Set<IEnergyGrid> seen );
+	double extractProviderPower( double amt, Actionable mode, Set<IEnergyGridProvider> seen );
 
 	/**
 	 * internal use only
 	 */
-	double getEnergyDemand( double d, Set<IEnergyGrid> seen );
+	double injectProviderPower( double amt, Actionable mode, Set<IEnergyGridProvider> seen );
+
+	/**
+	 * internal use only
+	 */
+	double getProviderEnergyDemand( double d, Set<IEnergyGridProvider> seen );
+
+	/**
+	 * internal use only
+	 */
+	double getProviderStoredEnergy();
+
+	/**
+	 * internal use only
+	 */
+	double getProviderMaxEnergy();
 }

--- a/src/main/java/appeng/integration/modules/ic2/IC2PowerSinkAdapter.java
+++ b/src/main/java/appeng/integration/modules/ic2/IC2PowerSinkAdapter.java
@@ -28,6 +28,7 @@ import net.minecraft.util.EnumFacing;
 import ic2.api.energy.prefab.BasicSink;
 import ic2.api.energy.tile.IEnergyEmitter;
 
+import appeng.api.config.Actionable;
 import appeng.api.config.PowerUnits;
 import appeng.integration.abstraction.IC2PowerSink;
 import appeng.tile.powersink.IExternalPowerSink;
@@ -76,7 +77,7 @@ public class IC2PowerSinkAdapter extends BasicSink implements IC2PowerSink
 	@Override
 	public double injectEnergy( EnumFacing directionFrom, double amount, double voltage )
 	{
-		return PowerUnits.EU.convertTo( PowerUnits.AE, this.powerSink.injectExternalPower( PowerUnits.EU, amount ) );
+		return PowerUnits.EU.convertTo( PowerUnits.AE, this.powerSink.injectExternalPower( PowerUnits.EU, amount, Actionable.MODULATE ) );
 	}
 
 	@Override

--- a/src/main/java/appeng/me/cache/EnergyGridCache.java
+++ b/src/main/java/appeng/me/cache/EnergyGridCache.java
@@ -65,7 +65,7 @@ import appeng.me.energy.EnergyWatcher;
 public class EnergyGridCache implements IEnergyGrid
 {
 
-	private static final double MAX_BUFFER_STORAGE = 1000;
+	private static final double MAX_BUFFER_STORAGE = 200;
 	private static final Comparator<IEnergyGridProvider> COMPARATOR_HIGHEST_AMOUNT_STORED_FIRST = ( o1, o2 ) -> Double.compare( o2.getProviderStoredEnergy(),
 			o1.getProviderStoredEnergy() );
 

--- a/src/main/java/appeng/me/cache/EnergyGridCache.java
+++ b/src/main/java/appeng/me/cache/EnergyGridCache.java
@@ -688,11 +688,13 @@ public class EnergyGridCache implements IEnergyGrid
 			double extracted = Math.min( amt, this.stored );
 
 			if( mode == Actionable.MODULATE )
+			{
 				this.stored -= extracted;
 
-			if( this.stored < MAX_BUFFER_STORAGE - 0.001 )
-			{
-				EnergyGridCache.this.myGrid.postEvent( new MENetworkPowerStorage( this, PowerEventType.REQUEST_POWER ) );
+				if( this.stored < MAX_BUFFER_STORAGE - 0.001 )
+				{
+					EnergyGridCache.this.myGrid.postEvent( new MENetworkPowerStorage( this, PowerEventType.REQUEST_POWER ) );
+				}
 			}
 
 			if( extracted < amt )
@@ -715,7 +717,9 @@ public class EnergyGridCache implements IEnergyGrid
 			double toStore = Math.min( amt, MAX_BUFFER_STORAGE - this.stored );
 
 			if( mode == Actionable.MODULATE )
+			{
 				this.stored += toStore;
+			}
 
 			return amt - toStore;
 		}
@@ -747,6 +751,5 @@ public class EnergyGridCache implements IEnergyGrid
 		{
 			this.stored += amount;
 		}
-	};
-
+	}
 }

--- a/src/main/java/appeng/me/cache/EnergyGridCache.java
+++ b/src/main/java/appeng/me/cache/EnergyGridCache.java
@@ -55,7 +55,6 @@ import appeng.api.networking.events.MENetworkPowerStatusChange;
 import appeng.api.networking.events.MENetworkPowerStorage;
 import appeng.api.networking.events.MENetworkPowerStorage.PowerEventType;
 import appeng.api.networking.pathing.IPathingGrid;
-import appeng.api.networking.storage.IStackWatcherHost;
 import appeng.me.Grid;
 import appeng.me.GridNode;
 import appeng.me.energy.EnergyThreshold;
@@ -551,7 +550,7 @@ public class EnergyGridCache implements IEnergyGrid
 	{
 		if( machine instanceof IEnergyGridProvider )
 		{
-			this.energyGridProviders.remove( machine );
+			this.energyGridProviders.remove( (IEnergyGridProvider) machine );
 		}
 
 		// idle draw.
@@ -580,18 +579,19 @@ public class EnergyGridCache implements IEnergyGrid
 					this.lastRequester = null;
 				}
 
-				this.providers.remove( machine );
-				this.requesters.remove( machine );
+				this.providers.remove( ps );
+				this.requesters.remove( ps );
 			}
 		}
 
-		if( machine instanceof IStackWatcherHost )
+		if( machine instanceof IEnergyWatcherHost )
 		{
-			final IEnergyWatcher myWatcher = this.watchers.get( machine );
-			if( myWatcher != null )
+			final IEnergyWatcher watcher = this.watchers.get( node );
+
+			if( watcher != null )
 			{
-				myWatcher.reset();
-				this.watchers.remove( machine );
+				watcher.reset();
+				this.watchers.remove( node );
 			}
 		}
 	}
@@ -641,6 +641,7 @@ public class EnergyGridCache implements IEnergyGrid
 		{
 			final IEnergyWatcherHost swh = (IEnergyWatcherHost) machine;
 			final EnergyWatcher iw = new EnergyWatcher( this, swh );
+
 			this.watchers.put( node, iw );
 			swh.updateWatcher( iw );
 		}

--- a/src/main/java/appeng/me/cache/EnergyGridCache.java
+++ b/src/main/java/appeng/me/cache/EnergyGridCache.java
@@ -19,13 +19,13 @@
 package appeng.me.cache;
 
 
+import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
-import java.util.LinkedList;
 import java.util.NavigableSet;
 import java.util.PriorityQueue;
 import java.util.Queue;
@@ -64,23 +64,15 @@ import appeng.me.energy.EnergyWatcher;
 public class EnergyGridCache implements IEnergyGrid
 {
 
-	private static final Comparator<IEnergyGridProvider> COMPARATOR_HIGHEST_AMOUNT_STORED_FIRST = new Comparator<IEnergyGridProvider>()
-	{
-		public int compare( IEnergyGridProvider o1, IEnergyGridProvider o2 )
-		{
-			return Double.compare( o2.getProviderStoredEnergy(), o1.getProviderStoredEnergy() );
-		}
-	};
+	private static final Comparator<IEnergyGridProvider> COMPARATOR_HIGHEST_AMOUNT_STORED_FIRST = ( o1, o2 ) -> Double.compare( o2.getProviderStoredEnergy(),
+			o1.getProviderStoredEnergy() );
 
-	private static final Comparator<IEnergyGridProvider> COMPARATOR_LOWEST_PERCENTAGE_FIRST = new Comparator<IEnergyGridProvider>()
+	private static final Comparator<IEnergyGridProvider> COMPARATOR_LOWEST_PERCENTAGE_FIRST = ( o1, o2 ) ->
 	{
-		public int compare( IEnergyGridProvider o1, IEnergyGridProvider o2 )
-		{
-			final double percent1 = ( o1.getProviderStoredEnergy() + 1 ) / ( o1.getProviderMaxEnergy() + 1 );
-			final double percent2 = ( o2.getProviderStoredEnergy() + 1 ) / ( o2.getProviderMaxEnergy() + 1 );
+		final double percent1 = ( o1.getProviderStoredEnergy() + 1 ) / ( o1.getProviderMaxEnergy() + 1 );
+		final double percent2 = ( o2.getProviderStoredEnergy() + 1 ) / ( o2.getProviderMaxEnergy() + 1 );
 
-			return Double.compare( percent1, percent2 );
-		}
+		return Double.compare( percent1, percent2 );
 	};
 
 	private final NavigableSet<EnergyThreshold> interests = Sets.newTreeSet();
@@ -459,7 +451,7 @@ public class EnergyGridCache implements IEnergyGrid
 	@Override
 	public double injectPower( final double amt, final Actionable mode )
 	{
-		final Queue<IEnergyGridProvider> toVisit = new PriorityQueue<>(COMPARATOR_LOWEST_PERCENTAGE_FIRST);
+		final Queue<IEnergyGridProvider> toVisit = new PriorityQueue<>( COMPARATOR_LOWEST_PERCENTAGE_FIRST );
 		final Set<IEnergyGridProvider> visited = new HashSet<>();
 		toVisit.add( this );
 
@@ -471,8 +463,7 @@ public class EnergyGridCache implements IEnergyGrid
 			visited.add( next );
 
 			final double cannotHold = next.injectProviderPower( amt, Actionable.SIMULATE, visited );
-			leftover = next.injectProviderPower( leftover - cannotHold, mode, visited );
-
+			next.injectProviderPower( leftover - cannotHold, mode, visited );
 			leftover = cannotHold;
 
 			for( IEnergyGridProvider iEnergyGridProvider : next.providers() )
@@ -523,7 +514,7 @@ public class EnergyGridCache implements IEnergyGrid
 	@Override
 	public double getEnergyDemand( final double maxRequired )
 	{
-		final Queue<IEnergyGridProvider> toVisit = new LinkedList<>();
+		final Queue<IEnergyGridProvider> toVisit = new ArrayDeque<>();
 		final Set<IEnergyGridProvider> visited = new HashSet<>();
 		toVisit.add( this );
 

--- a/src/main/java/appeng/parts/networking/PartQuartzFiber.java
+++ b/src/main/java/appeng/parts/networking/PartQuartzFiber.java
@@ -20,7 +20,6 @@ package appeng.parts.networking;
 
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.EnumSet;
 import java.util.LinkedList;
 import java.util.Set;
@@ -169,8 +168,11 @@ public class PartQuartzFiber extends AEBasePart implements IEnergyGridProvider
 		try
 		{
 			final IEnergyGrid eg = this.getProxy().getEnergy();
+
 			if( !seen.contains( eg ) )
+			{
 				acquiredPower += eg.extractProviderPower( amt - acquiredPower, mode, seen );
+			}
 		}
 		catch( final GridAccessException e )
 		{
@@ -180,8 +182,11 @@ public class PartQuartzFiber extends AEBasePart implements IEnergyGridProvider
 		try
 		{
 			final IEnergyGrid eg = this.outerProxy.getEnergy();
+
 			if( !seen.contains( eg ) )
+			{
 				acquiredPower += eg.extractProviderPower( amt - acquiredPower, mode, seen );
+			}
 		}
 		catch( final GridAccessException e )
 		{
@@ -201,7 +206,9 @@ public class PartQuartzFiber extends AEBasePart implements IEnergyGridProvider
 		{
 			final IEnergyGrid eg = this.getProxy().getEnergy();
 			if( !seen.contains( eg ) )
+			{
 				amount = eg.injectProviderPower( amount, mode, seen );
+			}
 		}
 		catch( final GridAccessException e )
 		{
@@ -212,7 +219,9 @@ public class PartQuartzFiber extends AEBasePart implements IEnergyGridProvider
 		{
 			final IEnergyGrid eg = this.outerProxy.getEnergy();
 			if( !seen.contains( eg ) )
+			{
 				amount = eg.injectProviderPower( amount, mode, seen );
+			}
 		}
 		catch( final GridAccessException e )
 		{
@@ -231,7 +240,9 @@ public class PartQuartzFiber extends AEBasePart implements IEnergyGridProvider
 		{
 			final IEnergyGrid eg = this.getProxy().getEnergy();
 			if( !seen.contains( eg ) )
+			{
 				demand += eg.getProviderEnergyDemand( amt - demand, seen );
+			}
 		}
 		catch( final GridAccessException e )
 		{
@@ -242,7 +253,9 @@ public class PartQuartzFiber extends AEBasePart implements IEnergyGridProvider
 		{
 			final IEnergyGrid eg = this.outerProxy.getEnergy();
 			if( !seen.contains( eg ) )
+			{
 				demand += eg.getProviderEnergyDemand( amt - demand, seen );
+			}
 		}
 		catch( final GridAccessException e )
 		{

--- a/src/main/java/appeng/parts/networking/PartQuartzFiber.java
+++ b/src/main/java/appeng/parts/networking/PartQuartzFiber.java
@@ -19,7 +19,10 @@
 package appeng.parts.networking;
 
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.EnumSet;
+import java.util.LinkedList;
 import java.util.Set;
 
 import net.minecraft.entity.player.EntityPlayer;
@@ -131,14 +134,14 @@ public class PartQuartzFiber extends AEBasePart implements IEnergyGridProvider
 	}
 
 	@Override
-	public double extractAEPower( final double amt, final Actionable mode, final Set<IEnergyGrid> seen )
+	public Collection<IEnergyGridProvider> providers()
 	{
-		double acquiredPower = 0;
+		Collection<IEnergyGridProvider> stuff = new LinkedList<>();
 
 		try
 		{
 			final IEnergyGrid eg = this.getProxy().getEnergy();
-			acquiredPower += eg.extractAEPower( amt - acquiredPower, mode, seen );
+			stuff.add( eg );
 		}
 		catch( final GridAccessException e )
 		{
@@ -148,7 +151,37 @@ public class PartQuartzFiber extends AEBasePart implements IEnergyGridProvider
 		try
 		{
 			final IEnergyGrid eg = this.outerProxy.getEnergy();
-			acquiredPower += eg.extractAEPower( amt - acquiredPower, mode, seen );
+			stuff.add( eg );
+		}
+		catch( final GridAccessException e )
+		{
+			// :P
+		}
+
+		return stuff;
+	}
+
+	@Override
+	public double extractProviderPower( final double amt, final Actionable mode, final Set<IEnergyGridProvider> seen )
+	{
+		double acquiredPower = 0;
+
+		try
+		{
+			final IEnergyGrid eg = this.getProxy().getEnergy();
+			if( !seen.contains( eg ) )
+				acquiredPower += eg.extractProviderPower( amt - acquiredPower, mode, seen );
+		}
+		catch( final GridAccessException e )
+		{
+			// :P
+		}
+
+		try
+		{
+			final IEnergyGrid eg = this.outerProxy.getEnergy();
+			if( !seen.contains( eg ) )
+				acquiredPower += eg.extractProviderPower( amt - acquiredPower, mode, seen );
 		}
 		catch( final GridAccessException e )
 		{
@@ -159,16 +192,16 @@ public class PartQuartzFiber extends AEBasePart implements IEnergyGridProvider
 	}
 
 	@Override
-	public double injectAEPower( final double amt, final Actionable mode, final Set<IEnergyGrid> seen )
+	public double injectProviderPower( final double amt, final Actionable mode, final Set<IEnergyGridProvider> seen )
 	{
+
+		double amount = amt;
 
 		try
 		{
 			final IEnergyGrid eg = this.getProxy().getEnergy();
 			if( !seen.contains( eg ) )
-			{
-				return eg.injectAEPower( amt, mode, seen );
-			}
+				amount = eg.injectProviderPower( amount, mode, seen );
 		}
 		catch( final GridAccessException e )
 		{
@@ -179,27 +212,26 @@ public class PartQuartzFiber extends AEBasePart implements IEnergyGridProvider
 		{
 			final IEnergyGrid eg = this.outerProxy.getEnergy();
 			if( !seen.contains( eg ) )
-			{
-				return eg.injectAEPower( amt, mode, seen );
-			}
+				amount = eg.injectProviderPower( amount, mode, seen );
 		}
 		catch( final GridAccessException e )
 		{
 			// :P
 		}
 
-		return amt;
+		return amount;
 	}
 
 	@Override
-	public double getEnergyDemand( final double amt, final Set<IEnergyGrid> seen )
+	public double getProviderEnergyDemand( final double amt, final Set<IEnergyGridProvider> seen )
 	{
 		double demand = 0;
 
 		try
 		{
 			final IEnergyGrid eg = this.getProxy().getEnergy();
-			demand += eg.getEnergyDemand( amt - demand, seen );
+			if( !seen.contains( eg ) )
+				demand += eg.getProviderEnergyDemand( amt - demand, seen );
 		}
 		catch( final GridAccessException e )
 		{
@@ -209,7 +241,8 @@ public class PartQuartzFiber extends AEBasePart implements IEnergyGridProvider
 		try
 		{
 			final IEnergyGrid eg = this.outerProxy.getEnergy();
-			demand += eg.getEnergyDemand( amt - demand, seen );
+			if( !seen.contains( eg ) )
+				demand += eg.getProviderEnergyDemand( amt - demand, seen );
 		}
 		catch( final GridAccessException e )
 		{
@@ -217,6 +250,18 @@ public class PartQuartzFiber extends AEBasePart implements IEnergyGridProvider
 		}
 
 		return demand;
+	}
+
+	@Override
+	public double getProviderStoredEnergy()
+	{
+		return 0;
+	}
+
+	@Override
+	public double getProviderMaxEnergy()
+	{
+		return 0;
 	}
 
 	@Override

--- a/src/main/java/appeng/tile/misc/TileCharger.java
+++ b/src/main/java/appeng/tile/misc/TileCharger.java
@@ -130,7 +130,7 @@ public class TileCharger extends AENetworkPowerTile implements ICrankable, IGrid
 	@Override
 	public void applyTurn()
 	{
-		this.injectExternalPower( PowerUnits.AE, 150 );
+		this.injectExternalPower( PowerUnits.AE, 150, Actionable.MODULATE );
 
 		final ItemStack myItem = this.inv.getStackInSlot( 0 );
 		if( this.getInternalCurrentPower() > 1499 )
@@ -222,7 +222,7 @@ public class TileCharger extends AENetworkPowerTile implements ICrankable, IGrid
 			try
 			{
 				this.injectExternalPower( PowerUnits.AE, this.getProxy().getEnergy().extractAEPower( Math.min( 500.0, 1500.0 - this.getInternalCurrentPower() ),
-						Actionable.MODULATE, PowerMultiplier.ONE ) );
+						Actionable.MODULATE, PowerMultiplier.ONE ), Actionable.MODULATE );
 			}
 			catch( final GridAccessException e )
 			{
@@ -246,7 +246,8 @@ public class TileCharger extends AENetworkPowerTile implements ICrankable, IGrid
 			{
 				final double oldPower = this.getInternalCurrentPower();
 
-				final double adjustment = ps.injectAEPower( myItem, this.extractAEPower( 150.0, Actionable.MODULATE, PowerMultiplier.CONFIG ), Actionable.MODULATE );
+				final double adjustment = ps.injectAEPower( myItem, this.extractAEPower( 150.0, Actionable.MODULATE, PowerMultiplier.CONFIG ),
+						Actionable.MODULATE );
 				this.setInternalCurrentPower( this.getInternalCurrentPower() + adjustment );
 
 				if( oldPower > this.getInternalCurrentPower() )

--- a/src/main/java/appeng/tile/networking/TileController.java
+++ b/src/main/java/appeng/tile/networking/TileController.java
@@ -29,6 +29,7 @@ import net.minecraftforge.items.wrapper.EmptyHandler;
 
 import appeng.api.config.Actionable;
 import appeng.api.networking.GridFlags;
+import appeng.api.networking.energy.IEnergyGrid;
 import appeng.api.networking.events.MENetworkControllerChange;
 import appeng.api.networking.events.MENetworkEventSubscribe;
 import appeng.api.networking.events.MENetworkPowerStatusChange;
@@ -137,7 +138,9 @@ public class TileController extends AENetworkPowerTile
 	{
 		try
 		{
-			return this.getProxy().getEnergy().getEnergyDemand( 8000 );
+			final IEnergyGrid grid = this.getProxy().getEnergy();
+
+			return grid.getEnergyDemand( maxReceived );
 		}
 		catch( final GridAccessException e )
 		{
@@ -151,12 +154,10 @@ public class TileController extends AENetworkPowerTile
 	{
 		try
 		{
-			final double ret = this.getProxy().getEnergy().injectPower( power, mode );
-			if( mode == Actionable.SIMULATE )
-			{
-				return ret;
-			}
-			return 0;
+			final IEnergyGrid grid = this.getProxy().getEnergy();
+			final double leftOver = grid.injectPower( power, mode );
+
+			return leftOver;
 		}
 		catch( final GridAccessException e )
 		{

--- a/src/main/java/appeng/tile/networking/TileEnergyAcceptor.java
+++ b/src/main/java/appeng/tile/networking/TileEnergyAcceptor.java
@@ -69,6 +69,7 @@ public class TileEnergyAcceptor extends AENetworkPowerTile
 		try
 		{
 			final IEnergyGrid grid = this.getProxy().getEnergy();
+
 			return grid.getEnergyDemand( maxRequired );
 		}
 		catch( final GridAccessException e )
@@ -84,11 +85,8 @@ public class TileEnergyAcceptor extends AENetworkPowerTile
 		{
 			final IEnergyGrid grid = this.getProxy().getEnergy();
 			final double leftOver = grid.injectPower( power, mode );
-			if( mode == Actionable.SIMULATE )
-			{
-				return leftOver;
-			}
-			return 0.0;
+
+			return leftOver;
 		}
 		catch( final GridAccessException e )
 		{

--- a/src/main/java/appeng/tile/powersink/ForgeEnergyAdapter.java
+++ b/src/main/java/appeng/tile/powersink/ForgeEnergyAdapter.java
@@ -4,6 +4,7 @@ package appeng.tile.powersink;
 
 import net.minecraftforge.energy.IEnergyStorage;
 
+import appeng.api.config.Actionable;
 import appeng.api.config.PowerUnits;
 
 
@@ -23,15 +24,10 @@ class ForgeEnergyAdapter implements IEnergyStorage
 	@Override
 	public final int receiveEnergy( int maxReceive, boolean simulate )
 	{
-		final int networkDemand = (int) Math.floor( this.sink.getExternalPowerDemand( PowerUnits.RF, maxReceive ) );
-		final int used = Math.min( maxReceive, networkDemand );
+		final double offered = (double) maxReceive;
+		final double overflow = this.sink.injectExternalPower( PowerUnits.RF, offered, simulate ? Actionable.SIMULATE : Actionable.MODULATE );
 
-		if( !simulate )
-		{
-			this.sink.injectExternalPower( PowerUnits.RF, used );
-		}
-
-		return used;
+		return (int) ( maxReceive - overflow );
 	}
 
 	@Override

--- a/src/main/java/appeng/tile/powersink/IExternalPowerSink.java
+++ b/src/main/java/appeng/tile/powersink/IExternalPowerSink.java
@@ -19,6 +19,7 @@
 package appeng.tile.powersink;
 
 
+import appeng.api.config.Actionable;
 import appeng.api.config.PowerUnits;
 import appeng.api.networking.energy.IAEPowerStorage;
 
@@ -26,8 +27,22 @@ import appeng.api.networking.energy.IAEPowerStorage;
 public interface IExternalPowerSink extends IAEPowerStorage
 {
 
-	double injectExternalPower( PowerUnits input, double amt );
+	/**
+	 * Inject power into the network
+	 * 
+	 * @param externalUnit The {@link PowerUnits} used by the input
+	 * @param amount The amount offered to the sink.
+	 * @param mode Modulate or simulate the operation.
+	 * @return The unused amount, which could not be inserted into the sink.
+	 */
+	double injectExternalPower( PowerUnits externalUnit, double amount, Actionable mode );
 
+	/**
+	 * 
+	 * @param externalUnit The {@link PowerUnits} used by the input
+	 * @param maxPowerRequired Limit the demand to this upper bound.
+	 * @return The amount of power demanded by the sink.
+	 */
 	double getExternalPowerDemand( PowerUnits externalUnit, double maxPowerRequired );
 
 }

--- a/src/main/java/appeng/tile/powersink/TeslaEnergyAdapter.java
+++ b/src/main/java/appeng/tile/powersink/TeslaEnergyAdapter.java
@@ -21,6 +21,7 @@ package appeng.tile.powersink;
 
 import net.darkhax.tesla.api.ITeslaConsumer;
 
+import appeng.api.config.Actionable;
 import appeng.api.config.PowerUnits;
 
 
@@ -41,17 +42,10 @@ class TeslaEnergyAdapter implements ITeslaConsumer
 	public long givePower( long power, boolean simulated )
 	{
 		// Cut it down to what we can represent in a double
-		double powerDbl = (double) power;
+		double offeredPower = (double) power;
 
-		double networkDemand = this.sink.getExternalPowerDemand( PowerUnits.RF, powerDbl );
-		long used = (long) Math.min( powerDbl, networkDemand );
+		final double overflow = this.sink.injectExternalPower( PowerUnits.RF, offeredPower, simulated ? Actionable.SIMULATE : Actionable.MODULATE );
 
-		if( !simulated )
-		{
-			this.sink.injectExternalPower( PowerUnits.RF, used );
-		}
-
-		return used;
+		return (long) ( power - overflow );
 	}
-
 }


### PR DESCRIPTION
Reworked the old recursive approach to a queue based loop.
Extract will try to prefer the next grid with the hightest amount of stored energy.
Inject will try to prefer the grid with the lowest percentage stored.
Other operations are first come, first serve.

----
Edit

This replaces the old not really working buffer with a special
IAEPowerStorage acting as buffer/proxy for the local energy demand as
well as temporary overflow should something provide more energy than
requested.

Currently it set to hold a maximum of 1000 AE (+ optional overflow until
consumed). It will only be used locally, no other grid can use it to
avoid starving the neighbor grids before finding a energy cell.

1000 AE is certainl excessive for a local storage in nearly all cases. Around 10 to 100 would certainly be more fitting. But a local network with 8 drives full of 64k cells will extract about 180 AE per tick, which should be about the amount a local buffer should provide to avoid reaching out to energy cells in other grids. Thus 200 AE might be fine.

Another idea might be to link it to the idle drain. So every gridnode would add/remove their idle draw to the maximum on top off a small buffer to accomendate for the energy use by channels.
---

Fixes #1004