### PR TITLE
Make UVLLoader a bit more robust

### DIFF
--- a/src/main/java/appeng/client/render/model/UVLModelLoader.java
+++ b/src/main/java/appeng/client/render/model/UVLModelLoader.java
@@ -191,17 +191,19 @@ public enum UVLModelLoader implements ICustomModelLoader
 		{
 			modelPath = modelPath.substring( "models/".length() );
 		}
+
 		try( InputStreamReader io = new InputStreamReader( Minecraft.getMinecraft()
 				.getResourceManager()
 				.getResource( new ResourceLocation( modelLocation.getResourceDomain(), "models/" + modelPath + ".json" ) )
 				.getInputStream() ) )
 		{
-			return gson.fromJson( io, UVLMarker.class ).uvlMarker;
+			return gson.fromJson( io, UVLMarker.class ).ae2_uvl_marker;
 		}
-		catch( IOException e )
+		catch( Exception e )
 		{
-
+			// Catch-all in case of any JSON parser issues.
 		}
+
 		return false;
 	}
 
@@ -387,7 +389,7 @@ public enum UVLModelLoader implements ICustomModelLoader
 
 	class UVLMarker
 	{
-		boolean uvlMarker = false;
+		boolean ae2_uvl_marker = false;
 	}
 
 }

--- a/src/main/resources/assets/appliedenergistics2/models/block/charged_quartz_ore.json
+++ b/src/main/resources/assets/appliedenergistics2/models/block/charged_quartz_ore.json
@@ -1,5 +1,5 @@
 {
-    "uvlMarker": true,
+    "ae2_uvl_marker": true,
     "parent": "block/block",
     "textures": {
         "block": "blocks/stone",

--- a/src/main/resources/assets/appliedenergistics2/models/block/chest/cell_state_full.json
+++ b/src/main/resources/assets/appliedenergistics2/models/block/chest/cell_state_full.json
@@ -1,5 +1,5 @@
 {
-  "uvlMarker": true,
+  "ae2_uvl_marker": true,
   "textures": {
     "backdrop": "appliedenergistics2:blocks/chest/cell_state_backdrop",
     "state": "appliedenergistics2:blocks/chest/cell_state_full"

--- a/src/main/resources/assets/appliedenergistics2/models/block/chest/cell_state_online.json
+++ b/src/main/resources/assets/appliedenergistics2/models/block/chest/cell_state_online.json
@@ -1,5 +1,5 @@
 {
-  "uvlMarker": true,
+  "ae2_uvl_marker": true,
   "textures": {
     "backdrop": "appliedenergistics2:blocks/chest/cell_state_backdrop",
     "state": "appliedenergistics2:blocks/chest/cell_state_online"

--- a/src/main/resources/assets/appliedenergistics2/models/block/chest/cell_state_types_full.json
+++ b/src/main/resources/assets/appliedenergistics2/models/block/chest/cell_state_types_full.json
@@ -1,5 +1,5 @@
 {
-  "uvlMarker": true,
+  "ae2_uvl_marker": true,
   "textures": {
     "backdrop": "appliedenergistics2:blocks/chest/cell_state_backdrop",
     "state": "appliedenergistics2:blocks/chest/cell_state_types_full"

--- a/src/main/resources/assets/appliedenergistics2/models/block/chest/lights_on.json
+++ b/src/main/resources/assets/appliedenergistics2/models/block/chest/lights_on.json
@@ -1,5 +1,5 @@
 {
-  "uvlMarker": true,
+  "ae2_uvl_marker": true,
   "textures": {
     "lights_bright": "appliedenergistics2:blocks/chest/lights_on_bright",
     "lights_medium": "appliedenergistics2:blocks/chest/lights_on_medium",

--- a/src/main/resources/assets/appliedenergistics2/models/block/controller/controller_block_conflicted.json
+++ b/src/main/resources/assets/appliedenergistics2/models/block/controller/controller_block_conflicted.json
@@ -1,5 +1,5 @@
 {
-    "uvlMarker": true,
+    "ae2_uvl_marker": true,
     "parent": "block/block",
     "textures": {
         "block": "appliedenergistics2:blocks/controller_powered",

--- a/src/main/resources/assets/appliedenergistics2/models/block/controller/controller_block_online.json
+++ b/src/main/resources/assets/appliedenergistics2/models/block/controller/controller_block_online.json
@@ -1,5 +1,5 @@
 {
-    "uvlMarker": true,
+    "ae2_uvl_marker": true,
     "parent": "block/block",
     "textures": {
         "block": "appliedenergistics2:blocks/controller_powered",

--- a/src/main/resources/assets/appliedenergistics2/models/block/controller/controller_column_conflicted.json
+++ b/src/main/resources/assets/appliedenergistics2/models/block/controller/controller_column_conflicted.json
@@ -1,5 +1,5 @@
 {
-    "uvlMarker": true,
+    "ae2_uvl_marker": true,
     "parent": "block/block",
     "textures": {
         "block": "appliedenergistics2:blocks/controller_column_powered",

--- a/src/main/resources/assets/appliedenergistics2/models/block/controller/controller_column_online.json
+++ b/src/main/resources/assets/appliedenergistics2/models/block/controller/controller_column_online.json
@@ -1,5 +1,5 @@
 {
-    "uvlMarker": true,
+    "ae2_uvl_marker": true,
     "parent": "block/block",
     "textures": {
         "block": "appliedenergistics2:blocks/controller_column_powered",

--- a/src/main/resources/assets/appliedenergistics2/models/block/drive_cell_empty.json
+++ b/src/main/resources/assets/appliedenergistics2/models/block/drive_cell_empty.json
@@ -1,5 +1,5 @@
 {
-  "uvlMarker": true,
+  "ae2_uvl_marker": true,
   "textures": {
     "front": "appliedenergistics2:blocks/drive_cell_states"
   },

--- a/src/main/resources/assets/appliedenergistics2/models/block/drive_cell_full.json
+++ b/src/main/resources/assets/appliedenergistics2/models/block/drive_cell_full.json
@@ -1,5 +1,5 @@
 {
-  "uvlMarker": true,
+  "ae2_uvl_marker": true,
   "textures": {
     "front": "appliedenergistics2:blocks/drive_cell_states"
   },

--- a/src/main/resources/assets/appliedenergistics2/models/block/drive_cell_on.json
+++ b/src/main/resources/assets/appliedenergistics2/models/block/drive_cell_on.json
@@ -1,5 +1,5 @@
 {
-  "uvlMarker": true,
+  "ae2_uvl_marker": true,
   "textures": {
     "front": "appliedenergistics2:blocks/drive_cell_states"
   },

--- a/src/main/resources/assets/appliedenergistics2/models/block/drive_cell_types_full.json
+++ b/src/main/resources/assets/appliedenergistics2/models/block/drive_cell_types_full.json
@@ -1,5 +1,5 @@
 {
-  "uvlMarker": true,
+  "ae2_uvl_marker": true,
   "textures": {
     "front": "appliedenergistics2:blocks/drive_cell_states"
   },

--- a/src/main/resources/assets/appliedenergistics2/models/block/molecular_assembler_lights.json
+++ b/src/main/resources/assets/appliedenergistics2/models/block/molecular_assembler_lights.json
@@ -1,5 +1,5 @@
 {
-  "uvlMarker": true,
+  "ae2_uvl_marker": true,
   "parent": "block/block",
   "textures": {
     "all": "appliedenergistics2:blocks/molecular_assembler_lights"

--- a/src/main/resources/assets/appliedenergistics2/models/block/security_station_on.json
+++ b/src/main/resources/assets/appliedenergistics2/models/block/security_station_on.json
@@ -1,5 +1,5 @@
 {
-    "uvlMarker": true,
+    "ae2_uvl_marker": true,
     "parent": "block/block",
     "textures": {
         "particle": "appliedenergistics2:blocks/security_station_side",

--- a/src/main/resources/assets/appliedenergistics2/models/block/wireless_access_point_on.json
+++ b/src/main/resources/assets/appliedenergistics2/models/block/wireless_access_point_on.json
@@ -1,5 +1,5 @@
 {
-    "uvlMarker": true,
+    "ae2_uvl_marker": true,
     "ambientocclusion": false,
     "textures": {
         "torch": "appliedenergistics2:blocks/wireless_access_point_on"

--- a/src/main/resources/assets/appliedenergistics2/models/part/conversion_monitor_locked_on.json
+++ b/src/main/resources/assets/appliedenergistics2/models/part/conversion_monitor_locked_on.json
@@ -1,5 +1,5 @@
 {
-  "uvlMarker": true,
+  "ae2_uvl_marker": true,
   "textures": {
     "lightsBright": "appliedenergistics2:parts/conversion_monitor_bright",
     "lightsMedium": "appliedenergistics2:parts/conversion_monitor_medium_locked",

--- a/src/main/resources/assets/appliedenergistics2/models/part/conversion_monitor_on.json
+++ b/src/main/resources/assets/appliedenergistics2/models/part/conversion_monitor_on.json
@@ -1,5 +1,5 @@
 {
-  "uvlMarker": true,
+  "ae2_uvl_marker": true,
   "textures": {
     "lightsBright": "appliedenergistics2:parts/conversion_monitor_bright",
     "lightsMedium": "appliedenergistics2:parts/conversion_monitor_medium",

--- a/src/main/resources/assets/appliedenergistics2/models/part/crafting_terminal_on.json
+++ b/src/main/resources/assets/appliedenergistics2/models/part/crafting_terminal_on.json
@@ -1,5 +1,5 @@
 {
-  "uvlMarker": true,
+  "ae2_uvl_marker": true,
   "textures": {
     "lightsBright": "appliedenergistics2:parts/crafting_terminal_bright",
     "lightsMedium": "appliedenergistics2:parts/crafting_terminal_medium",

--- a/src/main/resources/assets/appliedenergistics2/models/part/display_status_has_channel.json
+++ b/src/main/resources/assets/appliedenergistics2/models/part/display_status_has_channel.json
@@ -1,5 +1,5 @@
 {
-  "uvlMarker": true,
+  "ae2_uvl_marker": true,
   "textures": {
     "indicator": "appliedenergistics2:parts/monitor_sides_status_has_channel"
   },

--- a/src/main/resources/assets/appliedenergistics2/models/part/display_status_on.json
+++ b/src/main/resources/assets/appliedenergistics2/models/part/display_status_on.json
@@ -1,5 +1,5 @@
 {
-  "uvlMarker": true,
+  "ae2_uvl_marker": true,
   "textures": {
     "indicator": "appliedenergistics2:parts/monitor_sides_status_on"
   },

--- a/src/main/resources/assets/appliedenergistics2/models/part/export_bus_has_channel.json
+++ b/src/main/resources/assets/appliedenergistics2/models/part/export_bus_has_channel.json
@@ -1,5 +1,5 @@
 {
-  "uvlMarker": true,
+  "ae2_uvl_marker": true,
   "textures": {
     "indicator": "appliedenergistics2:parts/monitor_sides_status_has_channel"
   },

--- a/src/main/resources/assets/appliedenergistics2/models/part/export_bus_on.json
+++ b/src/main/resources/assets/appliedenergistics2/models/part/export_bus_on.json
@@ -1,5 +1,5 @@
 {
-  "uvlMarker": true,
+  "ae2_uvl_marker": true,
   "textures": {
     "indicator": "appliedenergistics2:parts/monitor_sides_status_on"
   },

--- a/src/main/resources/assets/appliedenergistics2/models/part/import_bus_has_channel.json
+++ b/src/main/resources/assets/appliedenergistics2/models/part/import_bus_has_channel.json
@@ -1,5 +1,5 @@
 {
-  "uvlMarker": true,
+  "ae2_uvl_marker": true,
   "textures": {
     "indicator": "appliedenergistics2:parts/monitor_sides_status_has_channel"
   },

--- a/src/main/resources/assets/appliedenergistics2/models/part/import_bus_on.json
+++ b/src/main/resources/assets/appliedenergistics2/models/part/import_bus_on.json
@@ -1,5 +1,5 @@
 {
-  "uvlMarker": true,
+  "ae2_uvl_marker": true,
   "textures": {
     "indicator": "appliedenergistics2:parts/monitor_sides_status_on"
   },

--- a/src/main/resources/assets/appliedenergistics2/models/part/interface_has_channel.json
+++ b/src/main/resources/assets/appliedenergistics2/models/part/interface_has_channel.json
@@ -1,5 +1,5 @@
 {
-  "uvlMarker": true,
+  "ae2_uvl_marker": true,
   "textures": {
     "indicator": "appliedenergistics2:parts/monitor_sides_status_has_channel"
   },

--- a/src/main/resources/assets/appliedenergistics2/models/part/interface_on.json
+++ b/src/main/resources/assets/appliedenergistics2/models/part/interface_on.json
@@ -1,5 +1,5 @@
 {
-  "uvlMarker": true,
+  "ae2_uvl_marker": true,
   "textures": {
     "indicator": "appliedenergistics2:parts/monitor_sides_status_on"
   },

--- a/src/main/resources/assets/appliedenergistics2/models/part/interface_terminal_on.json
+++ b/src/main/resources/assets/appliedenergistics2/models/part/interface_terminal_on.json
@@ -1,5 +1,5 @@
 {
-  "uvlMarker": true,
+  "ae2_uvl_marker": true,
   "textures": {
     "lightsBright": "appliedenergistics2:parts/interface_terminal_bright",
     "lightsMedium": "appliedenergistics2:parts/interface_terminal_medium",

--- a/src/main/resources/assets/appliedenergistics2/models/part/level_emitter_base_on.json
+++ b/src/main/resources/assets/appliedenergistics2/models/part/level_emitter_base_on.json
@@ -1,5 +1,5 @@
 {
-  "uvlMarker": true,
+  "ae2_uvl_marker": true,
   "ambientocclusion": false,
   "textures": {
     "emitter": "appliedenergistics2:parts/level_emitter_on",

--- a/src/main/resources/assets/appliedenergistics2/models/part/level_emitter_status_has_channel.json
+++ b/src/main/resources/assets/appliedenergistics2/models/part/level_emitter_status_has_channel.json
@@ -1,5 +1,5 @@
 {
-  "uvlMarker": true,
+  "ae2_uvl_marker": true,
   "textures": {
     "indicator": "appliedenergistics2:parts/monitor_sides_status_has_channel"
   },

--- a/src/main/resources/assets/appliedenergistics2/models/part/level_emitter_status_on.json
+++ b/src/main/resources/assets/appliedenergistics2/models/part/level_emitter_status_on.json
@@ -1,5 +1,5 @@
 {
-  "uvlMarker": true,
+  "ae2_uvl_marker": true,
   "textures": {
     "indicator": "appliedenergistics2:parts/monitor_sides_status_on"
   },

--- a/src/main/resources/assets/appliedenergistics2/models/part/monitor_base.json
+++ b/src/main/resources/assets/appliedenergistics2/models/part/monitor_base.json
@@ -1,5 +1,5 @@
 {
-  "uvlMarker": true,
+  "ae2_uvl_marker": true,
   "textures": {
     "sides": "appliedenergistics2:parts/monitor_sides",
     "back": "appliedenergistics2:parts/monitor_back",

--- a/src/main/resources/assets/appliedenergistics2/models/part/monitor_bright_on.json
+++ b/src/main/resources/assets/appliedenergistics2/models/part/monitor_bright_on.json
@@ -1,5 +1,5 @@
 {
-  "uvlMarker": true,
+  "ae2_uvl_marker": true,
   "ambientocclusion": false,
   "textures": {
     "lights": "appliedenergistics2:parts/monitor_light"

--- a/src/main/resources/assets/appliedenergistics2/models/part/monitor_dark_on.json
+++ b/src/main/resources/assets/appliedenergistics2/models/part/monitor_dark_on.json
@@ -1,5 +1,5 @@
 {
-  "uvlMarker": true,
+  "ae2_uvl_marker": true,
   "textures": {
     "lights": "appliedenergistics2:parts/monitor_light"
   },

--- a/src/main/resources/assets/appliedenergistics2/models/part/monitor_medium_on.json
+++ b/src/main/resources/assets/appliedenergistics2/models/part/monitor_medium_on.json
@@ -1,5 +1,5 @@
 {
-  "uvlMarker": true,
+  "ae2_uvl_marker": true,
   "textures": {
     "lights": "appliedenergistics2:parts/monitor_light"
   },

--- a/src/main/resources/assets/appliedenergistics2/models/part/p2p/p2p_tunnel_status_has_channel.json
+++ b/src/main/resources/assets/appliedenergistics2/models/part/p2p/p2p_tunnel_status_has_channel.json
@@ -1,5 +1,5 @@
 {
-  "uvlMarker": true,
+  "ae2_uvl_marker": true,
   "textures": {
     "indicator": "appliedenergistics2:parts/monitor_sides_status_has_channel"
   },

--- a/src/main/resources/assets/appliedenergistics2/models/part/p2p/p2p_tunnel_status_on.json
+++ b/src/main/resources/assets/appliedenergistics2/models/part/p2p/p2p_tunnel_status_on.json
@@ -1,5 +1,5 @@
 {
-  "uvlMarker": true,
+  "ae2_uvl_marker": true,
   "textures": {
     "indicator": "appliedenergistics2:parts/monitor_sides_status_on"
   },

--- a/src/main/resources/assets/appliedenergistics2/models/part/pattern_terminal_on.json
+++ b/src/main/resources/assets/appliedenergistics2/models/part/pattern_terminal_on.json
@@ -1,5 +1,5 @@
 {
-  "uvlMarker": true,
+  "ae2_uvl_marker": true,
   "textures": {
     "lightsBright": "appliedenergistics2:parts/pattern_terminal_bright",
     "lightsMedium": "appliedenergistics2:parts/pattern_terminal_medium",

--- a/src/main/resources/assets/appliedenergistics2/models/part/storage_bus_has_channel.json
+++ b/src/main/resources/assets/appliedenergistics2/models/part/storage_bus_has_channel.json
@@ -1,5 +1,5 @@
 {
-  "uvlMarker": true,
+  "ae2_uvl_marker": true,
   "textures": {
     "indicator": "appliedenergistics2:parts/monitor_sides_status_has_channel"
   },

--- a/src/main/resources/assets/appliedenergistics2/models/part/storage_bus_on.json
+++ b/src/main/resources/assets/appliedenergistics2/models/part/storage_bus_on.json
@@ -1,5 +1,5 @@
 {
-  "uvlMarker": true,
+  "ae2_uvl_marker": true,
   "textures": {
     "indicator": "appliedenergistics2:parts/monitor_sides_status_on"
   },

--- a/src/main/resources/assets/appliedenergistics2/models/part/storage_monitor_locked_on.json
+++ b/src/main/resources/assets/appliedenergistics2/models/part/storage_monitor_locked_on.json
@@ -1,5 +1,5 @@
 {
-  "uvlMarker": true,
+  "ae2_uvl_marker": true,
   "textures": {
     "lightsBright": "appliedenergistics2:parts/storage_monitor_bright",
     "lightsMedium": "appliedenergistics2:parts/storage_monitor_medium",

--- a/src/main/resources/assets/appliedenergistics2/models/part/storage_monitor_on.json
+++ b/src/main/resources/assets/appliedenergistics2/models/part/storage_monitor_on.json
@@ -1,5 +1,5 @@
 {
-  "uvlMarker": true,
+  "ae2_uvl_marker": true,
   "textures": {
     "lightsBright": "appliedenergistics2:parts/storage_monitor_bright",
     "lightsMedium": "appliedenergistics2:parts/storage_monitor_medium",

--- a/src/main/resources/assets/appliedenergistics2/models/part/terminal_on.json
+++ b/src/main/resources/assets/appliedenergistics2/models/part/terminal_on.json
@@ -1,5 +1,5 @@
 {
-  "uvlMarker": true,
+  "ae2_uvl_marker": true,
   "textures": {
     "lightsBright": "appliedenergistics2:parts/terminal_bright",
     "lightsMedium": "appliedenergistics2:parts/terminal_medium",

--- a/src/main/resources/assets/appliedenergistics2/models/part/toggle_bus_status_has_channel.json
+++ b/src/main/resources/assets/appliedenergistics2/models/part/toggle_bus_status_has_channel.json
@@ -1,5 +1,5 @@
 {
-  "uvlMarker": true,
+  "ae2_uvl_marker": true,
   "textures": {
     "indicator": "appliedenergistics2:parts/monitor_sides_status_on"
   },

--- a/src/main/resources/assets/appliedenergistics2/models/part/toggle_bus_status_on.json
+++ b/src/main/resources/assets/appliedenergistics2/models/part/toggle_bus_status_on.json
@@ -1,5 +1,5 @@
 {
-  "uvlMarker": true,
+  "ae2_uvl_marker": true,
   "textures": {
     "indicator": "appliedenergistics2:parts/monitor_sides_status_on"
   },

--- a/src/main/resources/assets/appliedenergistics2/models/part/transition_plane_has_channel.json
+++ b/src/main/resources/assets/appliedenergistics2/models/part/transition_plane_has_channel.json
@@ -1,5 +1,5 @@
 {
-  "uvlMarker": true,
+  "ae2_uvl_marker": true,
   "textures": {
     "sides": "appliedenergistics2:parts/monitor_sides_status",
     "back": "appliedenergistics2:parts/transition_plane_back",

--- a/src/main/resources/assets/appliedenergistics2/models/part/transition_plane_on.json
+++ b/src/main/resources/assets/appliedenergistics2/models/part/transition_plane_on.json
@@ -1,5 +1,5 @@
 {
-  "uvlMarker": true,
+  "ae2_uvl_marker": true,
   "textures": {
     "sides": "appliedenergistics2:parts/monitor_sides_status",
     "back": "appliedenergistics2:parts/transition_plane_back",

--- a/src/test/resources/assets/uvlightmapjsontest/models/block/uvlblock.json
+++ b/src/test/resources/assets/uvlightmapjsontest/models/block/uvlblock.json
@@ -1,5 +1,5 @@
 {
-    "uvlMarker": true,
+    "ae2_uvl_marker": true,
     "textures": {
         "0": "blocks/obsidian",
         "1": "uvlightmapjsontest:blocks/BlockControllerLights"


### PR DESCRIPTION
Catch all parsing exceptions instead of propagating them upwards as these are meaningless for the actual test.
Renamed uvlMarker to ae2_uvl_marker just in case some other mod uses the same key.