### PR TITLE
Further StorageChannel refactoring

### DIFF
--- a/src/main/java/appeng/core/features/registries/cell/BasicCellHandler.java
+++ b/src/main/java/appeng/core/features/registries/cell/BasicCellHandler.java
@@ -33,6 +33,7 @@ import appeng.api.storage.IMEInventoryHandler;
 import appeng.api.storage.ISaveProvider;
 import appeng.api.storage.IStorageChannel;
 import appeng.api.storage.channels.IItemStorageChannel;
+import appeng.api.storage.data.IAEStack;
 import appeng.api.util.AEPartLocation;
 import appeng.core.sync.GuiBridge;
 import appeng.me.storage.CellInventory;
@@ -50,7 +51,7 @@ public class BasicCellHandler implements ICellHandler
 	}
 
 	@Override
-	public IMEInventoryHandler getCellInventory( final ItemStack is, final ISaveProvider container, final IStorageChannel channel )
+	public <T extends IAEStack<T>> IMEInventoryHandler<T> getCellInventory( final ItemStack is, final ISaveProvider container, final IStorageChannel<T> channel )
 	{
 		if( channel == AEApi.instance().storage().getStorageChannel( IItemStorageChannel.class ) )
 		{

--- a/src/main/java/appeng/core/features/registries/cell/CellRegistry.java
+++ b/src/main/java/appeng/core/features/registries/cell/CellRegistry.java
@@ -29,6 +29,7 @@ import appeng.api.storage.ICellRegistry;
 import appeng.api.storage.IMEInventoryHandler;
 import appeng.api.storage.ISaveProvider;
 import appeng.api.storage.IStorageChannel;
+import appeng.api.storage.data.IAEStack;
 
 
 public class CellRegistry implements ICellRegistry
@@ -85,7 +86,7 @@ public class CellRegistry implements ICellRegistry
 	}
 
 	@Override
-	public IMEInventoryHandler getCellInventory( final ItemStack is, final ISaveProvider container, final IStorageChannel chan )
+	public <T extends IAEStack<T>> IMEInventoryHandler<T> getCellInventory( final ItemStack is, final ISaveProvider container, final IStorageChannel<T> chan )
 	{
 		if( is.isEmpty() )
 		{

--- a/src/main/java/appeng/parts/automation/PartFormationPlane.java
+++ b/src/main/java/appeng/parts/automation/PartFormationPlane.java
@@ -20,6 +20,7 @@ package appeng.parts.automation;
 
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import net.minecraft.entity.Entity;
@@ -400,11 +401,11 @@ public class PartFormationPlane extends PartUpgradeable implements ICellContaine
 	{
 		if( this.getProxy().isActive() && channel == AEApi.instance().storage().getStorageChannel( IItemStorageChannel.class ) )
 		{
-			final List<IMEInventoryHandler> Handler = new ArrayList<>( 1 );
-			Handler.add( this.myHandler );
-			return Handler;
+			final List<IMEInventoryHandler> handler = new ArrayList<>( 1 );
+			handler.add( this.myHandler );
+			return handler;
 		}
-		return new ArrayList<>();
+		return Collections.emptyList();
 	}
 
 	@Override

--- a/src/main/java/appeng/parts/misc/PartStorageBus.java
+++ b/src/main/java/appeng/parts/misc/PartStorageBus.java
@@ -577,7 +577,7 @@ public class PartStorageBus extends PartUpgradeable implements IGridTickable, IC
 				return Collections.singletonList( out );
 			}
 		}
-		return Arrays.asList( new IMEInventoryHandler[] {} );
+		return Collections.emptyList();
 	}
 
 	@Override

--- a/src/main/java/appeng/tile/storage/TileChest.java
+++ b/src/main/java/appeng/tile/storage/TileChest.java
@@ -643,14 +643,19 @@ public class TileChest extends AENetworkPowerTile implements IMEChest, ITerminal
 		{
 			try
 			{
-				return Collections.singletonList( this.getHandler( channel ) );
+				final IMEInventoryHandler handler = this.getHandler( channel );
+
+				if( handler != null )
+				{
+					return Collections.singletonList( handler );
+				}
 			}
 			catch( final ChestNoHandler e )
 			{
 				// :P
 			}
 		}
-		return new ArrayList<>();
+		return Collections.emptyList();
 	}
 
 	@Override


### PR DESCRIPTION
Updated Drives to support more than Item and Fluid cells.
Use Collections.emptyList() instead of creating empty ArrayLists.
Fixes a NPE with uninitialized ME Chests.

Fixes #3150