### PR TITLE
Set base biome to "void" to shut up warning.

### DIFF
--- a/src/main/java/appeng/spatial/BiomeGenStorage.java
+++ b/src/main/java/appeng/spatial/BiomeGenStorage.java
@@ -27,7 +27,7 @@ public class BiomeGenStorage extends Biome
 
 	public BiomeGenStorage()
 	{
-		super( new BiomeProperties( "Storage Cell" ).setRainDisabled().setTemperature( -100 ) );
+		super( new BiomeProperties( "Storage Cell" ).setBaseBiome( "void" ).setRainDisabled().setTemperature( -100 ) );
 
 		this.decorator.treesPerChunk = 0;
 		this.decorator.flowersPerChunk = 0;


### PR DESCRIPTION
Fixes #3118 