### PR TITLE
Backport dupe fix.

### DIFF
--- a/src/main/java/appeng/parts/misc/ItemHandlerAdapter.java
+++ b/src/main/java/appeng/parts/misc/ItemHandlerAdapter.java
@@ -136,10 +136,12 @@ class ItemHandlerAdapter implements IMEInventory<IAEItemStack>, IBaseMonitor<IAE
 						extracted.stackSize = remainingCurrentSlot;
 					}
 
-					// We're just gonna use the first stack we get our hands on as the template for the rest
+					// We're just gonna use the first stack we get our hands on as the template for the rest.
+					// In case some stupid itemhandler (aka forge) returns an internal state we have to do a second
+					// expensive copy again.
 					if( gathered == null )
 					{
-						gathered = extracted;
+						gathered = extracted.copy();
 					}
 					else
 					{


### PR DESCRIPTION
fixes #2813

Forge returns reference to internal itemstack on simulate. Always make a copy to be safe.