### PR TITLE
Rework ContainerInscriber validation

### DIFF
--- a/src/main/java/appeng/container/implementations/ContainerInscriber.java
+++ b/src/main/java/appeng/container/implementations/ContainerInscriber.java
@@ -120,15 +120,13 @@ public class ContainerInscriber extends ContainerUpgradeable implements IProgres
 
 		if( s == this.middle )
 		{
-			boolean matches = false;
-			boolean found = false;
-
 			IItemDefinition press = AEApi.instance().definitions().materials().namePress();
 			if( press.isSameAs( top ) || press.isSameAs( bot ) )
 			{
 				return !press.isSameAs( is );
 			}
 
+			boolean matches = false;
 			for( final IInscriberRecipe recipe : AEApi.instance().registries().inscriber().getRecipes() )
 			{
 				final boolean matchA = !top
@@ -147,21 +145,19 @@ public class ContainerInscriber extends ContainerUpgradeable implements IProgres
 					{
 						if( Platform.itemComparisons().isSameItem( is, option ) )
 						{
-							found = true;
+							return true;
 						}
 					}
 				}
 			}
-
-			if( matches && !found )
+			if( matches )
 			{
 				return false;
 			}
 		}
-
-		if( ( s == this.top && !bot.isEmpty() ) || ( s == this.bottom && !top.isEmpty() ) )
+		else if( ( s == this.top && !bot.isEmpty() ) || ( s == this.bottom && !top.isEmpty() ) )
 		{
-			ItemStack otherSlot = ItemStack.EMPTY;
+			ItemStack otherSlot;
 			if( s == this.top )
 			{
 				otherSlot = this.bottom.getStack();
@@ -179,9 +175,9 @@ public class ContainerInscriber extends ContainerUpgradeable implements IProgres
 			}
 
 			// everything else
-			boolean isValid = false;
 			for( final IInscriberRecipe recipe : AEApi.instance().registries().inscriber().getRecipes() )
 			{
+				boolean isValid = false;
 				if( Platform.itemComparisons().isSameItem( otherSlot, recipe.getTopOptional().orElse( ItemStack.EMPTY ) ) )
 				{
 					isValid = Platform.itemComparisons().isSameItem( is, recipe.getBottomOptional().orElse( ItemStack.EMPTY ) );
@@ -193,14 +189,10 @@ public class ContainerInscriber extends ContainerUpgradeable implements IProgres
 
 				if( isValid )
 				{
-					break;
+					return true;
 				}
 			}
-
-			if( !isValid )
-			{
-				return false;
-			}
+			return false;
 		}
 
 		return true;

--- a/src/main/java/appeng/container/implementations/ContainerInscriber.java
+++ b/src/main/java/appeng/container/implementations/ContainerInscriber.java
@@ -132,20 +132,20 @@ public class ContainerInscriber extends ContainerUpgradeable implements IProgres
 			for( final IInscriberRecipe recipe : AEApi.instance().registries().inscriber().getRecipes() )
 			{
 				final boolean matchA = !top
-						.isEmpty() && ( Platform.itemComparisons().matchesItem( top, recipe.getTopOptional().orElse( ItemStack.EMPTY ) ) || Platform
+						.isEmpty() && ( Platform.itemComparisons().isSameItem( top, recipe.getTopOptional().orElse( ItemStack.EMPTY ) ) || Platform
 								.itemComparisons()
-								.matchesItem( top, recipe.getBottomOptional().orElse( ItemStack.EMPTY ) ) );
+								.isSameItem( top, recipe.getBottomOptional().orElse( ItemStack.EMPTY ) ) );
 				final boolean matchB = !bot
-						.isEmpty() && ( Platform.itemComparisons().matchesItem( bot, recipe.getTopOptional().orElse( ItemStack.EMPTY ) ) || Platform
+						.isEmpty() && ( Platform.itemComparisons().isSameItem( bot, recipe.getTopOptional().orElse( ItemStack.EMPTY ) ) || Platform
 								.itemComparisons()
-								.matchesItem( bot, recipe.getBottomOptional().orElse( ItemStack.EMPTY ) ) );
+								.isSameItem( bot, recipe.getBottomOptional().orElse( ItemStack.EMPTY ) ) );
 
 				if( matchA || matchB )
 				{
 					matches = true;
 					for( final ItemStack option : recipe.getInputs() )
 					{
-						if( Platform.itemComparisons().matchesItem( is, option ) )
+						if( Platform.itemComparisons().isSameItem( is, option ) )
 						{
 							found = true;
 						}
@@ -182,13 +182,13 @@ public class ContainerInscriber extends ContainerUpgradeable implements IProgres
 			boolean isValid = false;
 			for( final IInscriberRecipe recipe : AEApi.instance().registries().inscriber().getRecipes() )
 			{
-				if( Platform.itemComparisons().matchesItem( otherSlot, recipe.getTopOptional().orElse( ItemStack.EMPTY ) ) )
+				if( Platform.itemComparisons().isSameItem( otherSlot, recipe.getTopOptional().orElse( ItemStack.EMPTY ) ) )
 				{
-					isValid = Platform.itemComparisons().matchesItem( is, recipe.getBottomOptional().orElse( ItemStack.EMPTY ) );
+					isValid = Platform.itemComparisons().isSameItem( is, recipe.getBottomOptional().orElse( ItemStack.EMPTY ) );
 				}
-				else if( Platform.itemComparisons().matchesItem( otherSlot, recipe.getBottomOptional().orElse( ItemStack.EMPTY ) ) )
+				else if( Platform.itemComparisons().isSameItem( otherSlot, recipe.getBottomOptional().orElse( ItemStack.EMPTY ) ) )
 				{
-					isValid = Platform.itemComparisons().matchesItem( is, recipe.getTopOptional().orElse( ItemStack.EMPTY ) );
+					isValid = Platform.itemComparisons().isSameItem( is, recipe.getTopOptional().orElse( ItemStack.EMPTY ) );
 				}
 
 				if( isValid )

--- a/src/main/java/appeng/container/implementations/ContainerInscriber.java
+++ b/src/main/java/appeng/container/implementations/ContainerInscriber.java
@@ -120,35 +120,32 @@ public class ContainerInscriber extends ContainerUpgradeable implements IProgres
 
 		if( s == this.middle )
 		{
-			for( final ItemStack optional : AEApi.instance().registries().inscriber().getOptionals() )
-			{
-				if( Platform.itemComparisons().isSameItem( optional, is ) )
-				{
-					return false;
-				}
-			}
-
 			boolean matches = false;
 			boolean found = false;
 
+			IItemDefinition press = AEApi.instance().definitions().materials().namePress();
+			if( press.isSameAs( top ) || press.isSameAs( bot ) )
+			{
+				return !press.isSameAs( is );
+			}
+
 			for( final IInscriberRecipe recipe : AEApi.instance().registries().inscriber().getRecipes() )
 			{
-				final boolean matchA = ( top.isEmpty() && !recipe.getTopOptional().isPresent() ) || ( Platform.itemComparisons().isSameItem( top,
-						recipe.getTopOptional().orElse( ItemStack.EMPTY ) ) ) && // and...
-						( ( bot.isEmpty() && !recipe.getBottomOptional().isPresent() ) || ( Platform.itemComparisons().isSameItem( bot,
-								recipe.getBottomOptional().orElse( ItemStack.EMPTY ) ) ) );
-
-				final boolean matchB = ( bot.isEmpty() && !recipe.getTopOptional().isPresent() ) || ( Platform.itemComparisons().isSameItem( bot,
-						recipe.getTopOptional().orElse( ItemStack.EMPTY ) ) ) && // and...
-						( ( top.isEmpty() && !recipe.getBottomOptional().isPresent() ) || ( Platform.itemComparisons().isSameItem( top,
-								recipe.getBottomOptional().orElse( ItemStack.EMPTY ) ) ) );
+				final boolean matchA = !top
+						.isEmpty() && ( Platform.itemComparisons().matchesItem( top, recipe.getTopOptional().orElse( ItemStack.EMPTY ) ) || Platform
+								.itemComparisons()
+								.matchesItem( top, recipe.getBottomOptional().orElse( ItemStack.EMPTY ) ) );
+				final boolean matchB = !bot
+						.isEmpty() && ( Platform.itemComparisons().matchesItem( bot, recipe.getTopOptional().orElse( ItemStack.EMPTY ) ) || Platform
+								.itemComparisons()
+								.matchesItem( bot, recipe.getBottomOptional().orElse( ItemStack.EMPTY ) ) );
 
 				if( matchA || matchB )
 				{
 					matches = true;
 					for( final ItemStack option : recipe.getInputs() )
 					{
-						if( Platform.itemComparisons().isSameItem( is, option ) )
+						if( Platform.itemComparisons().matchesItem( is, option ) )
 						{
 							found = true;
 						}
@@ -185,13 +182,13 @@ public class ContainerInscriber extends ContainerUpgradeable implements IProgres
 			boolean isValid = false;
 			for( final IInscriberRecipe recipe : AEApi.instance().registries().inscriber().getRecipes() )
 			{
-				if( Platform.itemComparisons().isSameItem( recipe.getTopOptional().orElse( ItemStack.EMPTY ), otherSlot ) )
+				if( Platform.itemComparisons().matchesItem( otherSlot, recipe.getTopOptional().orElse( ItemStack.EMPTY ) ) )
 				{
-					isValid = Platform.itemComparisons().isSameItem( is, recipe.getBottomOptional().orElse( ItemStack.EMPTY ) );
+					isValid = Platform.itemComparisons().matchesItem( is, recipe.getBottomOptional().orElse( ItemStack.EMPTY ) );
 				}
-				else if( Platform.itemComparisons().isSameItem( recipe.getBottomOptional().orElse( ItemStack.EMPTY ), otherSlot ) )
+				else if( Platform.itemComparisons().matchesItem( otherSlot, recipe.getBottomOptional().orElse( ItemStack.EMPTY ) ) )
 				{
-					isValid = Platform.itemComparisons().isSameItem( is, recipe.getTopOptional().orElse( ItemStack.EMPTY ) );
+					isValid = Platform.itemComparisons().matchesItem( is, recipe.getTopOptional().orElse( ItemStack.EMPTY ) );
 				}
 
 				if( isValid )

--- a/src/main/java/appeng/container/slot/SlotRestrictedInput.java
+++ b/src/main/java/appeng/container/slot/SlotRestrictedInput.java
@@ -172,7 +172,7 @@ public class SlotRestrictedInput extends AppEngSlot
 
 				for( final ItemStack optional : AEApi.instance().registries().inscriber().getOptionals() )
 				{
-					if( Platform.itemComparisons().matchesItem( i, optional ) )
+					if( Platform.itemComparisons().isSameItem( i, optional ) )
 					{
 						return true;
 					}

--- a/src/main/java/appeng/container/slot/SlotRestrictedInput.java
+++ b/src/main/java/appeng/container/slot/SlotRestrictedInput.java
@@ -172,7 +172,7 @@ public class SlotRestrictedInput extends AppEngSlot
 
 				for( final ItemStack optional : AEApi.instance().registries().inscriber().getOptionals() )
 				{
-					if( Platform.itemComparisons().isSameItem( optional, i ) )
+					if( Platform.itemComparisons().matchesItem( i, optional ) )
 					{
 						return true;
 					}

--- a/src/main/java/appeng/tile/misc/TileInscriber.java
+++ b/src/main/java/appeng/tile/misc/TileInscriber.java
@@ -285,7 +285,7 @@ public class TileInscriber extends AENetworkPowerTile implements IGridTickable, 
 	}
 
 	@Nullable
-	public IInscriberRecipe getTask( final ItemStack input, final ItemStack plateA, final ItemStack plateB )
+	private IInscriberRecipe getTask( final ItemStack input, final ItemStack plateA, final ItemStack plateB )
 	{
 		ItemStack renamedItem = input;
 

--- a/src/main/java/appeng/tile/misc/TileInscriber.java
+++ b/src/main/java/appeng/tile/misc/TileInscriber.java
@@ -383,7 +383,7 @@ public class TileInscriber extends AENetworkPowerTile implements IGridTickable, 
 			{
 				for( final ItemStack option : recipe.getInputs() )
 				{
-					if( Platform.itemComparisons().isSameItem( this.sideItemHandler.getStackInSlot( 0 ), option ) )
+					if( Platform.itemComparisons().isSameItem( input, option ) )
 					{
 						return recipe;
 					}

--- a/src/main/java/appeng/tile/misc/TileInscriber.java
+++ b/src/main/java/appeng/tile/misc/TileInscriber.java
@@ -369,21 +369,21 @@ public class TileInscriber extends AENetworkPowerTile implements IGridTickable, 
 		for( final IInscriberRecipe recipe : AEApi.instance().registries().inscriber().getRecipes() )
 		{
 
-			final boolean matchA = ( plateA.isEmpty() && !recipe.getTopOptional().isPresent() ) || ( Platform.itemComparisons().matchesItem( plateA,
+			final boolean matchA = ( plateA.isEmpty() && !recipe.getTopOptional().isPresent() ) || ( Platform.itemComparisons().isSameItem( plateA,
 					recipe.getTopOptional().orElse( ItemStack.EMPTY ) ) ) && // and...
-					( ( plateB.isEmpty() && !recipe.getBottomOptional().isPresent() ) || ( Platform.itemComparisons().matchesItem( plateB,
+					( ( plateB.isEmpty() && !recipe.getBottomOptional().isPresent() ) || ( Platform.itemComparisons().isSameItem( plateB,
 							recipe.getBottomOptional().orElse( ItemStack.EMPTY ) ) ) );
 
-			final boolean matchB = ( plateB.isEmpty() && !recipe.getTopOptional().isPresent() ) || ( Platform.itemComparisons().matchesItem( plateB,
+			final boolean matchB = ( plateB.isEmpty() && !recipe.getTopOptional().isPresent() ) || ( Platform.itemComparisons().isSameItem( plateB,
 					recipe.getTopOptional().orElse( ItemStack.EMPTY ) ) ) && // and...
-					( ( plateA.isEmpty() && !recipe.getBottomOptional().isPresent() ) || ( Platform.itemComparisons().matchesItem( plateA,
+					( ( plateA.isEmpty() && !recipe.getBottomOptional().isPresent() ) || ( Platform.itemComparisons().isSameItem( plateA,
 							recipe.getBottomOptional().orElse( ItemStack.EMPTY ) ) ) );
 
 			if( matchA || matchB )
 			{
 				for( final ItemStack option : recipe.getInputs() )
 				{
-					if( Platform.itemComparisons().matchesItem( this.sideItemHandler.getStackInSlot( 0 ), option ) )
+					if( Platform.itemComparisons().isSameItem( this.sideItemHandler.getStackInSlot( 0 ), option ) )
 					{
 						return recipe;
 					}
@@ -610,7 +610,7 @@ public class TileInscriber extends AENetworkPowerTile implements IGridTickable, 
 				}
 				for( final ItemStack optionals : AEApi.instance().registries().inscriber().getOptionals() )
 				{
-					if( Platform.itemComparisons().matchesItem( stack, optionals ) )
+					if( Platform.itemComparisons().isSameItem( stack, optionals ) )
 					{
 						return true;
 					}

--- a/src/main/java/appeng/tile/misc/TileInscriber.java
+++ b/src/main/java/appeng/tile/misc/TileInscriber.java
@@ -281,9 +281,13 @@ public class TileInscriber extends AENetworkPowerTile implements IGridTickable, 
 	@Nullable
 	public IInscriberRecipe getTask()
 	{
-		final ItemStack plateA = this.topItemHandler.getStackInSlot( 0 );
-		final ItemStack plateB = this.bottomItemHandler.getStackInSlot( 0 );
-		ItemStack renamedItem = this.sideItemHandler.getStackInSlot( 0 );
+		return getTask( this.sideItemHandler.getStackInSlot( 0 ), this.topItemHandler.getStackInSlot( 0 ), this.bottomItemHandler.getStackInSlot( 0 ) );
+	}
+
+	@Nullable
+	public IInscriberRecipe getTask( final ItemStack input, final ItemStack plateA, final ItemStack plateB )
+	{
+		ItemStack renamedItem = input;
 
 		if( !plateA.isEmpty() && plateA.getCount() > 1 )
 		{
@@ -365,21 +369,21 @@ public class TileInscriber extends AENetworkPowerTile implements IGridTickable, 
 		for( final IInscriberRecipe recipe : AEApi.instance().registries().inscriber().getRecipes() )
 		{
 
-			final boolean matchA = ( plateA.isEmpty() && !recipe.getTopOptional().isPresent() ) || ( Platform.itemComparisons().isSameItem( plateA,
+			final boolean matchA = ( plateA.isEmpty() && !recipe.getTopOptional().isPresent() ) || ( Platform.itemComparisons().matchesItem( plateA,
 					recipe.getTopOptional().orElse( ItemStack.EMPTY ) ) ) && // and...
-					( ( plateB.isEmpty() && !recipe.getBottomOptional().isPresent() ) || ( Platform.itemComparisons().isSameItem( plateB,
+					( ( plateB.isEmpty() && !recipe.getBottomOptional().isPresent() ) || ( Platform.itemComparisons().matchesItem( plateB,
 							recipe.getBottomOptional().orElse( ItemStack.EMPTY ) ) ) );
 
-			final boolean matchB = ( plateB.isEmpty() && !recipe.getTopOptional().isPresent() ) || ( Platform.itemComparisons().isSameItem( plateB,
+			final boolean matchB = ( plateB.isEmpty() && !recipe.getTopOptional().isPresent() ) || ( Platform.itemComparisons().matchesItem( plateB,
 					recipe.getTopOptional().orElse( ItemStack.EMPTY ) ) ) && // and...
-					( ( plateA.isEmpty() && !recipe.getBottomOptional().isPresent() ) || ( Platform.itemComparisons().isSameItem( plateA,
+					( ( plateA.isEmpty() && !recipe.getBottomOptional().isPresent() ) || ( Platform.itemComparisons().matchesItem( plateA,
 							recipe.getBottomOptional().orElse( ItemStack.EMPTY ) ) ) );
 
 			if( matchA || matchB )
 			{
 				for( final ItemStack option : recipe.getInputs() )
 				{
-					if( Platform.itemComparisons().isSameItem( option, this.sideItemHandler.getStackInSlot( 0 ) ) )
+					if( Platform.itemComparisons().matchesItem( this.sideItemHandler.getStackInSlot( 0 ), option ) )
 					{
 						return recipe;
 					}
@@ -606,7 +610,7 @@ public class TileInscriber extends AENetworkPowerTile implements IGridTickable, 
 				}
 				for( final ItemStack optionals : AEApi.instance().registries().inscriber().getOptionals() )
 				{
-					if( Platform.itemComparisons().isSameItem( optionals, stack ) )
+					if( Platform.itemComparisons().matchesItem( stack, optionals ) )
 					{
 						return true;
 					}

--- a/src/main/java/appeng/util/helpers/ItemComparisonHelper.java
+++ b/src/main/java/appeng/util/helpers/ItemComparisonHelper.java
@@ -76,26 +76,6 @@ public class ItemComparisonHelper
 	}
 
 	/**
-	 * Like {@link ItemComparisonHelper#isSameItem(ItemStack, ItemStack)} but allows the filter with wildcard metadata
-	 *
-	 * @return true, if is can be used for filter.
-	 */
-	public boolean matchesItem( @Nonnull final ItemStack is, @Nonnull final ItemStack filter )
-	{
-		if( !this.isNbtTagEqual( is.getTagCompound(), filter.getTagCompound() ) )
-		{
-			return false;
-		}
-
-		if( is.getItem() != filter.getItem() )
-		{
-			return false;
-		}
-
-		return filter.getMetadata() == OreDictionary.WILDCARD_VALUE || filter.getMetadata() == is.getMetadata();
-	}
-
-	/**
 	 * Similar to {@link ItemComparisonHelper#isEqualItem(ItemStack, ItemStack)},
 	 * but it can further check, if both match the same {@link FuzzyMode}
 	 * or are considered equal by the {@link OreDictionary}

--- a/src/main/java/appeng/util/helpers/ItemComparisonHelper.java
+++ b/src/main/java/appeng/util/helpers/ItemComparisonHelper.java
@@ -76,6 +76,26 @@ public class ItemComparisonHelper
 	}
 
 	/**
+	 * Like {@link ItemComparisonHelper#isSameItem(ItemStack, ItemStack)} but allows the filter with wildcard metadata
+	 *
+	 * @return true, if is can be used for filter.
+	 */
+	public boolean matchesItem( @Nonnull final ItemStack is, @Nonnull final ItemStack filter )
+	{
+		if( !this.isNbtTagEqual( is.getTagCompound(), filter.getTagCompound() ) )
+		{
+			return false;
+		}
+
+		if( is.getItem() != filter.getItem() )
+		{
+			return false;
+		}
+
+		return filter.getMetadata() == OreDictionary.WILDCARD_VALUE || filter.getMetadata() == is.getMetadata();
+	}
+
+	/**
 	 * Similar to {@link ItemComparisonHelper#isEqualItem(ItemStack, ItemStack)},
 	 * but it can further check, if both match the same {@link FuzzyMode}
 	 * or are considered equal by the {@link OreDictionary}


### PR DESCRIPTION
Old validation wouln't allow an item as input if it is used as an optional in any other inscriber recipe. While not an big issue with our own recipes it's weird behavior if we want to allow custom recipes.