### PR TITLE
Updated to latest Forge RB.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ aebasename=appliedenergistics2
 #########################################################
 minecraft_version=1.12.2
 mcp_mappings=snapshot_20171003
-forge_version=14.23.0.2491
+forge_version=14.23.1.2554
 
 #########################################################
 # Installable                                           #


### PR DESCRIPTION
While this is not ideal for a stable release, switching to the latest RB
of Forge avoids the broken recipes in previous versions.