### PR TITLE
Fixes #3255: Cache invalid patterns instead computing them every frame.

### DIFF
--- a/src/main/java/appeng/items/misc/ItemEncodedPattern.java
+++ b/src/main/java/appeng/items/misc/ItemEncodedPattern.java
@@ -211,6 +211,7 @@ public class ItemEncodedPattern extends AEBaseItem implements ICraftingPatternIt
 	public ItemStack getOutput( final ItemStack item )
 	{
 		ItemStack out = SIMPLE_CACHE.get( item );
+
 		if( out != null )
 		{
 			return out;
@@ -224,12 +225,9 @@ public class ItemEncodedPattern extends AEBaseItem implements ICraftingPatternIt
 
 		final ICraftingPatternDetails details = this.getPatternForItem( item, w );
 
-		if( details == null )
-		{
-			return ItemStack.EMPTY;
-		}
+		out = details != null ? details.getOutputs()[0].createItemStack() : ItemStack.EMPTY;
 
-		SIMPLE_CACHE.put( item, out = details.getCondensedOutputs()[0].createItemStack() );
+		SIMPLE_CACHE.put( item, out );
 		return out;
 	}
 }


### PR DESCRIPTION
Also includes a small change to always use the first (top) output slot as icon and not a random condensed one.