### PR TITLE
Fixes #3217: Allow caps to be used as P2P attunements.

### DIFF
--- a/src/api/java/appeng/api/features/IP2PTunnelRegistry.java
+++ b/src/api/java/appeng/api/features/IP2PTunnelRegistry.java
@@ -28,6 +28,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.common.capabilities.Capability;
 
 import appeng.api.config.TunnelType;
 
@@ -47,6 +48,7 @@ public interface IP2PTunnelRegistry
 	 */
 	void addNewAttunement( @Nonnull ItemStack trigger, @Nullable TunnelType type );
 	void addNewAttunement( @Nonnull String ModId, @Nullable TunnelType type );
+	void addNewAttunement( @Nonnull Capability<?> cap, @Nullable TunnelType type );
 
 	/**
 	 * returns null if no attunement can be found.


### PR DESCRIPTION
Adds a more abstract approach to map a cap to a certain type instead of
the hardcoded ForgeEnergy case.
Reorders the check from exact ItemStack > ModId > ForgeEnergy to
ItemStack > Cap > ModId. Thus the mod wildcard will be used last.
Support for ForgeEnergy and FluidHandlerItems by default.
Result for items supporting multiple capabilities is not defined.

---
API change is backwards compatible as it is only intended to be called, never implemented.