### PR TITLE
Fixes CraftTweaker deploying incomplete releases.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,6 +24,7 @@ tesla_version=1.0.61
 ic2_version=2.8.19-ex112
 top_version=1.12-1.4.18-10
 cofhcore_version=1.12-4.+
+crafttweaker_version=4.0.10.310
 
 #########################################################
 # Deployment                                            #

--- a/gradle/scripts/dependencies.gradle
+++ b/gradle/scripts/dependencies.gradle
@@ -82,7 +82,7 @@ dependencies {
     compileOnly "net.industrial-craft:industrialcraft-2:${ic2_version}:api"
     compileOnly "mcjty.theoneprobe:TheOneProbe-1.12:${top_version}:api"
     compileOnly "cofh:CoFHCore:${cofhcore_version}:deobf"
-    compileOnly "CraftTweaker2:CraftTweaker2-API:4.+"
+    compileOnly "CraftTweaker2:CraftTweaker2-API:${crafttweaker_version}"
 
     // at runtime, use the full JEI jar
     runtime "mezz.jei:jei_${minecraft_version}:${jei_version}"


### PR DESCRIPTION
Due to CraftTweaker not deploying necessary dependencies, we cannot
rely on building against the most recent compatible version. Instead we
have to build against a specific known release to avoid it but have to
risk incompatibilities should there be changes on later versions.