### PR TITLE
Fixes #3296: Prevent invalid TileEntites from updating their block.

### DIFF
--- a/src/main/java/appeng/tile/crafting/TileCraftingStorageTile.java
+++ b/src/main/java/appeng/tile/crafting/TileCraftingStorageTile.java
@@ -74,7 +74,7 @@ public class TileCraftingStorageTile extends TileCraftingTile
 	@Override
 	public int getStorageBytes()
 	{
-		if( this.world == null || this.notLoaded() )
+		if( this.world == null || this.notLoaded() || this.isInvalid() )
 		{
 			return 0;
 		}

--- a/src/main/java/appeng/tile/crafting/TileCraftingTile.java
+++ b/src/main/java/appeng/tile/crafting/TileCraftingTile.java
@@ -143,7 +143,7 @@ public class TileCraftingTile extends AENetworkTile implements IAEMultiBlock, IP
 
 	public void updateMeta( final boolean updateFormed )
 	{
-		if( this.world == null || this.notLoaded() )
+		if( this.world == null || this.notLoaded() || this.isInvalid() )
 		{
 			return;
 		}

--- a/src/main/java/appeng/tile/networking/TileEnergyCell.java
+++ b/src/main/java/appeng/tile/networking/TileEnergyCell.java
@@ -84,7 +84,7 @@ public class TileEnergyCell extends AENetworkTile implements IAEPowerStorage
 
 	private void changePowerLevel()
 	{
-		if( this.notLoaded() )
+		if( this.notLoaded() || this.isInvalid() )
 		{
 			return;
 		}


### PR DESCRIPTION
Updating the blockstate of invalid TEs will cause Forge to restore the
block including the TE leading to invalid TEs sticking around after
being moved.