### PR TITLE
Reworked cable connections

### DIFF
--- a/src/api/java/appeng/api/util/AECableSize.java
+++ b/src/api/java/appeng/api/util/AECableSize.java
@@ -1,0 +1,43 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2013 AlgorithmX2
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.util;
+
+
+public enum AECableSize
+{
+	NONE,
+	THIN,
+	NORMAL,
+	DENSE;
+
+	public static AECableSize min( AECableSize a, AECableSize b )
+	{
+		return a.compareTo( b ) < 0 ? a : b;
+	}
+
+	public static AECableSize max( AECableSize a, AECableSize b )
+	{
+		return a.compareTo( b ) > 0 ? a : b;
+	}
+}

--- a/src/api/java/appeng/api/util/AECableSize.java
+++ b/src/api/java/appeng/api/util/AECableSize.java
@@ -27,7 +27,6 @@ package appeng.api.util;
 public enum AECableSize
 {
 	NONE,
-	THIN,
 	NORMAL,
 	DENSE;
 

--- a/src/api/java/appeng/api/util/AECableType.java
+++ b/src/api/java/appeng/api/util/AECableType.java
@@ -34,7 +34,7 @@ public enum AECableType
 	/**
 	 * Connections to this block should render as glass.
 	 */
-	GLASS( AECableVariant.GLASS, AECableSize.THIN ),
+	GLASS( AECableVariant.GLASS, AECableSize.NORMAL ),
 
 	/**
 	 * Connections to this block should render as covered.
@@ -121,7 +121,7 @@ public enum AECableType
 			case GLASS:
 				switch( size )
 				{
-					case THIN:
+					case NORMAL:
 						return GLASS;
 					default:
 						break;

--- a/src/api/java/appeng/api/util/AECableType.java
+++ b/src/api/java/appeng/api/util/AECableType.java
@@ -29,32 +29,32 @@ public enum AECableType
 	/**
 	 * No Cable present.
 	 */
-	NONE,
+	NONE( AECableVariant.NONE, AECableSize.NONE ),
 
 	/**
 	 * Connections to this block should render as glass.
 	 */
-	GLASS,
+	GLASS( AECableVariant.GLASS, AECableSize.THIN ),
 
 	/**
 	 * Connections to this block should render as covered.
 	 */
-	COVERED,
+	COVERED( AECableVariant.COVERED, AECableSize.NORMAL ),
 
 	/**
 	 * Connections to this block should render as smart.
 	 */
-	SMART,
+	SMART( AECableVariant.SMART, AECableSize.NORMAL ),
 
 	/**
 	 * Smart Dense Cable, represents a tier 2 block that can carry 32 channels.
 	 */
-	DENSE_COVERED,
+	DENSE_COVERED( AECableVariant.COVERED, AECableSize.DENSE ),
 
 	/**
 	 * Smart Dense Cable, represents a tier 2 block that can carry 32 channels.
 	 */
-	DENSE_SMART;
+	DENSE_SMART( AECableVariant.SMART, AECableSize.DENSE );
 
 	public static final AECableType[] VALIDCABLES = {
 			GLASS,
@@ -64,4 +64,97 @@ public enum AECableType
 			DENSE_SMART
 	};
 
+	private final AECableVariant variant;
+	private final AECableSize size;
+
+	private AECableType( AECableVariant variant, AECableSize size )
+	{
+		this.variant = variant;
+		this.size = size;
+	}
+
+	public AECableSize size()
+	{
+		return size;
+	}
+
+	public AECableVariant variant()
+	{
+		return variant;
+	}
+
+	public boolean isValid()
+	{
+		return this.variant != AECableVariant.NONE && this.size != AECableSize.NONE;
+	}
+
+	public boolean isDense()
+	{
+		return this.size == AECableSize.DENSE;
+	}
+
+	public boolean isSmart()
+	{
+		return this.variant == AECableVariant.SMART;
+	}
+
+	public static AECableType min( AECableType a, AECableType b )
+	{
+		final AECableVariant v = AECableVariant.min( a.variant(), b.variant() );
+		final AECableSize s = AECableSize.min( a.size(), b.size() );
+
+		return AECableType.from( v, s );
+	}
+
+	public static AECableType max( AECableType a, AECableType b )
+	{
+		final AECableVariant v = AECableVariant.max( a.variant(), b.variant() );
+		final AECableSize s = AECableSize.max( a.size(), b.size() );
+
+		return AECableType.from( v, s );
+	}
+
+	private static AECableType from( AECableVariant variant, AECableSize size )
+	{
+		switch( variant )
+		{
+			case GLASS:
+				switch( size )
+				{
+					case THIN:
+						return GLASS;
+					default:
+						break;
+				}
+
+				break;
+			case COVERED:
+				switch( size )
+				{
+					case NORMAL:
+						return COVERED;
+					case DENSE:
+						return DENSE_COVERED;
+					default:
+						break;
+				}
+
+				break;
+			case SMART:
+				switch( size )
+				{
+					case NORMAL:
+						return SMART;
+					case DENSE:
+						return DENSE_SMART;
+					default:
+						break;
+				}
+				break;
+			default:
+				break;
+		}
+
+		return NONE;
+	}
 }

--- a/src/api/java/appeng/api/util/AECableVariant.java
+++ b/src/api/java/appeng/api/util/AECableVariant.java
@@ -1,0 +1,43 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2013 AlgorithmX2
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.util;
+
+
+public enum AECableVariant
+{
+	NONE,
+	GLASS,
+	COVERED,
+	SMART;
+
+	public static AECableVariant min( AECableVariant a, AECableVariant b )
+	{
+		return a.compareTo( b ) < 0 ? a : b;
+	}
+
+	public static AECableVariant max( AECableVariant a, AECableVariant b )
+	{
+		return a.compareTo( b ) > 0 ? a : b;
+	}
+}

--- a/src/main/java/appeng/client/render/cablebus/CableBuilder.java
+++ b/src/main/java/appeng/client/render/cablebus/CableBuilder.java
@@ -121,18 +121,16 @@ class CableBuilder
 	 */
 	public void addCableCore( AECableType cableType, AEColor color, List<BakedQuad> quadsOut )
 	{
-		switch( cableType )
+		switch( cableType.size() )
 		{
-			case GLASS:
+			case THIN:
 				this.addCableCore( CableCoreType.GLASS, color, quadsOut );
 				break;
-			case COVERED:
-			case SMART:
+			case NORMAL:
 				this.addCableCore( CableCoreType.COVERED, color, quadsOut );
 				break;
-			case DENSE_COVERED:
-			case DENSE_SMART:
-				this.addCableCore( CableCoreType.DENSE_SMART, color, quadsOut );
+			case DENSE:
+				this.addCableCore( CableCoreType.DENSE, color, quadsOut );
 				break;
 			default:
 		}
@@ -153,7 +151,7 @@ class CableBuilder
 			case COVERED:
 				cubeBuilder.addCube( 5, 5, 5, 11, 11, 11 );
 				break;
-			case DENSE_SMART:
+			case DENSE:
 				cubeBuilder.addCube( 3, 3, 3, 13, 13, 13 );
 				break;
 		}
@@ -329,7 +327,6 @@ class CableBuilder
 
 	public void addConstrainedCoveredConnection( EnumFacing facing, AEColor cableColor, int distanceFromEdge, List<BakedQuad> quadsOut )
 	{
-
 		// The core of a covered cable reaches up to 5 voxels from the block edge, so
 		// drawing a connection can only occur from there onwards
 		if( distanceFromEdge >= 5 )
@@ -348,6 +345,11 @@ class CableBuilder
 
 	public void addSmartConnection( EnumFacing facing, AEColor cableColor, AECableType connectionType, boolean cableBusAdjacent, int channels, List<BakedQuad> quadsOut )
 	{
+		if( connectionType == AECableType.COVERED || connectionType == AECableType.GLASS )
+		{
+			this.addCoveredConnection( facing, cableColor, connectionType, cableBusAdjacent, quadsOut );
+			return;
+		}
 
 		CubeBuilder cubeBuilder = new CubeBuilder( this.format, quadsOut );
 

--- a/src/main/java/appeng/client/render/cablebus/CableBuilder.java
+++ b/src/main/java/appeng/client/render/cablebus/CableBuilder.java
@@ -121,15 +121,17 @@ class CableBuilder
 	 */
 	public void addCableCore( AECableType cableType, AEColor color, List<BakedQuad> quadsOut )
 	{
-		switch( cableType.size() )
+		switch( cableType )
 		{
-			case THIN:
+			case GLASS:
 				this.addCableCore( CableCoreType.GLASS, color, quadsOut );
 				break;
-			case NORMAL:
+			case COVERED:
+			case SMART:
 				this.addCableCore( CableCoreType.COVERED, color, quadsOut );
 				break;
-			case DENSE:
+			case DENSE_COVERED:
+			case DENSE_SMART:
 				this.addCableCore( CableCoreType.DENSE, color, quadsOut );
 				break;
 			default:

--- a/src/main/java/appeng/client/render/cablebus/CableBusBakedModel.java
+++ b/src/main/java/appeng/client/render/cablebus/CableBusBakedModel.java
@@ -169,20 +169,7 @@ public class CableBusBakedModel implements IBakedModel
 
 		final AECableType secondType = sides.get( firstSide.getOpposite() );
 
-		// Certain cable types have restrictions on when they're rendered as a straight connection
-		switch( cableType )
-		{
-			case GLASS:
-				return firstType == AECableType.GLASS && secondType == AECableType.GLASS;
-			case DENSE_COVERED:
-				return firstType == AECableType.DENSE_COVERED && secondType == AECableType.DENSE_COVERED;
-			case DENSE_SMART:
-				return firstType == AECableType.DENSE_SMART && secondType == AECableType.DENSE_SMART;
-			default:
-				break;
-		}
-
-		return true;
+		return firstType == secondType;
 	}
 
 	private void addCableQuads( CableBusRenderState renderState, List<BakedQuad> quadsOut )

--- a/src/main/java/appeng/client/render/cablebus/CableCoreType.java
+++ b/src/main/java/appeng/client/render/cablebus/CableCoreType.java
@@ -40,7 +40,7 @@ import appeng.core.AppEng;
  */
 public enum CableCoreType
 {
-	GLASS( "parts/cable/core/glass" ), COVERED( "parts/cable/core/covered" ), DENSE_SMART( "parts/cable/core/dense_smart" );
+	GLASS( "parts/cable/core/glass" ), COVERED( "parts/cable/core/covered" ), DENSE( "parts/cable/core/dense_smart" );
 
 	private static final Map<AECableType, CableCoreType> cableMapping = generateCableMapping();
 
@@ -55,8 +55,8 @@ public enum CableCoreType
 		result.put( AECableType.GLASS, CableCoreType.GLASS );
 		result.put( AECableType.COVERED, CableCoreType.COVERED );
 		result.put( AECableType.SMART, CableCoreType.COVERED );
-		result.put( AECableType.DENSE_COVERED, CableCoreType.DENSE_SMART );
-		result.put( AECableType.DENSE_SMART, CableCoreType.DENSE_SMART );
+		result.put( AECableType.DENSE_COVERED, CableCoreType.DENSE );
+		result.put( AECableType.DENSE_SMART, CableCoreType.DENSE );
 
 		return ImmutableMap.copyOf( result );
 	}

--- a/src/main/java/appeng/parts/CableBusContainer.java
+++ b/src/main/java/appeng/parts/CableBusContainer.java
@@ -1157,9 +1157,6 @@ public class CableBusContainer extends CableBusStorage implements AEMultiTile, I
 
 		if( cable != null )
 		{
-			final boolean isSmart = cable.getCableConnectionType() == AECableType.SMART || cable.getCableConnectionType() == AECableType.DENSE_SMART;
-			final boolean isDense = cable.getCableConnectionType() == AECableType.DENSE_COVERED || cable.getCableConnectionType() == AECableType.DENSE_SMART;
-
 			renderState.setCableColor( cable.getCableColor() );
 			renderState.setCableType( cable.getCableConnectionType() );
 			renderState.setCoreType( CableCoreType.fromCableType( cable.getCableConnectionType() ) );
@@ -1184,11 +1181,10 @@ public class CableBusContainer extends CableBusStorage implements AEMultiTile, I
 
 				if( adjacentTe instanceof IGridHost )
 				{
-					if( !( adjacentTe instanceof IPartHost ) || isDense )
-					{
-						IGridHost gridHost = (IGridHost) adjacentTe;
-						connectionType = gridHost.getCableConnectionType( AEPartLocation.fromFacing( facing.getOpposite() ) );
-					}
+					final IGridHost gridHost = (IGridHost) adjacentTe;
+					final AECableType adjacentType = gridHost.getCableConnectionType( AEPartLocation.fromFacing( facing.getOpposite() ) );
+
+					connectionType = AECableType.min( connectionType, adjacentType );
 				}
 
 				// Check if the adjacent TE is a cable bus or not
@@ -1205,7 +1201,7 @@ public class CableBusContainer extends CableBusStorage implements AEMultiTile, I
 			// adjacent tile requires it
 			for( EnumFacing facing : EnumFacing.values() )
 			{
-				int channels = isSmart ? cable.getChannelsOnSide( facing ) : 0;
+				int channels = cable.getCableConnectionType().isSmart() ? cable.getChannelsOnSide( facing ) : 0;
 				renderState.getChannelsOnSide().put( facing, channels );
 			}
 		}

--- a/src/main/java/appeng/parts/networking/PartDenseCable.java
+++ b/src/main/java/appeng/parts/networking/PartDenseCable.java
@@ -136,7 +136,7 @@ public abstract class PartDenseCable extends PartCable
 		if( te instanceof IGridHost )
 		{
 			final AECableType t = ( (IGridHost) te ).getCableConnectionType( of.getOpposite() );
-			return t == AECableType.DENSE_COVERED || t == AECableType.DENSE_SMART;
+			return t.isDense();
 		}
 
 		return false;


### PR DESCRIPTION
Added enums for cable variants and sizes.
Rules for connections between a cable and another cable or grid member
are much more simpler without any exceptions for certain combinations.
1/ Connections are rendered as the lowest type between cores.
2/ Each type uses are core for clear separation between different ones.
3/ The core will always be on the cable with the higher order.

**Planned for rv6**