### PR TITLE
Updated Cell Registry safety and docs

### DIFF
--- a/src/api/java/appeng/api/storage/ICellRegistry.java
+++ b/src/api/java/appeng/api/storage/ICellRegistry.java
@@ -24,7 +24,11 @@
 package appeng.api.storage;
 
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 
 import appeng.api.IAppEngApi;
 import appeng.api.storage.data.IAEStack;
@@ -42,9 +46,12 @@ public interface ICellRegistry
 	/**
 	 * Register a new handler.
 	 *
+	 * Never be call before {@link FMLInitializationEvent} was handled by AE2.
+	 * Will throw an exception otherwise.
+	 *
 	 * @param handler cell handler
 	 */
-	void addCellHandler( ICellHandler handler );
+	void addCellHandler( @Nonnull ICellHandler handler );
 
 	/**
 	 * return true, if you can get a InventoryHandler for the item passed.
@@ -63,6 +70,7 @@ public interface ICellRegistry
 	 *
 	 * @return the handler registered for this item type.
 	 */
+	@Nullable
 	ICellHandler getHandler( ItemStack is );
 
 	/**
@@ -74,5 +82,6 @@ public interface ICellRegistry
 	 *
 	 * @return new IMEInventoryHandler, or null if there isn't one.
 	 */
+	@Nullable
 	<T extends IAEStack<T>> IMEInventoryHandler<T> getCellInventory( ItemStack is, ISaveProvider host, IStorageChannel<T> chan );
 }

--- a/src/main/java/appeng/core/features/registries/cell/BasicCellHandler.java
+++ b/src/main/java/appeng/core/features/registries/cell/BasicCellHandler.java
@@ -41,7 +41,7 @@ import appeng.me.storage.CellInventoryHandler;
 import appeng.util.Platform;
 
 
-public class BasicCellHandler implements ICellHandler
+public final class BasicCellHandler implements ICellHandler
 {
 
 	@Override

--- a/src/main/java/appeng/core/features/registries/cell/CellRegistry.java
+++ b/src/main/java/appeng/core/features/registries/cell/CellRegistry.java
@@ -22,6 +22,9 @@ package appeng.core.features.registries.cell;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
+
 import net.minecraft.item.ItemStack;
 
 import appeng.api.storage.ICellHandler;
@@ -43,12 +46,15 @@ public class CellRegistry implements ICellRegistry
 	}
 
 	@Override
-	public void addCellHandler( final ICellHandler h )
+	public void addCellHandler( final ICellHandler handler )
 	{
-		if( h != null )
-		{
-			this.handlers.add( h );
-		}
+		Preconditions.checkNotNull( handler, "Called before FMLInitializationEvent." );
+		Preconditions.checkArgument( !this.handlers.contains( handler ), "Tried to register the same handler instance twice." );
+
+		this.handlers.add( handler );
+
+		// Verify that the first entry is always our own handler.
+		Verify.verify( this.handlers.get( 0 ) instanceof BasicCellHandler );
 	}
 
 	@Override

--- a/src/main/java/appeng/core/features/registries/cell/CreativeCellHandler.java
+++ b/src/main/java/appeng/core/features/registries/cell/CreativeCellHandler.java
@@ -38,7 +38,7 @@ import appeng.me.storage.CreativeCellInventory;
 import appeng.util.Platform;
 
 
-public class CreativeCellHandler implements ICellHandler
+public final class CreativeCellHandler implements ICellHandler
 {
 
 	@Override


### PR DESCRIPTION
The Cell registry now ensures that the first handler is our own as other
addons might depend on it.
Updated docs to match the new requirements.
Made internal handler classes final.