### PR TITLE
IAEStack#fuzzyComparison now compares the same subtypes.

### DIFF
--- a/src/api/java/appeng/api/storage/data/IAEStack.java
+++ b/src/api/java/appeng/api/storage/data/IAEStack.java
@@ -149,16 +149,14 @@ public interface IAEStack<T extends IAEStack<T>>
 	boolean equals( Object obj );
 
 	/**
-	 * compare stacks using fuzzy logic
+	 * Compare the same subtype of {@link IAEStack} with another using a fuzzy comparison.
 	 *
-	 * a IAEItemStack to another AEItemStack or a ItemStack.
-	 *
-	 * @param st stacks
-	 * @param mode used fuzzy mode
+	 * @param other The stack to compare.
+	 * @param mode Which {@link FuzzyMode} should be used.
 	 *
 	 * @return true if two stacks are equal based on AE Fuzzy Comparison.
 	 */
-	boolean fuzzyComparison( Object st, FuzzyMode mode );
+	boolean fuzzyComparison( T other, FuzzyMode mode );
 
 	/**
 	 * Slower for disk saving, but smaller/more efficient for packets.
@@ -200,7 +198,7 @@ public interface IAEStack<T extends IAEStack<T>>
 
 	/**
 	 * Returns itemstack for display and similar purposes. Always has a count of 1.
-	 * 
+	 *
 	 * @return itemstack
 	 */
 	ItemStack asItemStackRepresentation();

--- a/src/main/java/appeng/util/item/AEFluidStack.java
+++ b/src/main/java/appeng/util/item/AEFluidStack.java
@@ -31,7 +31,6 @@ import io.netty.buffer.ByteBuf;
 
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompressedStreamTools;
-import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
@@ -207,7 +206,7 @@ public final class AEFluidStack extends AEStack<IAEFluidStack> implements IAEFlu
 
 		if( this.tagCompound != null )
 		{
-			i.setTag( "tag", (NBTBase) this.tagCompound );
+			i.setTag( "tag", this.tagCompound );
 		}
 		else
 		{
@@ -216,19 +215,9 @@ public final class AEFluidStack extends AEStack<IAEFluidStack> implements IAEFlu
 	}
 
 	@Override
-	public boolean fuzzyComparison( final Object st, final FuzzyMode mode )
+	public boolean fuzzyComparison( final IAEFluidStack other, final FuzzyMode mode )
 	{
-		if( st instanceof FluidStack )
-		{
-			return ( (FluidStack) st ).getFluid() == this.fluid;
-		}
-
-		if( st instanceof IAEFluidStack )
-		{
-			return ( (IAEFluidStack) st ).getFluid() == this.fluid;
-		}
-
-		return false;
+		return this.fluid == other.getFluid();
 	}
 
 	@Override
@@ -289,7 +278,7 @@ public final class AEFluidStack extends AEStack<IAEFluidStack> implements IAEFlu
 
 			if( is.getFluid() == this.fluid )
 			{
-				final NBTTagCompound ta = (NBTTagCompound) this.tagCompound;
+				final NBTTagCompound ta = this.tagCompound;
 				final NBTTagCompound tb = is.tag;
 				if( ta == tb )
 				{
@@ -347,7 +336,7 @@ public final class AEFluidStack extends AEStack<IAEFluidStack> implements IAEFlu
 	public ItemStack asItemStackRepresentation()
 	{
 		// TODO: fluids, how do they even work?
-		return FluidUtil.getFilledBucket( getFluidStack() );
+		return FluidUtil.getFilledBucket( this.getFluidStack() );
 	}
 
 	@Override
@@ -358,7 +347,7 @@ public final class AEFluidStack extends AEStack<IAEFluidStack> implements IAEFlu
 
 		i.writeByte( mask );
 
-		writeToStream( i );
+		this.writeToStream( i );
 
 		this.putPacketValue( i, this.getStackSize() );
 		this.putPacketValue( i, this.getCountRequestable() );

--- a/src/main/java/appeng/util/item/AEItemStack.java
+++ b/src/main/java/appeng/util/item/AEItemStack.java
@@ -163,37 +163,17 @@ public final class AEItemStack extends AEStack<IAEItemStack> implements IAEItemS
 	}
 
 	@Override
-	public boolean fuzzyComparison( final Object st, final FuzzyMode mode )
+	public boolean fuzzyComparison( final IAEItemStack other, final FuzzyMode mode )
 	{
-		if( st instanceof IAEItemStack )
+		if( mode == FuzzyMode.IGNORE_ALL && OreHelper.INSTANCE.sameOre( this, other ) )
 		{
-			final IAEItemStack other = (IAEItemStack) st;
-
-			if( OreHelper.INSTANCE.sameOre( this, other ) )
-			{
-				return true;
-			}
-
-			final ItemStack itemStack = this.getDefinition();
-			final ItemStack otherStack = other.getDefinition();
-
-			return this.fuzzyItemStackComparison( itemStack, otherStack, mode );
+			return true;
 		}
 
-		if( st instanceof ItemStack )
-		{
-			final ItemStack otherStack = (ItemStack) st;
+		final ItemStack itemStack = this.getDefinition();
+		final ItemStack otherStack = other.getDefinition();
 
-			if( OreHelper.INSTANCE.sameOre( this, otherStack ) )
-			{
-				return true;
-			}
-
-			final ItemStack itemStack = this.getDefinition();
-			return this.fuzzyItemStackComparison( itemStack, otherStack, mode );
-		}
-
-		return false;
+		return this.fuzzyItemStackComparison( itemStack, otherStack, mode );
 	}
 
 	@Override


### PR DESCRIPTION
To reduce the amount of instanceof checks, it will now compare the same
subtype.
Comparing an ItemStack and IAEItemStack can simply wrap it before
calling it. Heavy use should already use an IAEStack internal.
Analogue for fluids or other types.