### PR TITLE
Fixes #3389: Prevent inventory cache from becoming unmatched.

### DIFF
--- a/src/main/java/appeng/me/GridNode.java
+++ b/src/main/java/appeng/me/GridNode.java
@@ -320,7 +320,7 @@ public class GridNode implements IGridNode, IPathItem
 		{
 			final IPathingGrid pg = g.getCache( IPathingGrid.class );
 			final IEnergyGrid eg = g.getCache( IEnergyGrid.class );
-			return this.meetsChannelRequirements() && eg.isNetworkPowered() && !pg.isNetworkBooting();
+			return eg.isNetworkPowered() && !pg.isNetworkBooting() && this.meetsChannelRequirements();
 		}
 		return false;
 	}

--- a/src/main/java/appeng/me/cache/NetworkMonitor.java
+++ b/src/main/java/appeng/me/cache/NetworkMonitor.java
@@ -31,7 +31,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
+import com.google.common.collect.Queues;
 
 import appeng.api.config.AccessRestriction;
 import appeng.api.config.Actionable;
@@ -49,7 +49,7 @@ import appeng.me.storage.ItemWatcher;
 public class NetworkMonitor<T extends IAEStack<T>> implements IMEMonitor<T>
 {
 	@Nonnull
-	private static final Deque<NetworkMonitor<?>> GLOBAL_DEPTH = Lists.newLinkedList();
+	private static final Deque<NetworkMonitor<?>> GLOBAL_DEPTH = Queues.newArrayDeque();
 
 	@Nonnull
 	private final GridStorageCache myGridCache;

--- a/src/main/java/appeng/me/cache/PathGridCache.java
+++ b/src/main/java/appeng/me/cache/PathGridCache.java
@@ -402,7 +402,7 @@ public class PathGridCache implements IPathingGrid
 	@Override
 	public boolean isNetworkBooting()
 	{
-		return !this.active.isEmpty() && !this.booting;
+		return !this.booting && !this.active.isEmpty();
 	}
 
 	@Override

--- a/src/main/java/appeng/me/storage/MEMonitorIInventory.java
+++ b/src/main/java/appeng/me/storage/MEMonitorIInventory.java
@@ -19,9 +19,10 @@
 package appeng.me.storage;
 
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedList;
+import java.util.List;
 import java.util.Map.Entry;
 import java.util.NavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
@@ -144,7 +145,7 @@ public class MEMonitorIInventory implements IMEMonitor<IAEItemStack>, ITickingMo
 	public TickRateModulation onTick()
 	{
 
-		final LinkedList<IAEItemStack> changes = new LinkedList<>();
+		final List<IAEItemStack> changes = new ArrayList<>();
 
 		this.list.resetStatus();
 		int high = 0;

--- a/src/main/java/appeng/parts/misc/ItemHandlerAdapter.java
+++ b/src/main/java/appeng/parts/misc/ItemHandlerAdapter.java
@@ -284,14 +284,7 @@ class ItemHandlerAdapter implements IMEInventory<IAEItemStack>, IBaseMonitor<IAE
 				final IAEItemStack oldAeIS = this.cachedAeStacks[slot];
 				final ItemStack newIS = this.itemHandler.getStackInSlot( slot );
 
-				if( oldAeIS != null && oldAeIS.isSameType( newIS ) )
-				{
-					this.addPossibleStackSizeChange( slot, oldAeIS, newIS, changes );
-				}
-				else
-				{
-					this.addItemChange( slot, oldAeIS, newIS, changes );
-				}
+				this.handlePossibleSlotChanges( slot, oldAeIS, newIS, changes );
 			}
 
 			// Handle cases where the number of slots actually is lower now than before
@@ -316,7 +309,19 @@ class ItemHandlerAdapter implements IMEInventory<IAEItemStack>, IBaseMonitor<IAE
 			return changes;
 		}
 
-		private void addPossibleStackSizeChange( int slot, IAEItemStack oldAeIS, ItemStack newIS, List<IAEItemStack> changes )
+		private void handlePossibleSlotChanges( int slot, IAEItemStack oldAeIS, ItemStack newIS, List<IAEItemStack> changes )
+		{
+			if( oldAeIS != null && oldAeIS.isSameType( newIS ) )
+			{
+				this.handleStackSizeChanged( slot, oldAeIS, newIS, changes );
+			}
+			else
+			{
+				this.handleItemChanged( slot, oldAeIS, newIS, changes );
+			}
+		}
+
+		private void handleStackSizeChanged( int slot, IAEItemStack oldAeIS, ItemStack newIS, List<IAEItemStack> changes )
 		{
 			// Still the same item, but amount might have changed
 			final long diff = newIS.getCount() - oldAeIS.getStackSize();
@@ -334,7 +339,7 @@ class ItemHandlerAdapter implements IMEInventory<IAEItemStack>, IBaseMonitor<IAE
 			}
 		}
 
-		private void addItemChange( int slot, IAEItemStack oldAeIS, ItemStack newIS, List<IAEItemStack> changes )
+		private void handleItemChanged( int slot, IAEItemStack oldAeIS, ItemStack newIS, List<IAEItemStack> changes )
 		{
 			// Completely different item
 			this.cachedAeStacks[slot] = AEItemStack.fromItemStack( newIS );

--- a/src/main/java/appeng/util/item/AEItemStack.java
+++ b/src/main/java/appeng/util/item/AEItemStack.java
@@ -294,7 +294,7 @@ public final class AEItemStack extends AEStack<IAEItemStack> implements IAEItemS
 	@Override
 	public String toString()
 	{
-		return this.getDefinition().toString();
+		return this.getStackSize() + "x" + this.getDefinition().getItem().getUnlocalizedName() + "@" + this.getDefinition().getItemDamage();
 	}
 
 	@SideOnly( Side.CLIENT )
@@ -347,7 +347,7 @@ public final class AEItemStack extends AEStack<IAEItemStack> implements IAEItemS
 	@Override
 	public ItemStack asItemStackRepresentation()
 	{
-		return getDefinition().copy();
+		return this.getDefinition().copy();
 	}
 
 	@Override


### PR DESCRIPTION
Removed the redundant `ItemStack` array to avoid it from differ from the `IAEItemStack` as it could be influenced by external means. This could also reduce the memory consumption a bit as `IAEItemStack`s are deduplicated. But mostly limited to unstackable items with equal NBT data.

Needs some testing in case `IAEItemStack#isSameType(ItemStack)` behaves differently in regards to NBT data.