### PR TITLE
Add a config option to disable the CraftingManager fallback.

### DIFF
--- a/src/main/java/appeng/core/AEConfig.java
+++ b/src/main/java/appeng/core/AEConfig.java
@@ -213,7 +213,9 @@ public final class AEConfig extends Configuration implements IConfigurableObject
 		{
 			if( feature.isVisible() )
 			{
-				if( this.get( "Features." + feature.category(), feature.key(), feature.isEnabled() ).getBoolean( feature.isEnabled() ) )
+				final Property option = this.get( "Features." + feature.category(), feature.key(), feature.isEnabled(), feature.comment() );
+
+				if( option.getBoolean( feature.isEnabled() ) )
 				{
 					this.featureFlags.add( feature );
 				}

--- a/src/main/java/appeng/core/features/AEFeature.java
+++ b/src/main/java/appeng/core/features/AEFeature.java
@@ -155,6 +155,7 @@ public enum AEFeature
 	MOLECULAR_ASSEMBLER( "MolecularAssembler", Constants.CATEGORY_CRAFTING_FEATURES ),
 	PATTERNS( "Patterns", Constants.CATEGORY_CRAFTING_FEATURES ),
 	CRAFTING_CPU( "CraftingCPU", Constants.CATEGORY_CRAFTING_FEATURES ),
+	CRAFTING_MANAGER_FALLBACK( "CraftingManagerFallback", Constants.CATEGORY_CRAFTING_FEATURES, "Use CraftingManager to find an alternative recipe, after a pattern rejected an ingredient. Should be enabled to avoid issues, but can have a minor performance impact." ),
 
 	BASIC_CARDS( "BasicCards", Constants.CATEGORY_UPGRADES ),
 	ADVANCED_CARDS( "AdvancedCards", Constants.CATEGORY_UPGRADES ),
@@ -178,17 +179,29 @@ public enum AEFeature
 	private final String key;
 	private final String category;
 	private final boolean enabled;
+	private final String comment;
 
 	AEFeature( final String key, final String cat )
 	{
 		this( key, cat, true );
 	}
 
+	AEFeature( final String key, final String cat, final String comment )
+	{
+		this( key, cat, true, comment );
+	}
+
 	AEFeature( final String key, final String cat, final boolean enabled )
+	{
+		this( key, cat, enabled, null );
+	}
+
+	AEFeature( final String key, final String cat, final boolean enabled, final String comment )
 	{
 		this.key = key;
 		this.category = cat;
 		this.enabled = enabled;
+		this.comment = comment;
 	}
 
 	/**
@@ -214,6 +227,11 @@ public enum AEFeature
 	public boolean isEnabled()
 	{
 		return this.enabled;
+	}
+
+	public String comment()
+	{
+		return this.comment;
 	}
 
 	private enum Constants

--- a/src/main/java/appeng/helpers/PatternHelper.java
+++ b/src/main/java/appeng/helpers/PatternHelper.java
@@ -41,7 +41,9 @@ import appeng.api.networking.crafting.ICraftingPatternDetails;
 import appeng.api.storage.channels.IItemStorageChannel;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.container.ContainerNull;
+import appeng.core.AEConfig;
 import appeng.core.AELog;
+import appeng.core.features.AEFeature;
 import appeng.util.ItemSorters;
 import appeng.util.Platform;
 import appeng.util.item.AEItemStack;
@@ -267,7 +269,7 @@ public class PatternHelper implements ICraftingPatternDetails, Comparable<Patter
 				return true;
 			}
 		}
-		else
+		else if( AEConfig.instance().isFeatureEnabled( AEFeature.CRAFTING_MANAGER_FALLBACK ) )
 		{
 			final ItemStack testOutput = CraftingManager.findMatchingResult( this.testFrame, w );
 


### PR DESCRIPTION
Using the `CraftingManager` to find an alternative recipe can be a bit costly as it scales with the amount of mods/recipes.

In general this should probably be avoided at all. If a mod adds alternative recipes e.g. a unique one for every single oredict equivalent or for different NBT data, it is clearly a bad decision on their side.

Therefore it will be enabled for backwards compatibility in rv5, but disabled by default in rv6.
In case of no major issues resulting from disabling it, it is scheduled to be completely removed in 1.13.