### PR TITLE
Use @Instance for mod lifecycle.

### DIFF
--- a/src/main/java/appeng/block/misc/BlockTinyTNT.java
+++ b/src/main/java/appeng/block/misc/BlockTinyTNT.java
@@ -69,7 +69,7 @@ public class BlockTinyTNT extends AEBaseBlock implements ICustomCollision
 		this.setHardness( 0F );
 
 		EntityRegistry.registerModEntity( new ResourceLocation( AppEng.MOD_ID, EntityTinyTNTPrimed.class.getName() ), EntityTinyTNTPrimed.class,
-				"EntityTinyTNTPrimed", EntityIds.get( EntityTinyTNTPrimed.class ), AppEng.instance(), 16, 4, true );
+				"EntityTinyTNTPrimed", EntityIds.get( EntityTinyTNTPrimed.class ), AppEng.instance, 16, 4, true );
 	}
 
 	@Override

--- a/src/main/java/appeng/core/AppEng.java
+++ b/src/main/java/appeng/core/AppEng.java
@@ -23,8 +23,6 @@ import java.io.File;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import javax.annotation.Nonnull;
-
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.Lists;
 
@@ -35,6 +33,7 @@ import net.minecraftforge.common.config.Configuration;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.Mod.Instance;
 import net.minecraftforge.fml.common.SidedProxy;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLInterModComms;
@@ -92,8 +91,8 @@ public final class AppEng
 	// + net.minecraftforge.common.ForgeVersion.revisionVersion + '.' // revisionVersion
 	// + net.minecraftforge.common.ForgeVersion.buildVersion + ",)"; // buildVersion
 
-	@Nonnull
-	private static final AppEng INSTANCE = new AppEng();
+	@Instance( MOD_ID )
+	public static AppEng instance;
 
 	private final Registration registration;
 
@@ -112,19 +111,12 @@ public final class AppEng
 	 */
 	private ExportConfig exportConfig;
 
-	private AppEng()
+	public AppEng()
 	{
 		FMLCommonHandler.instance().registerCrashCallable( new ModCrashEnhancement( CrashInfo.MOD_VERSION ) );
 
 		this.registration = new Registration();
 		MinecraftForge.EVENT_BUS.register( this.registration );
-	}
-
-	@Nonnull
-	@Mod.InstanceFactory
-	public static AppEng instance()
-	{
-		return INSTANCE;
 	}
 
 	public Biome getStorageBiome()

--- a/src/main/java/appeng/debug/BlockChunkloader.java
+++ b/src/main/java/appeng/debug/BlockChunkloader.java
@@ -37,7 +37,7 @@ public class BlockChunkloader extends AEBaseTileBlock implements LoadingCallback
 	public BlockChunkloader()
 	{
 		super( Material.IRON );
-		ForgeChunkManager.setForcedChunkLoadingCallback( AppEng.instance(), this );
+		ForgeChunkManager.setForcedChunkLoadingCallback( AppEng.instance, this );
 	}
 
 	@Override

--- a/src/main/java/appeng/debug/TileChunkLoader.java
+++ b/src/main/java/appeng/debug/TileChunkLoader.java
@@ -60,7 +60,7 @@ public class TileChunkLoader extends AEBaseTile implements ITickable
 			return;
 		}
 
-		this.ct = ForgeChunkManager.requestTicket( AppEng.instance(), this.world, Type.NORMAL );
+		this.ct = ForgeChunkManager.requestTicket( AppEng.instance, this.world, Type.NORMAL );
 
 		if( this.ct == null )
 		{

--- a/src/main/java/appeng/items/materials/MaterialType.java
+++ b/src/main/java/appeng/items/materials/MaterialType.java
@@ -145,7 +145,7 @@ public enum MaterialType
 
 		EntityRegistry.registerModEntity( new ResourceLocation( "appliedenergistics2", this.droppedEntity.getName() ), this.droppedEntity,
 				this.droppedEntity.getSimpleName(),
-				EntityIds.get( this.droppedEntity ), AppEng.instance(), 16, 4,
+				EntityIds.get( this.droppedEntity ), AppEng.instance, 16, 4,
 				true );
 	}
 
@@ -156,7 +156,7 @@ public enum MaterialType
 		this.droppedEntity = c;
 		EntityRegistry.registerModEntity( new ResourceLocation( "appliedenergistics2", this.droppedEntity.getName() ), this.droppedEntity,
 				this.droppedEntity.getSimpleName(),
-				EntityIds.get( this.droppedEntity ), AppEng.instance(), 16, 4,
+				EntityIds.get( this.droppedEntity ), AppEng.instance, 16, 4,
 				true );
 	}
 

--- a/src/main/java/appeng/items/misc/ItemCrystalSeed.java
+++ b/src/main/java/appeng/items/misc/ItemCrystalSeed.java
@@ -66,7 +66,7 @@ public class ItemCrystalSeed extends AEBaseItem implements IGrowableCrystal
 		this.setHasSubtypes( true );
 
 		EntityRegistry.registerModEntity( new ResourceLocation( "appliedenergistics2", EntityGrowingCrystal.class.getName() ), EntityGrowingCrystal.class,
-				EntityGrowingCrystal.class.getSimpleName(), EntityIds.get( EntityGrowingCrystal.class ), AppEng.instance(), 16, 4, true );
+				EntityGrowingCrystal.class.getSimpleName(), EntityIds.get( EntityGrowingCrystal.class ), AppEng.instance, 16, 4, true );
 	}
 
 	@Nullable

--- a/src/main/java/appeng/items/storage/ItemSpatialStorageCell.java
+++ b/src/main/java/appeng/items/storage/ItemSpatialStorageCell.java
@@ -89,7 +89,7 @@ public class ItemSpatialStorageCell extends AEBaseItem implements ISpatialStorag
 	@Override
 	public ISpatialDimension getSpatialDimension()
 	{
-		final int id = AppEng.instance().getStorageDimensionID();
+		final int id = AppEng.instance.getStorageDimensionID();
 		World w = DimensionManager.getWorld( id );
 		if( w == null )
 		{

--- a/src/main/java/appeng/me/cache/PathGridCache.java
+++ b/src/main/java/appeng/me/cache/PathGridCache.java
@@ -371,15 +371,15 @@ public class PathGridCache implements IPathingGrid
 
 		if( ch < 128 )
 		{
-			return AppEng.instance().getAdvancementTriggers().getNetworkApprentice();
+			return AppEng.instance.getAdvancementTriggers().getNetworkApprentice();
 		}
 
 		if( ch < 2048 )
 		{
-			return AppEng.instance().getAdvancementTriggers().getNetworkEngineer();
+			return AppEng.instance.getAdvancementTriggers().getNetworkEngineer();
 		}
 
-		return AppEng.instance().getAdvancementTriggers().getNetworkAdmin();
+		return AppEng.instance.getAdvancementTriggers().getNetworkAdmin();
 	}
 
 	@MENetworkEventSubscribe

--- a/src/main/java/appeng/services/VersionChecker.java
+++ b/src/main/java/appeng/services/VersionChecker.java
@@ -192,7 +192,7 @@ public final class VersionChecker implements Runnable
 			}
 
 			versionInf.setString( "newFileName", "appliedenergistics2-" + ghFormatted + ".jar" );
-			FMLInterModComms.sendRuntimeMessage( AppEng.instance(), "VersionChecker", "addUpdate", versionInf );
+			FMLInterModComms.sendRuntimeMessage( AppEng.instance, "VersionChecker", "addUpdate", versionInf );
 
 			AELog.info( "Reported new version to VersionChecker mod." );
 		}

--- a/src/main/java/appeng/spatial/StorageChunkProvider.java
+++ b/src/main/java/appeng/spatial/StorageChunkProvider.java
@@ -51,7 +51,7 @@ public class StorageChunkProvider extends ChunkGeneratorOverworld
 		final Chunk chunk = new Chunk( this.world, x, z );
 
 		final byte[] biomes = chunk.getBiomeArray();
-		Biome biome = AppEng.instance().getStorageBiome();
+		Biome biome = AppEng.instance.getStorageBiome();
 		byte biomeId = (byte) Biome.getIdForBiome( biome );
 
 		for( int k = 0; k < biomes.length; ++k )

--- a/src/main/java/appeng/spatial/StorageHelper.java
+++ b/src/main/java/appeng/spatial/StorageHelper.java
@@ -115,7 +115,7 @@ public class StorageHelper
 			{
 				if( link.dim.provider instanceof StorageWorldProvider )
 				{
-					AppEng.instance().getAdvancementTriggers().getSpatialExplorer().trigger( player );
+					AppEng.instance.getAdvancementTriggers().getSpatialExplorer().trigger( player );
 				}
 
 				player.mcServer.getPlayerList().transferPlayerToDimension( player, link.dim.provider.getDimension(), new METeleporter( newWorld, link ) );

--- a/src/main/java/appeng/spatial/StorageWorldProvider.java
+++ b/src/main/java/appeng/spatial/StorageWorldProvider.java
@@ -44,7 +44,7 @@ public class StorageWorldProvider extends WorldProvider
 	public StorageWorldProvider()
 	{
 		this.hasSkyLight = true;
-		this.biome = AppEng.instance().getStorageBiome();
+		this.biome = AppEng.instance.getStorageBiome();
 		this.biomeProvider = new BiomeProviderSingle( this.biome );
 	}
 
@@ -101,7 +101,7 @@ public class StorageWorldProvider extends WorldProvider
 	@Override
 	public DimensionType getDimensionType()
 	{
-		return AppEng.instance().getStorageDimensionType();
+		return AppEng.instance.getStorageDimensionType();
 	}
 
 	@Override

--- a/src/main/java/appeng/util/Platform.java
+++ b/src/main/java/appeng/util/Platform.java
@@ -374,15 +374,15 @@ public class Platform
 		{
 			if( tile == null && type.getType() == GuiHostType.ITEM )
 			{
-				p.openGui( AppEng.instance(), type.ordinal() << 4, p.getEntityWorld(), p.inventory.currentItem, 0, 0 );
+				p.openGui( AppEng.instance, type.ordinal() << 4, p.getEntityWorld(), p.inventory.currentItem, 0, 0 );
 			}
 			else if( tile == null || type.getType() == GuiHostType.ITEM )
 			{
-				p.openGui( AppEng.instance(), type.ordinal() << 4 | ( 1 << 3 ), p.getEntityWorld(), x, y, z );
+				p.openGui( AppEng.instance, type.ordinal() << 4 | ( 1 << 3 ), p.getEntityWorld(), x, y, z );
 			}
 			else
 			{
-				p.openGui( AppEng.instance(), type.ordinal() << 4 | ( side.ordinal() ), tile.getWorld(), x, y, z );
+				p.openGui( AppEng.instance, type.ordinal() << 4 | ( side.ordinal() ), tile.getWorld(), x, y, z );
 			}
 		}
 	}


### PR DESCRIPTION
This is janitorial work to bring things up to date with modern Forge
practice. There's no need for a factory, just annotate a public data
member and Forge promises to manage the mod as a singleton.

The factory method gets removed, too. We don't need it since Forge is
fine just calling the (now public) no-arg constructor.