### PR TITLE
Remove call to neighborChanged() (#3462)

### DIFF
--- a/src/main/java/appeng/items/tools/quartz/ToolQuartzWrench.java
+++ b/src/main/java/appeng/items/tools/quartz/ToolQuartzWrench.java
@@ -67,7 +67,6 @@ public class ToolQuartzWrench extends AEBaseItem implements IAEWrench, IToolHamm
 
 			if( b.rotateBlock( world, pos, side ) )
 			{
-				b.neighborChanged( Platform.AIR_BLOCK.getDefaultState(), world, pos, Platform.AIR_BLOCK, pos );
 				player.swingArm( hand );
 				return !world.isRemote ? EnumActionResult.SUCCESS : EnumActionResult.FAIL;
 			}


### PR DESCRIPTION
No need to manually call neighbor changed on anyone, the engine
already schedules that when rotateBlock() is called. This just caused
funky-ness and an exception.