### PR TITLE
Fixes issue with Fluid Channel not being sent changes.

### DIFF
--- a/src/main/java/appeng/util/Platform.java
+++ b/src/main/java/appeng/util/Platform.java
@@ -1262,6 +1262,7 @@ public class Platform
 		}
 
 		gs.postAlterationOfStoredItems( itemChannel, itemChanges, src );
+		gs.postAlterationOfStoredItems( fluidChannel, fluidChanges, src );
 	}
 
 	public static <T extends IAEStack<T>> void postListChanges( final IItemList<T> before, final IItemList<T> after, final IMEMonitorHandlerReceiver<T> meMonitorPassthrough, final IActionSource source )


### PR DESCRIPTION
When a cell is removed from a ME Drive/Chest, any fluid channel changes are not being sent to watchers.
This is a fix for ExtraCells/ExtraCells2#560