### PR TITLE
Fix DriveBakedModel to not crash when SLOT_STATE is null

### DIFF
--- a/src/main/java/appeng/block/storage/BlockDrive.java
+++ b/src/main/java/appeng/block/storage/BlockDrive.java
@@ -74,13 +74,8 @@ public class BlockDrive extends AEBaseTileBlock
 	public IBlockState getExtendedState( IBlockState state, IBlockAccess world, BlockPos pos )
 	{
 		TileDrive te = this.getTileEntity( world, pos );
-		if( te == null )
-		{
-			return super.getExtendedState( state, world, pos );
-		}
-
 		IExtendedBlockState extState = (IExtendedBlockState) super.getExtendedState( state, world, pos );
-		return extState.withProperty( SLOTS_STATE, DriveSlotsState.fromChestOrDrive( te ) );
+		return extState.withProperty( SLOTS_STATE, te == null ? DriveSlotsState.createEmpty( 10 ) : DriveSlotsState.fromChestOrDrive( te ) );
 	}
 
 	@Override

--- a/src/main/java/appeng/block/storage/DriveSlotsState.java
+++ b/src/main/java/appeng/block/storage/DriveSlotsState.java
@@ -75,4 +75,14 @@ public class DriveSlotsState
 		}
 		return new DriveSlotsState( slots );
 	}
+
+	public static DriveSlotsState createEmpty( int slotCount )
+	{
+		DriveSlotState[] slots = new DriveSlotState[slotCount];
+		for( int i = 0; i < slotCount; i++ )
+		{
+			slots[i] = DriveSlotState.EMPTY;
+		}
+		return new DriveSlotsState( slots );
+	}
 }

--- a/src/main/java/appeng/client/render/model/DriveBakedModel.java
+++ b/src/main/java/appeng/client/render/model/DriveBakedModel.java
@@ -66,11 +66,6 @@ public class DriveBakedModel implements IBakedModel
 			IExtendedBlockState extState = (IExtendedBlockState) state;
 			DriveSlotsState slotsState = extState.getValue( BlockDrive.SLOTS_STATE );
 
-			if( slotsState == null )
-			{
-				return result;
-			}
-
 			for( int row = 0; row < 5; row++ )
 			{
 				for( int col = 0; col < 2; col++ )

--- a/src/main/java/appeng/client/render/model/DriveBakedModel.java
+++ b/src/main/java/appeng/client/render/model/DriveBakedModel.java
@@ -66,6 +66,11 @@ public class DriveBakedModel implements IBakedModel
 			IExtendedBlockState extState = (IExtendedBlockState) state;
 			DriveSlotsState slotsState = extState.getValue( BlockDrive.SLOTS_STATE );
 
+			if( slotsState == null )
+			{
+				return result;
+			}
+
 			for( int row = 0; row < 5; row++ )
 			{
 				for( int col = 0; col < 2; col++ )


### PR DESCRIPTION
SLOT_STATE can be null when the  TE does not exist.

This should fix #3254

