### PR TITLE
Fix AEBaseTile to respect overridden markDirty implementations.

### DIFF
--- a/src/main/java/appeng/tile/AEBaseTile.java
+++ b/src/main/java/appeng/tile/AEBaseTile.java
@@ -488,7 +488,7 @@ public class AEBaseTile extends TileEntity implements IOrientable, ICommonTile, 
 
 	public void saveChanges()
 	{
-		super.markDirty();
+		markDirty();
 	}
 
 	public boolean requiresTESR()


### PR DESCRIPTION
Fixes #3548 