### PR TITLE
Fix CellInventory to not mess with the item definition

### DIFF
--- a/src/main/java/appeng/me/storage/CellInventory.java
+++ b/src/main/java/appeng/me/storage/CellInventory.java
@@ -223,7 +223,7 @@ public class CellInventory implements ICellInventory
 		// any NBT data for empty cells instead of relying on an empty IItemContainer
 		if( CellInventory.isStorageCell( input.getDefinition() ) )
 		{
-			final IMEInventory meInventory = getCell( input.getDefinition(), null );
+			final IMEInventory meInventory = getCell( input.createItemStack(), null );
 			if( meInventory != null && !this.isEmpty( meInventory ) )
 			{
 				return input;


### PR DESCRIPTION
getCell initalizes the ItemStack with an empty NBT and therefore was messing with the item definition.

Fixes #3449