### PR TITLE
Search box improvements

### DIFF
--- a/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
@@ -482,6 +482,8 @@ public class GuiMEMonitorable extends AEBaseMEGui implements ISortSource, IConfi
 				this.repo.setSearchString( this.searchField.getText() );
 				this.repo.updateView();
 				this.setScrollBar();
+				// tell forge the key event is handled and should not be sent out
+				this.keyHandled = true;
 			}
 			else
 			{

--- a/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
@@ -319,12 +319,10 @@ public class GuiMEMonitorable extends AEBaseMEGui implements ISortSource, IConfi
 		final Enum searchModeSetting = AEConfig.instance().getConfigManager().getSetting( Settings.SEARCH_MODE );
 
 		final boolean isAutoFocus = SearchBoxMode.AUTOSEARCH == searchModeSetting || SearchBoxMode.JEI_AUTOSEARCH == searchModeSetting || SearchBoxMode.AUTOSEARCH_KEEP == searchModeSetting || SearchBoxMode.JEI_AUTOSEARCH_KEEP == searchModeSetting;
-		final boolean isManualFocus = SearchBoxMode.MANUAL_SEARCH == searchModeSetting || SearchBoxMode.JEI_MANUAL_SEARCH == searchModeSetting || SearchBoxMode.MANUAL_SEARCH_KEEP == searchModeSetting || SearchBoxMode.JEI_MANUAL_SEARCH_KEEP == searchModeSetting;
 		final boolean isKeepFilter = SearchBoxMode.AUTOSEARCH_KEEP == searchModeSetting || SearchBoxMode.JEI_AUTOSEARCH_KEEP == searchModeSetting || SearchBoxMode.MANUAL_SEARCH_KEEP == searchModeSetting || SearchBoxMode.JEI_MANUAL_SEARCH_KEEP == searchModeSetting;
 		final boolean isJEIEnabled = SearchBoxMode.JEI_AUTOSEARCH == searchModeSetting || SearchBoxMode.JEI_MANUAL_SEARCH == searchModeSetting;
 
 		this.searchField.setFocused( isAutoFocus );
-		this.searchField.setCanLoseFocus( isManualFocus );
 
 		if( isJEIEnabled )
 		{

--- a/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
@@ -470,7 +470,7 @@ public class GuiMEMonitorable extends AEBaseMEGui implements ISortSource, IConfi
 	{
 		if( !this.checkHotbarKeys( key ) )
 		{
-			if( key == 15 ) // TAB
+			if( key == Keyboard.KEY_TAB )
 			{
 				this.searchField.setFocused( !this.searchField.isFocused() );
 				return;

--- a/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
@@ -306,7 +306,7 @@ public class GuiMEMonitorable extends AEBaseMEGui implements ISortSource, IConfi
 		this.searchField.setEnableBackgroundDrawing( false );
 		this.searchField.setMaxStringLength( 25 );
 		this.searchField.setTextColor( 0xFFFFFF );
-		this.searchField.setSelectionColor( 0xFF99FF99 );
+		this.searchField.setSelectionColor( 0xFF008000 );
 		this.searchField.setVisible( true );
 
 		if( this.viewCell || this instanceof GuiWirelessTerm )

--- a/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
@@ -470,6 +470,12 @@ public class GuiMEMonitorable extends AEBaseMEGui implements ISortSource, IConfi
 	{
 		if( !this.checkHotbarKeys( key ) )
 		{
+			if( key == 15 ) // TAB
+			{
+				this.searchField.setFocused( !this.searchField.isFocused() );
+				return;
+			}
+
 			if( character == ' ' && this.searchField.getText().isEmpty() )
 			{
 				return;

--- a/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
@@ -95,6 +95,9 @@ public class GuiMEMonitorable extends AEBaseMEGui implements ISortSource, IConfi
 	private GuiImgButton SortDirBox;
 	private GuiImgButton searchBoxSettings;
 	private GuiImgButton terminalStyleBox;
+	private boolean isAutoFocus = false;
+	private int currentMouseX = 0;
+	private int currentMouseY = 0;
 
 	public GuiMEMonitorable( final InventoryPlayer inventoryPlayer, final ITerminalHost te )
 	{
@@ -224,8 +227,10 @@ public class GuiMEMonitorable extends AEBaseMEGui implements ISortSource, IConfi
 		Keyboard.enableRepeatEvents( true );
 
 		this.maxRows = this.getMaxRows();
-		this.perRow = AEConfig.instance().getConfigManager().getSetting(
-				Settings.TERMINAL_STYLE ) != TerminalStyle.FULL ? 9 : 9 + ( ( this.width - this.standardSize ) / 18 );
+		this.perRow = AEConfig.instance()
+				.getConfigManager()
+				.getSetting(
+						Settings.TERMINAL_STYLE ) != TerminalStyle.FULL ? 9 : 9 + ( ( this.width - this.standardSize ) / 18 );
 
 		final int magicNumber = 114 + 1;
 		final int extraSpace = this.height - magicNumber - this.reservedSpace;
@@ -290,8 +295,10 @@ public class GuiMEMonitorable extends AEBaseMEGui implements ISortSource, IConfi
 		offset += 20;
 
 		this.buttonList.add(
-				this.searchBoxSettings = new GuiImgButton( this.guiLeft - 18, offset, Settings.SEARCH_MODE, AEConfig.instance().getConfigManager().getSetting(
-						Settings.SEARCH_MODE ) ) );
+				this.searchBoxSettings = new GuiImgButton( this.guiLeft - 18, offset, Settings.SEARCH_MODE, AEConfig.instance()
+						.getConfigManager()
+						.getSetting(
+								Settings.SEARCH_MODE ) ) );
 
 		offset += 20;
 
@@ -318,11 +325,11 @@ public class GuiMEMonitorable extends AEBaseMEGui implements ISortSource, IConfi
 
 		final Enum searchModeSetting = AEConfig.instance().getConfigManager().getSetting( Settings.SEARCH_MODE );
 
-		final boolean isAutoFocus = SearchBoxMode.AUTOSEARCH == searchModeSetting || SearchBoxMode.JEI_AUTOSEARCH == searchModeSetting || SearchBoxMode.AUTOSEARCH_KEEP == searchModeSetting || SearchBoxMode.JEI_AUTOSEARCH_KEEP == searchModeSetting;
+		this.isAutoFocus = SearchBoxMode.AUTOSEARCH == searchModeSetting || SearchBoxMode.JEI_AUTOSEARCH == searchModeSetting || SearchBoxMode.AUTOSEARCH_KEEP == searchModeSetting || SearchBoxMode.JEI_AUTOSEARCH_KEEP == searchModeSetting;
 		final boolean isKeepFilter = SearchBoxMode.AUTOSEARCH_KEEP == searchModeSetting || SearchBoxMode.JEI_AUTOSEARCH_KEEP == searchModeSetting || SearchBoxMode.MANUAL_SEARCH_KEEP == searchModeSetting || SearchBoxMode.JEI_MANUAL_SEARCH_KEEP == searchModeSetting;
 		final boolean isJEIEnabled = SearchBoxMode.JEI_AUTOSEARCH == searchModeSetting || SearchBoxMode.JEI_MANUAL_SEARCH == searchModeSetting;
 
-		this.searchField.setFocused( isAutoFocus );
+		this.searchField.setFocused( this.isAutoFocus );
 
 		if( isJEIEnabled )
 		{
@@ -372,6 +379,9 @@ public class GuiMEMonitorable extends AEBaseMEGui implements ISortSource, IConfi
 	{
 		this.fontRenderer.drawString( this.getGuiDisplayName( this.myName.getLocal() ), 8, 6, 4210752 );
 		this.fontRenderer.drawString( GuiText.inventory.getLocal(), 8, this.ySize - 96 + 3, 4210752 );
+
+		this.currentMouseX = mouseX;
+		this.currentMouseY = mouseY;
 	}
 
 	@Override
@@ -468,6 +478,7 @@ public class GuiMEMonitorable extends AEBaseMEGui implements ISortSource, IConfi
 	@Override
 	protected void keyTyped( final char character, final int key ) throws IOException
 	{
+
 		if( !this.checkHotbarKeys( key ) )
 		{
 			if( key == Keyboard.KEY_TAB )
@@ -476,9 +487,22 @@ public class GuiMEMonitorable extends AEBaseMEGui implements ISortSource, IConfi
 				return;
 			}
 
+			if( this.searchField.isFocused() && ( key == Keyboard.KEY_ESCAPE || key == Keyboard.KEY_RETURN ) )
+			{
+				this.searchField.setFocused( false );
+				return;
+			}
+
 			if( character == ' ' && this.searchField.getText().isEmpty() )
 			{
 				return;
+			}
+
+			final boolean mouseInGui = this.isPointInRegion( 0, 0, this.xSize, this.ySize, this.currentMouseX, this.currentMouseY );
+
+			if( this.isAutoFocus && !this.searchField.isFocused() && mouseInGui )
+			{
+				this.searchField.setFocused( true );
 			}
 
 			if( this.searchField.textboxKeyTyped( character, key ) )
@@ -487,7 +511,7 @@ public class GuiMEMonitorable extends AEBaseMEGui implements ISortSource, IConfi
 				this.repo.updateView();
 				this.setScrollBar();
 				// tell forge the key event is handled and should not be sent out
-				this.keyHandled = true;
+				this.keyHandled = mouseInGui;
 			}
 			else
 			{

--- a/src/main/java/appeng/client/gui/widgets/MEGuiTextField.java
+++ b/src/main/java/appeng/client/gui/widgets/MEGuiTextField.java
@@ -43,6 +43,7 @@ public class MEGuiTextField extends GuiTextField
 	private final int _yPos;
 	private final int _width;
 	private final int _height;
+	private final int _fontPad;
 	private int selectionColor = 0xFF00FF00;
 
 	/**
@@ -59,6 +60,7 @@ public class MEGuiTextField extends GuiTextField
 	{
 		super( 0, fontRenderer, xPos + PADDING, yPos + PADDING, width - 2 * PADDING - fontRenderer.getCharWidth( '_' ), height - 2 * PADDING );
 
+		this._fontPad = fontRenderer.getCharWidth( '_' );
 		this._xPos = xPos;
 		this._yPos = yPos;
 		this._width = width;
@@ -107,8 +109,30 @@ public class MEGuiTextField extends GuiTextField
 	}
 
 	@Override
+	public void drawTextBox()
+	{
+		if( this.getVisible() )
+		{
+			if( this.isFocused() )
+			{
+				drawRect( this.x - PADDING + 1, this.y - PADDING + 1, this.x + this.width + this._fontPad + PADDING - 1, this.y + this.height + PADDING - 1,
+						0xFF606060 );
+			}
+			else
+			{
+				drawRect( this.x - PADDING + 1, this.y - PADDING + 1, this.x + this.width + this._fontPad + PADDING - 1, this.y + this.height + PADDING - 1,
+						0xFFA8A8A8 );
+			}
+			super.drawTextBox();
+		}
+	}
+
+	@Override
 	public void drawSelectionBox( int startX, int startY, int endX, int endY )
 	{
+		if( !this.isFocused() )
+			return;
+
 		if( startX < endX )
 		{
 			int i = startX;
@@ -159,4 +183,5 @@ public class MEGuiTextField extends GuiTextField
 		GlStateManager.disableColorLogic();
 		GlStateManager.enableTexture2D();
 	}
+
 }


### PR DESCRIPTION
When the search box has the focus, tell forge to not send any other events.
Pressing TAB toggles the focus.
Improve visual indication if box is focused or not.