### PR TITLE
Performance improvements for saveChanges() and ICellInventory

### DIFF
--- a/src/api/java/appeng/api/storage/ICellHandler.java
+++ b/src/api/java/appeng/api/storage/ICellHandler.java
@@ -52,12 +52,12 @@ public interface ICellHandler
 	 *
 	 * @param is a storage cell item.
 	 * @param host anytime the contents of your storage cell changes it should use this to request a save, please
-	 * note, this value can be null.
+	 * note, this value can be null. If provided, the host is responsible for persisting the cell content.
 	 * @param channel the storage channel requested.
 	 *
 	 * @return a new IMEHandler for the provided item
 	 */
-	<T extends IAEStack<T>> IMEInventoryHandler<T> getCellInventory( ItemStack is, ISaveProvider host, IStorageChannel<T> channel );
+	<T extends IAEStack<T>> ICellInventoryHandler<T> getCellInventory( ItemStack is, ISaveProvider host, IStorageChannel<T> channel );
 
 	/**
 	 * Called when the storage cell is planed in an ME Chest and the user tries to open the terminal side, if your item

--- a/src/api/java/appeng/api/storage/ICellInventory.java
+++ b/src/api/java/appeng/api/storage/ICellInventory.java
@@ -118,4 +118,9 @@ public interface ICellInventory<T extends IAEStack<T>> extends IMEInventory<T>
 	 * @return the status number for this drive.
 	 */
 	int getStatusForCell();
+
+	/**
+	 * Tells the cell to persist to NBT
+	 */
+	void persist();
 }

--- a/src/api/java/appeng/api/storage/ICellInventoryHandler.java
+++ b/src/api/java/appeng/api/storage/ICellInventoryHandler.java
@@ -34,7 +34,7 @@ public interface ICellInventoryHandler<T extends IAEStack<T>> extends IMEInvento
 	/**
 	 * @return get access to the Cell Inventory.
 	 */
-	ICellInventory getCellInv();
+	ICellInventory<T> getCellInv();
 
 	boolean isPreformatted();
 

--- a/src/api/java/appeng/api/storage/ICellRegistry.java
+++ b/src/api/java/appeng/api/storage/ICellRegistry.java
@@ -77,11 +77,11 @@ public interface ICellRegistry
 	 * returns an IMEInventoryHandler for the provided item.
 	 *
 	 * @param is item with inventory handler
-	 * @param host can be null, or the hosting tile / part.
+	 * @param host can be null. If provided, the host is responsible for persisting the cell content.
 	 * @param chan the storage channel to request the handler for.
 	 *
 	 * @return new IMEInventoryHandler, or null if there isn't one.
 	 */
 	@Nullable
-	<T extends IAEStack<T>> IMEInventoryHandler<T> getCellInventory( ItemStack is, ISaveProvider host, IStorageChannel<T> chan );
+	<T extends IAEStack<T>> ICellInventoryHandler<T> getCellInventory( ItemStack is, ISaveProvider host, IStorageChannel<T> chan );
 }

--- a/src/api/java/appeng/api/storage/ISaveProvider.java
+++ b/src/api/java/appeng/api/storage/ISaveProvider.java
@@ -24,8 +24,11 @@
 package appeng.api.storage;
 
 
+/**
+ * Tells the cell provider that changes have been made an the cell must be persisted
+ *
+ */
 public interface ISaveProvider
 {
-
-	void saveChanges( IMEInventory<?> cellInventory );
+	void saveChanges( ICellInventory<?> cellInventory );
 }

--- a/src/main/java/appeng/core/features/registries/cell/BasicItemCellHandler.java
+++ b/src/main/java/appeng/core/features/registries/cell/BasicItemCellHandler.java
@@ -51,11 +51,11 @@ public class BasicItemCellHandler implements ICellHandler
 	}
 
 	@Override
-	public <T extends IAEStack<T>> IMEInventoryHandler<T> getCellInventory( final ItemStack is, final ISaveProvider container, final IStorageChannel<T> channel )
+	public <T extends IAEStack<T>> ICellInventoryHandler<T> getCellInventory( final ItemStack is, final ISaveProvider container, final IStorageChannel<T> channel )
 	{
 		if( channel == AEApi.instance().storage().getStorageChannel( IItemStorageChannel.class ) )
 		{
-			return ItemCellInventory.getCell( is, container );
+			return (ICellInventoryHandler<T>) ItemCellInventory.getCell( is, container );
 		}
 
 		return null;

--- a/src/main/java/appeng/core/features/registries/cell/CellRegistry.java
+++ b/src/main/java/appeng/core/features/registries/cell/CellRegistry.java
@@ -28,8 +28,8 @@ import com.google.common.base.Verify;
 import net.minecraft.item.ItemStack;
 
 import appeng.api.storage.ICellHandler;
+import appeng.api.storage.ICellInventoryHandler;
 import appeng.api.storage.ICellRegistry;
-import appeng.api.storage.IMEInventoryHandler;
 import appeng.api.storage.ISaveProvider;
 import appeng.api.storage.IStorageChannel;
 import appeng.api.storage.data.IAEStack;
@@ -92,7 +92,7 @@ public class CellRegistry implements ICellRegistry
 	}
 
 	@Override
-	public <T extends IAEStack<T>> IMEInventoryHandler<T> getCellInventory( final ItemStack is, final ISaveProvider container, final IStorageChannel<T> chan )
+	public <T extends IAEStack<T>> ICellInventoryHandler<T> getCellInventory( final ItemStack is, final ISaveProvider container, final IStorageChannel<T> chan )
 	{
 		if( is.isEmpty() )
 		{

--- a/src/main/java/appeng/core/features/registries/cell/CreativeCellHandler.java
+++ b/src/main/java/appeng/core/features/registries/cell/CreativeCellHandler.java
@@ -26,6 +26,7 @@ import net.minecraft.tileentity.TileEntity;
 import appeng.api.AEApi;
 import appeng.api.implementations.tiles.IChestOrDrive;
 import appeng.api.storage.ICellHandler;
+import appeng.api.storage.ICellInventoryHandler;
 import appeng.api.storage.IMEInventory;
 import appeng.api.storage.IMEInventoryHandler;
 import appeng.api.storage.ISaveProvider;
@@ -48,7 +49,7 @@ public final class CreativeCellHandler implements ICellHandler
 	}
 
 	@Override
-	public IMEInventoryHandler getCellInventory( final ItemStack is, final ISaveProvider container, final IStorageChannel channel )
+	public ICellInventoryHandler getCellInventory( final ItemStack is, final ISaveProvider container, final IStorageChannel channel )
 	{
 		if( channel == AEApi.instance().storage().getStorageChannel( IItemStorageChannel.class ) && !is.isEmpty() && is
 				.getItem() instanceof ItemCreativeStorageCell )

--- a/src/main/java/appeng/fluids/helper/DualityFluidInterface.java
+++ b/src/main/java/appeng/fluids/helper/DualityFluidInterface.java
@@ -577,7 +577,7 @@ public class DualityFluidInterface implements IGridTickable, IStorageMonitorable
 
 	public void saveChanges()
 	{
-		this.iHost.getTileEntity().markDirty();
+		this.iHost.saveChanges();
 	}
 
 	@Override

--- a/src/main/java/appeng/fluids/helper/IFluidInterfaceHost.java
+++ b/src/main/java/appeng/fluids/helper/IFluidInterfaceHost.java
@@ -36,4 +36,6 @@ public interface IFluidInterfaceHost extends IActionHost, IGridProxyable, IUpgra
 	EnumSet<EnumFacing> getTargets();
 
 	TileEntity getTileEntity();
+	
+	void saveChanges();
 }

--- a/src/main/java/appeng/fluids/registries/BasicFluidCellHandler.java
+++ b/src/main/java/appeng/fluids/registries/BasicFluidCellHandler.java
@@ -51,11 +51,11 @@ public class BasicFluidCellHandler implements ICellHandler
 	}
 
 	@Override
-	public <T extends IAEStack<T>> IMEInventoryHandler<T> getCellInventory( final ItemStack is, final ISaveProvider container, final IStorageChannel<T> channel )
+	public <T extends IAEStack<T>> ICellInventoryHandler<T> getCellInventory( final ItemStack is, final ISaveProvider container, final IStorageChannel<T> channel )
 	{
 		if( channel == AEApi.instance().storage().getStorageChannel( IFluidStorageChannel.class ) )
 		{
-			return (IMEInventoryHandler<T>) FluidCellInventory.getCell( is, container );
+			return (ICellInventoryHandler<T>) FluidCellInventory.getCell( is, container );
 		}
 
 		return null;

--- a/src/main/java/appeng/fluids/storage/FluidCellInventory.java
+++ b/src/main/java/appeng/fluids/storage/FluidCellInventory.java
@@ -29,7 +29,7 @@ import appeng.api.config.Actionable;
 import appeng.api.exceptions.AppEngException;
 import appeng.api.implementations.items.IStorageCell;
 import appeng.api.networking.security.IActionSource;
-import appeng.api.storage.IMEInventoryHandler;
+import appeng.api.storage.ICellInventoryHandler;
 import appeng.api.storage.ISaveProvider;
 import appeng.api.storage.IStorageChannel;
 import appeng.api.storage.channels.IFluidStorageChannel;
@@ -47,17 +47,12 @@ import appeng.me.storage.AbstractCellInventory;
  */
 public class FluidCellInventory extends AbstractCellInventory<IAEFluidStack>
 {
-	protected FluidCellInventory( final NBTTagCompound data, final ISaveProvider container )
-	{
-		super( data, container, 8000 );
-	}
-
 	private FluidCellInventory( final ItemStack o, final ISaveProvider container ) throws AppEngException
 	{
 		super( o, container, 8000 );
 	}
 
-	public static IMEInventoryHandler<IAEFluidStack> getCell( final ItemStack o, final ISaveProvider container2 )
+	public static ICellInventoryHandler<IAEFluidStack> getCell( final ItemStack o, final ISaveProvider container2 )
 	{
 		try
 		{
@@ -123,7 +118,6 @@ public class FluidCellInventory extends AbstractCellInventory<IAEFluidStack>
 				if( mode == Actionable.MODULATE )
 				{
 					l.setStackSize( l.getStackSize() + remainingItemSlots );
-					this.updateItemCount( remainingItemSlots );
 					this.saveChanges();
 				}
 				return r;
@@ -133,7 +127,6 @@ public class FluidCellInventory extends AbstractCellInventory<IAEFluidStack>
 				if( mode == Actionable.MODULATE )
 				{
 					l.setStackSize( l.getStackSize() + input.getStackSize() );
-					this.updateItemCount( input.getStackSize() );
 					this.saveChanges();
 				}
 				return null;
@@ -155,8 +148,6 @@ public class FluidCellInventory extends AbstractCellInventory<IAEFluidStack>
 						toWrite.amount = remainingItemCount;
 
 						this.cellItems.add( AEFluidStack.fromFluidStack( toWrite ) );
-						this.updateItemCount( toWrite.amount );
-
 						this.saveChanges();
 					}
 					return AEFluidStack.fromFluidStack( toReturn );
@@ -164,7 +155,6 @@ public class FluidCellInventory extends AbstractCellInventory<IAEFluidStack>
 
 				if( mode == Actionable.MODULATE )
 				{
-					this.updateItemCount( input.getStackSize() );
 					this.cellItems.add( input );
 					this.saveChanges();
 				}
@@ -198,7 +188,6 @@ public class FluidCellInventory extends AbstractCellInventory<IAEFluidStack>
 				results.setStackSize( l.getStackSize() );
 				if( mode == Actionable.MODULATE )
 				{
-					this.updateItemCount( -l.getStackSize() );
 					l.setStackSize( 0 );
 					this.saveChanges();
 				}
@@ -209,7 +198,6 @@ public class FluidCellInventory extends AbstractCellInventory<IAEFluidStack>
 				if( mode == Actionable.MODULATE )
 				{
 					l.setStackSize( l.getStackSize() - size );
-					this.updateItemCount( -size );
 					this.saveChanges();
 				}
 			}

--- a/src/main/java/appeng/helpers/DualityInterface.java
+++ b/src/main/java/appeng/helpers/DualityInterface.java
@@ -561,14 +561,6 @@ public class DualityInterface implements IGridTickable, IStorageMonitorable, IIn
 		return this.storage;
 	}
 
-	public void markDirty()
-	{
-		for( int slot = 0; slot < this.storage.getSlots(); slot++ )
-		{
-			this.storage.markDirty( slot );
-		}
-	}
-
 	@Override
 	public TickingRequest getTickingRequest( final IGridNode node )
 	{
@@ -869,8 +861,7 @@ public class DualityInterface implements IGridTickable, IStorageMonitorable, IIn
 		{
 			this.cancelCrafting();
 		}
-
-		this.markDirty();
+		this.iHost.saveChanges();
 	}
 
 	private void cancelCrafting()
@@ -1251,8 +1242,8 @@ public class DualityInterface implements IGridTickable, IStorageMonitorable, IIn
 	public void setPriority( final int newValue )
 	{
 		this.priority = newValue;
-		this.markDirty();
-
+		this.iHost.saveChanges();
+		
 		try
 		{
 			this.gridProxy.getGrid().postEvent( new MENetworkCraftingPatternChange( this, this.gridProxy.getNode() ) );

--- a/src/main/java/appeng/items/tools/powered/ToolMatterCannon.java
+++ b/src/main/java/appeng/items/tools/powered/ToolMatterCannon.java
@@ -54,11 +54,9 @@ import appeng.api.config.Upgrades;
 import appeng.api.implementations.items.IStorageCell;
 import appeng.api.storage.ICellInventory;
 import appeng.api.storage.ICellInventoryHandler;
-import appeng.api.storage.IMEInventory;
 import appeng.api.storage.IStorageChannel;
 import appeng.api.storage.channels.IItemStorageChannel;
 import appeng.api.storage.data.IAEItemStack;
-import appeng.api.storage.data.IAEStack;
 import appeng.api.storage.data.IItemList;
 import appeng.api.util.AEColor;
 import appeng.api.util.DimensionalCoord;
@@ -77,7 +75,6 @@ import appeng.items.contents.CellUpgrades;
 import appeng.items.misc.ItemPaintBall;
 import appeng.items.tools.powered.powersink.AEBasePoweredItem;
 import appeng.me.helpers.PlayerSource;
-import appeng.me.storage.ItemCellInventoryHandler;
 import appeng.tile.misc.TilePaint;
 import appeng.util.LookDirection;
 import appeng.util.Platform;
@@ -97,12 +94,15 @@ public class ToolMatterCannon extends AEBasePoweredItem implements IStorageCell<
 	{
 		super.addCheckedInformation( stack, world, lines, advancedTooltips );
 
-		final IMEInventory<IAEItemStack> cdi = AEApi.instance().registries().cell().getCellInventory( stack, null,
-				AEApi.instance().storage().getStorageChannel( IItemStorageChannel.class ) );
+		final ICellInventoryHandler<IAEItemStack> cdi = AEApi.instance()
+				.registries()
+				.cell()
+				.getCellInventory( stack, null,
+						AEApi.instance().storage().getStorageChannel( IItemStorageChannel.class ) );
 
-		if( cdi instanceof ItemCellInventoryHandler )
+		if( cdi != null )
 		{
-			final ICellInventory cd = ( (ICellInventoryHandler) cdi ).getCellInv();
+			final ICellInventory<IAEItemStack> cd = cdi.getCellInv();
 			if( cd != null )
 			{
 				lines.add( cd.getUsedBytes() + " " + GuiText.Of.getLocal() + ' ' + cd.getTotalBytes() + ' ' + GuiText.BytesUsed.getLocal() );
@@ -124,17 +124,22 @@ public class ToolMatterCannon extends AEBasePoweredItem implements IStorageCell<
 				shots += cu.getInstalledUpgrades( Upgrades.SPEED );
 			}
 
-			final IMEInventory inv = AEApi.instance().registries().cell().getCellInventory( p.getHeldItem( hand ), null,
-					AEApi.instance().storage().getStorageChannel( IItemStorageChannel.class ) );
+			final ICellInventoryHandler<IAEItemStack> inv = AEApi.instance()
+					.registries()
+					.cell()
+					.getCellInventory( p.getHeldItem( hand ), null,
+							AEApi.instance().storage().getStorageChannel( IItemStorageChannel.class ) );
 			if( inv != null )
 			{
-				final IItemList itemList = inv.getAvailableItems( AEApi.instance().storage().getStorageChannel( IItemStorageChannel.class ).createList() );
-				IAEStack aeAmmo = itemList.getFirstItem();
-				if( aeAmmo instanceof IAEItemStack )
+				final IItemList<IAEItemStack> itemList = inv
+						.getAvailableItems( AEApi.instance().storage().getStorageChannel( IItemStorageChannel.class ).createList() );
+				IAEItemStack req = itemList.getFirstItem();
+				if( req instanceof IAEItemStack )
 				{
-					shots = Math.min( shots, (int) aeAmmo.getStackSize() );
+					shots = Math.min( shots, (int) req.getStackSize() );
 					for( int sh = 0; sh < shots; sh++ )
 					{
+						IAEItemStack aeAmmo = req.copy();
 						this.extractAEPower( p.getHeldItem( hand ), 1600, Actionable.MODULATE );
 
 						if( Platform.isClient() )

--- a/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
+++ b/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
@@ -206,7 +206,7 @@ public final class CraftingCPUCluster implements IAECluster, ICraftingCPU
 		}
 
 		te.setCoreBlock( false );
-		te.markDirty();
+		te.saveChanges();
 		this.tiles.add( 0, te );
 
 		if( te.isStorage() )
@@ -395,7 +395,7 @@ public final class CraftingCPUCluster implements IAECluster, ICraftingCPU
 
 	private void markDirty()
 	{
-		this.getCore().markDirty();
+		this.getCore().saveChanges();
 	}
 
 	private void postCraftingStatusChange( final IAEItemStack diff )

--- a/src/main/java/appeng/me/storage/CreativeCellInventory.java
+++ b/src/main/java/appeng/me/storage/CreativeCellInventory.java
@@ -25,6 +25,7 @@ import appeng.api.AEApi;
 import appeng.api.config.AccessRestriction;
 import appeng.api.config.Actionable;
 import appeng.api.networking.security.IActionSource;
+import appeng.api.storage.ICellInventoryHandler;
 import appeng.api.storage.IMEInventoryHandler;
 import appeng.api.storage.IStorageChannel;
 import appeng.api.storage.channels.IItemStorageChannel;
@@ -53,7 +54,7 @@ public class CreativeCellInventory implements IMEInventoryHandler<IAEItemStack>
 		}
 	}
 
-	public static IMEInventoryHandler getCell( final ItemStack o )
+	public static ICellInventoryHandler getCell( final ItemStack o )
 	{
 		return new ItemCellInventoryHandler( new CreativeCellInventory( o ) );
 	}

--- a/src/main/java/appeng/me/storage/DriveWatcher.java
+++ b/src/main/java/appeng/me/storage/DriveWatcher.java
@@ -45,6 +45,11 @@ public class DriveWatcher<T extends IAEStack<T>> extends MEInventoryHandler<T>
 		this.cord = cod;
 	}
 
+	public int getStatus()
+	{
+		return this.handler.getStatusForCell( this.is, this.getInternal() );
+	}
+
 	@Override
 	public T injectItems( final T input, final Actionable type, final IActionSource src )
 	{
@@ -54,7 +59,7 @@ public class DriveWatcher<T extends IAEStack<T>> extends MEInventoryHandler<T>
 
 		if( type == Actionable.MODULATE && ( a == null || a.getStackSize() != size ) )
 		{
-			final int newStatus = this.handler.getStatusForCell( this.is, this.getInternal() );
+			final int newStatus = this.getStatus();
 
 			if( newStatus != this.oldStatus )
 			{
@@ -73,7 +78,7 @@ public class DriveWatcher<T extends IAEStack<T>> extends MEInventoryHandler<T>
 
 		if( type == Actionable.MODULATE && a != null )
 		{
-			final int newStatus = this.handler.getStatusForCell( this.is, this.getInternal() );
+			final int newStatus = this.getStatus();
 
 			if( newStatus != this.oldStatus )
 			{

--- a/src/main/java/appeng/me/storage/ItemCellInventory.java
+++ b/src/main/java/appeng/me/storage/ItemCellInventory.java
@@ -28,8 +28,8 @@ import appeng.api.config.Actionable;
 import appeng.api.exceptions.AppEngException;
 import appeng.api.implementations.items.IStorageCell;
 import appeng.api.networking.security.IActionSource;
+import appeng.api.storage.ICellInventoryHandler;
 import appeng.api.storage.IMEInventory;
-import appeng.api.storage.IMEInventoryHandler;
 import appeng.api.storage.ISaveProvider;
 import appeng.api.storage.IStorageChannel;
 import appeng.api.storage.channels.IItemStorageChannel;
@@ -40,17 +40,12 @@ import appeng.core.AELog;
 
 public class ItemCellInventory extends AbstractCellInventory<IAEItemStack>
 {
-	protected ItemCellInventory( final NBTTagCompound data, final ISaveProvider container )
-	{
-		super( data, container, 8 );
-	}
-
 	private ItemCellInventory( final ItemStack o, final ISaveProvider container ) throws AppEngException
 	{
 		super( o, container, 8 );
 	}
 
-	public static IMEInventoryHandler getCell( final ItemStack o, final ISaveProvider container2 )
+	public static ICellInventoryHandler<IAEItemStack> getCell( final ItemStack o, final ISaveProvider container2 )
 	{
 		try
 		{
@@ -95,7 +90,7 @@ public class ItemCellInventory extends AbstractCellInventory<IAEItemStack>
 		final Item type = i.getItem();
 		if( type instanceof IStorageCell )
 		{
-			if ( ( (IStorageCell) type ).getChannel() == AEApi.instance().storage().getStorageChannel( IItemStorageChannel.class ) )
+			if( ( (IStorageCell) type ).getChannel() == AEApi.instance().storage().getStorageChannel( IItemStorageChannel.class ) )
 			{
 				return ( (IStorageCell) type ).isStorageCell( i );
 			}
@@ -148,7 +143,6 @@ public class ItemCellInventory extends AbstractCellInventory<IAEItemStack>
 				if( mode == Actionable.MODULATE )
 				{
 					l.setStackSize( l.getStackSize() + remainingItemCount );
-					this.updateItemCount( remainingItemCount );
 					this.saveChanges();
 				}
 				return r;
@@ -158,7 +152,6 @@ public class ItemCellInventory extends AbstractCellInventory<IAEItemStack>
 				if( mode == Actionable.MODULATE )
 				{
 					l.setStackSize( l.getStackSize() + input.getStackSize() );
-					this.updateItemCount( input.getStackSize() );
 					this.saveChanges();
 				}
 				return null;
@@ -180,8 +173,6 @@ public class ItemCellInventory extends AbstractCellInventory<IAEItemStack>
 						toWrite.setStackSize( remainingItemCount );
 
 						this.cellItems.add( toWrite );
-						this.updateItemCount( toWrite.getStackSize() );
-
 						this.saveChanges();
 					}
 					return toReturn;
@@ -189,7 +180,6 @@ public class ItemCellInventory extends AbstractCellInventory<IAEItemStack>
 
 				if( mode == Actionable.MODULATE )
 				{
-					this.updateItemCount( input.getStackSize() );
 					this.cellItems.add( input );
 					this.saveChanges();
 				}
@@ -223,7 +213,6 @@ public class ItemCellInventory extends AbstractCellInventory<IAEItemStack>
 				Results.setStackSize( l.getStackSize() );
 				if( mode == Actionable.MODULATE )
 				{
-					this.updateItemCount( -l.getStackSize() );
 					l.setStackSize( 0 );
 					this.saveChanges();
 				}
@@ -234,7 +223,6 @@ public class ItemCellInventory extends AbstractCellInventory<IAEItemStack>
 				if( mode == Actionable.MODULATE )
 				{
 					l.setStackSize( l.getStackSize() - size );
-					this.updateItemCount( -size );
 					this.saveChanges();
 				}
 			}

--- a/src/main/java/appeng/parts/automation/PartAbstractFormationPlane.java
+++ b/src/main/java/appeng/parts/automation/PartAbstractFormationPlane.java
@@ -15,6 +15,7 @@ import appeng.api.parts.IPart;
 import appeng.api.parts.IPartCollisionHelper;
 import appeng.api.parts.IPartHost;
 import appeng.api.storage.ICellContainer;
+import appeng.api.storage.ICellInventory;
 import appeng.api.storage.IMEInventory;
 import appeng.api.storage.data.IAEStack;
 import appeng.api.storage.data.IItemList;
@@ -257,7 +258,7 @@ public abstract class PartAbstractFormationPlane<T extends IAEStack<T>> extends 
 	}
 
 	@Override
-	public void saveChanges( final IMEInventory cell )
+	public void saveChanges( final ICellInventory<?> cell )
 	{
 		// nope!
 	}

--- a/src/main/java/appeng/parts/automation/PartFormationPlane.java
+++ b/src/main/java/appeng/parts/automation/PartFormationPlane.java
@@ -61,6 +61,7 @@ import appeng.api.networking.events.MENetworkPowerStatusChange;
 import appeng.api.networking.security.IActionSource;
 import appeng.api.parts.IPartItem;
 import appeng.api.parts.IPartModel;
+import appeng.api.storage.ICellInventory;
 import appeng.api.storage.IMEInventoryHandler;
 import appeng.api.storage.IStorageChannel;
 import appeng.api.storage.channels.IItemStorageChannel;

--- a/src/main/java/appeng/parts/misc/PartSharedStorageBus.java
+++ b/src/main/java/appeng/parts/misc/PartSharedStorageBus.java
@@ -39,7 +39,7 @@ import appeng.api.networking.ticking.IGridTickable;
 import appeng.api.parts.IPartCollisionHelper;
 import appeng.api.parts.IPartModel;
 import appeng.api.storage.ICellContainer;
-import appeng.api.storage.IMEInventory;
+import appeng.api.storage.ICellInventory;
 import appeng.api.storage.IMEInventoryHandler;
 import appeng.api.storage.IStorageChannel;
 import appeng.api.storage.channels.IItemStorageChannel;
@@ -126,7 +126,7 @@ public abstract class PartSharedStorageBus extends PartUpgradeable implements IG
 	}
 
 	@Override
-	public void saveChanges( IMEInventory<?> cellInventory )
+	public void saveChanges( ICellInventory<?> cellInventory )
 	{
 	}
 

--- a/src/main/java/appeng/parts/misc/PartStorageBus.java
+++ b/src/main/java/appeng/parts/misc/PartStorageBus.java
@@ -58,6 +58,7 @@ import appeng.api.parts.IPartCollisionHelper;
 import appeng.api.parts.IPartHost;
 import appeng.api.parts.IPartModel;
 import appeng.api.storage.ICellContainer;
+import appeng.api.storage.ICellInventory;
 import appeng.api.storage.IMEInventory;
 import appeng.api.storage.IMEInventoryHandler;
 import appeng.api.storage.IMEMonitorHandlerReceiver;
@@ -599,7 +600,7 @@ public class PartStorageBus extends PartUpgradeable implements IGridTickable, IC
 	 * }
 	 */
 	@Override
-	public void saveChanges( final IMEInventory cellInventory )
+	public void saveChanges( final ICellInventory<?> cellInventory )
 	{
 		// nope!
 	}

--- a/src/main/java/appeng/tile/AEBaseTile.java
+++ b/src/main/java/appeng/tile/AEBaseTile.java
@@ -492,6 +492,7 @@ public class AEBaseTile extends TileEntity implements IOrientable, ICommonTile, 
 	{
 		if( this.world != null )
 		{
+			this.world.markChunkDirty( this.pos, this );
 			if( !this.markDirtyQueued )
 			{
 				TickHandler.INSTANCE.addCallable( null, this::markDirtyAtEndOfTick );

--- a/src/main/java/appeng/tile/AEBaseTile.java
+++ b/src/main/java/appeng/tile/AEBaseTile.java
@@ -52,6 +52,7 @@ import appeng.core.AELog;
 import appeng.core.features.IStackSrc;
 import appeng.helpers.ICustomNameObject;
 import appeng.helpers.IPriorityHost;
+import appeng.hooks.TickHandler;
 import appeng.tile.inventory.AppEngInternalAEInventory;
 import appeng.util.Platform;
 import appeng.util.SettingsFrom;
@@ -68,6 +69,7 @@ public class AEBaseTile extends TileEntity implements IOrientable, ICommonTile, 
 	private EnumFacing forward = null;
 	private EnumFacing up = null;
 	private IBlockState state;
+	private boolean markDirtyQueued = false;
 
 	@Override
 	public boolean shouldRefresh( final World world, final BlockPos pos, final IBlockState oldState, final IBlockState newSate )
@@ -488,7 +490,21 @@ public class AEBaseTile extends TileEntity implements IOrientable, ICommonTile, 
 
 	public void saveChanges()
 	{
-		markDirty();
+		if( this.world != null )
+		{
+			if( !this.markDirtyQueued )
+			{
+				TickHandler.INSTANCE.addCallable( null, this::markDirtyAtEndOfTick );
+				this.markDirtyQueued = true;
+			}
+		}
+	}
+
+	private Object markDirtyAtEndOfTick( final World w )
+	{
+		this.markDirty();
+		this.markDirtyQueued = false;
+		return null;
 	}
 
 	public boolean requiresTESR()

--- a/src/main/java/appeng/tile/crafting/TileCraftingMonitorTile.java
+++ b/src/main/java/appeng/tile/crafting/TileCraftingMonitorTile.java
@@ -159,7 +159,7 @@ public class TileCraftingMonitorTile extends TileCraftingTile implements IColora
 		}
 
 		this.paintedColor = newPaintedColor;
-		this.markDirty();
+		this.saveChanges();
 		this.markForUpdate();
 		return true;
 	}

--- a/src/main/java/appeng/tile/crafting/TileMolecularAssembler.java
+++ b/src/main/java/appeng/tile/crafting/TileMolecularAssembler.java
@@ -133,7 +133,7 @@ public class TileMolecularAssembler extends AENetworkInvTile implements IUpgrade
 				}
 
 				this.updateSleepiness();
-				this.markDirty();
+				this.saveChanges();
 				return true;
 			}
 		}
@@ -398,7 +398,7 @@ public class TileMolecularAssembler extends AENetworkInvTile implements IUpgrade
 			// did it eject?
 			if( this.gridInv.getStackInSlot( 9 ).isEmpty() )
 			{
-				this.markDirty();
+				this.saveChanges();
 			}
 
 			this.ejectHeldItems();
@@ -487,7 +487,7 @@ public class TileMolecularAssembler extends AENetworkInvTile implements IUpgrade
 					// ;P
 				}
 
-				this.markDirty();
+				this.saveChanges();
 				this.updateSleepiness();
 				return this.isAwake ? TickRateModulation.IDLE : TickRateModulation.SLEEP;
 			}
@@ -509,7 +509,7 @@ public class TileMolecularAssembler extends AENetworkInvTile implements IUpgrade
 					{
 						this.gridInv.setStackInSlot( 9, is );
 						this.gridInv.setStackInSlot( x, ItemStack.EMPTY );
-						this.markDirty();
+						this.saveChanges();
 						return;
 					}
 				}
@@ -580,7 +580,7 @@ public class TileMolecularAssembler extends AENetworkInvTile implements IUpgrade
 
 		if( size != newSize )
 		{
-			this.markDirty();
+			this.saveChanges();
 		}
 
 		return output;

--- a/src/main/java/appeng/tile/inventory/AppEngCellInventory.java
+++ b/src/main/java/appeng/tile/inventory/AppEngCellInventory.java
@@ -1,0 +1,119 @@
+
+package appeng.tile.inventory;
+
+
+import net.minecraft.item.ItemStack;
+
+import appeng.api.storage.ICellInventoryHandler;
+import appeng.util.inv.IAEAppEngInventory;
+import appeng.util.inv.IInternalItemHandler;
+import appeng.util.inv.filter.IAEItemFilter;
+
+
+public class AppEngCellInventory implements IInternalItemHandler
+{
+	private final AppEngInternalInventory inv;
+	private final ICellInventoryHandler handlerForSlot[];
+
+	public AppEngCellInventory( final IAEAppEngInventory host, final int slots )
+	{
+		this.inv = new AppEngInternalInventory( host, slots, 1 );
+		this.handlerForSlot = new ICellInventoryHandler[slots];
+	}
+
+	public void setHandler( final int slot, final ICellInventoryHandler handler )
+	{
+		this.handlerForSlot[slot] = handler;
+	}
+
+	public void setFilter( IAEItemFilter filter )
+	{
+		this.inv.setFilter( filter );
+	}
+
+	@Override
+	public void setStackInSlot( int slot, ItemStack stack )
+	{
+		this.persist( slot );
+		this.inv.setStackInSlot( slot, stack );
+		this.cleanup( slot );
+	}
+
+	@Override
+	public int getSlots()
+	{
+		return this.inv.getSlots();
+	}
+
+	@Override
+	public ItemStack getStackInSlot( int slot )
+	{
+		this.persist( slot );
+		return this.inv.getStackInSlot( slot );
+	}
+
+	@Override
+	public ItemStack insertItem( int slot, ItemStack stack, boolean simulate )
+	{
+		this.persist( slot );
+		final ItemStack ret = inv.insertItem( slot, stack, simulate );
+		this.cleanup( slot );
+		return ret;
+	}
+
+	@Override
+	public ItemStack extractItem( int slot, int amount, boolean simulate )
+	{
+		this.persist( slot );
+		final ItemStack ret = inv.extractItem( slot, amount, simulate );
+		this.cleanup( slot );
+		return ret;
+	}
+
+	@Override
+	public int getSlotLimit( int slot )
+	{
+		return inv.getSlotLimit( slot );
+	}
+
+	@Override
+	public boolean isItemValidForSlot( int slot, ItemStack stack )
+	{
+		return inv.isItemValidForSlot( slot, stack );
+	}
+
+	@Override
+	public void markDirty( int slot )
+	{
+		this.persist( slot );
+		this.inv.markDirty( slot );
+		this.cleanup( slot );
+	}
+
+	public void persist()
+	{
+		for( int i = 0; i < this.getSlots(); ++i )
+		{
+			this.persist( i );
+		}
+	}
+
+	private void persist( int slot )
+	{
+		if( this.handlerForSlot[slot] != null )
+		{
+			this.handlerForSlot[slot].getCellInv().persist();
+		}
+	}
+
+	private void cleanup( int slot )
+	{
+		if( this.handlerForSlot[slot] != null )
+		{
+			if( this.handlerForSlot[slot].getCellInv().getItemStack() != this.inv.getStackInSlot( slot ) )
+			{
+				this.handlerForSlot[slot] = null;
+			}
+		}
+	}
+}

--- a/src/main/java/appeng/tile/misc/TileCellWorkbench.java
+++ b/src/main/java/appeng/tile/misc/TileCellWorkbench.java
@@ -185,7 +185,7 @@ public class TileCellWorkbench extends AEBaseTile implements IUpgradeableHost, I
 					this.config.setStackInSlot( x, ItemStack.EMPTY );
 				}
 
-				this.markDirty();
+				this.saveChanges();
 			}
 
 			this.locked = false;

--- a/src/main/java/appeng/tile/misc/TileInscriber.java
+++ b/src/main/java/appeng/tile/misc/TileInscriber.java
@@ -380,7 +380,7 @@ public class TileInscriber extends AENetworkPowerTile implements IGridTickable, 
 						this.sideItemHandler.setStackInSlot( 0, ItemStack.EMPTY );
 					}
 				}
-				this.markDirty();
+				this.saveChanges();
 			}
 			else if( this.finalStep == 16 )
 			{

--- a/src/main/java/appeng/tile/misc/TileInterface.java
+++ b/src/main/java/appeng/tile/misc/TileInterface.java
@@ -130,7 +130,7 @@ public class TileInterface extends AENetworkInvTile implements IGridTickable, II
 
 		this.configureNodeSides();
 		this.markForUpdate();
-		this.markDirty();
+		this.saveChanges();
 	}
 
 	private void configureNodeSides()
@@ -143,12 +143,6 @@ public class TileInterface extends AENetworkInvTile implements IGridTickable, II
 		{
 			this.getProxy().setValidSides( EnumSet.complementOf( EnumSet.of( this.getForward() ) ) );
 		}
-	}
-
-	@Override
-	public void markDirty()
-	{
-		this.duality.markDirty();
 	}
 
 	@Override

--- a/src/main/java/appeng/tile/misc/TilePaint.java
+++ b/src/main/java/appeng/tile/misc/TilePaint.java
@@ -191,7 +191,7 @@ public class TilePaint extends AEBaseTile
 		}
 
 		this.markForUpdate();
-		this.markDirty();
+		this.saveChanges();
 	}
 
 	private void updateData()
@@ -265,7 +265,7 @@ public class TilePaint extends AEBaseTile
 
 			this.maxLit();
 			this.markForUpdate();
-			this.markDirty();
+			this.saveChanges();
 		}
 	}
 

--- a/src/main/java/appeng/tile/misc/TileSecurityStation.java
+++ b/src/main/java/appeng/tile/misc/TileSecurityStation.java
@@ -363,7 +363,7 @@ public class TileSecurityStation extends AENetworkTile implements ITerminalHost,
 		}
 
 		this.paintedColor = newPaintedColor;
-		this.markDirty();
+		this.saveChanges();
 		this.markForUpdate();
 		return true;
 	}

--- a/src/main/java/appeng/tile/misc/TileVibrationChamber.java
+++ b/src/main/java/appeng/tile/misc/TileVibrationChamber.java
@@ -261,7 +261,7 @@ public class TileVibrationChamber extends AENetworkInvTile implements IGridTicka
 					this.inv.setStackInSlot( 0, is );
 				}
 
-				this.markDirty();
+				this.saveChanges();
 			}
 		}
 

--- a/src/main/java/appeng/tile/networking/TileCableBus.java
+++ b/src/main/java/appeng/tile/networking/TileCableBus.java
@@ -312,7 +312,7 @@ public class TileCableBus extends AEBaseTile implements AEMultiTile, ICustomColl
 	@Override
 	public void markForSave()
 	{
-		super.markDirty();
+		this.saveChanges();
 	}
 
 	@Override

--- a/src/main/java/appeng/tile/networking/TileWireless.java
+++ b/src/main/java/appeng/tile/networking/TileWireless.java
@@ -163,9 +163,10 @@ public class TileWireless extends AENetworkInvTile implements IWirelessAccessPoi
 	}
 
 	@Override
-	public void markDirty()
+	public void saveChanges()
 	{
 		this.updatePower();
+		super.saveChanges();
 	}
 
 	@Override


### PR DESCRIPTION
*) saveChanges: queue a markDirty with the TickHandler. Remove direct calls to markDirty
*) ICellInventory: provide a persist() method to save cell contents to NBT. If a ISaveProvider is provided, delegate persisting to the provider.

Fixes #3553