### PR TITLE
Restore behaviour of ESC always closing the GUI

### DIFF
--- a/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
@@ -487,7 +487,7 @@ public class GuiMEMonitorable extends AEBaseMEGui implements ISortSource, IConfi
 				return;
 			}
 
-			if( this.searchField.isFocused() && ( key == Keyboard.KEY_ESCAPE || key == Keyboard.KEY_RETURN ) )
+			if( this.searchField.isFocused() && key == Keyboard.KEY_RETURN )
 			{
 				this.searchField.setFocused( false );
 				return;


### PR DESCRIPTION
Turns out to be more annoying than useful. Enter or Tab can still remove focus from the search box.