### PR TITLE
Cleanup oredict and entity registration

### DIFF
--- a/src/main/java/appeng/block/misc/BlockTinyTNT.java
+++ b/src/main/java/appeng/block/misc/BlockTinyTNT.java
@@ -37,17 +37,13 @@ import net.minecraft.init.SoundEvents;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
-import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundCategory;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.Explosion;
 import net.minecraft.world.World;
-import net.minecraftforge.fml.common.registry.EntityRegistry;
 
 import appeng.block.AEBaseBlock;
-import appeng.core.AppEng;
-import appeng.entity.EntityIds;
 import appeng.entity.EntityTinyTNTPrimed;
 import appeng.helpers.ICustomCollision;
 
@@ -67,9 +63,6 @@ public class BlockTinyTNT extends AEBaseBlock implements ICustomCollision
 
 		this.setSoundType( SoundType.GROUND );
 		this.setHardness( 0F );
-
-		EntityRegistry.registerModEntity( new ResourceLocation( AppEng.MOD_ID, EntityTinyTNTPrimed.class.getName() ), EntityTinyTNTPrimed.class,
-				"EntityTinyTNTPrimed", EntityIds.get( EntityTinyTNTPrimed.class ), AppEng.instance(), 16, 4, true );
 	}
 
 	@Override

--- a/src/main/java/appeng/bootstrap/ItemDefinitionBuilder.java
+++ b/src/main/java/appeng/bootstrap/ItemDefinitionBuilder.java
@@ -144,7 +144,7 @@ class ItemDefinitionBuilder implements IItemBuilder
 		item.setCreativeTab( this.creativeTab );
 
 		// Register all extra handlers
-		this.boostrapComponents.forEach( component -> component.apply( item ) );
+		this.boostrapComponents.forEach( component -> this.factory.addBootstrapComponent( component.apply( item ) ) );
 
 		// Register custom dispenser behavior if requested
 		if( this.dispenserBehaviorSupplier != null )

--- a/src/main/java/appeng/bootstrap/components/IEntityRegistrationComponent.java
+++ b/src/main/java/appeng/bootstrap/components/IEntityRegistrationComponent.java
@@ -1,0 +1,12 @@
+package appeng.bootstrap.components;
+
+import net.minecraftforge.fml.common.registry.EntityEntry;
+import net.minecraftforge.registries.IForgeRegistry;
+
+import appeng.bootstrap.IBootstrapComponent;
+
+@FunctionalInterface
+public interface IEntityRegistrationComponent extends IBootstrapComponent
+{
+	void entityRegistration( IForgeRegistry<EntityEntry> entityRegistry );
+}

--- a/src/main/java/appeng/client/ClientHelper.java
+++ b/src/main/java/appeng/client/ClientHelper.java
@@ -26,10 +26,8 @@ import java.util.Random;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GlStateManager;
-import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Items;
-import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.RayTraceResult;
@@ -42,6 +40,7 @@ import net.minecraftforge.client.model.ModelLoaderRegistry;
 import net.minecraftforge.common.ForgeModContainer;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.client.FMLClientHandler;
+import net.minecraftforge.fml.client.registry.RenderingRegistry;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
 import appeng.api.parts.CableRenderMode;
@@ -85,30 +84,14 @@ public class ClientHelper extends ServerHelper
 		{
 			ModelLoaderRegistry.registerLoader( UVLModelLoader.INSTANCE );
 		}
+
+		RenderingRegistry.registerEntityRenderingHandler( EntityTinyTNTPrimed.class, manager -> new RenderTinyTNTPrimed( manager ) );
+		RenderingRegistry.registerEntityRenderingHandler( EntityFloatingItem.class, manager -> new RenderFloatingItem( manager ) );
 	}
 
 	@Override
 	public void init()
 	{
-		// final Block fluixBlock = GameRegistry.findBlock( "appliedenergistics2", "fluix" );
-		// Item fluixItem = Item.getItemFromBlock( fluixBlock );
-		// ModelResourceLocation itemModelResourceLocation = new ModelResourceLocation( "appliedenergistics2:fluix",
-		// "inventory" );
-		// final int DEFAULT_ITEM_SUBTYPE = 0;
-		// final ItemModelMesher mesher = Minecraft.getMinecraft().getRenderItem().getItemModelMesher();
-		// // mesher.register( fluixItem, DEFAULT_ITEM_SUBTYPE, itemModelResourceLocation );
-		//
-		// final ResourceLocation resource = new ResourceLocation( "appliedenergistics2", "stair.fluix" );
-		// final ModelResourceLocation fluixStairModel = new ModelResourceLocation( resource, "inventory" );
-		// AELog.info( "FluixStairModel: " + fluixStairModel );
-		//
-		// final Set<Item> items = AEApi.instance().definitions().blocks().fluixStairs().maybeItem().asSet();
-		// for( Item item : items )
-		// {
-		// AELog.info( "Registering with %s with unlocalized %s", item, item.getUnlocalizedName() );
-		// mesher.register( item, DEFAULT_ITEM_SUBTYPE, fluixStairModel );
-		// }
-
 	}
 
 	@Override
@@ -199,11 +182,6 @@ public class ClientHelper extends ServerHelper
 	@Override
 	public void postInit()
 	{
-		// RenderingRegistry.registerBlockHandler( WorldRender.INSTANCE );
-		final RenderManager inst = Minecraft.getMinecraft().getRenderManager();
-
-		inst.entityRenderMap.put( EntityTinyTNTPrimed.class, new RenderTinyTNTPrimed( inst ) );
-		inst.entityRenderMap.put( EntityFloatingItem.class, new RenderFloatingItem( inst ) );
 	}
 
 	@Override
@@ -330,29 +308,20 @@ public class ClientHelper extends ServerHelper
 		final EntityPlayer player = mc.player;
 		if( player.isSneaking() )
 		{
-			final EnumHand hand;
-			if( !player.getHeldItem( EnumHand.MAIN_HAND ).isEmpty() && player.getHeldItem( EnumHand.MAIN_HAND ).getItem() instanceof IMouseWheelItem )
-			{
-				hand = EnumHand.MAIN_HAND;
-			}
-			else if( !player.getHeldItem( EnumHand.OFF_HAND ).isEmpty() && player.getHeldItem( EnumHand.OFF_HAND ).getItem() instanceof IMouseWheelItem )
-			{
-				hand = EnumHand.OFF_HAND;
-			}
-			else
-			{
-				return;
-			}
+			final boolean mainHand = player.getHeldItem( EnumHand.MAIN_HAND ).getItem() instanceof IMouseWheelItem;
+			final boolean offHand = player.getHeldItem( EnumHand.OFF_HAND ).getItem() instanceof IMouseWheelItem;
 
-			final ItemStack is = player.getHeldItem( hand );
-			try
+			if( mainHand || offHand )
 			{
-				NetworkHandler.instance().sendToServer( new PacketValueConfig( "Item", me.getDwheel() > 0 ? "WheelUp" : "WheelDown" ) );
-				me.setCanceled( true );
-			}
-			catch( final IOException e )
-			{
-				AELog.debug( e );
+				try
+				{
+					NetworkHandler.instance().sendToServer( new PacketValueConfig( "Item", me.getDwheel() > 0 ? "WheelUp" : "WheelDown" ) );
+					me.setCanceled( true );
+				}
+				catch( final IOException e )
+				{
+					AELog.debug( e );
+				}
 			}
 		}
 	}

--- a/src/main/java/appeng/core/api/definitions/ApiBlocks.java
+++ b/src/main/java/appeng/core/api/definitions/ApiBlocks.java
@@ -29,6 +29,7 @@ import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemSlab;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.common.registry.EntityEntryBuilder;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.oredict.OreDictionary;
@@ -93,6 +94,7 @@ import appeng.bootstrap.BlockRenderingCustomizer;
 import appeng.bootstrap.FeatureFactory;
 import appeng.bootstrap.IBlockRendering;
 import appeng.bootstrap.IItemRendering;
+import appeng.bootstrap.components.IEntityRegistrationComponent;
 import appeng.bootstrap.components.IOreDictComponent;
 import appeng.bootstrap.components.IPostInitComponent;
 import appeng.bootstrap.components.IPreInitComponent;
@@ -126,6 +128,8 @@ import appeng.decorative.solid.BlockQuartzPillar;
 import appeng.decorative.solid.BlockSkyStone;
 import appeng.decorative.solid.BlockSkyStone.SkystoneType;
 import appeng.decorative.stair.BlockStairCommon;
+import appeng.entity.EntityIds;
+import appeng.entity.EntityTinyTNTPrimed;
 import appeng.fluids.block.BlockFluidInterface;
 import appeng.fluids.tile.TileFluidInterface;
 import appeng.hooks.DispenserBehaviorTinyTNT;
@@ -345,6 +349,16 @@ public final class ApiBlocks implements IBlocks
 				.features( AEFeature.TINY_TNT )
 				.bootstrap( ( block, item ) -> (IPreInitComponent) side -> BlockDispenser.DISPENSE_BEHAVIOR_REGISTRY.putObject( item,
 						new DispenserBehaviorTinyTNT() ) )
+				.bootstrap( ( block, item ) -> (IEntityRegistrationComponent) r ->
+				{
+					r.register( EntityEntryBuilder.create()
+							.entity( EntityTinyTNTPrimed.class )
+							.id( new ResourceLocation( "appliedenergistics2", EntityTinyTNTPrimed.class.getName() ),
+									EntityIds.get( EntityTinyTNTPrimed.class ) )
+							.name( "EntityTinyTNTPrimed" )
+							.tracker( 16, 4, true )
+							.build() );
+				} )
 				.build();
 		this.securityStation = registry.block( "security_station", BlockSecurityStation::new )
 				.features( AEFeature.SECURITY )

--- a/src/main/java/appeng/core/api/definitions/ApiItems.java
+++ b/src/main/java/appeng/core/api/definitions/ApiItems.java
@@ -19,10 +19,14 @@
 package appeng.core.api.definitions;
 
 
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.common.registry.EntityEntryBuilder;
+
 import appeng.api.definitions.IItemDefinition;
 import appeng.api.definitions.IItems;
 import appeng.api.util.AEColoredItemDefinition;
 import appeng.bootstrap.FeatureFactory;
+import appeng.bootstrap.components.IEntityRegistrationComponent;
 import appeng.client.render.crafting.ItemEncodedPatternRendering;
 import appeng.core.CreativeTabFacade;
 import appeng.core.features.AEFeature;
@@ -30,6 +34,8 @@ import appeng.debug.ToolDebugCard;
 import appeng.debug.ToolEraser;
 import appeng.debug.ToolMeteoritePlacer;
 import appeng.debug.ToolReplicatorCard;
+import appeng.entity.EntityGrowingCrystal;
+import appeng.entity.EntityIds;
 import appeng.fluids.items.BasicFluidStorageCell;
 import appeng.fluids.items.FluidDummyItem;
 import appeng.fluids.items.FluidDummyItemRendering;
@@ -231,6 +237,16 @@ public final class ApiItems implements IItems
 		this.crystalSeed = registry.item( "crystal_seed", ItemCrystalSeed::new )
 				.features( AEFeature.CRYSTAL_SEEDS )
 				.rendering( new ItemCrystalSeedRendering() )
+				.bootstrap( item -> (IEntityRegistrationComponent) r ->
+				{
+					r.register( EntityEntryBuilder.create()
+							.entity( EntityGrowingCrystal.class )
+							.id( new ResourceLocation( "appliedenergistics2", EntityGrowingCrystal.class.getName() ),
+									EntityIds.get( EntityGrowingCrystal.class ) )
+							.name( EntityGrowingCrystal.class.getSimpleName() )
+							.tracker( 16, 4, true )
+							.build() );
+				} )
 				.build();
 
 		// rv1

--- a/src/main/java/appeng/core/api/definitions/ApiMaterials.java
+++ b/src/main/java/appeng/core/api/definitions/ApiMaterials.java
@@ -22,6 +22,8 @@ package appeng.core.api.definitions;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.common.registry.EntityEntryBuilder;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
@@ -30,7 +32,11 @@ import appeng.api.definitions.IMaterials;
 import appeng.bootstrap.FeatureFactory;
 import appeng.bootstrap.IItemRendering;
 import appeng.bootstrap.ItemRenderingCustomizer;
+import appeng.bootstrap.components.IEntityRegistrationComponent;
 import appeng.core.features.DamagedItemDefinition;
+import appeng.entity.EntityChargedQuartz;
+import appeng.entity.EntityIds;
+import appeng.entity.EntitySingularity;
 import appeng.items.materials.ItemMaterial;
 import appeng.items.materials.MaterialType;
 
@@ -132,6 +138,22 @@ public final class ApiMaterials implements IMaterials
 								.map( MaterialType::getModel )
 								.collect( Collectors.toList() ) );
 					}
+				} )
+				.bootstrap( item -> (IEntityRegistrationComponent) r ->
+				{
+					r.register( EntityEntryBuilder.create()
+							.entity( EntitySingularity.class )
+							.id( new ResourceLocation( "appliedenergistics2", EntitySingularity.class.getName() ), EntityIds.get( EntitySingularity.class ) )
+							.name( EntitySingularity.class.getSimpleName() )
+							.tracker( 16, 4, true )
+							.build() );
+					r.register( EntityEntryBuilder.create()
+							.entity( EntityChargedQuartz.class )
+							.id( new ResourceLocation( "appliedenergistics2", EntityChargedQuartz.class.getName() ),
+									EntityIds.get( EntityChargedQuartz.class ) )
+							.name( EntityChargedQuartz.class.getSimpleName() )							
+							.tracker( 16, 4, true )
+							.build() );
 				} )
 				.build();
 

--- a/src/main/java/appeng/entity/RenderTinyTNTPrimed.java
+++ b/src/main/java/appeng/entity/RenderTinyTNTPrimed.java
@@ -25,7 +25,6 @@ import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.client.renderer.texture.TextureMap;
-import net.minecraft.entity.Entity;
 import net.minecraft.init.Blocks;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.relauncher.Side;
@@ -33,7 +32,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 
 
 @SideOnly( Side.CLIENT )
-public class RenderTinyTNTPrimed extends Render
+public class RenderTinyTNTPrimed extends Render<EntityTinyTNTPrimed>
 {
 
 	public RenderTinyTNTPrimed( final RenderManager p_i46134_1_ )
@@ -43,12 +42,7 @@ public class RenderTinyTNTPrimed extends Render
 	}
 
 	@Override
-	public void doRender( final Entity tnt, final double x, final double y, final double z, final float unused, final float life )
-	{
-		this.renderPrimedTNT( (EntityTinyTNTPrimed) tnt, x, y, z, unused, life );
-	}
-
-	private void renderPrimedTNT( final EntityTinyTNTPrimed tnt, final double x, final double y, final double z, final float unused, final float life )
+	public void doRender( final EntityTinyTNTPrimed tnt, final double x, final double y, final double z, final float unused, final float life )
 	{
 		final BlockRendererDispatcher blockrendererdispatcher = Minecraft.getMinecraft().getBlockRendererDispatcher();
 		GlStateManager.pushMatrix();
@@ -105,7 +99,7 @@ public class RenderTinyTNTPrimed extends Render
 	}
 
 	@Override
-	protected ResourceLocation getEntityTexture( final Entity entity )
+	protected ResourceLocation getEntityTexture( final EntityTinyTNTPrimed entity )
 	{
 		return TextureMap.LOCATION_BLOCKS_TEXTURE;
 	}

--- a/src/main/java/appeng/items/materials/ItemMaterial.java
+++ b/src/main/java/appeng/items/materials/ItemMaterial.java
@@ -202,54 +202,17 @@ public final class ItemMaterial extends AEBaseItem implements IStorageComponent,
 		return mat.getStackSrc();
 	}
 
-	public void makeUnique()
+	public void registerOredicts()
 	{
 		for( final MaterialType mt : ImmutableSet.copyOf( this.dmgToMaterial.values() ) )
 		{
 			if( mt.getOreName() != null )
 			{
-				ItemStack replacement = ItemStack.EMPTY;
-
 				final String[] names = mt.getOreName().split( "," );
 
 				for( final String name : names )
 				{
-					if( !replacement.isEmpty() )
-					{
-						break;
-					}
-
-					final List<ItemStack> options = OreDictionary.getOres( name );
-					if( options != OreDictionary.EMPTY_LIST && options.size() > 0 )
-					{
-						for( final ItemStack is : options )
-						{
-							if( !is.isEmpty() )
-							{
-								replacement = is.copy();
-								break;
-							}
-						}
-					}
-				}
-
-				if( replacement.isEmpty() || AEConfig.instance().useAEVersion( mt ) )
-				{
-					// continue using the AE2 item.
-					for( final String name : names )
-					{
-						OreDictionary.registerOre( name, mt.stack( 1 ) );
-					}
-				}
-				else
-				{
-					if( mt.getItemInstance() == this )
-					{
-						this.dmgToMaterial.remove( mt.getDamageValue() );
-					}
-
-					mt.setItemInstance( replacement.getItem() );
-					mt.setDamageValue( replacement.getItemDamage() );
+					OreDictionary.registerOre( name, mt.stack( 1 ) );
 				}
 			}
 		}
@@ -341,8 +304,9 @@ public final class ItemMaterial extends AEBaseItem implements IStorageComponent,
 
 		try
 		{
-			eqi = droppedEntity.getConstructor( World.class, double.class, double.class, double.class, ItemStack.class ).newInstance( w, location.posX,
-					location.posY, location.posZ, itemstack );
+			eqi = droppedEntity.getConstructor( World.class, double.class, double.class, double.class, ItemStack.class )
+					.newInstance( w, location.posX,
+							location.posY, location.posZ, itemstack );
 		}
 		catch( final Throwable t )
 		{

--- a/src/main/java/appeng/items/materials/MaterialType.java
+++ b/src/main/java/appeng/items/materials/MaterialType.java
@@ -27,13 +27,11 @@ import net.minecraft.entity.Entity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.fml.common.registry.EntityRegistry;
 
 import appeng.core.AppEng;
 import appeng.core.features.AEFeature;
 import appeng.core.features.MaterialStackSrc;
 import appeng.entity.EntityChargedQuartz;
-import appeng.entity.EntityIds;
 import appeng.entity.EntitySingularity;
 
 
@@ -148,11 +146,6 @@ public enum MaterialType
 	{
 		this( metaValue, modelName, features );
 		this.droppedEntity = c;
-
-		EntityRegistry.registerModEntity( new ResourceLocation( "appliedenergistics2", this.droppedEntity.getName() ), this.droppedEntity,
-				this.droppedEntity.getSimpleName(),
-				EntityIds.get( this.droppedEntity ), AppEng.instance(), 16, 4,
-				true );
 	}
 
 	MaterialType( final int metaValue, String modelName, final Set<AEFeature> features, final String oreDictionary, final Class<? extends Entity> c )
@@ -160,10 +153,6 @@ public enum MaterialType
 		this( metaValue, modelName, features );
 		this.oreName = oreDictionary;
 		this.droppedEntity = c;
-		EntityRegistry.registerModEntity( new ResourceLocation( "appliedenergistics2", this.droppedEntity.getName() ), this.droppedEntity,
-				this.droppedEntity.getSimpleName(),
-				EntityIds.get( this.droppedEntity ), AppEng.instance(), 16, 4,
-				true );
 	}
 
 	MaterialType( final int metaValue, String modelName, final Set<AEFeature> features, final String oreDictionary )

--- a/src/main/java/appeng/items/misc/ItemCrystalSeed.java
+++ b/src/main/java/appeng/items/misc/ItemCrystalSeed.java
@@ -32,9 +32,7 @@ import net.minecraft.entity.Entity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.NonNullList;
-import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
-import net.minecraftforge.fml.common.registry.EntityRegistry;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
@@ -42,10 +40,8 @@ import appeng.api.AEApi;
 import appeng.api.definitions.IMaterials;
 import appeng.api.implementations.items.IGrowableCrystal;
 import appeng.api.recipes.ResolverResult;
-import appeng.core.AppEng;
 import appeng.core.localization.ButtonToolTips;
 import appeng.entity.EntityGrowingCrystal;
-import appeng.entity.EntityIds;
 import appeng.items.AEBaseItem;
 import appeng.util.Platform;
 
@@ -64,9 +60,6 @@ public class ItemCrystalSeed extends AEBaseItem implements IGrowableCrystal
 	public ItemCrystalSeed()
 	{
 		this.setHasSubtypes( true );
-
-		EntityRegistry.registerModEntity( new ResourceLocation( "appliedenergistics2", EntityGrowingCrystal.class.getName() ), EntityGrowingCrystal.class,
-				EntityGrowingCrystal.class.getSimpleName(), EntityIds.get( EntityGrowingCrystal.class ), AppEng.instance(), 16, 4, true );
 	}
 
 	@Nullable


### PR DESCRIPTION
Moves the registrations to the relevant forge events.
This removes the ore camouflage, which may be controversial. But this will go away anyways with 1.13 and the tag system.
