### PR TITLE
Power off a network in case it losses its local buffer.

### DIFF
--- a/src/main/java/appeng/me/cache/EnergyGridCache.java
+++ b/src/main/java/appeng/me/cache/EnergyGridCache.java
@@ -678,6 +678,12 @@ public class EnergyGridCache implements IEnergyGrid
 			{
 				EnergyGridCache.this.myGrid.postEvent( new MENetworkPowerStorage( this, PowerEventType.REQUEST_POWER ) );
 			}
+
+			if( this.stored < 0.01 )
+			{
+				EnergyGridCache.this.ticksSinceHasPowerChange = 0;
+				EnergyGridCache.this.publicPowerState( false, EnergyGridCache.this.myGrid );
+			}
 		}
 	}
 }


### PR DESCRIPTION
This better indicates power issue with dynamic consumption like
extracting/inserting items into a network. E.g. the terminals will
shutdown, no light/channel/etc indicators.

Due to the networks trying to extract from the largest possible energy
storage first, the network buffer will be used as last option after
energy cells or controllers.

Potentially needs evaluation in case of adhoc networks with a high
transfer rate locally. Increasing the local buffer might be an idea or
have it scale with the amount of local gridnodes. As long as it does not
invalidates energy cells.