### PR TITLE
(#2842) Re-add support for the OpenComputers network P2P Tunnel

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -27,6 +27,7 @@ cofhcore_version=1.12.2-4.5.2.19
 crafttweaker_version=4.1.8.9
 inventorytweaks_version=1.63
 ctm_version=0.3.0.15
+opencomputers_version=MC1.12.2-1.7.+
 
 #########################################################
 # Deployment                                            #

--- a/gradle/scripts/dependencies.gradle
+++ b/gradle/scripts/dependencies.gradle
@@ -73,6 +73,11 @@ repositories {
 		name = "CurseForge"
 		url = "https://minecraft.curseforge.com/api/maven/"
 	}
+
+    maven {
+        name 'OpenComputers Maven'
+        url "http://maven.cil.li/"
+    }
 }
 
 configurations {
@@ -84,6 +89,7 @@ dependencies {
     mods "mcp.mobius.waila:Hwyla:${hwyla_version}"
     mods "net.industrial-craft:industrialcraft-2:${ic2_version}:dev"
     mods "mcjty.theoneprobe:TheOneProbe-${minecraft_version}:${top_version}"
+    mods "li.cil.oc:OpenComputers:${opencomputers_version}"
 
     // compile against provided APIs
     compileOnly "mezz.jei:jei_${minecraft_version}:${jei_version}:api"
@@ -95,6 +101,7 @@ dependencies {
     compileOnly "CraftTweaker2:CraftTweaker2-API:${crafttweaker_version}"
 	compileOnly "inventory-tweaks:InventoryTweaks:${inventorytweaks_version}:api"
     compileOnly "team.chisel.ctm:CTM:MC1.12-${ctm_version}"
+    compileOnly "li.cil.oc:OpenComputers:${opencomputers_version}:api"
 
     // at runtime, use the full JEI jar
     runtime "mezz.jei:jei_${minecraft_version}:${jei_version}"

--- a/gradle/scripts/optional.gradle
+++ b/gradle/scripts/optional.gradle
@@ -53,3 +53,14 @@ task deinstallTop(type: Delete) {
     delete fileTree(dir: minecraft.runDir + "/mods", include: "*TheOneProbe*.jar")
 }
 
+// OpenComputers
+task installOpenComputers(type: Copy, dependsOn: "deinstallOpenComputers") {
+    from { configurations.mods }
+    include "**/*OpenComputers*.jar"
+    into file(minecraft.runDir + "/mods")
+}
+
+task deinstallOpenComputers(type: Delete) {
+    delete fileTree(dir: minecraft.runDir + "/mods", include: "*OpenComputers*.jar")
+}
+

--- a/src/api/java/appeng/api/definitions/IParts.java
+++ b/src/api/java/appeng/api/definitions/IParts.java
@@ -88,7 +88,7 @@ public interface IParts
 
 	IItemDefinition p2PTunnelLight();
 
-	// IItemDefinition p2PTunnelOpenComputers();
+	IItemDefinition p2PTunnelOpenComputers();
 
 	IItemDefinition cableAnchor();
 

--- a/src/main/java/appeng/capabilities/Capabilities.java
+++ b/src/main/java/appeng/capabilities/Capabilities.java
@@ -19,6 +19,8 @@
 package appeng.capabilities;
 
 
+import li.cil.oc.api.network.Environment;
+import li.cil.oc.api.network.SidedEnvironment;
 import net.darkhax.tesla.api.ITeslaConsumer;
 import net.darkhax.tesla.api.ITeslaHolder;
 import net.minecraft.nbt.NBTBase;
@@ -53,6 +55,10 @@ public final class Capabilities
 	public static Capability<ITeslaHolder> TESLA_HOLDER;
 
 	public static Capability<IEnergyStorage> FORGE_ENERGY;
+
+	public static Capability<Environment> OC_ENVIRONMENT;
+
+	public static Capability<SidedEnvironment> OC_SIDED_ENVIRONMENT;
 
 	/**
 	 * Register AE2 provided capabilities.
@@ -97,6 +103,24 @@ public final class Capabilities
 	private static void capIEnergyStorageRegistered( Capability<IEnergyStorage> cap )
 	{
 		FORGE_ENERGY = cap;
+	}
+
+	@CapabilityInject( Environment.class )
+	private static void capEnvironmentRegistered( Capability<Environment> cap )
+	{
+		if( IntegrationRegistry.INSTANCE.isEnabled( IntegrationType.OpenComputers ) )
+		{
+			OC_ENVIRONMENT = cap;
+		}
+	}
+
+	@CapabilityInject( SidedEnvironment.class )
+	private static void capSidedEnvironmentRegistered( Capability<SidedEnvironment> cap )
+	{
+		if( IntegrationRegistry.INSTANCE.isEnabled( IntegrationType.OpenComputers ) )
+		{
+			OC_SIDED_ENVIRONMENT = cap;
+		}
 	}
 
 	// Create a storage implementation that does not do anything

--- a/src/main/java/appeng/core/api/definitions/ApiParts.java
+++ b/src/main/java/appeng/core/api/definitions/ApiParts.java
@@ -70,7 +70,7 @@ public final class ApiParts implements IParts
 	private final IItemDefinition p2PTunnelEU;
 	private final IItemDefinition p2PTunnelFE;
 	private final IItemDefinition p2PTunnelLight;
-	// private final IItemDefinition p2PTunnelOpenComputers;
+	private final IItemDefinition p2PTunnelOpenComputers;
 	private final IItemDefinition cableAnchor;
 	private final IItemDefinition monitor;
 	private final IItemDefinition semiDarkMonitor;
@@ -131,8 +131,7 @@ public final class ApiParts implements IParts
 		this.p2PTunnelEU = new DamagedItemDefinition( "part.tunnel.eu", itemPart.createPart( PartType.P2P_TUNNEL_IC2 ) );
 		this.p2PTunnelFE = new DamagedItemDefinition( "part.tunnel.fe", itemPart.createPart( PartType.P2P_TUNNEL_FE ) );
 		this.p2PTunnelLight = new DamagedItemDefinition( "part.tunnel.light", itemPart.createPart( PartType.P2P_TUNNEL_LIGHT ) );
-		// this.p2PTunnelOpenComputers = new DamagedItemDefinition( itemMultiPart.createPart(
-		// PartType.P2PTunnelOpenComputers ) );
+		this.p2PTunnelOpenComputers = new DamagedItemDefinition( "part.tunnel.open_computers", itemPart.createPart( PartType.P2P_TUNNEL_OPEN_COMPUTERS ) );
 		this.cableAnchor = new DamagedItemDefinition( "part.cable_anchor", itemPart.createPart( PartType.CABLE_ANCHOR ) );
 		this.monitor = new DamagedItemDefinition( "part.monitor", itemPart.createPart( PartType.MONITOR ) );
 		this.semiDarkMonitor = new DamagedItemDefinition( "part.monitor.semi_dark", itemPart.createPart( PartType.SEMI_DARK_MONITOR ) );
@@ -335,13 +334,11 @@ public final class ApiParts implements IParts
 		return this.p2PTunnelLight;
 	}
 
-	/*
-	 * @Override
-	 * public IItemDefinition p2PTunnelOpenComputers()
-	 * {
-	 * return this.p2PTunnelOpenComputers;
-	 * }
-	 */
+	 @Override
+	 public IItemDefinition p2PTunnelOpenComputers()
+	 {
+		 return this.p2PTunnelOpenComputers;
+	 }
 
 	@Override
 	public IItemDefinition cableAnchor()

--- a/src/main/java/appeng/core/features/registries/P2PTunnelRegistry.java
+++ b/src/main/java/appeng/core/features/registries/P2PTunnelRegistry.java
@@ -110,6 +110,18 @@ public final class P2PTunnelRegistry implements IP2PTunnelRegistry
 		this.addNewAttunement( this.getModItem( "enderio", "itemredstoneconduit", OreDictionary.WILDCARD_VALUE ), TunnelType.REDSTONE );
 
 		/**
+		/* OpenComputers.
+		 */
+
+		this.addNewAttunement( this.getModItem( "opencomputers", "cable", 0 ), TunnelType.COMPUTER_MESSAGE );
+		this.addNewAttunement( this.getModItem( "opencomputers", "adapter", 0 ), TunnelType.COMPUTER_MESSAGE );
+		this.addNewAttunement( this.getModItem( "opencomputers", "relay", 0 ), TunnelType.COMPUTER_MESSAGE );
+		this.addNewAttunement( this.getModItem( "opencomputers", "card", 7 ), TunnelType.COMPUTER_MESSAGE );
+		this.addNewAttunement( this.getModItem( "opencomputers", "card", 9 ), TunnelType.COMPUTER_MESSAGE );
+		this.addNewAttunement( this.getModItem( "opencomputers", "upgrade", 31 ), TunnelType.COMPUTER_MESSAGE );
+		this.addNewAttunement( this.getModItem( "opencomputers", "analyzer", 0 ), TunnelType.COMPUTER_MESSAGE );
+
+		/**
 		 * attune based on lots of random item related stuff
 		 */
 

--- a/src/main/java/appeng/integration/IntegrationType.java
+++ b/src/main/java/appeng/integration/IntegrationType.java
@@ -23,6 +23,7 @@ import appeng.integration.modules.crafttweaker.CTModule;
 import appeng.integration.modules.ic2.IC2Module;
 import appeng.integration.modules.inventorytweaks.InventoryTweaksModule;
 import appeng.integration.modules.jei.JEIModule;
+import appeng.integration.modules.opencomputers.OpenComputersModule;
 import appeng.integration.modules.theoneprobe.TheOneProbeModule;
 import appeng.integration.modules.waila.WailaModule;
 
@@ -71,7 +72,14 @@ public enum IntegrationType
 
 	Mekanism( IntegrationSide.BOTH, "Mekanism", "mekanism" ),
 
-	OpenComputers( IntegrationSide.BOTH, "OpenComputers", "opencomputers" ),
+	OpenComputers( IntegrationSide.BOTH, "OpenComputers", "opencomputers" )
+	{
+		@Override
+		public IIntegrationModule createInstance()
+		{
+			return new OpenComputersModule();
+		}
+	},
 
 	THE_ONE_PROBE( IntegrationSide.BOTH, "TheOneProbe", "theoneprobe" )
 	{

--- a/src/main/java/appeng/integration/modules/opencomputers/OpenComputersModule.java
+++ b/src/main/java/appeng/integration/modules/opencomputers/OpenComputersModule.java
@@ -1,0 +1,57 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.integration.modules.opencomputers;
+
+
+import li.cil.oc.api.Items;
+
+import appeng.api.AEApi;
+import appeng.api.config.TunnelType;
+import appeng.api.features.IP2PTunnelRegistry;
+import appeng.integration.IIntegrationModule;
+import appeng.integration.IntegrationHelper;
+
+
+
+public class OpenComputersModule implements IIntegrationModule
+{
+	public OpenComputersModule()
+	{
+		IntegrationHelper.testClassExistence( this, li.cil.oc.api.Items.class );
+		IntegrationHelper.testClassExistence( this, li.cil.oc.api.Network.class );
+		IntegrationHelper.testClassExistence( this, li.cil.oc.api.network.Environment.class );
+		IntegrationHelper.testClassExistence( this, li.cil.oc.api.network.SidedEnvironment.class );
+		IntegrationHelper.testClassExistence( this, li.cil.oc.api.network.Node.class );
+		IntegrationHelper.testClassExistence( this, li.cil.oc.api.network.Message.class );
+	}
+
+	@Override
+	public void postInit()
+	{
+		final IP2PTunnelRegistry reg = AEApi.instance().registries().p2pTunnel();
+
+		reg.addNewAttunement( Items.get( "cable" ).createItemStack( 1 ), TunnelType.COMPUTER_MESSAGE );
+		reg.addNewAttunement( Items.get( "adapter" ).createItemStack( 1 ), TunnelType.COMPUTER_MESSAGE );
+		reg.addNewAttunement( Items.get( "relay" ).createItemStack( 1 ), TunnelType.COMPUTER_MESSAGE );
+		reg.addNewAttunement( Items.get( "lancard" ).createItemStack( 1 ), TunnelType.COMPUTER_MESSAGE );
+		reg.addNewAttunement( Items.get( "linkedcard" ).createItemStack( 1 ), TunnelType.COMPUTER_MESSAGE );
+		reg.addNewAttunement( Items.get( "wlancard" ).createItemStack( 1 ), TunnelType.COMPUTER_MESSAGE );
+		reg.addNewAttunement( Items.get( "analyzer" ).createItemStack( 1 ), TunnelType.COMPUTER_MESSAGE );
+	}
+}

--- a/src/main/java/appeng/items/parts/PartType.java
+++ b/src/main/java/appeng/items/parts/PartType.java
@@ -73,6 +73,7 @@ import appeng.parts.p2p.PartP2PFluids;
 import appeng.parts.p2p.PartP2PIC2Power;
 import appeng.parts.p2p.PartP2PItems;
 import appeng.parts.p2p.PartP2PLight;
+import appeng.parts.p2p.PartP2POpenComputers;
 import appeng.parts.p2p.PartP2PRedstone;
 import appeng.parts.p2p.PartP2PTunnelME;
 import appeng.parts.reporting.PartConversionMonitor;
@@ -313,8 +314,17 @@ public enum PartType
 		}
 	},
 
-	// P2PTunnelOpenComputers( 468, EnumSet.of( AEFeature.P2PTunnel, AEFeature.P2PTunnelOpenComputers ), EnumSet.of(
-	// IntegrationType.OpenComputers ), PartP2POpenComputers.class, GuiText.OCTunnel ),
+
+	P2P_TUNNEL_OPEN_COMPUTERS( 468, "p2p_tunnel_open_computers", EnumSet.of( AEFeature.P2P_TUNNEL,
+			AEFeature.P2P_TUNNEL_OPEN_COMPUTERS ), EnumSet.of( IntegrationType.OpenComputers ),
+			PartP2POpenComputers.class, GuiText.OCTunnel )
+	{
+		@Override
+		String getUnlocalizedName()
+		{
+			return "p2p_tunnel";
+		}
+	},
 
 	INTERFACE_TERMINAL( 480, "interface_terminal", EnumSet.of( AEFeature.INTERFACE_TERMINAL ), EnumSet
 			.noneOf( IntegrationType.class ), PartInterfaceTerminal.class ),

--- a/src/main/java/appeng/parts/p2p/PartP2PTunnel.java
+++ b/src/main/java/appeng/parts/p2p/PartP2PTunnel.java
@@ -276,14 +276,10 @@ public abstract class PartP2PTunnel<T extends PartP2PTunnel> extends PartBasicSt
 					newType = parts.p2PTunnelRedstone().maybeStack( 1 ).orElse( ItemStack.EMPTY );
 					break;
 
-				/*
-				 * case COMPUTER_MESSAGE:
-				 * for( ItemStack stack : parts.p2PTunnelOpenComputers().maybeStack( 1 ).asSet() )
-				 * {
-				 * newType = stack;
-				 * }
-				 * break;
-				 */
+
+				 case COMPUTER_MESSAGE:
+					newType = parts.p2PTunnelOpenComputers().maybeStack( 1 ).orElse( ItemStack.EMPTY );
+					 break;
 
 				default:
 					newType = ItemStack.EMPTY;

--- a/src/main/resources/assets/appliedenergistics2/models/item/part/p2p_tunnel_open_computers.json
+++ b/src/main/resources/assets/appliedenergistics2/models/item/part/p2p_tunnel_open_computers.json
@@ -1,0 +1,6 @@
+{
+    "parent": "appliedenergistics2:item/part/p2p_tunnel",
+    "textures": {
+        "type": "opencomputers:blocks/adapter_side"
+    }
+}

--- a/src/main/resources/assets/appliedenergistics2/models/part/p2p/p2p_tunnel_open_computers.json
+++ b/src/main/resources/assets/appliedenergistics2/models/part/p2p/p2p_tunnel_open_computers.json
@@ -1,0 +1,6 @@
+{
+    "parent": "appliedenergistics2:part/p2p/p2p_tunnel_base",
+    "textures": {
+        "type": "opencomputers:blocks/adapter_side"
+    }
+}


### PR DESCRIPTION
The OpenComputers P2P tunnel was disabled during the port to 1.8. This
commit re-adds the OpenComputers P2P tunnel. The implementation is based
on the OpenComputers P2P tunnel code from AE2 in 1.7.10, updated and
refactored based on the IC2 P2P tunnel and general integration module
design.

Tested and working on Minecraft 1.12.2, Forge version 14.23.4.2750,
with OpenComputers version 1.7.2.67, connecting a RAID block, tier 3
screen and keyboard to both a tier 3 computer and a tier 3 server.
Also successfully tested AE2 with the OpenComputers mod removed.

Also happy to split into separate commits if preferred, wasn't entirely sure about this from contributing guide, which mentions splitting into logical units, so not sure if that meant separate commits for changes to different areas of the codebase, or if it meant separate commits for each piece of overall functionality change.