### PR TITLE
Fixes #3746: Revert OreDict use for cable anchors. 

### DIFF
--- a/src/main/resources/assets/appliedenergistics2/recipes/_constants.json
+++ b/src/main/resources/assets/appliedenergistics2/recipes/_constants.json
@@ -40,6 +40,25 @@
         ]
     },
     {
+        "name": "appliedenergistics2:knife",
+        "conditions": [
+            {
+                "type": "appliedenergistics2:features",
+                "features": "quartz_knife"
+            }
+        ],
+        "ingredient": [
+            {
+                "item": "appliedenergistics2:certus_quartz_cutting_knife",
+                "data": 32767
+            },
+            {
+                "item": "appliedenergistics2:nether_quartz_cutting_knife",
+                "data": 32767
+            }
+        ]
+    },
+    {
         "name": "appliedenergistics2:cable",
         "ingredient": [
             {

--- a/src/main/resources/assets/appliedenergistics2/recipes/network/parts/cable_anchor.json
+++ b/src/main/resources/assets/appliedenergistics2/recipes/network/parts/cable_anchor.json
@@ -9,8 +9,7 @@
             "item": "#appliedenergistics2:metalIngots"
         },
         {
-            "type": "forge:ore_dict",
-            "ore": "itemQuartzKnife"
+            "item": "#appliedenergistics2:knife"
         }
     ]
 }


### PR DESCRIPTION
Blame Forge for crashes.