### PR TITLE
Fix #3810 #3813

### DIFF
--- a/src/main/java/appeng/client/render/FacadeBakedItemModel.java
+++ b/src/main/java/appeng/client/render/FacadeBakedItemModel.java
@@ -45,6 +45,7 @@ public class FacadeBakedItemModel extends DelegateBakedModel
 
 	private final ItemStack textureStack;
 	private final FacadeBuilder facadeBuilder;
+	private List<BakedQuad> quads = null;
 
 	protected FacadeBakedItemModel( IBakedModel base, ItemStack textureStack, FacadeBuilder facadeBuilder )
 	{
@@ -60,9 +61,13 @@ public class FacadeBakedItemModel extends DelegateBakedModel
 		{
 			return Collections.emptyList();
 		}
-		List<BakedQuad> quads = new ArrayList<>();
-		quads.addAll( this.facadeBuilder.buildFacadeItemQuads( this.textureStack, EnumFacing.NORTH ) );
-		quads.addAll( this.getBaseModel().getQuads( state, side, rand ) );
+		if( quads == null )
+		{
+		    quads = new ArrayList<>();
+            quads.addAll( this.facadeBuilder.buildFacadeItemQuads( this.textureStack, EnumFacing.NORTH ) );
+            quads.addAll( this.getBaseModel().getQuads( state, side, rand ) );
+            quads = Collections.unmodifiableList( quads );
+        }
 		return quads;
 	}
 

--- a/src/main/java/appeng/client/render/FacadeDispatcherBakedModel.java
+++ b/src/main/java/appeng/client/render/FacadeDispatcherBakedModel.java
@@ -21,9 +21,12 @@ package appeng.client.render;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import javax.annotation.Nullable;
 
+import it.unimi.dsi.fastutil.ints.Int2ObjectArrayMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.client.renderer.block.model.IBakedModel;
@@ -47,6 +50,7 @@ public class FacadeDispatcherBakedModel extends DelegateBakedModel
 {
 	private final VertexFormat format;
 	private final FacadeBuilder facadeBuilder;
+	private final Int2ObjectMap<FacadeBakedItemModel> cache = new Int2ObjectArrayMap<>();
 
 	public FacadeDispatcherBakedModel( IBakedModel baseModel, VertexFormat format, FacadeBuilder facadeBuilder )
 	{
@@ -91,7 +95,15 @@ public class FacadeDispatcherBakedModel extends DelegateBakedModel
 
 				ItemStack textureItem = itemFacade.getTextureItem( stack );
 
-				return new FacadeBakedItemModel( FacadeDispatcherBakedModel.this.getBaseModel(), textureItem, FacadeDispatcherBakedModel.this.facadeBuilder );
+				int hash = Objects.hash( textureItem.getItem().getRegistryName(), textureItem.getMetadata(), textureItem.getTagCompound() );
+				FacadeBakedItemModel model = FacadeDispatcherBakedModel.this.cache.get( hash );
+				if( model == null )
+				{
+				    model = new FacadeBakedItemModel(FacadeDispatcherBakedModel.this.getBaseModel(), textureItem, FacadeDispatcherBakedModel.this.facadeBuilder);
+                    FacadeDispatcherBakedModel.this.cache.put(hash, model);
+                }
+
+				return model;
 			}
 		};
 	}

--- a/src/main/java/appeng/thirdparty/codechicken/lib/model/Quad.java
+++ b/src/main/java/appeng/thirdparty/codechicken/lib/model/Quad.java
@@ -46,7 +46,6 @@ public class Quad implements IVertexProducer, ISmartVertexConsumer
 	public CachedFormat format;
 
 	public int tintIndex = -1;
-	// TODO, sometimes this is null because people don't do models properly.
 	public EnumFacing orientation;
 	public boolean diffuseLighting = true;
 	public TextureAtlasSprite sprite;
@@ -130,6 +129,10 @@ public class Quad implements IVertexProducer, ISmartVertexConsumer
 			{
 				this.vertexIndex = 0;
 				this.full = true;
+				if(orientation == null)
+				{
+				    calculateOrientation(false);
+                }
 			}
 		}
 	}
@@ -195,30 +198,40 @@ public class Quad implements IVertexProducer, ISmartVertexConsumer
 			vec[1] = (float) MathHelper.clamp( vec[1], bb.minY, bb.maxY );
 			vec[2] = (float) MathHelper.clamp( vec[2], bb.minZ, bb.maxZ );
 		}
-
-		this.v1.set( this.vertices[3].vec );
-		this.t.set( this.vertices[1].vec );
-		this.v1.sub( this.t );
-
-		this.v2.set( this.vertices[2].vec );
-		this.t.set( this.vertices[0].vec );
-		this.v2.sub( this.t );
-
-		this.normal.cross( this.v2, this.v1 );
-		this.normal.normalize();
-
-		if( this.format.hasNormal )
-		{
-			for( Vertex vertex : this.vertices )
-			{
-				vertex.normal[0] = this.normal.x;
-				vertex.normal[1] = this.normal.y;
-				vertex.normal[2] = this.normal.z;
-				vertex.normal[3] = 0;
-			}
-		}
-		this.orientation = EnumFacing.getFacingFromVector( this.normal.x, this.normal.y, this.normal.z );
+		calculateOrientation(true);
 	}
+
+    /**
+     * Re-calculates the Orientation of this quad,
+     * optionally the normal vector.
+     *
+     * @param setNormal If the normal vector should be updated.
+     */
+	public void calculateOrientation( boolean setNormal )
+    {
+        this.v1.set( this.vertices[3].vec );
+        this.t.set( this.vertices[1].vec );
+        this.v1.sub( this.t );
+
+        this.v2.set( this.vertices[2].vec );
+        this.t.set( this.vertices[0].vec );
+        this.v2.sub( this.t );
+
+        this.normal.cross( this.v2, this.v1 );
+        this.normal.normalize();
+
+        if( this.format.hasNormal && setNormal)
+        {
+            for( Vertex vertex : this.vertices )
+            {
+                vertex.normal[0] = this.normal.x;
+                vertex.normal[1] = this.normal.y;
+                vertex.normal[2] = this.normal.z;
+                vertex.normal[3] = 0;
+            }
+        }
+        this.orientation = EnumFacing.getFacingFromVector( this.normal.x, this.normal.y, this.normal.z );
+    }
 
 	/**
 	 * Used to create a new quad complete copy of this one.


### PR DESCRIPTION
Fixes #3810 #3813

Fixes `Quad` crashing when a `BakedQuad` with a null orientation is piped in. Should be noted this is an error with the `BakedQuad`, they should never have null orientations.

Fixes some performance issues with facades, uses some very basic caching to cache the sliced quads from item models.