### PR TITLE
Color Applicator enhancements

### DIFF
--- a/src/main/java/appeng/client/ClientHelper.java
+++ b/src/main/java/appeng/client/ClientHelper.java
@@ -311,7 +311,7 @@ public class ClientHelper extends ServerHelper
 	@SubscribeEvent
 	public void wheelEvent( final MouseEvent me )
 	{
-		if( me.getDwheel() == 0 )
+		if( me.getDwheel() == 0 && me.getButton() != 2 )
 		{
 			return;
 		}
@@ -327,7 +327,12 @@ public class ClientHelper extends ServerHelper
 			{
 				try
 				{
-					NetworkHandler.instance().sendToServer( new PacketValueConfig( "Item", me.getDwheel() > 0 ? "WheelUp" : "WheelDown" ) );
+					if( me.getDwheel() != 0 )
+					{
+						NetworkHandler.instance().sendToServer( new PacketValueConfig( "MouseWheel", me.getDwheel() > 0 ? "WheelUp" : "WheelDown" ) );
+					} else {
+						NetworkHandler.instance().sendToServer( new PacketValueConfig( "MiddleClick", me.isButtonstate() ? "WheelDown" : "WheelUp" ) );
+					}
 					me.setCanceled( true );
 				}
 				catch( final IOException e )

--- a/src/main/java/appeng/core/sync/packets/PacketValueConfig.java
+++ b/src/main/java/appeng/core/sync/packets/PacketValueConfig.java
@@ -99,7 +99,7 @@ public class PacketValueConfig extends AppEngPacket
 	{
 		final Container c = player.openContainer;
 
-		if( this.Name.equals( "Item" ) && ( ( !player.getHeldItem( EnumHand.MAIN_HAND ).isEmpty() && player.getHeldItem( EnumHand.MAIN_HAND )
+		if( ( this.Name.equals( "MouseWheel" ) || this.Name.equals( "MiddleClick" ) ) && ( ( !player.getHeldItem( EnumHand.MAIN_HAND ).isEmpty() && player.getHeldItem( EnumHand.MAIN_HAND )
 				.getItem() instanceof IMouseWheelItem ) || ( !player.getHeldItem( EnumHand.OFF_HAND )
 						.isEmpty() && player.getHeldItem( EnumHand.OFF_HAND ).getItem() instanceof IMouseWheelItem ) ) )
 		{
@@ -119,7 +119,14 @@ public class PacketValueConfig extends AppEngPacket
 
 			final ItemStack is = player.getHeldItem( hand );
 			final IMouseWheelItem si = (IMouseWheelItem) is.getItem();
-			si.onWheel( is, this.Value.equals( "WheelUp" ) );
+			if ( this.Name.equals( "MouseWheel" ) )
+			{
+				si.onWheel( is, this.Value.equals( "WheelUp" ) );
+			}
+			else
+			{
+				si.onWheelClick( is, this.Value.equals( "WheelDown" ), player );
+			}
 		}
 		else if( this.Name.equals( "Terminal.Cpu" ) && c instanceof ContainerCraftingStatus )
 		{

--- a/src/main/java/appeng/helpers/IMouseWheelItem.java
+++ b/src/main/java/appeng/helpers/IMouseWheelItem.java
@@ -19,6 +19,7 @@
 package appeng.helpers;
 
 
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 
 
@@ -26,4 +27,6 @@ public interface IMouseWheelItem
 {
 
 	void onWheel( ItemStack is, boolean up );
+
+	void onWheelClick( ItemStack is, boolean state, EntityPlayer player );
 }

--- a/src/main/java/appeng/items/tools/powered/ToolColorApplicator.java
+++ b/src/main/java/appeng/items/tools/powered/ToolColorApplicator.java
@@ -112,6 +112,8 @@ public class ToolColorApplicator extends AEBasePoweredItem implements IStorageCe
 	@Override
 	public EnumActionResult onItemUse( ItemStack is, EntityPlayer p, World w, BlockPos pos, EnumHand hand, EnumFacing side, float hitX, float hitY, float hitZ )
 	{
+		boolean lastDye = false;
+
 		final Block blk = w.getBlockState( pos ).getBlock();
 
 		ItemStack paintBall = this.getColor( is );
@@ -121,14 +123,18 @@ public class ToolColorApplicator extends AEBasePoweredItem implements IStorageCe
 				.cell()
 				.getCellInventory( is, null,
 						AEApi.instance().storage().getStorageChannel( IItemStorageChannel.class ) );
-		if( inv != null )
+		if( !paintBall.isEmpty() && inv != null )
 		{
-			final IAEItemStack option = inv.extractItems( AEItemStack.fromItemStack( paintBall ), Actionable.SIMULATE, new BaseActionSource() );
+			final IAEItemStack option = inv.extractItems( AEItemStack.fromItemStack( paintBall ).setStackSize( 2 ), Actionable.SIMULATE, new BaseActionSource() );
 
 			if( option != null )
 			{
 				paintBall = option.createItemStack();
 				paintBall.setCount( 1 );
+				if ( option.getStackSize() == 1 )
+				{
+					lastDye = true;
+				}
 			}
 			else
 			{
@@ -153,6 +159,10 @@ public class ToolColorApplicator extends AEBasePoweredItem implements IStorageCe
 						{
 							inv.extractItems( AEItemStack.fromItemStack( paintBall ), Actionable.MODULATE, new BaseActionSource() );
 							this.extractAEPower( is, powerPerUse, Actionable.MODULATE );
+							if ( lastDye )
+							{
+								this.setColor(is, ItemStack.EMPTY);
+							}
 							return EnumActionResult.SUCCESS;
 						}
 					}
@@ -166,6 +176,10 @@ public class ToolColorApplicator extends AEBasePoweredItem implements IStorageCe
 					inv.extractItems( AEItemStack.fromItemStack( paintBall ), Actionable.MODULATE, new BaseActionSource() );
 					this.extractAEPower( is, powerPerUse, Actionable.MODULATE );
 					( (TilePaint) painted ).cleanSide( side.getOpposite() );
+					if ( lastDye )
+					{
+						this.setColor(is, ItemStack.EMPTY);
+					}
 					return EnumActionResult.SUCCESS;
 				}
 			}
@@ -179,6 +193,10 @@ public class ToolColorApplicator extends AEBasePoweredItem implements IStorageCe
 					{
 						inv.extractItems( AEItemStack.fromItemStack( paintBall ), Actionable.MODULATE, new BaseActionSource() );
 						this.extractAEPower( is, powerPerUse, Actionable.MODULATE );
+						if ( lastDye )
+						{
+							this.setColor(is, ItemStack.EMPTY);
+						}
 						return EnumActionResult.SUCCESS;
 					}
 				}
@@ -259,7 +277,7 @@ public class ToolColorApplicator extends AEBasePoweredItem implements IStorageCe
 			}
 		}
 
-		return this.findNextColor( is, ItemStack.EMPTY, 0 );
+		return ItemStack.EMPTY;
 	}
 
 	private ItemStack findNextColor( final ItemStack is, final ItemStack anchor, final int scrollOffset )
@@ -411,14 +429,7 @@ public class ToolColorApplicator extends AEBasePoweredItem implements IStorageCe
 
 	public void cycleColors( final ItemStack is, final ItemStack paintBall, final int i )
 	{
-		if( paintBall.isEmpty() )
-		{
-			this.setColor( is, this.getColor( is ) );
-		}
-		else
-		{
-			this.setColor( is, this.findNextColor( is, paintBall, i ) );
-		}
+		this.setColor( is, this.findNextColor( is, paintBall, i ) );
 	}
 
 	@Override

--- a/src/main/java/appeng/parts/networking/PartCable.java
+++ b/src/main/java/appeng/parts/networking/PartCable.java
@@ -29,12 +29,14 @@ import io.netty.buffer.ByteBuf;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
-
+import net.minecraft.util.EnumHand;
 import appeng.api.AEApi;
 import appeng.api.config.SecurityPermissions;
 import appeng.api.definitions.IParts;
 import appeng.api.implementations.parts.IPartCable;
+import appeng.api.implementations.tiles.IColorableTile;
 import appeng.api.networking.GridFlags;
 import appeng.api.networking.IGridConnection;
 import appeng.api.networking.IGridHost;
@@ -48,6 +50,7 @@ import appeng.api.util.AEColor;
 import appeng.api.util.AEPartLocation;
 import appeng.api.util.IReadOnlyCollection;
 import appeng.items.parts.ItemPart;
+import appeng.items.tools.powered.ToolColorApplicator;
 import appeng.me.GridAccessException;
 import appeng.parts.AEBasePart;
 import appeng.util.Platform;
@@ -70,6 +73,30 @@ public class PartCable extends AEBasePart implements IPartCable
 		this.getProxy().setFlags( GridFlags.PREFERRED );
 		this.getProxy().setIdlePowerUsage( 0.0 );
 		this.getProxy().setColor( AEColor.values()[( (ItemPart) is.getItem() ).variantOf( is.getItemDamage() )] );
+	}
+	
+	@Override
+	public void onPlacement( final EntityPlayer player, final EnumHand hand, final ItemStack held, final AEPartLocation side )
+	{
+		super.onPlacement( player, hand, held, side );
+		TileEntity te = this.getHost().getTile();
+		if( te instanceof IColorableTile )
+		{
+			ItemStack applicator = null;
+			if( player.getHeldItemMainhand().getItem() instanceof ToolColorApplicator )
+			{
+				applicator = player.getHeldItemMainhand();
+			}
+			else if( player.getHeldItemOffhand().getItem() instanceof ToolColorApplicator )
+			{
+				applicator = player.getHeldItemOffhand();
+			}
+			
+			if( applicator != null )
+			{
+				( ( ToolColorApplicator ) applicator.getItem() ).onItemUse( applicator, player, te.getWorld(), te.getPos(), hand, side.getFacing(), 0F, 0F, 0F );
+			}
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Enhancements to the Color Applicator:
- Improve the indication that a dye is empty. Fixes #3895 
- Select a color by clicking on a colorable block. Fixes #88
- Place properly colored cables when holding Color Applicator in the other hand. Fixes #3854