### PR TITLE
(#3800) Don't fire PowerStatusChange events while extracting power.

### DIFF
--- a/src/main/java/appeng/me/cache/EnergyGridCache.java
+++ b/src/main/java/appeng/me/cache/EnergyGridCache.java
@@ -110,6 +110,7 @@ public class EnergyGridCache implements IEnergyGrid
 	private double lastStoredPower = -1;
 
 	private final GridPowerStorage localStorage = new GridPowerStorage();
+	private boolean localStorageEmptiedThisTick = false;
 
 	public EnergyGridCache( final IGrid g )
 	{
@@ -193,6 +194,7 @@ public class EnergyGridCache implements IEnergyGrid
 
 		// power information.
 		boolean currentlyHasPower = false;
+		this.localStorageEmptiedThisTick = false;
 
 		if( this.drainPerTick > 0.0001 )
 		{
@@ -222,7 +224,7 @@ public class EnergyGridCache implements IEnergyGrid
 		{
 			this.publicPowerState( true, this.myGrid );
 		}
-		else if( !this.hasPower )
+		else if( !this.hasPower || this.localStorageEmptiedThisTick )
 		{
 			this.publicPowerState( false, this.myGrid );
 		}
@@ -682,7 +684,7 @@ public class EnergyGridCache implements IEnergyGrid
 			if( this.stored < 0.01 )
 			{
 				EnergyGridCache.this.ticksSinceHasPowerChange = 0;
-				EnergyGridCache.this.publicPowerState( false, EnergyGridCache.this.myGrid );
+				EnergyGridCache.this.localStorageEmptiedThisTick = true;
 			}
 		}
 	}


### PR DESCRIPTION
EnergyGridCache.extractProviderPower holds an iterator over its provider
set while calling extractAEPower on each provider.  When it extracts
power from its localStorage and empties it, firing a PowerStatusChange
event immediately can de-power a TileController and trigger the
destruction of the ME grid which both the TileController and
EnergyGridCache are part of. This in turn causes the TileController to
be removed from the EnergyGridCache's provider set while the iterator is
still live, resulting in a ConcurrentModificationException.

Instead of firing the event immediately, set a semaphore to notify the
EnergyGridCache the localStorage is out of power and rely on the
already-existing logic to fire the PowerStatusChange once grid power
extraction has completed.

Evidence in this backtrace: https://pastebin.com/yJLtAcx8

I described the scenario which allows me to reliably trigger the CME in
#3915. With this patch I can no longer trigger it. I don't know whether
there are any ramifications from delaying the event until later in the
update code, or if there are better ways to deal with this. Only trying
to help :-)