### PR TITLE
Fixes #4119 Sort the list of items so that missing items appear first

### DIFF
--- a/src/main/java/appeng/client/gui/implementations/GuiCraftConfirm.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiCraftConfirm.java
@@ -243,6 +243,24 @@ public class GuiCraftConfirm extends AEBaseGui
 
 		final int offY = 23;
 
+		// Sort the list of items so that missing (and partially-missing) items appear first.
+		this.visual.sort(new Comparator<IAEItemStack>() {
+			@Override
+			public int compare(IAEItemStack lhs, IAEItemStack rhs) {
+				IAEItemStack lhsMissing = GuiCraftConfirm.this.missing.findPrecise(lhs);
+				IAEItemStack rhsMissing = GuiCraftConfirm.this.missing.findPrecise(rhs);
+				boolean isLhsMissing = lhsMissing != null && lhsMissing.getStackSize() > 0;
+				boolean isRhsMissing = rhsMissing != null && rhsMissing.getStackSize() > 0;
+
+				if (isLhsMissing && !isRhsMissing) {
+					return -1;
+				} else if (isRhsMissing && !isLhsMissing) {
+					return 1;
+				} else {
+					return (int) (lhs.getStackSize() - rhs.getStackSize());
+				}
+			}
+		});
 		for( int z = viewStart; z < Math.min( viewEnd, this.visual.size() ); z++ )
 		{
 			final IAEItemStack refStack = this.visual.get( z );// repo.getReferenceItem( z );


### PR DESCRIPTION
So I'm not sure if this is in the right style or whatever, so happy to take suggestions. I do think this approach (i.e. sorting explicitly in the GUI code) is better than the current approach which relies on the fact that packets are received in a certain order to put things in the right order.

Here we explicitly sort the items so that missing items appear first. Secondarily, items with the biggest stack appear second.