### PR TITLE
Update API JavaDocs for clarification

### DIFF
--- a/src/api/java/appeng/api/networking/IGridBlock.java
+++ b/src/api/java/appeng/api/networking/IGridBlock.java
@@ -123,7 +123,7 @@ public interface IGridBlock
 	/**
 	 * Determines what item stack is used to render this node in the GUI.
 	 *
-	 * @return the render item stack to use to render this node, null is valid, and will not show this node.
+	 * @return the render item stack to use to render this node. Returning an empty ItemStack will not show this node.
 	 */
 	@Nonnull
 	ItemStack getMachineRepresentation();

--- a/src/api/java/appeng/api/parts/IPart.java
+++ b/src/api/java/appeng/api/parts/IPart.java
@@ -291,6 +291,9 @@ public interface IPart extends IBoxProvider, ICustomCableConnection
 
 	/**
 	 * Used to determine which parts can be placed on what cables.
+	 * 
+	 * Dense cables are not allowed for functional (getGridNode returns a node) parts.
+	 * Doing so will result in crashes.
 	 *
 	 * @param what placed part
 	 *


### PR DESCRIPTION
Update the API JavaDocs for IGridBlock.getMachineRepresentation() and IPart.canBePlacedOn() to better document the assumptions made by AE2 for these methods.

- Dense cables should not have functional (grid connected) parts.
- IGridBlock.getMachineRepresentation is non nullable.