### PR TITLE
Better 'dimension ID taken' error message

### DIFF
--- a/src/main/java/appeng/core/Registration.java
+++ b/src/main/java/appeng/core/Registration.java
@@ -197,8 +197,18 @@ final class Registration
 			config.save();
 		}
 		this.storageDimensionID = config.getStorageDimensionID();
-
-		DimensionManager.registerDimension( this.storageDimensionID, this.storageDimensionType );
+		try
+		{
+			DimensionManager.registerDimension( this.storageDimensionID, this.storageDimensionType );
+		}
+		catch (IllegalArgumentException iaexc)
+		{
+			if(DimensionManager.isDimensionRegistered(this.storageDimensionID))
+			{
+				throw new IllegalStateException("Our Dimension was taken by " + DimensionManager.getById(this.storageDimensionID).getName() ,iaexc);
+			}
+			throw iaexc;
+		}
 	}
 
 	private void registerCraftHandlers( final IRecipeHandlerRegistry registry )

--- a/src/main/java/appeng/core/Registration.java
+++ b/src/main/java/appeng/core/Registration.java
@@ -205,7 +205,7 @@ final class Registration
 		{
 			if(DimensionManager.isDimensionRegistered(this.storageDimensionID))
 			{
-				throw new IllegalStateException("Our Dimension was taken by " + DimensionManager.getById(this.storageDimensionID).getName() ,iaexc);
+				throw new IllegalStateException("Our Dimension was taken by " + DimensionType.getById(this.storageDimensionID).getName() ,iaexc);
 			}
 			throw iaexc;
 		}


### PR DESCRIPTION
Now includes the Name of the Dimension, which took our ID.
Should help resolving errors like these more easily: #4189