### PR TITLE
Avoid quadratic behavior from rebuilding the entire crafting cache for each interface visited

### DIFF
--- a/src/main/java/appeng/me/cache/CraftingGridCache.java
+++ b/src/main/java/appeng/me/cache/CraftingGridCache.java
@@ -114,6 +114,7 @@ public class CraftingGridCache implements ICraftingGrid, ICraftingProviderHelper
 	private IStorageGrid storageGrid;
 	private IEnergyGrid energyGrid;
 	private boolean updateList = false;
+	private boolean updatePatterns = false;
 
 	public CraftingGridCache( final IGrid grid )
 	{
@@ -136,6 +137,12 @@ public class CraftingGridCache implements ICraftingGrid, ICraftingProviderHelper
 		{
 			this.updateList = false;
 			this.updateCPUClusters();
+		}
+
+		if( this.updatePatterns )
+		{
+			this.updatePatterns = false;
+			this.updatePatterns();
 		}
 
 		final Iterator<CraftingLinkNexus> craftingLinkIterator = this.craftingLinks.values().iterator();
@@ -185,7 +192,7 @@ public class CraftingGridCache implements ICraftingGrid, ICraftingProviderHelper
 		if( machine instanceof ICraftingProvider )
 		{
 			this.craftingProviders.remove( machine );
-			this.updatePatterns();
+			this.updatePatterns = true;
 		}
 	}
 
@@ -219,7 +226,7 @@ public class CraftingGridCache implements ICraftingGrid, ICraftingProviderHelper
 		if( machine instanceof ICraftingProvider )
 		{
 			this.craftingProviders.add( (ICraftingProvider) machine );
-			this.updatePatterns();
+			this.updatePatterns = true;
 		}
 	}
 
@@ -337,7 +344,7 @@ public class CraftingGridCache implements ICraftingGrid, ICraftingProviderHelper
 	@MENetworkEventSubscribe
 	public void updateCPUClusters( final MENetworkCraftingPatternChange c )
 	{
-		this.updatePatterns();
+		this.updatePatterns = true;
 	}
 
 	@Override


### PR DESCRIPTION
Instead rebuild it at most once per tick, like cpu clusters.

This is particularly important when channels are disabled, since in that case even adding a cable visits every grid node. 

The critical change for that is the one in `public void updateCPUClusters( final MENetworkCraftingPatternChange c )`. The similar changes in add/removeNode provide smaller but still noticeable speedups when removing or adding a cable that actually changes network topology.

This avoids 800ms tick spikes when just placing cables on my 160 interface channels-disabled network.