### PR TITLE
Fix CraftTweaker Grindstone second optional output

### DIFF
--- a/src/main/java/appeng/integration/modules/crafttweaker/GrinderRecipes.java
+++ b/src/main/java/appeng/integration/modules/crafttweaker/GrinderRecipes.java
@@ -62,7 +62,7 @@ public class GrinderRecipes
 			final ItemStack s2 = CTModule.toStack( secondary2Output );
 			if( !s2.isEmpty() )
 			{
-				builder.withFirstOptional( s2, secondary2Chance == null ? 1.0f : secondary2Chance );
+				builder.withSecondOptional( s2, secondary2Chance == null ? 1.0f : secondary2Chance );
 			}
 			CTModule.MODIFICATIONS.add( new Add( builder.build() ) );
 		}


### PR DESCRIPTION
Fixes an issue where the CraftTweaker Grindstone integration registered the second optional output as first optional output