### PR TITLE
Fixes #4254: NPE from Dense Cables with INTERNAL Connections

### DIFF
--- a/src/main/java/appeng/parts/networking/PartDenseCable.java
+++ b/src/main/java/appeng/parts/networking/PartDenseCable.java
@@ -76,6 +76,11 @@ public abstract class PartDenseCable extends PartCable
 
 		for( final AEPartLocation of : this.getConnections() )
 		{
+			if ( of == AEPartLocation.INTERNAL )
+			{
+				continue;
+			}
+
 			if( this.isDense( of ) )
 			{
 				switch( of )


### PR DESCRIPTION
This pull request fixes issue #4254 by skipping over internal connections within the `getBoxes` method.

I considered putting a check into `isDense`, but as that's a private method only used in `getBoxes` I concluded that it's best to put it into `getBoxes` from a logical standpoint. If there are plans to re-use `isDense` in the future, the check should likely be moved or duplicated there instead.