### PR TITLE
Fix infinite sources duping arbitrary fluids

### DIFF
--- a/src/main/java/appeng/fluids/parts/FluidHandlerAdapter.java
+++ b/src/main/java/appeng/fluids/parts/FluidHandlerAdapter.java
@@ -114,6 +114,11 @@ public class FluidHandlerAdapter implements IMEInventory<IAEFluidStack>, IBaseMo
 			return null;
 		}
 
+		// Check if the gathered fluid stack is actually equal
+		if ( !gathered.isFluidEqual(requestedFluidStack) ) {
+			return null;
+		}
+
 		if( mode == Actionable.MODULATE )
 		{
 			try


### PR DESCRIPTION
I'm surprised this hasn't been reported before. This is a cross-mod interaction that allows duping arbitrary fluids.

## Synopsys
When plugged to a network with a fluid storage bus, certain infinite sources from other mods can trick the network into duping arbitrary fluids, completely ignoring the fluid they're configured to. This is due to AE2 not checking the actual gathered fluid.

I fixed this by introducing a simple check if the gathered fluid is equal to the requested one.

For reference, see how [Extra Utilities 2](https://github.com/rwtema/Extra-Utilities-2-Source/blob/ff6b75ebc334ee0f1a2c2d1fd1394f8d7e4da0bb/1.10.2/src/main/java/com/rwtema/extrautils2/tile/TileDrum.java#L320) and [Thermal Expansion](https://github.com/CoFH/ThermalExpansion/blob/8ea25f853358bfe2d9f9359bf6d979f0de9e16fa/src/main/java/cofh/thermalexpansion/block/device/TileWaterGen.java#L363) provide infinite fluids.

![image](https://user-images.githubusercontent.com/22255622/73881092-d51cc600-48b3-11ea-97a4-bd0c1927c8b1.png)

## Steps to Reproduce
Among other mods, this can be easily reproduced with Aqueous Accumulators from Thermal Expansion or Creative Drums from Extra Utilities 2.

**TL;DR: see [this video](https://i.neeve.co/LovelyCooperativeBeardeddragon.mp4).**

1. Install Thermal Expansion (and everything it depends on) or Extra Utilities 2
2. If you've installed Thermal Expansion:
    1. Run the game once to create the config file
    2. Navigate into `instance/config/cofh/thermalexpansion/`
    3. Open `common.cfg` and switch the following to true
```
Device {
    WaterGen {
        # If TRUE, the Aqueous Accumulator will act as an Infinite Source and will also function in the Nether.
        B:Infinite=true
    }
}
```
3. Create a small network consisting of an ME Fluid Interface, ME Fluid Storage Bus, some kind of energy provider
4. Connect either a Creative Drum from Extra Utilities 2 filled with water **OR** an Aqueous Accumulator from Thermal Expansion to the network using the ME Fluid Storage Bus. With AqAc, enable auto-output towards the ME Fluid Storage Bus
5. Grab a bucket of lava and configure the ME Fluid Interface to expose lava

You should see 4 buckets of lava appear inside the ME Fluid Interface despite the network having no lava in storage. This works for any kind of fluid.