### PR TITLE
Change remainingItemCount in BasicCellInventory to long to avoid overflows

### DIFF
--- a/src/main/java/appeng/me/storage/BasicCellInventory.java
+++ b/src/main/java/appeng/me/storage/BasicCellInventory.java
@@ -175,7 +175,7 @@ public class BasicCellInventory<T extends IAEStack<T>> extends AbstractCellInven
 
 		if( this.canHoldNewItem() ) // room for new type, and for at least one item!
 		{
-			final int remainingItemCount = (int) this.getRemainingItemCount() - this.getBytesPerType() * this.itemsPerByte;
+			final long remainingItemCount = this.getRemainingItemCount() - (long)this.getBytesPerType() * (long)this.itemsPerByte;
 			if( remainingItemCount > 0 )
 			{
 				if( input.getStackSize() > remainingItemCount )


### PR DESCRIPTION
The underlaying issue was discussed here: https://github.com/ExtraCells/ExtraCells2/issues/684

Large liquid cells (>256k) will fail to store fluids because the itemsPerByte are 8000, causing empty cells to exceed (2^31)-1 remaining items.

since getRemainingItemCount() returns a long anyways the fix is not more than changing the variable type.

Explicitly cast the multiplication to avoid any potential overflowing there as well. The calculation is a long calculation already anyways.