### PR TITLE
Memory Card Clearing Fix - Removing onItemUse in ToolMemoryCard

### DIFF
--- a/src/main/java/appeng/items/tools/ToolMemoryCard.java
+++ b/src/main/java/appeng/items/tools/ToolMemoryCard.java
@@ -183,23 +183,6 @@ public class ToolMemoryCard extends AEBaseItem implements IMemoryCard
 	}
 
 	@Override
-	public EnumActionResult onItemUse( final EntityPlayer player, final World w, final BlockPos pos, final EnumHand hand, final EnumFacing side, final float hx, final float hy, final float hz )
-	{
-		if( player.isSneaking() )
-		{
-			if( !w.isRemote )
-			{
-				this.clearCard( player, w, hand );
-			}
-			return EnumActionResult.SUCCESS;
-		}
-		else
-		{
-			return super.onItemUse( player, w, pos, hand, side, hx, hy, hz );
-		}
-	}
-
-	@Override
 	public ActionResult<ItemStack> onItemRightClick( World w, EntityPlayer player, EnumHand hand )
 	{
 		if( player.isSneaking() )


### PR DESCRIPTION
There is a bug in some forge servers where a memory card is set and then cleared at the same time during a sneak + right click. In some cases, reported online, removing an item in your offhand fixes the issue. In others restarting the client helps. In my case, and in other people around the internet, this doesn't work. I looked at the code, and it looks like the clearing logic happens correctly during the "onItemRightClick" call. The "onItemUse" call contains the same logic. I removed the "onItemUse" function, and from testing the memory card will still clear correctly while now functioning normally.  
