### PR TITLE
Fixes multiblock removal for QNB/CraftingCluster

### DIFF
--- a/src/main/java/appeng/tile/crafting/CraftingTileEntity.java
+++ b/src/main/java/appeng/tile/crafting/CraftingTileEntity.java
@@ -246,6 +246,11 @@ public class CraftingTileEntity extends AENetworkTileEntity implements IAEMultiB
     }
 
     public void breakCluster() {
+        // Since breaking the cluster will most likely also update the TE's state,
+        // it's essential that we're not working with outdated block-state information,
+        // since this particular TE's block might already have been removed (state=air)
+        updateContainingBlockInfo();
+
         if (this.cluster != null) {
             this.cluster.cancel();
             final IMEInventory<IAEItemStack> inv = this.cluster.getInventory();

--- a/src/main/java/appeng/tile/qnb/QuantumBridgeTileEntity.java
+++ b/src/main/java/appeng/tile/qnb/QuantumBridgeTileEntity.java
@@ -289,6 +289,11 @@ public class QuantumBridgeTileEntity extends AENetworkInvTileEntity implements I
     }
 
     public void breakCluster() {
+        // Since breaking the cluster will most likely also update the TE's state,
+        // it's essential that we're not working with outdated block-state information,
+        // since this particular TE's block might already have been removed (state=air)
+        updateContainingBlockInfo();
+
         if (this.cluster != null) {
             this.cluster.destroy();
         }


### PR DESCRIPTION
Multiblocks sometimes can't be broken because during removal, they update their own block-state to display the disconnected state, effectively reversing their own removal. This occurs because the cached block state in the tile entity base class is outdated and doesn't reflect the removal.