### PR TITLE
Fix more MultiBlock issues

### DIFF
--- a/src/main/java/appeng/block/crafting/AbstractCraftingUnitBlock.java
+++ b/src/main/java/appeng/block/crafting/AbstractCraftingUnitBlock.java
@@ -23,10 +23,13 @@ import net.minecraft.block.BlockState;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.state.BooleanProperty;
 import net.minecraft.state.StateContainer;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ActionResultType;
+import net.minecraft.util.Direction;
 import net.minecraft.util.Hand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.BlockRayTraceResult;
+import net.minecraft.world.IWorld;
 import net.minecraft.world.World;
 
 import appeng.block.AEBaseTileBlock;
@@ -52,6 +55,16 @@ public abstract class AbstractCraftingUnitBlock<T extends CraftingTileEntity> ex
         super.fillStateContainer(builder);
         builder.add(POWERED);
         builder.add(FORMED);
+    }
+
+    @Override
+    public BlockState updatePostPlacement(BlockState stateIn, Direction facing, BlockState facingState, IWorld worldIn,
+            BlockPos currentPos, BlockPos facingPos) {
+        TileEntity te = worldIn.getTileEntity(currentPos);
+        if (te != null) {
+            te.requestModelDataUpdate();
+        }
+        return super.updatePostPlacement(stateIn, facing, facingState, worldIn, currentPos, facingPos);
     }
 
     @Override

--- a/src/main/java/appeng/container/implementations/CraftingCPUContainer.java
+++ b/src/main/java/appeng/container/implementations/CraftingCPUContainer.java
@@ -47,7 +47,6 @@ import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.ConfigValuePacket;
 import appeng.core.sync.packets.MEInventoryUpdatePacket;
 import appeng.helpers.ICustomNameObject;
-import appeng.me.cluster.IAEMultiBlock;
 import appeng.me.cluster.implementations.CraftingCPUCluster;
 import appeng.tile.crafting.CraftingTileEntity;
 import appeng.util.Platform;
@@ -82,7 +81,7 @@ public class CraftingCPUContainer extends AEBaseContainer
         }
 
         if (te instanceof CraftingTileEntity) {
-            this.setCPU((ICraftingCPU) ((IAEMultiBlock) te).getCluster());
+            this.setCPU(((CraftingTileEntity) te).getCluster());
         }
 
         if (this.getNetwork() == null && Platform.isServer()) {

--- a/src/main/java/appeng/me/cluster/IAECluster.java
+++ b/src/main/java/appeng/me/cluster/IAECluster.java
@@ -47,5 +47,5 @@ public interface IAECluster {
      */
     boolean isDestroyed();
 
-    Iterator<IGridHost> getTiles();
+    Iterator<? extends IGridHost> getTiles();
 }

--- a/src/main/java/appeng/me/cluster/IAEMultiBlock.java
+++ b/src/main/java/appeng/me/cluster/IAEMultiBlock.java
@@ -18,11 +18,11 @@
 
 package appeng.me.cluster;
 
-public interface IAEMultiBlock {
+public interface IAEMultiBlock<Cluster extends IAECluster> {
 
     void disconnect(boolean b);
 
-    IAECluster getCluster();
+    Cluster getCluster();
 
     boolean isValid();
 }

--- a/src/main/java/appeng/me/cluster/MBCalculator.java
+++ b/src/main/java/appeng/me/cluster/MBCalculator.java
@@ -25,17 +25,21 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
 import appeng.api.util.AEPartLocation;
-import appeng.api.util.WorldCoord;
 import appeng.core.AELog;
 import appeng.util.Platform;
 
-public abstract class MBCalculator {
+public abstract class MBCalculator<TTile extends IAEMultiBlock<TCluster>, TCluster extends IAECluster> {
 
+    /**
+     * To avoid recursive cluster rebuilds, we use a global field to prevent this
+     * from happening. This is set to the cluster that is currently causing a
+     * Multiblock modification.
+     */
     private static WeakReference<IAECluster> modificationInProgress = new WeakReference<>(null);
 
-    private final IAEMultiBlock target;
+    protected final TTile target;
 
-    public MBCalculator(final IAEMultiBlock t) {
+    public MBCalculator(final TTile t) {
         this.target = t;
     }
 
@@ -54,10 +58,10 @@ public abstract class MBCalculator {
         return modificationInProgress.get() != null;
     }
 
-    public void updateMultiblockAfterNeighborUpdate(final World world, final WorldCoord loc, BlockPos changedPos) {
+    public void updateMultiblockAfterNeighborUpdate(final World world, final BlockPos loc, BlockPos changedPos) {
         boolean recheck;
 
-        IAECluster cluster = target.getCluster();
+        TCluster cluster = target.getCluster();
         if (cluster != null) {
             if (isWithinBounds(changedPos, cluster.getBoundsMin(), cluster.getBoundsMax())) {
                 // If the location is part of the current multiblock, always re-check
@@ -69,9 +73,8 @@ public abstract class MBCalculator {
             }
         } else {
             // Always recheck if the tile is not part of a cluster, because the adjacent
-            // block could have
-            // previously been a valid tile, but in a wrong placement, or the other way
-            // around.
+            // block could have previously been a valid tile, but in a wrong placement,
+            // or the other way around.
             recheck = true;
         }
 
@@ -80,7 +83,7 @@ public abstract class MBCalculator {
         }
     }
 
-    public void calculateMultiblock(final World world, final WorldCoord loc) {
+    public void calculateMultiblock(final World world, final BlockPos loc) {
         if (Platform.isClient() || isModificationInProgress()) {
             return;
         }
@@ -92,34 +95,31 @@ public abstract class MBCalculator {
         }
 
         try {
-            final WorldCoord min = loc.copy();
-            final WorldCoord max = loc.copy();
+            final BlockPos.Mutable min = new BlockPos.Mutable(loc);
+            final BlockPos.Mutable max = new BlockPos.Mutable(loc);
 
             // find size of MB structure...
-            while (this.isValidTileAt(world, min.x - 1, min.y, min.z)) {
-                min.x--;
+            while (this.isValidTileAt(world, min.getX() - 1, min.getY(), min.getZ())) {
+                min.setX(min.getX() - 1);
             }
-            while (this.isValidTileAt(world, min.x, min.y - 1, min.z)) {
-                min.y--;
+            while (this.isValidTileAt(world, min.getX(), min.getY() - 1, min.getZ())) {
+                min.setY(min.getY() - 1);
             }
-            while (this.isValidTileAt(world, min.x, min.y, min.z - 1)) {
-                min.z--;
+            while (this.isValidTileAt(world, min.getX(), min.getY(), min.getZ() - 1)) {
+                min.setZ(min.getZ() - 1);
             }
-            while (this.isValidTileAt(world, max.x + 1, max.y, max.z)) {
-                max.x++;
+            while (this.isValidTileAt(world, max.getX() + 1, max.getY(), max.getZ())) {
+                max.setX(max.getX() + 1);
             }
-            while (this.isValidTileAt(world, max.x, max.y + 1, max.z)) {
-                max.y++;
+            while (this.isValidTileAt(world, max.getX(), max.getY() + 1, max.getZ())) {
+                max.setY(max.getY() + 1);
             }
-            while (this.isValidTileAt(world, max.x, max.y, max.z + 1)) {
-                max.z++;
+            while (this.isValidTileAt(world, max.getX(), max.getY(), max.getZ() + 1)) {
+                max.setZ(max.getZ() + 1);
             }
 
             if (this.checkMultiblockScale(min, max)) {
                 if (this.verifyUnownedRegion(world, min, max)) {
-                    IAECluster c = this.createCluster(world, min, max);
-                    setModificationInProgress(c);
-
                     try {
                         if (!this.verifyInternalStructure(world, min, max)) {
                             this.disconnect();
@@ -131,16 +131,19 @@ public abstract class MBCalculator {
                     }
 
                     boolean updateGrid = false;
-                    final IAECluster cluster = this.target.getCluster();
-                    if (cluster == null) {
-                        this.updateTiles(c, world, min, max);
+                    TCluster cluster = this.target.getCluster();
+                    if (cluster == null || !cluster.getBoundsMin().equals(min) || !cluster.getBoundsMax().equals(max)) {
+                        cluster = this.createCluster(world, min, max);
+                        setModificationInProgress(cluster);
+                        // NOTE: The following will break existing clusters within the bounds
+                        this.updateTiles(cluster, world, min, max);
 
                         updateGrid = true;
                     } else {
-                        c = cluster;
+                        setModificationInProgress(cluster);
                     }
 
-                    c.updateStatus(updateGrid);
+                    cluster.updateStatus(updateGrid);
                     return;
                 }
             }
@@ -173,11 +176,12 @@ public abstract class MBCalculator {
      *
      * @return true if structure has correct dimensions or size
      */
-    public abstract boolean checkMultiblockScale(WorldCoord min, WorldCoord max);
+    public abstract boolean checkMultiblockScale(BlockPos min, BlockPos max);
 
-    private boolean verifyUnownedRegion(final World w, final WorldCoord min, final WorldCoord max) {
+    private boolean verifyUnownedRegion(final World w, final BlockPos min, final BlockPos max) {
         for (final AEPartLocation side : AEPartLocation.SIDE_LOCATIONS) {
-            if (this.verifyUnownedRegionInner(w, min.x, min.y, min.z, max.x, max.y, max.z, side)) {
+            if (this.verifyUnownedRegionInner(w, min.getX(), min.getY(), min.getZ(), max.getX(), max.getY(), max.getZ(),
+                    side)) {
                 return false;
             }
         }
@@ -194,14 +198,16 @@ public abstract class MBCalculator {
      *
      * @return created cluster
      */
-    public abstract IAECluster createCluster(World w, WorldCoord min, WorldCoord max);
+    public abstract TCluster createCluster(World w, BlockPos min, BlockPos max);
 
-    public abstract boolean verifyInternalStructure(World world, WorldCoord min, WorldCoord max);
+    public abstract boolean verifyInternalStructure(World world, BlockPos min, BlockPos max);
 
     /**
      * disassembles the multi-block.
      */
-    public abstract void disconnect();
+    public void disconnect() {
+        this.target.disconnect(true);
+    }
 
     /**
      * configure the multi-block tiles, most of the important stuff is in here.
@@ -211,7 +217,7 @@ public abstract class MBCalculator {
      * @param min min world coord
      * @param max max world coord
      */
-    public abstract void updateTiles(IAECluster c, World w, WorldCoord min, WorldCoord max);
+    public abstract void updateTiles(TCluster c, World w, BlockPos min, BlockPos max);
 
     /**
      * check if the tile entities are correct for the structure.
@@ -253,14 +259,10 @@ public abstract class MBCalculator {
                 return false;
         }
 
-        for (int x = minX; x <= maxX; x++) {
-            for (int y = minY; y <= maxY; y++) {
-                for (int z = minZ; z <= maxZ; z++) {
-                    final TileEntity te = w.getTileEntity(new BlockPos(x, y, z));
-                    if (this.isValidTile(te)) {
-                        return true;
-                    }
-                }
+        for (BlockPos p : BlockPos.getAllInBoxMutable(minX, minY, minZ, maxX, maxY, maxZ)) {
+            final TileEntity te = w.getTileEntity(p);
+            if (this.isValidTile(te)) {
+                return true;
             }
         }
 

--- a/src/main/java/appeng/me/cluster/implementations/CraftingCPUCalculator.java
+++ b/src/main/java/appeng/me/cluster/implementations/CraftingCPUCalculator.java
@@ -29,32 +29,27 @@ import appeng.api.networking.IGridHost;
 import appeng.api.networking.IGridNode;
 import appeng.api.networking.events.MENetworkCraftingCpuChange;
 import appeng.api.util.AEPartLocation;
-import appeng.api.util.WorldCoord;
-import appeng.me.cluster.IAECluster;
 import appeng.me.cluster.IAEMultiBlock;
 import appeng.me.cluster.MBCalculator;
 import appeng.tile.crafting.CraftingTileEntity;
 
-public class CraftingCPUCalculator extends MBCalculator {
+public class CraftingCPUCalculator extends MBCalculator<CraftingTileEntity, CraftingCPUCluster> {
 
-    private final CraftingTileEntity tqb;
-
-    public CraftingCPUCalculator(final IAEMultiBlock t) {
+    public CraftingCPUCalculator(final CraftingTileEntity t) {
         super(t);
-        this.tqb = (CraftingTileEntity) t;
     }
 
     @Override
-    public boolean checkMultiblockScale(final WorldCoord min, final WorldCoord max) {
-        if (max.x - min.x > 16) {
+    public boolean checkMultiblockScale(final BlockPos min, final BlockPos max) {
+        if (max.getX() - min.getX() > 16) {
             return false;
         }
 
-        if (max.y - min.y > 16) {
+        if (max.getY() - min.getY() > 16) {
             return false;
         }
 
-        if (max.z - min.z > 16) {
+        if (max.getZ() - min.getZ() > 16) {
             return false;
         }
 
@@ -62,27 +57,23 @@ public class CraftingCPUCalculator extends MBCalculator {
     }
 
     @Override
-    public IAECluster createCluster(final World w, final WorldCoord min, final WorldCoord max) {
+    public CraftingCPUCluster createCluster(final World w, final BlockPos min, final BlockPos max) {
         return new CraftingCPUCluster(min, max);
     }
 
     @Override
-    public boolean verifyInternalStructure(final World w, final WorldCoord min, final WorldCoord max) {
+    public boolean verifyInternalStructure(final World w, final BlockPos min, final BlockPos max) {
         boolean storage = false;
 
-        for (int x = min.x; x <= max.x; x++) {
-            for (int y = min.y; y <= max.y; y++) {
-                for (int z = min.z; z <= max.z; z++) {
-                    final IAEMultiBlock te = (IAEMultiBlock) w.getTileEntity(new BlockPos(x, y, z));
+        for (BlockPos blockPos : BlockPos.getAllInBoxMutable(min, max)) {
+            final IAEMultiBlock<?> te = (IAEMultiBlock<?>) w.getTileEntity(blockPos);
 
-                    if (!te.isValid()) {
-                        return false;
-                    }
+            if (te == null || !te.isValid()) {
+                return false;
+            }
 
-                    if (!storage && te instanceof CraftingTileEntity) {
-                        storage = ((CraftingTileEntity) te).getStorageBytes() > 0;
-                    }
-                }
+            if (!storage && te instanceof CraftingTileEntity) {
+                storage = ((CraftingTileEntity) te).getStorageBytes() > 0;
             }
         }
 
@@ -90,22 +81,11 @@ public class CraftingCPUCalculator extends MBCalculator {
     }
 
     @Override
-    public void disconnect() {
-        this.tqb.disconnect(true);
-    }
-
-    @Override
-    public void updateTiles(final IAECluster cl, final World w, final WorldCoord min, final WorldCoord max) {
-        final CraftingCPUCluster c = (CraftingCPUCluster) cl;
-
-        for (int x = min.x; x <= max.x; x++) {
-            for (int y = min.y; y <= max.y; y++) {
-                for (int z = min.z; z <= max.z; z++) {
-                    final CraftingTileEntity te = (CraftingTileEntity) w.getTileEntity(new BlockPos(x, y, z));
-                    te.updateStatus(c);
-                    c.addTile(te);
-                }
-            }
+    public void updateTiles(final CraftingCPUCluster c, final World w, final BlockPos min, final BlockPos max) {
+        for (BlockPos blockPos : BlockPos.getAllInBoxMutable(min, max)) {
+            final CraftingTileEntity te = (CraftingTileEntity) w.getTileEntity(blockPos);
+            te.updateStatus(c);
+            c.addTile(te);
         }
 
         c.done();

--- a/src/main/java/appeng/me/cluster/implementations/CraftingCPUCalculator.java
+++ b/src/main/java/appeng/me/cluster/implementations/CraftingCPUCalculator.java
@@ -90,7 +90,7 @@ public class CraftingCPUCalculator extends MBCalculator<CraftingTileEntity, Craf
 
         c.done();
 
-        final Iterator<IGridHost> i = c.getTiles();
+        final Iterator<CraftingTileEntity> i = c.getTiles();
         while (i.hasNext()) {
             final IGridHost gh = i.next();
             final IGridNode n = gh.getGridNode(AEPartLocation.INTERNAL);

--- a/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
+++ b/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
@@ -18,12 +18,7 @@
 
 package appeng.me.cluster.implementations;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
 
 import com.google.common.collect.ImmutableList;
@@ -45,14 +40,7 @@ import appeng.api.crafting.ICraftingHelper;
 import appeng.api.networking.IGrid;
 import appeng.api.networking.IGridHost;
 import appeng.api.networking.IGridNode;
-import appeng.api.networking.crafting.CraftingItemList;
-import appeng.api.networking.crafting.ICraftingCPU;
-import appeng.api.networking.crafting.ICraftingGrid;
-import appeng.api.networking.crafting.ICraftingJob;
-import appeng.api.networking.crafting.ICraftingLink;
-import appeng.api.networking.crafting.ICraftingMedium;
-import appeng.api.networking.crafting.ICraftingPatternDetails;
-import appeng.api.networking.crafting.ICraftingRequester;
+import appeng.api.networking.crafting.*;
 import appeng.api.networking.energy.IEnergyGrid;
 import appeng.api.networking.events.MENetworkCraftingCpuChange;
 import appeng.api.networking.security.IActionSource;
@@ -62,15 +50,10 @@ import appeng.api.storage.IMEMonitorHandlerReceiver;
 import appeng.api.storage.channels.IItemStorageChannel;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.api.storage.data.IItemList;
-import appeng.api.util.WorldCoord;
 import appeng.container.ContainerNull;
 import appeng.core.AELog;
 import appeng.core.Api;
-import appeng.crafting.CraftBranchFailure;
-import appeng.crafting.CraftingJob;
-import appeng.crafting.CraftingLink;
-import appeng.crafting.CraftingWatcher;
-import appeng.crafting.MECraftingInventory;
+import appeng.crafting.*;
 import appeng.me.cache.CraftingGridCache;
 import appeng.me.cluster.IAECluster;
 import appeng.me.cluster.MBCalculator;
@@ -116,9 +99,9 @@ public final class CraftingCPUCluster implements IAECluster, ICraftingCPU {
     private long startItemCount;
     private long remainingItemCount;
 
-    public CraftingCPUCluster(final WorldCoord boundsMin, final WorldCoord boundsMax) {
-        this.boundsMin = boundsMin.getBlockPos();
-        this.boundsMax = boundsMax.getBlockPos();
+    public CraftingCPUCluster(final BlockPos boundsMin, final BlockPos boundsMax) {
+        this.boundsMin = boundsMin.toImmutable();
+        this.boundsMax = boundsMax.toImmutable();
     }
 
     @Override
@@ -175,7 +158,10 @@ public final class CraftingCPUCluster implements IAECluster, ICraftingCPU {
         }
         this.isDestroyed = true;
 
-        MBCalculator.setModificationInProgress(this);
+        boolean ownsModification = !MBCalculator.isModificationInProgress();
+        if (ownsModification) {
+            MBCalculator.setModificationInProgress(this);
+        }
         try {
             boolean posted = false;
 
@@ -192,7 +178,9 @@ public final class CraftingCPUCluster implements IAECluster, ICraftingCPU {
                 r.updateStatus(null);
             }
         } finally {
-            MBCalculator.setModificationInProgress(null);
+            if (ownsModification) {
+                MBCalculator.setModificationInProgress(null);
+            }
         }
     }
 

--- a/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
+++ b/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
@@ -185,8 +185,8 @@ public final class CraftingCPUCluster implements IAECluster, ICraftingCPU {
     }
 
     @Override
-    public Iterator<IGridHost> getTiles() {
-        return (Iterator) this.tiles.iterator();
+    public Iterator<CraftingTileEntity> getTiles() {
+        return this.tiles.iterator();
     }
 
     void addTile(final CraftingTileEntity te) {

--- a/src/main/java/appeng/me/cluster/implementations/QuantumCalculator.java
+++ b/src/main/java/appeng/me/cluster/implementations/QuantumCalculator.java
@@ -25,31 +25,25 @@ import net.minecraft.world.World;
 
 import appeng.api.definitions.IBlockDefinition;
 import appeng.api.definitions.IBlocks;
-import appeng.api.util.WorldCoord;
 import appeng.core.Api;
-import appeng.me.cluster.IAECluster;
 import appeng.me.cluster.IAEMultiBlock;
 import appeng.me.cluster.MBCalculator;
 import appeng.tile.qnb.QuantumBridgeTileEntity;
 
-public class QuantumCalculator extends MBCalculator {
+public class QuantumCalculator extends MBCalculator<QuantumBridgeTileEntity, QuantumCluster> {
 
-    private final QuantumBridgeTileEntity tqb;
-
-    public QuantumCalculator(final IAEMultiBlock t) {
+    public QuantumCalculator(final QuantumBridgeTileEntity t) {
         super(t);
-        this.tqb = (QuantumBridgeTileEntity) t;
     }
 
     @Override
-    public boolean checkMultiblockScale(final WorldCoord min, final WorldCoord max) {
+    public boolean checkMultiblockScale(final BlockPos min, final BlockPos max) {
+        if ((max.getX() - min.getX() + 1) * (max.getY() - min.getY() + 1) * (max.getZ() - min.getZ() + 1) == 9) {
+            final int ones = ((max.getX() - min.getX()) == 0 ? 1 : 0) + ((max.getY() - min.getY()) == 0 ? 1 : 0)
+                    + ((max.getZ() - min.getZ()) == 0 ? 1 : 0);
 
-        if ((max.x - min.x + 1) * (max.y - min.y + 1) * (max.z - min.z + 1) == 9) {
-            final int ones = ((max.x - min.x) == 0 ? 1 : 0) + ((max.y - min.y) == 0 ? 1 : 0)
-                    + ((max.z - min.z) == 0 ? 1 : 0);
-
-            final int threes = ((max.x - min.x) == 2 ? 1 : 0) + ((max.y - min.y) == 2 ? 1 : 0)
-                    + ((max.z - min.z) == 2 ? 1 : 0);
+            final int threes = ((max.getX() - min.getX()) == 2 ? 1 : 0) + ((max.getY() - min.getY()) == 2 ? 1 : 0)
+                    + ((max.getZ() - min.getZ()) == 2 ? 1 : 0);
 
             return ones == 1 && threes == 2;
         }
@@ -57,36 +51,31 @@ public class QuantumCalculator extends MBCalculator {
     }
 
     @Override
-    public IAECluster createCluster(final World w, final WorldCoord min, final WorldCoord max) {
+    public QuantumCluster createCluster(final World w, final BlockPos min, final BlockPos max) {
         return new QuantumCluster(min, max);
     }
 
     @Override
-    public boolean verifyInternalStructure(final World w, final WorldCoord min, final WorldCoord max) {
+    public boolean verifyInternalStructure(final World w, final BlockPos min, final BlockPos max) {
 
         byte num = 0;
 
-        for (int x = min.x; x <= max.x; x++) {
-            for (int y = min.y; y <= max.y; y++) {
-                for (int z = min.z; z <= max.z; z++) {
-                    final BlockPos p = new BlockPos(x, y, z);
-                    final IAEMultiBlock te = (IAEMultiBlock) w.getTileEntity(p);
+        for (BlockPos p : BlockPos.getAllInBoxMutable(min, max)) {
+            final IAEMultiBlock<?> te = (IAEMultiBlock<?>) w.getTileEntity(p);
 
-                    if (!te.isValid()) {
-                        return false;
-                    }
+            if (te == null || !te.isValid()) {
+                return false;
+            }
 
-                    num++;
-                    final IBlocks blocks = Api.instance().definitions().blocks();
-                    if (num == 5) {
-                        if (!this.isBlockAtLocation(w, p, blocks.quantumLink())) {
-                            return false;
-                        }
-                    } else {
-                        if (!this.isBlockAtLocation(w, p, blocks.quantumRing())) {
-                            return false;
-                        }
-                    }
+            num++;
+            final IBlocks blocks = Api.instance().definitions().blocks();
+            if (num == 5) {
+                if (!this.isBlockAtLocation(w, p, blocks.quantumLink())) {
+                    return false;
+                }
+            } else {
+                if (!this.isBlockAtLocation(w, p, blocks.quantumRing())) {
+                    return false;
                 }
             }
         }
@@ -94,39 +83,29 @@ public class QuantumCalculator extends MBCalculator {
     }
 
     @Override
-    public void disconnect() {
-        this.tqb.disconnect(true);
-    }
-
-    @Override
-    public void updateTiles(final IAECluster cl, final World w, final WorldCoord min, final WorldCoord max) {
+    public void updateTiles(final QuantumCluster c, final World w, final BlockPos min, final BlockPos max) {
         byte num = 0;
         byte ringNum = 0;
-        final QuantumCluster c = (QuantumCluster) cl;
 
-        for (int x = min.x; x <= max.x; x++) {
-            for (int y = min.y; y <= max.y; y++) {
-                for (int z = min.z; z <= max.z; z++) {
-                    final QuantumBridgeTileEntity te = (QuantumBridgeTileEntity) w.getTileEntity(new BlockPos(x, y, z));
+        for (BlockPos p : BlockPos.getAllInBoxMutable(min, max)) {
+            final QuantumBridgeTileEntity te = (QuantumBridgeTileEntity) w.getTileEntity(p);
 
-                    num++;
-                    final byte flags;
-                    if (num == 5) {
-                        flags = num;
-                        c.setCenter(te);
-                    } else {
-                        if (num == 1 || num == 3 || num == 7 || num == 9) {
-                            flags = (byte) (this.tqb.getCorner() | num);
-                        } else {
-                            flags = num;
-                        }
-                        c.getRing()[ringNum] = te;
-                        ringNum++;
-                    }
-
-                    te.updateStatus(c, flags, true);
+            num++;
+            final byte flags;
+            if (num == 5) {
+                flags = num;
+                c.setCenter(te);
+            } else {
+                if (num == 1 || num == 3 || num == 7 || num == 9) {
+                    flags = (byte) (this.target.getCorner() | num);
+                } else {
+                    flags = num;
                 }
+                c.getRing()[ringNum] = te;
+                ringNum++;
             }
+
+            te.updateStatus(c, flags, true);
         }
     }
 

--- a/src/main/java/appeng/me/cluster/implementations/QuantumCluster.java
+++ b/src/main/java/appeng/me/cluster/implementations/QuantumCluster.java
@@ -33,7 +33,6 @@ import appeng.api.events.LocatableEventAnnounce;
 import appeng.api.events.LocatableEventAnnounce.LocatableEvent;
 import appeng.api.exceptions.FailedConnectionException;
 import appeng.api.features.ILocatable;
-import appeng.api.networking.IGridHost;
 import appeng.api.networking.IGridNode;
 import appeng.api.util.AEPartLocation;
 import appeng.core.AELog;
@@ -238,7 +237,7 @@ public class QuantumCluster implements ILocatable, IAECluster {
     }
 
     @Override
-    public Iterator<IGridHost> getTiles() {
+    public Iterator<QuantumBridgeTileEntity> getTiles() {
         return new ChainedIterator<>(this.getRing()[0], this.getRing()[1], this.getRing()[2], this.getRing()[3],
                 this.getRing()[4], this.getRing()[5], this.getRing()[6], this.getRing()[7], this.center);
     }

--- a/src/main/java/appeng/me/cluster/implementations/QuantumCluster.java
+++ b/src/main/java/appeng/me/cluster/implementations/QuantumCluster.java
@@ -36,7 +36,6 @@ import appeng.api.features.ILocatable;
 import appeng.api.networking.IGridHost;
 import appeng.api.networking.IGridNode;
 import appeng.api.util.AEPartLocation;
-import appeng.api.util.WorldCoord;
 import appeng.core.AELog;
 import appeng.core.Api;
 import appeng.me.cache.helpers.ConnectionWrapper;
@@ -58,9 +57,9 @@ public class QuantumCluster implements ILocatable, IAECluster {
     private long otherSide;
     private QuantumBridgeTileEntity center;
 
-    public QuantumCluster(final WorldCoord min, final WorldCoord max) {
-        this.boundsMin = min.getBlockPos();
-        this.boundsMax = max.getBlockPos();
+    public QuantumCluster(final BlockPos min, final BlockPos max) {
+        this.boundsMin = min.toImmutable();
+        this.boundsMax = max.toImmutable();
         this.setRing(new QuantumBridgeTileEntity[8]);
     }
 

--- a/src/main/java/appeng/me/cluster/implementations/SpatialPylonCalculator.java
+++ b/src/main/java/appeng/me/cluster/implementations/SpatialPylonCalculator.java
@@ -22,45 +22,36 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
-import appeng.api.util.WorldCoord;
-import appeng.me.cluster.IAECluster;
 import appeng.me.cluster.IAEMultiBlock;
 import appeng.me.cluster.MBCalculator;
 import appeng.tile.spatial.SpatialPylonTileEntity;
 
-public class SpatialPylonCalculator extends MBCalculator {
+public class SpatialPylonCalculator extends MBCalculator<SpatialPylonTileEntity, SpatialPylonCluster> {
 
-    private final SpatialPylonTileEntity tqb;
-
-    public SpatialPylonCalculator(final IAEMultiBlock t) {
+    public SpatialPylonCalculator(final SpatialPylonTileEntity t) {
         super(t);
-        this.tqb = (SpatialPylonTileEntity) t;
     }
 
     @Override
-    public boolean checkMultiblockScale(final WorldCoord min, final WorldCoord max) {
-        return (min.x == max.x && min.y == max.y && min.z != max.z)
-                || (min.x == max.x && min.y != max.y && min.z == max.z)
-                || (min.x != max.x && min.y == max.y && min.z == max.z);
+    public boolean checkMultiblockScale(final BlockPos min, final BlockPos max) {
+        return (min.getX() == max.getX() && min.getY() == max.getY() && min.getZ() != max.getZ())
+                || (min.getX() == max.getX() && min.getY() != max.getY() && min.getZ() == max.getZ())
+                || (min.getX() != max.getX() && min.getY() == max.getY() && min.getZ() == max.getZ());
     }
 
     @Override
-    public IAECluster createCluster(final World w, final WorldCoord min, final WorldCoord max) {
-        return new SpatialPylonCluster(w, min.getBlockPos(), max.getBlockPos());
+    public SpatialPylonCluster createCluster(final World w, final BlockPos min, final BlockPos max) {
+        return new SpatialPylonCluster(w, min, max);
     }
 
     @Override
-    public boolean verifyInternalStructure(final World w, final WorldCoord min, final WorldCoord max) {
+    public boolean verifyInternalStructure(final World w, final BlockPos min, final BlockPos max) {
 
-        for (int x = min.x; x <= max.x; x++) {
-            for (int y = min.y; y <= max.y; y++) {
-                for (int z = min.z; z <= max.z; z++) {
-                    final IAEMultiBlock te = (IAEMultiBlock) w.getTileEntity(new BlockPos(x, y, z));
+        for (BlockPos p : BlockPos.getAllInBoxMutable(min, max)) {
+            final IAEMultiBlock<?> te = (IAEMultiBlock<?>) w.getTileEntity(p);
 
-                    if (!te.isValid()) {
-                        return false;
-                    }
-                }
+            if (te == null || !te.isValid()) {
+                return false;
             }
         }
 
@@ -68,22 +59,11 @@ public class SpatialPylonCalculator extends MBCalculator {
     }
 
     @Override
-    public void disconnect() {
-        this.tqb.disconnect(true);
-    }
-
-    @Override
-    public void updateTiles(final IAECluster cl, final World w, final WorldCoord min, final WorldCoord max) {
-        final SpatialPylonCluster c = (SpatialPylonCluster) cl;
-
-        for (int x = min.x; x <= max.x; x++) {
-            for (int y = min.y; y <= max.y; y++) {
-                for (int z = min.z; z <= max.z; z++) {
-                    final SpatialPylonTileEntity te = (SpatialPylonTileEntity) w.getTileEntity(new BlockPos(x, y, z));
-                    te.updateStatus(c);
-                    c.getLine().add((te));
-                }
-            }
+    public void updateTiles(final SpatialPylonCluster c, final World w, final BlockPos min, final BlockPos max) {
+        for (BlockPos p : BlockPos.getAllInBoxMutable(min, max)) {
+            final SpatialPylonTileEntity te = (SpatialPylonTileEntity) w.getTileEntity(p);
+            te.updateStatus(c);
+            c.getLine().add(te);
         }
     }
 

--- a/src/main/java/appeng/me/cluster/implementations/SpatialPylonCluster.java
+++ b/src/main/java/appeng/me/cluster/implementations/SpatialPylonCluster.java
@@ -25,7 +25,6 @@ import java.util.List;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
-import appeng.api.networking.IGridHost;
 import appeng.me.cluster.IAECluster;
 import appeng.me.cluster.MBCalculator;
 import appeng.tile.spatial.SpatialPylonTileEntity;
@@ -88,8 +87,8 @@ public class SpatialPylonCluster implements IAECluster {
     }
 
     @Override
-    public Iterator<IGridHost> getTiles() {
-        return (Iterator) this.getLine().iterator();
+    public Iterator<SpatialPylonTileEntity> getTiles() {
+        return this.getLine().iterator();
     }
 
     public int tileCount() {

--- a/src/main/java/appeng/me/helpers/AENetworkProxyMultiblock.java
+++ b/src/main/java/appeng/me/helpers/AENetworkProxyMultiblock.java
@@ -41,11 +41,10 @@ public class AENetworkProxyMultiblock extends AENetworkProxy implements IGridMul
         if (this.getCluster() == null) {
             return new ChainedIterator<>();
         }
-
         return new ProxyNodeIterator(this.getCluster().getTiles());
     }
 
     private IAECluster getCluster() {
-        return ((IAEMultiBlock) this.getMachine()).getCluster();
+        return ((IAEMultiBlock<?>) this.getMachine()).getCluster();
     }
 }

--- a/src/main/java/appeng/tile/crafting/CraftingTileEntity.java
+++ b/src/main/java/appeng/tile/crafting/CraftingTileEntity.java
@@ -18,11 +18,7 @@
 
 package appeng.tile.crafting;
 
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.Optional;
+import java.util.*;
 
 import javax.annotation.Nonnull;
 
@@ -35,7 +31,6 @@ import net.minecraft.util.Direction;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockReader;
 import net.minecraftforge.client.model.data.IModelData;
-import net.minecraftforge.common.util.Constants;
 
 import appeng.api.config.Actionable;
 import appeng.api.implementations.IPowerChannelState;
@@ -52,7 +47,6 @@ import appeng.api.util.WorldCoord;
 import appeng.block.crafting.AbstractCraftingUnitBlock;
 import appeng.block.crafting.AbstractCraftingUnitBlock.CraftingUnitType;
 import appeng.core.Api;
-import appeng.me.cluster.IAECluster;
 import appeng.me.cluster.IAEMultiBlock;
 import appeng.me.cluster.implementations.CraftingCPUCalculator;
 import appeng.me.cluster.implementations.CraftingCPUCluster;
@@ -61,7 +55,8 @@ import appeng.me.helpers.AENetworkProxyMultiblock;
 import appeng.tile.grid.AENetworkTileEntity;
 import appeng.util.Platform;
 
-public class CraftingTileEntity extends AENetworkTileEntity implements IAEMultiBlock, IPowerChannelState {
+public class CraftingTileEntity extends AENetworkTileEntity
+        implements IAEMultiBlock<CraftingCPUCluster>, IPowerChannelState {
 
     private final CraftingCPUCalculator calc = new CraftingCPUCalculator(this);
     private CompoundNBT previousState = null;
@@ -112,7 +107,7 @@ public class CraftingTileEntity extends AENetworkTileEntity implements IAEMultiB
             return false;
         }
 
-        final AbstractCraftingUnitBlock unit = (AbstractCraftingUnitBlock) this.world.getBlockState(this.pos)
+        final AbstractCraftingUnitBlock<?> unit = (AbstractCraftingUnitBlock<?>) this.world.getBlockState(this.pos)
                 .getBlock();
         return unit.type == CraftingUnitType.ACCELERATOR;
     }
@@ -121,11 +116,11 @@ public class CraftingTileEntity extends AENetworkTileEntity implements IAEMultiB
     public void onReady() {
         super.onReady();
         this.getProxy().setVisualRepresentation(this.getItemFromTile(this));
-        this.calc.calculateMultiblock(world, getLocation());
+        this.calc.calculateMultiblock(world, pos);
     }
 
     public void updateMultiBlock(BlockPos changedPos) {
-        this.calc.updateMultiblockAfterNeighborUpdate(this.world, this.getLocation(), changedPos);
+        this.calc.updateMultiblockAfterNeighborUpdate(this.world, pos, changedPos);
     }
 
     public void updateStatus(final CraftingCPUCluster c) {
@@ -160,7 +155,7 @@ public class CraftingTileEntity extends AENetworkTileEntity implements IAEMultiB
                 // Not using flag 2 here (only send to clients, prevent block update) will cause
                 // infinite loops
                 // In case there is an inconsistency in the crafting clusters.
-                this.world.setBlockState(this.pos, newState, Constants.BlockFlags.BLOCK_UPDATE);
+                this.world.setBlockState(this.pos, newState, 2);
             }
         }
 
@@ -214,7 +209,7 @@ public class CraftingTileEntity extends AENetworkTileEntity implements IAEMultiB
     }
 
     @Override
-    public IAECluster getCluster() {
+    public CraftingCPUCluster getCluster() {
         return this.cluster;
     }
 

--- a/src/main/java/appeng/tile/crafting/CraftingTileEntity.java
+++ b/src/main/java/appeng/tile/crafting/CraftingTileEntity.java
@@ -18,14 +18,17 @@
 
 package appeng.tile.crafting;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.Optional;
 
 import javax.annotation.Nonnull;
 
 import net.minecraft.block.BlockState;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundNBT;
-import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntityType;
 import net.minecraft.util.Direction;
 import net.minecraft.util.math.BlockPos;
@@ -35,15 +38,12 @@ import net.minecraftforge.client.model.data.IModelData;
 import appeng.api.config.Actionable;
 import appeng.api.implementations.IPowerChannelState;
 import appeng.api.networking.GridFlags;
-import appeng.api.networking.IGridHost;
 import appeng.api.networking.events.MENetworkChannelsChanged;
 import appeng.api.networking.events.MENetworkEventSubscribe;
 import appeng.api.networking.events.MENetworkPowerStatusChange;
 import appeng.api.storage.IMEInventory;
 import appeng.api.storage.channels.IItemStorageChannel;
 import appeng.api.storage.data.IAEItemStack;
-import appeng.api.util.AEPartLocation;
-import appeng.api.util.WorldCoord;
 import appeng.block.crafting.AbstractCraftingUnitBlock;
 import appeng.block.crafting.AbstractCraftingUnitBlock.CraftingUnitType;
 import appeng.core.Api;
@@ -90,7 +90,7 @@ public class CraftingTileEntity extends AENetworkTileEntity
     @Override
     public boolean canBeRotated() {
         return true;// return BlockCraftingUnit.checkType( world.getBlockMetadata( xCoord, yCoord,
-                    // zCoord ),
+        // zCoord ),
         // BlockCraftingUnit.BASE_MONITOR );
     }
 
@@ -250,21 +250,18 @@ public class CraftingTileEntity extends AENetworkTileEntity
             this.cluster.cancel();
             final IMEInventory<IAEItemStack> inv = this.cluster.getInventory();
 
-            final LinkedList<WorldCoord> places = new LinkedList<>();
+            final LinkedList<BlockPos> places = new LinkedList<>();
 
-            final Iterator<IGridHost> i = this.cluster.getTiles();
+            final Iterator<CraftingTileEntity> i = this.cluster.getTiles();
             while (i.hasNext()) {
-                final IGridHost h = i.next();
+                final CraftingTileEntity h = i.next();
                 if (h == this) {
-                    places.add(new WorldCoord(this));
+                    places.add(pos);
                 } else {
-                    final TileEntity te = (TileEntity) h;
-
-                    for (final AEPartLocation d : AEPartLocation.SIDE_LOCATIONS) {
-                        final WorldCoord wc = new WorldCoord(te);
-                        wc.add(d, 1);
-                        if (this.world.isAirBlock(wc.getPos())) {
-                            places.add(wc);
+                    for (Direction d : Direction.values()) {
+                        BlockPos p = h.pos.offset(d);
+                        if (this.world.isAirBlock(p)) {
+                            places.add(p);
                         }
                     }
                 }
@@ -288,10 +285,10 @@ public class CraftingTileEntity extends AENetworkTileEntity
                         break;
                     }
 
-                    final WorldCoord wc = places.poll();
-                    places.add(wc);
+                    final BlockPos pos = places.poll();
+                    places.add(pos);
 
-                    Platform.spawnDrops(this.world, wc.getPos(), Collections.singletonList(g.createItemStack()));
+                    Platform.spawnDrops(this.world, pos, Collections.singletonList(g.createItemStack()));
                 }
             }
 

--- a/src/main/java/appeng/tile/qnb/QuantumBridgeTileEntity.java
+++ b/src/main/java/appeng/tile/qnb/QuantumBridgeTileEntity.java
@@ -49,7 +49,6 @@ import appeng.api.util.DimensionalCoord;
 import appeng.block.qnb.QnbFormedState;
 import appeng.core.Api;
 import appeng.me.GridAccessException;
-import appeng.me.cluster.IAECluster;
 import appeng.me.cluster.IAEMultiBlock;
 import appeng.me.cluster.implementations.QuantumCalculator;
 import appeng.me.cluster.implementations.QuantumCluster;
@@ -57,7 +56,8 @@ import appeng.tile.grid.AENetworkInvTileEntity;
 import appeng.tile.inventory.AppEngInternalInventory;
 import appeng.util.inv.InvOperation;
 
-public class QuantumBridgeTileEntity extends AENetworkInvTileEntity implements IAEMultiBlock, ITickableTileEntity {
+public class QuantumBridgeTileEntity extends AENetworkInvTileEntity
+        implements IAEMultiBlock<QuantumCluster>, ITickableTileEntity {
 
     public static final ModelProperty<QnbFormedState> FORMED_STATE = new ModelProperty<>();
 
@@ -191,7 +191,7 @@ public class QuantumBridgeTileEntity extends AENetworkInvTileEntity implements I
     }
 
     @Override
-    public IAECluster getCluster() {
+    public QuantumCluster getCluster() {
         return this.cluster;
     }
 
@@ -210,11 +210,7 @@ public class QuantumBridgeTileEntity extends AENetworkInvTileEntity implements I
             }
 
             if (this.isCorner() || this.isCenter()) {
-                final EnumSet<Direction> sides = EnumSet.noneOf(Direction.class);
-                for (final Direction dir : this.getAdjacentQuantumBridges()) {
-                    sides.add(dir);
-                }
-
+                EnumSet<Direction> sides = EnumSet.copyOf(this.getAdjacentQuantumBridges());
                 this.getProxy().setValidSides(sides);
             } else {
                 this.getProxy().setValidSides(EnumSet.allOf(Direction.class));
@@ -274,7 +270,7 @@ public class QuantumBridgeTileEntity extends AENetworkInvTileEntity implements I
     }
 
     public void neighborUpdate(BlockPos fromPos) {
-        this.calc.updateMultiblockAfterNeighborUpdate(this.world, this.getLocation(), fromPos);
+        this.calc.updateMultiblockAfterNeighborUpdate(this.world, this.pos, fromPos);
     }
 
     @Override

--- a/src/main/java/appeng/tile/spatial/SpatialPylonTileEntity.java
+++ b/src/main/java/appeng/tile/spatial/SpatialPylonTileEntity.java
@@ -43,7 +43,7 @@ import appeng.me.helpers.AENetworkProxy;
 import appeng.me.helpers.AENetworkProxyMultiblock;
 import appeng.tile.grid.AENetworkTileEntity;
 
-public class SpatialPylonTileEntity extends AENetworkTileEntity implements IAEMultiBlock {
+public class SpatialPylonTileEntity extends AENetworkTileEntity implements IAEMultiBlock<SpatialPylonCluster> {
 
     public static final ModelProperty<Integer> STATE = new ModelProperty<>(value -> {
         // The lower 6 bits are used
@@ -88,7 +88,7 @@ public class SpatialPylonTileEntity extends AENetworkTileEntity implements IAEMu
     @Override
     public void onReady() {
         super.onReady();
-        this.calc.calculateMultiblock(world, getLocation());
+        this.calc.calculateMultiblock(world, pos);
     }
 
     @Override
@@ -98,7 +98,7 @@ public class SpatialPylonTileEntity extends AENetworkTileEntity implements IAEMu
     }
 
     public void neighborChanged(BlockPos changedPos) {
-        this.calc.updateMultiblockAfterNeighborUpdate(this.world, this.getLocation(), changedPos);
+        this.calc.updateMultiblockAfterNeighborUpdate(this.world, pos, changedPos);
     }
 
     @Override
@@ -131,9 +131,9 @@ public class SpatialPylonTileEntity extends AENetworkTileEntity implements IAEMu
         this.displayBits = 0;
 
         if (this.cluster != null) {
-            if (this.cluster.getBoundsMin().equals(this.getLocation())) {
+            if (this.cluster.getBoundsMin().equals(this.pos)) {
                 this.displayBits = DISPLAY_END_MIN;
-            } else if (this.cluster.getBoundsMax().equals(this.getLocation())) {
+            } else if (this.cluster.getBoundsMax().equals(this.pos)) {
                 this.displayBits = DISPLAY_END_MAX;
             } else {
                 this.displayBits = DISPLAY_MIDDLE;

--- a/src/main/java/appeng/util/iterators/ProxyNodeIterator.java
+++ b/src/main/java/appeng/util/iterators/ProxyNodeIterator.java
@@ -25,9 +25,9 @@ import appeng.api.networking.IGridNode;
 import appeng.api.util.AEPartLocation;
 
 public final class ProxyNodeIterator implements Iterator<IGridNode> {
-    private final Iterator<IGridHost> hosts;
+    private final Iterator<? extends IGridHost> hosts;
 
-    public ProxyNodeIterator(final Iterator<IGridHost> hosts) {
+    public ProxyNodeIterator(final Iterator<? extends IGridHost> hosts) {
         this.hosts = hosts;
     }
 


### PR DESCRIPTION
Force cluster-rebuilds on the first detected change, if their bounds do not match.

Also use a client-side method to update connected textures
for crafting cubes if two previously distinct clusters are connected.
Refactored MBCalculator to use generics for type checks and remove more casts.