### PR TITLE
Use standard mechanics for damaging the quartz knife

### DIFF
--- a/src/main/java/appeng/items/tools/quartz/QuartzCuttingKnifeItem.java
+++ b/src/main/java/appeng/items/tools/quartz/QuartzCuttingKnifeItem.java
@@ -72,10 +72,12 @@ public class QuartzCuttingKnifeItem extends AEBaseItem implements IGuiItem {
 
     @Override
     public ItemStack getContainerItem(final ItemStack itemStack) {
-        ItemStack copy = itemStack.copy();
-        copy.setDamage(itemStack.getDamage() + 1);
-
-        return copy;
+        ItemStack damagedStack = itemStack.copy();
+        if (damagedStack.attemptDamageItem(1, random, null)) {
+            return ItemStack.EMPTY;
+        } else {
+            return damagedStack;
+        }
     }
 
     @Override


### PR DESCRIPTION
Fixes #4493

This change will also make the unbreaking enchantment on quartz knives work.