### PR TITLE
Remove xvfb steps as runData should now run headless

### DIFF
--- a/.github/workflows/branches.yml
+++ b/.github/workflows/branches.yml
@@ -25,10 +25,11 @@ jobs:
         run: ./gradlew clean --no-daemon
       - name: Validate no assets
         run: test ! -d ./src/generated
+      # FG does appear to read the deps in runData before it has written it. Separate step to avoid it
+      - name: Compile Java and prepare runData
+        run: ./gradlew compileJava prepareRunData --no-daemon
       - name: Generate assets
-        uses: GabrielBB/xvfb-action@v1.2
-        with:
-          run: ./gradlew runData --no-daemon
+        run: ./gradlew runData --no-daemon
       - name: Validate assets
         run: test -d ./src/generated -a -f ./src/generated/resources/.cache/cache
       - name: Build with Gradle

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -25,10 +25,11 @@ jobs:
         run: ./gradlew clean --no-daemon
       - name: Validate no assets
         run: test ! -d ./src/generated
+      # FG does appear to read the deps in runData before it has written it. Separate step to avoid it
+      - name: Compile Java and prepare runData
+        run: ./gradlew compileJava prepareRunData --no-daemon
       - name: Generate assets
-        uses: GabrielBB/xvfb-action@v1.2
-        with:
-          run: ./gradlew runData --no-daemon
+        run: ./gradlew runData --no-daemon
       - name: Validate assets
         run: test -d ./src/generated -a -f ./src/generated/resources/.cache/cache
       - name: Build with Gradle

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -25,10 +25,11 @@ jobs:
         run: ./gradlew clean --no-daemon
       - name: Validate no assets
         run: test ! -d ./src/generated
+      # FG does appear to read the deps in runData before it has written it. Separate step to avoid it
+      - name: Compile Java and prepare runData
+        run: ./gradlew compileJava prepareRunData --no-daemon
       - name: Generate assets
-        uses: GabrielBB/xvfb-action@v1.2
-        with:
-          run: ./gradlew runData --no-daemon
+        run: ./gradlew runData --no-daemon
       - name: Validate assets
         run: test -d ./src/generated -a -f ./src/generated/resources/.cache/cache
       - name: Build with Gradle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,10 +30,11 @@ jobs:
         run: chmod +x gradlew
       - name: Validate no assets
         run: test ! -d ./src/generated
+      # FG does appear to read the deps in runData before it has written it. Separate step to avoid it
+      - name: Compile Java and prepare runData
+        run: ./gradlew compileJava prepareRunData --no-daemon
       - name: Generate assets
-        uses: GabrielBB/xvfb-action@v1.2
-        with:
-          run: ./gradlew runData --no-daemon
+        run: ./gradlew runData --no-daemon
       - name: Validate assets
         run: test -d ./src/generated -a -f ./src/generated/resources/.cache/cache
       - name: Build with Gradle


### PR DESCRIPTION
Also run `prepareRunData` in a separate step to avoid a race condition with ForgeGradle writing the generated dependency after it has already written it for `runData`