### PR TITLE
Clean up global state for cable render mode

### DIFF
--- a/src/main/java/appeng/client/ClientHelper.java
+++ b/src/main/java/appeng/client/ClientHelper.java
@@ -138,15 +138,15 @@ public class ClientHelper extends ServerHelper {
     }
 
     @Override
-    public CableRenderMode getRenderMode() {
+    public CableRenderMode getCableRenderMode() {
         if (Platform.isServer()) {
-            return super.getRenderMode();
+            return super.getCableRenderMode();
         }
 
         final Minecraft mc = Minecraft.getInstance();
         final PlayerEntity player = mc.player;
 
-        return this.renderModeForPlayer(player);
+        return this.getCableRenderModeForPlayer(player);
     }
 
     @Override

--- a/src/main/java/appeng/core/CommonHelper.java
+++ b/src/main/java/appeng/core/CommonHelper.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Random;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import net.minecraft.client.util.InputMappings;
 import net.minecraft.entity.player.PlayerEntity;
@@ -55,11 +56,18 @@ public abstract class CommonHelper {
 
     public abstract void postInit();
 
-    public abstract CableRenderMode getRenderMode();
+    public abstract CableRenderMode getCableRenderMode();
 
     public abstract void triggerUpdates();
 
-    public abstract void updateRenderMode(PlayerEntity player);
+    /**
+     * Sets the player that is currently interacting with a cable or part attached
+     * to a cable. This will return that player's cable render mode from calls to
+     * {@link #getCableRenderMode()}, until another player or null is set.
+     * 
+     * @param player Null to revert to the default cable render mode.
+     */
+    public abstract void setPartInteractionPlayer(@Nullable PlayerEntity player);
 
     public abstract boolean isActionKey(@Nonnull final ActionKey key, InputMappings.Input input);
 

--- a/src/main/java/appeng/core/api/ApiPart.java
+++ b/src/main/java/appeng/core/api/ApiPart.java
@@ -41,6 +41,6 @@ public class ApiPart implements IPartHelper {
 
     @Override
     public CableRenderMode getCableRenderMode() {
-        return AppEng.proxy.getRenderMode();
+        return AppEng.proxy.getCableRenderMode();
     }
 }

--- a/src/main/java/appeng/core/api/definitions/ApiItems.java
+++ b/src/main/java/appeng/core/api/definitions/ApiItems.java
@@ -18,13 +18,13 @@
 
 package appeng.core.api.definitions;
 
-import java.awt.*;
 import java.util.function.Consumer;
 
 import net.minecraft.entity.EntityClassification;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemGroup;
 import net.minecraft.item.ItemModelsProperties;
+import net.minecraft.item.Rarity;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
@@ -241,7 +241,8 @@ public final class ApiItems implements IItems {
                 .features(AEFeature.NETWORK_TOOL).build();
 
         this.cellCreative = registry.item("creative_storage_cell", CreativeStorageCellItem::new)
-                .props(props -> props.maxStackSize(1)).features(AEFeature.STORAGE_CELLS, AEFeature.CREATIVE).build();
+                .props(props -> props.maxStackSize(1).rarity(Rarity.EPIC))
+                .features(AEFeature.STORAGE_CELLS, AEFeature.CREATIVE).build();
         this.viewCell = registry.item("view_cell", ViewCellItem::new).props(props -> props.maxStackSize(1))
                 .features(AEFeature.VIEW_CELL).build();
 

--- a/src/main/java/appeng/core/sync/packets/PartPlacementPacket.java
+++ b/src/main/java/appeng/core/sync/packets/PartPlacementPacket.java
@@ -68,11 +68,14 @@ public class PartPlacementPacket extends BasePacket {
     @Override
     public void serverPacketData(final INetworkInfo manager, final PlayerEntity player) {
         final ServerPlayerEntity sender = (ServerPlayerEntity) player;
-        AppEng.proxy.updateRenderMode(sender);
-        PartPlacement.setEyeHeight(this.eyeHeight);
-        PartPlacement.place(sender.getHeldItem(this.hand), new BlockPos(this.x, this.y, this.z),
-                Direction.values()[this.face], sender, this.hand, sender.world,
-                PartPlacement.PlaceType.INTERACT_FIRST_PASS, 0);
-        AppEng.proxy.updateRenderMode(null);
+        AppEng.proxy.setPartInteractionPlayer(sender);
+        try {
+            PartPlacement.setEyeHeight(this.eyeHeight);
+            PartPlacement.place(sender.getHeldItem(this.hand), new BlockPos(this.x, this.y, this.z),
+                    Direction.values()[this.face], sender, this.hand, sender.world,
+                    PartPlacement.PlaceType.INTERACT_FIRST_PASS, 0);
+        } finally {
+            AppEng.proxy.setPartInteractionPlayer(null);
+        }
     }
 }

--- a/src/main/java/appeng/parts/PartPlacement.java
+++ b/src/main/java/appeng/parts/PartPlacement.java
@@ -330,11 +330,12 @@ public class PartPlacement {
     }
 
     private static SelectedPart selectPart(final PlayerEntity player, final IPartHost host, final Vector3d pos) {
-        AppEng.proxy.updateRenderMode(player);
-        final SelectedPart sp = host.selectPart(pos);
-        AppEng.proxy.updateRenderMode(null);
-
-        return sp;
+        AppEng.proxy.setPartInteractionPlayer(player);
+        try {
+            return host.selectPart(pos);
+        } finally {
+            AppEng.proxy.setPartInteractionPlayer(null);
+        }
     }
 
     public static IFacadePart isFacade(final ItemStack held, final AEPartLocation side) {


### PR DESCRIPTION
Clean up the global state used to hack part interaction into respecting the player's facade render mode. Make the name more indicative of what is actually happening.