### PR TITLE
Fix name clash for ITooltip getWidth/getHeigth leading to AbstractMethodError

### DIFF
--- a/src/main/java/appeng/client/gui/AEBaseScreen.java
+++ b/src/main/java/appeng/client/gui/AEBaseScreen.java
@@ -158,14 +158,14 @@ public abstract class AEBaseScreen<T extends AEBaseContainer> extends ContainerS
     protected void drawGuiSlot(MatrixStack matrixStack, CustomSlotWidget slot, int mouseX, int mouseY,
             float partialTicks) {
         if (slot.isSlotEnabled()) {
-            final int left = slot.xPos();
-            final int top = slot.yPos();
-            final int right = left + slot.getWidth();
-            final int bottom = top + slot.getHeight();
+            final int left = slot.getTooltipAreaX();
+            final int top = slot.getTooltipAreaY();
+            final int right = left + slot.getTooltipAreaWidth();
+            final int bottom = top + slot.getTooltipAreaHeight();
 
             slot.drawContent(matrixStack, getMinecraft(), mouseX, mouseY, partialTicks);
 
-            if (this.isPointInRegion(left, top, slot.getWidth(), slot.getHeight(), mouseX, mouseY)
+            if (this.isPointInRegion(left, top, slot.getTooltipAreaWidth(), slot.getTooltipAreaHeight(), mouseX, mouseY)
                     && slot.canClick(getPlayer())) {
                 RenderSystem.colorMask(true, true, true, false);
                 this.fillGradient(matrixStack, left, top, right, bottom, -2130706433, -2130706433);
@@ -175,16 +175,16 @@ public abstract class AEBaseScreen<T extends AEBaseContainer> extends ContainerS
     }
 
     private void drawTooltip(MatrixStack matrixStack, ITooltip tooltip, int mouseX, int mouseY) {
-        final int x = tooltip.xPos(); // ((GuiImgButton) c).x;
-        int y = tooltip.yPos(); // ((GuiImgButton) c).y;
+        final int x = tooltip.getTooltipAreaX();
+        int y = tooltip.getTooltipAreaY();
 
-        if (x < mouseX && x + tooltip.getWidth() > mouseX && tooltip.isVisible()) {
-            if (y < mouseY && y + tooltip.getHeight() > mouseY) {
+        if (x < mouseX && x + tooltip.getTooltipAreaWidth() > mouseX && tooltip.isTooltipAreaVisible()) {
+            if (y < mouseY && y + tooltip.getTooltipAreaHeight() > mouseY) {
                 if (y < 15) {
                     y = 15;
                 }
 
-                final ITextComponent msg = tooltip.getMessage();
+                final ITextComponent msg = tooltip.getTooltipMessage();
                 this.drawTooltip(matrixStack, x + 11, y + 4, msg);
             }
         }
@@ -285,8 +285,8 @@ public abstract class AEBaseScreen<T extends AEBaseContainer> extends ContainerS
         }
 
         for (CustomSlotWidget slot : this.guiSlots) {
-            if (this.isPointInRegion(slot.xPos(), slot.yPos(), slot.getWidth(), slot.getHeight(), xCoord, yCoord)
-                    && slot.canClick(getPlayer())) {
+            if (this.isPointInRegion(slot.getTooltipAreaX(), slot.getTooltipAreaY(), slot.getTooltipAreaWidth(),
+                    slot.getTooltipAreaHeight(), xCoord, yCoord) && slot.canClick(getPlayer())) {
                 slot.slotClicked(getPlayer().inventory.getItemStack(), btn);
             }
         }

--- a/src/main/java/appeng/client/gui/widgets/ActionButton.java
+++ b/src/main/java/appeng/client/gui/widgets/ActionButton.java
@@ -27,7 +27,7 @@ import net.minecraft.util.text.StringTextComponent;
 import appeng.api.config.ActionItems;
 import appeng.core.localization.ButtonToolTips;
 
-public class ActionButton extends IconButton implements ITooltip {
+public class ActionButton extends IconButton {
     private static final Pattern PATTERN_NEW_LINE = Pattern.compile("\\n", Pattern.LITERAL);
     private final int iconIndex;
 

--- a/src/main/java/appeng/client/gui/widgets/CustomSlotWidget.java
+++ b/src/main/java/appeng/client/gui/widgets/CustomSlotWidget.java
@@ -39,32 +39,32 @@ public abstract class CustomSlotWidget extends AbstractGui implements ITooltip {
     }
 
     @Override
-    public ITextComponent getMessage() {
+    public ITextComponent getTooltipMessage() {
         return StringTextComponent.EMPTY;
     }
 
     @Override
-    public int xPos() {
+    public int getTooltipAreaX() {
         return this.x;
     }
 
     @Override
-    public int yPos() {
+    public int getTooltipAreaY() {
         return this.y;
     }
 
     @Override
-    public int getWidth() {
+    public int getTooltipAreaWidth() {
         return 16;
     }
 
     @Override
-    public int getHeight() {
+    public int getTooltipAreaHeight() {
         return 16;
     }
 
     @Override
-    public boolean isVisible() {
+    public boolean isTooltipAreaVisible() {
         return false;
     }
 

--- a/src/main/java/appeng/client/gui/widgets/ITooltip.java
+++ b/src/main/java/appeng/client/gui/widgets/ITooltip.java
@@ -36,38 +36,38 @@ public interface ITooltip {
      * @return tooltip message
      */
     @Nonnull
-    ITextComponent getMessage();
+    ITextComponent getTooltipMessage();
 
     /**
      * x Location for the object that triggers the tooltip.
      *
      * @return xPosition
      */
-    int xPos();
+    int getTooltipAreaX();
 
     /**
      * y Location for the object that triggers the tooltip.
      *
      * @return yPosition
      */
-    int yPos();
+    int getTooltipAreaY();
 
     /**
      * Width of the object that triggers the tooltip.
      *
      * @return width
      */
-    int getWidth();
+    int getTooltipAreaWidth();
 
     /**
      * Height for the object that triggers the tooltip.
      *
      * @return height
      */
-    int getHeight();
+    int getTooltipAreaHeight();
 
     /**
      * @return true if button being drawn
      */
-    boolean isVisible();
+    boolean isTooltipAreaVisible();
 }

--- a/src/main/java/appeng/client/gui/widgets/IconButton.java
+++ b/src/main/java/appeng/client/gui/widgets/IconButton.java
@@ -25,6 +25,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.widget.button.Button;
 import net.minecraft.client.renderer.texture.TextureManager;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.StringTextComponent;
 import net.minecraftforge.fml.client.gui.GuiUtils;
 
@@ -97,27 +98,32 @@ public abstract class IconButton extends Button implements ITooltip {
     protected abstract int getIconIndex();
 
     @Override
-    public int xPos() {
+    public ITextComponent getTooltipMessage() {
+        return getMessage();
+    }
+
+    @Override
+    public int getTooltipAreaX() {
         return this.x;
     }
 
     @Override
-    public int yPos() {
+    public int getTooltipAreaY() {
         return this.y;
     }
 
     @Override
-    public int getWidth() {
+    public int getTooltipAreaWidth() {
         return this.halfSize ? 8 : 16;
     }
 
     @Override
-    public int getHeight() {
+    public int getTooltipAreaHeight() {
         return this.halfSize ? 8 : 16;
     }
 
     @Override
-    public boolean isVisible() {
+    public boolean isTooltipAreaVisible() {
         return this.visible;
     }
 

--- a/src/main/java/appeng/client/gui/widgets/ProgressBar.java
+++ b/src/main/java/appeng/client/gui/widgets/ProgressBar.java
@@ -81,7 +81,7 @@ public class ProgressBar extends Widget implements ITooltip {
     }
 
     @Override
-    public ITextComponent getMessage() {
+    public ITextComponent getTooltipMessage() {
         if (this.fullMsg != null) {
             return this.fullMsg;
         }
@@ -92,27 +92,27 @@ public class ProgressBar extends Widget implements ITooltip {
     }
 
     @Override
-    public int xPos() {
+    public int getTooltipAreaX() {
         return this.x - 2;
     }
 
     @Override
-    public int yPos() {
+    public int getTooltipAreaY() {
         return this.y - 2;
     }
 
     @Override
-    public int getWidth() {
+    public int getTooltipAreaWidth() {
         return this.width + 4;
     }
 
     @Override
-    public int getHeight() {
+    public int getTooltipAreaHeight() {
         return this.height + 4;
     }
 
     @Override
-    public boolean isVisible() {
+    public boolean isTooltipAreaVisible() {
         return true;
     }
 

--- a/src/main/java/appeng/client/gui/widgets/SettingToggleButton.java
+++ b/src/main/java/appeng/client/gui/widgets/SettingToggleButton.java
@@ -279,7 +279,7 @@ public class SettingToggleButton<T extends Enum<T>> extends IconButton {
     }
 
     @Override
-    public ITextComponent getMessage() {
+    public ITextComponent getTooltipMessage() {
         ITextComponent displayName = null;
         ITextComponent displayValue = null;
 

--- a/src/main/java/appeng/client/gui/widgets/TabButton.java
+++ b/src/main/java/appeng/client/gui/widgets/TabButton.java
@@ -99,27 +99,32 @@ public class TabButton extends Button implements ITooltip {
     }
 
     @Override
-    public int xPos() {
+    public ITextComponent getTooltipMessage() {
+        return getMessage();
+    }
+
+    @Override
+    public int getTooltipAreaX() {
         return this.x;
     }
 
     @Override
-    public int yPos() {
+    public int getTooltipAreaY() {
         return this.y;
     }
 
     @Override
-    public int getWidth() {
+    public int getTooltipAreaWidth() {
         return 22;
     }
 
     @Override
-    public int getHeight() {
+    public int getTooltipAreaHeight() {
         return 22;
     }
 
     @Override
-    public boolean isVisible() {
+    public boolean isTooltipAreaVisible() {
         return this.visible;
     }
 

--- a/src/main/java/appeng/client/gui/widgets/ToggleButton.java
+++ b/src/main/java/appeng/client/gui/widgets/ToggleButton.java
@@ -77,7 +77,7 @@ public class ToggleButton extends Button implements ITooltip {
     }
 
     @Override
-    public ITextComponent getMessage() {
+    public ITextComponent getTooltipMessage() {
         if (this.displayName != null) {
             String name = I18n.format(this.displayName);
             String value = I18n.format(this.displayHint);
@@ -106,27 +106,27 @@ public class ToggleButton extends Button implements ITooltip {
     }
 
     @Override
-    public int xPos() {
+    public int getTooltipAreaX() {
         return this.x;
     }
 
     @Override
-    public int yPos() {
+    public int getTooltipAreaY() {
         return this.y;
     }
 
     @Override
-    public int getWidth() {
+    public int getTooltipAreaWidth() {
         return 16;
     }
 
     @Override
-    public int getHeight() {
+    public int getTooltipAreaHeight() {
         return 16;
     }
 
     @Override
-    public boolean isVisible() {
+    public boolean isTooltipAreaVisible() {
         return this.visible;
     }
 }

--- a/src/main/java/appeng/fluids/client/gui/widgets/FluidSlotWidget.java
+++ b/src/main/java/appeng/fluids/client/gui/widgets/FluidSlotWidget.java
@@ -1,6 +1,5 @@
 package appeng.fluids.client.gui.widgets;
 
-import java.awt.TextComponent;
 import java.util.Collections;
 
 import com.mojang.blaze3d.matrix.MatrixStack;
@@ -57,7 +56,8 @@ public class FluidSlotWidget extends CustomSlotWidget {
             final float blue = (attributes.getColor() & 255) / 255.0F;
             RenderSystem.color3f(red, green, blue);
 
-            blit(matrixStack, xPos(), yPos(), this.getBlitOffset(), getWidth(), getHeight(), sprite);
+            blit(matrixStack, getTooltipAreaX(), getTooltipAreaY(), this.getBlitOffset(), getTooltipAreaWidth(),
+                    getTooltipAreaHeight(), sprite);
         }
     }
 
@@ -81,7 +81,7 @@ public class FluidSlotWidget extends CustomSlotWidget {
     }
 
     @Override
-    public ITextComponent getMessage() {
+    public ITextComponent getTooltipMessage() {
         final IAEFluidStack fluid = this.getFluidStack();
         if (fluid != null) {
             return new TranslationTextComponent(fluid.getFluidStack().getTranslationKey());
@@ -90,7 +90,7 @@ public class FluidSlotWidget extends CustomSlotWidget {
     }
 
     @Override
-    public boolean isVisible() {
+    public boolean isTooltipAreaVisible() {
         return true;
     }
 

--- a/src/main/java/appeng/fluids/client/gui/widgets/FluidTankWidget.java
+++ b/src/main/java/appeng/fluids/client/gui/widgets/FluidTankWidget.java
@@ -89,7 +89,7 @@ public class FluidTankWidget extends Widget implements ITooltip {
     }
 
     @Override
-    public ITextComponent getMessage() {
+    public ITextComponent getTooltipMessage() {
         final IAEFluidStack fluid = this.tank.getFluidInSlot(this.slot);
         if (fluid != null && fluid.getStackSize() > 0) {
             return fluid.getFluid().getAttributes().getDisplayName(fluid.getFluidStack()).deepCopy()
@@ -99,27 +99,27 @@ public class FluidTankWidget extends Widget implements ITooltip {
     }
 
     @Override
-    public int xPos() {
+    public int getTooltipAreaX() {
         return this.x - 2;
     }
 
     @Override
-    public int yPos() {
+    public int getTooltipAreaY() {
         return this.y - 2;
     }
 
     @Override
-    public int getWidth() {
+    public int getTooltipAreaWidth() {
         return this.width + 4;
     }
 
     @Override
-    public int getHeight() {
+    public int getTooltipAreaHeight() {
         return this.height + 4;
     }
 
     @Override
-    public boolean isVisible() {
+    public boolean isTooltipAreaVisible() {
         return true;
     }
 

--- a/src/main/java/appeng/fluids/client/gui/widgets/OptionalFluidSlotWidget.java
+++ b/src/main/java/appeng/fluids/client/gui/widgets/OptionalFluidSlotWidget.java
@@ -48,7 +48,8 @@ public class OptionalFluidSlotWidget extends FluidSlotWidget {
         } else {
             RenderSystem.color4f(1.0F, 1.0F, 1.0F, 0.4F);
         }
-        GuiUtils.drawTexturedModalRect(guileft + this.xPos() - 1, guitop + this.yPos() - 1, this.srcX - 1,
-                this.srcY - 1, this.getWidth() + 2, this.getHeight() + 2, currentZIndex);
+        GuiUtils.drawTexturedModalRect(guileft + this.getTooltipAreaX() - 1, guitop + this.getTooltipAreaY() - 1,
+                this.srcX - 1, this.srcY - 1, this.getTooltipAreaWidth() + 2, this.getTooltipAreaHeight() + 2,
+                currentZIndex);
     }
 }


### PR DESCRIPTION
Fixes #4547: Name clash between ITooltip#getWidth, ITooltip#getHeight and Vanilla Widget methods leads to missing methods at runtime, since the implementing methods will be remapped to SRG names, while referees of the interface will try to call the renamed methods by their name in the interface, leading to an AbstractMethodError.