### PR TITLE
Plane Connection Refactor (#4556) [1.15]

### DIFF
--- a/src/main/java/appeng/container/implementations/FormationPlaneContainer.java
+++ b/src/main/java/appeng/container/implementations/FormationPlaneContainer.java
@@ -52,7 +52,7 @@ public class FormationPlaneContainer extends UpgradeableContainer {
         return helper.open(player, locator);
     }
 
-    @GuiSync(6)
+    @GuiSync(7)
     public YesNo placeMode;
 
     public FormationPlaneContainer(int id, final PlayerInventory ip, final FormationPlanePart te) {

--- a/src/main/java/appeng/fluids/parts/FluidAnnihilationPlanePart.java
+++ b/src/main/java/appeng/fluids/parts/FluidAnnihilationPlanePart.java
@@ -14,7 +14,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tags.FluidTags;
 import net.minecraft.tags.Tag;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.Direction;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockReader;
@@ -35,15 +34,12 @@ import appeng.api.networking.storage.IStorageGrid;
 import appeng.api.networking.ticking.IGridTickable;
 import appeng.api.networking.ticking.TickRateModulation;
 import appeng.api.networking.ticking.TickingRequest;
-import appeng.api.parts.IPart;
 import appeng.api.parts.IPartCollisionHelper;
-import appeng.api.parts.IPartHost;
 import appeng.api.parts.IPartModel;
 import appeng.api.storage.IMEInventory;
 import appeng.api.storage.channels.IFluidStorageChannel;
 import appeng.api.storage.data.IAEFluidStack;
 import appeng.api.util.AECableType;
-import appeng.api.util.AEPartLocation;
 import appeng.core.Api;
 import appeng.core.AppEng;
 import appeng.core.settings.TickRates;
@@ -53,6 +49,7 @@ import appeng.items.parts.PartModels;
 import appeng.me.GridAccessException;
 import appeng.me.helpers.MachineSource;
 import appeng.parts.BasicStatePart;
+import appeng.parts.automation.PlaneConnectionHelper;
 import appeng.parts.automation.PlaneConnections;
 import appeng.parts.automation.PlaneModelData;
 import appeng.parts.automation.PlaneModels;
@@ -73,129 +70,33 @@ public class FluidAnnihilationPlanePart extends BasicStatePart implements IGridT
 
     private final IActionSource mySrc = new MachineSource(this);
 
+    private final PlaneConnectionHelper connectionHelper = new PlaneConnectionHelper(this);
+
     public FluidAnnihilationPlanePart(final ItemStack is) {
         super(is);
     }
 
     @Override
     public void getBoxes(final IPartCollisionHelper bch) {
-        int minX = 1;
-        int minY = 1;
-        int maxX = 15;
-        int maxY = 15;
-
-        final IPartHost host = this.getHost();
-        if (host != null) {
-            final TileEntity te = host.getTile();
-
-            final BlockPos pos = te.getPos();
-
-            final Direction e = bch.getWorldX();
-            final Direction u = bch.getWorldY();
-
-            if (this.isAnnihilationPlane(te.getWorld().getTileEntity(pos.offset(e.getOpposite())), this.getSide())) {
-                minX = 0;
-            }
-
-            if (this.isAnnihilationPlane(te.getWorld().getTileEntity(pos.offset(e)), this.getSide())) {
-                maxX = 16;
-            }
-
-            if (this.isAnnihilationPlane(te.getWorld().getTileEntity(pos.offset(u.getOpposite())), this.getSide())) {
-                minY = 0;
-            }
-
-            if (this.isAnnihilationPlane(te.getWorld().getTileEntity(pos.offset(e)), this.getSide())) {
-                maxY = 16;
-            }
-        }
-
-        bch.addBox(5, 5, 14, 11, 11, 15);
-        bch.addBox(minX, minY, 15, maxX, maxY, 16);
+        connectionHelper.getBoxes(bch);
     }
 
     public PlaneConnections getConnections() {
-
-        final Direction facingRight, facingUp;
-        AEPartLocation location = this.getSide();
-        switch (location) {
-            case UP:
-                facingRight = Direction.EAST;
-                facingUp = Direction.NORTH;
-                break;
-            case DOWN:
-                facingRight = Direction.WEST;
-                facingUp = Direction.NORTH;
-                break;
-            case NORTH:
-                facingRight = Direction.WEST;
-                facingUp = Direction.UP;
-                break;
-            case SOUTH:
-                facingRight = Direction.EAST;
-                facingUp = Direction.UP;
-                break;
-            case WEST:
-                facingRight = Direction.SOUTH;
-                facingUp = Direction.UP;
-                break;
-            case EAST:
-                facingRight = Direction.NORTH;
-                facingUp = Direction.UP;
-                break;
-            default:
-            case INTERNAL:
-                return PlaneConnections.of(false, false, false, false);
-        }
-
-        boolean left = false, right = false, down = false, up = false;
-
-        final IPartHost host = this.getHost();
-        if (host != null) {
-            final TileEntity te = host.getTile();
-
-            final BlockPos pos = te.getPos();
-
-            if (this.isAnnihilationPlane(te.getWorld().getTileEntity(pos.offset(facingRight.getOpposite())),
-                    this.getSide())) {
-                left = true;
-            }
-
-            if (this.isAnnihilationPlane(te.getWorld().getTileEntity(pos.offset(facingRight)), this.getSide())) {
-                right = true;
-            }
-
-            if (this.isAnnihilationPlane(te.getWorld().getTileEntity(pos.offset(facingUp.getOpposite())),
-                    this.getSide())) {
-                down = true;
-            }
-
-            if (this.isAnnihilationPlane(te.getWorld().getTileEntity(pos.offset(facingUp)), this.getSide())) {
-                up = true;
-            }
-        }
-
-        return PlaneConnections.of(up, right, down, left);
+        return connectionHelper.getConnections();
     }
 
     @Override
     public void onNeighborChanged(IBlockReader w, BlockPos pos, BlockPos neighbor) {
         if (pos.offset(this.getSide().getFacing()).equals(neighbor)) {
             this.refresh();
+        } else {
+            connectionHelper.updateConnections();
         }
     }
 
     @Override
     public float getCableConnectionLength(AECableType cable) {
         return 1;
-    }
-
-    private boolean isAnnihilationPlane(final TileEntity blockTileEntity, final AEPartLocation side) {
-        if (blockTileEntity instanceof IPartHost) {
-            final IPart p = ((IPartHost) blockTileEntity).getPart(side);
-            return p != null && p.getClass() == this.getClass();
-        }
-        return false;
     }
 
     private void refresh() {

--- a/src/main/java/appeng/parts/automation/AbstractFormationPlanePart.java
+++ b/src/main/java/appeng/parts/automation/AbstractFormationPlanePart.java
@@ -4,16 +4,13 @@ package appeng.parts.automation;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.Direction;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockReader;
 
 import appeng.api.config.Actionable;
 import appeng.api.config.Settings;
 import appeng.api.networking.security.IActionSource;
-import appeng.api.parts.IPart;
 import appeng.api.parts.IPartCollisionHelper;
-import appeng.api.parts.IPartHost;
 import appeng.api.storage.IMEInventory;
 import appeng.api.storage.cells.ICellContainer;
 import appeng.api.storage.cells.ICellInventory;
@@ -30,6 +27,7 @@ public abstract class AbstractFormationPlanePart<T extends IAEStack<T>> extends 
     private boolean wasActive = false;
     private int priority = 0;
     protected boolean blocked = false;
+    private final PlaneConnectionHelper connectionHelper = new PlaneConnectionHelper(this);
 
     public AbstractFormationPlanePart(ItemStack is) {
         super(is);
@@ -64,103 +62,11 @@ public abstract class AbstractFormationPlanePart<T extends IAEStack<T>> extends 
 
     @Override
     public void getBoxes(final IPartCollisionHelper bch) {
-        int minX = 1;
-        int minY = 1;
-        int maxX = 15;
-        int maxY = 15;
-
-        final IPartHost host = this.getHost();
-        if (host != null) {
-            final TileEntity te = host.getTile();
-
-            final BlockPos pos = te.getPos();
-
-            final Direction e = bch.getWorldX();
-            final Direction u = bch.getWorldY();
-
-            if (this.isTransitionPlane(te.getWorld().getTileEntity(pos.offset(e.getOpposite())), this.getSide())) {
-                minX = 0;
-            }
-
-            if (this.isTransitionPlane(te.getWorld().getTileEntity(pos.offset(e)), this.getSide())) {
-                maxX = 16;
-            }
-
-            if (this.isTransitionPlane(te.getWorld().getTileEntity(pos.offset(u.getOpposite())), this.getSide())) {
-                minY = 0;
-            }
-
-            if (this.isTransitionPlane(te.getWorld().getTileEntity(pos.offset(u)), this.getSide())) {
-                maxY = 16;
-            }
-        }
-
-        bch.addBox(5, 5, 14, 11, 11, 15);
-        bch.addBox(minX, minY, 15, maxX, maxY, 16);
+        connectionHelper.getBoxes(bch);
     }
 
     public PlaneConnections getConnections() {
-
-        final Direction facingRight, facingUp;
-        AEPartLocation location = this.getSide();
-        switch (location) {
-            case UP:
-                facingRight = Direction.EAST;
-                facingUp = Direction.NORTH;
-                break;
-            case DOWN:
-                facingRight = Direction.WEST;
-                facingUp = Direction.NORTH;
-                break;
-            case NORTH:
-                facingRight = Direction.WEST;
-                facingUp = Direction.UP;
-                break;
-            case SOUTH:
-                facingRight = Direction.EAST;
-                facingUp = Direction.UP;
-                break;
-            case WEST:
-                facingRight = Direction.SOUTH;
-                facingUp = Direction.UP;
-                break;
-            case EAST:
-                facingRight = Direction.NORTH;
-                facingUp = Direction.UP;
-                break;
-            default:
-            case INTERNAL:
-                return PlaneConnections.of(false, false, false, false);
-        }
-
-        boolean left = false, right = false, down = false, up = false;
-
-        final IPartHost host = this.getHost();
-        if (host != null) {
-            final TileEntity te = host.getTile();
-
-            final BlockPos pos = te.getPos();
-
-            if (this.isTransitionPlane(te.getWorld().getTileEntity(pos.offset(facingRight.getOpposite())),
-                    this.getSide())) {
-                left = true;
-            }
-
-            if (this.isTransitionPlane(te.getWorld().getTileEntity(pos.offset(facingRight)), this.getSide())) {
-                right = true;
-            }
-
-            if (this.isTransitionPlane(te.getWorld().getTileEntity(pos.offset(facingUp.getOpposite())),
-                    this.getSide())) {
-                down = true;
-            }
-
-            if (this.isTransitionPlane(te.getWorld().getTileEntity(pos.offset(facingUp)), this.getSide())) {
-                up = true;
-            }
-        }
-
-        return PlaneConnections.of(up, right, down, left);
+        return connectionHelper.getConnections();
     }
 
     @Override
@@ -172,20 +78,14 @@ public abstract class AbstractFormationPlanePart<T extends IAEStack<T>> extends 
             final BlockPos tePos = te.getPos().offset(side.getFacing());
 
             this.blocked = !w.getBlockState(tePos).getMaterial().isReplaceable();
+        } else {
+            connectionHelper.updateConnections();
         }
     }
 
     @Override
     public float getCableConnectionLength(AECableType cable) {
         return 1;
-    }
-
-    protected boolean isTransitionPlane(final TileEntity blockTileEntity, final AEPartLocation side) {
-        if (blockTileEntity instanceof IPartHost) {
-            final IPart p = ((IPartHost) blockTileEntity).getPart(side);
-            return p != null && this.getClass() == p.getClass();
-        }
-        return false;
     }
 
     @Override

--- a/src/main/java/appeng/parts/automation/AnnihilationPlanePart.java
+++ b/src/main/java/appeng/parts/automation/AnnihilationPlanePart.java
@@ -35,7 +35,6 @@ import net.minecraft.tags.BlockTags;
 import net.minecraft.tags.ItemTags;
 import net.minecraft.tags.Tag;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.Direction;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
@@ -58,9 +57,7 @@ import appeng.api.networking.storage.IStorageGrid;
 import appeng.api.networking.ticking.IGridTickable;
 import appeng.api.networking.ticking.TickRateModulation;
 import appeng.api.networking.ticking.TickingRequest;
-import appeng.api.parts.IPart;
 import appeng.api.parts.IPartCollisionHelper;
-import appeng.api.parts.IPartHost;
 import appeng.api.parts.IPartModel;
 import appeng.api.storage.channels.IItemStorageChannel;
 import appeng.api.storage.data.IAEItemStack;
@@ -96,12 +93,14 @@ public class AnnihilationPlanePart extends BasicStatePart implements IGridTickab
     private boolean isAccepting = true;
     private boolean breaking = false;
 
+    private final PlaneConnectionHelper connectionHelper = new PlaneConnectionHelper(this);
+
     public AnnihilationPlanePart(final ItemStack is) {
         super(is);
     }
 
     @Override
-    public TickRateModulation call(final World world) throws Exception {
+    public TickRateModulation call(final World world) {
         this.breaking = false;
         return this.breakBlock(true);
     }
@@ -117,39 +116,8 @@ public class AnnihilationPlanePart extends BasicStatePart implements IGridTickab
             return;
         }
 
-        int minX = 1;
-        int minY = 1;
-        int maxX = 15;
-        int maxY = 15;
+        connectionHelper.getBoxes(bch);
 
-        final IPartHost host = this.getHost();
-        if (host != null) {
-            final TileEntity te = host.getTile();
-
-            final BlockPos pos = te.getPos();
-
-            final Direction e = bch.getWorldX();
-            final Direction u = bch.getWorldY();
-
-            if (this.isAnnihilationPlane(te.getWorld().getTileEntity(pos.offset(e.getOpposite())), this.getSide())) {
-                minX = 0;
-            }
-
-            if (this.isAnnihilationPlane(te.getWorld().getTileEntity(pos.offset(e)), this.getSide())) {
-                maxX = 16;
-            }
-
-            if (this.isAnnihilationPlane(te.getWorld().getTileEntity(pos.offset(u.getOpposite())), this.getSide())) {
-                minY = 0;
-            }
-
-            if (this.isAnnihilationPlane(te.getWorld().getTileEntity(pos.offset(e)), this.getSide())) {
-                maxY = 16;
-            }
-        }
-
-        bch.addBox(5, 5, 14, 11, 11, 15);
-        bch.addBox(minX, minY, 15, maxX, maxY, 16);
     }
 
     /**
@@ -157,73 +125,15 @@ public class AnnihilationPlanePart extends BasicStatePart implements IGridTickab
      *         visually.
      */
     public PlaneConnections getConnections() {
-
-        final Direction facingRight, facingUp;
-        AEPartLocation location = this.getSide();
-        switch (location) {
-            case UP:
-                facingRight = Direction.EAST;
-                facingUp = Direction.NORTH;
-                break;
-            case DOWN:
-                facingRight = Direction.WEST;
-                facingUp = Direction.NORTH;
-                break;
-            case NORTH:
-                facingRight = Direction.WEST;
-                facingUp = Direction.UP;
-                break;
-            case SOUTH:
-                facingRight = Direction.EAST;
-                facingUp = Direction.UP;
-                break;
-            case WEST:
-                facingRight = Direction.SOUTH;
-                facingUp = Direction.UP;
-                break;
-            case EAST:
-                facingRight = Direction.NORTH;
-                facingUp = Direction.UP;
-                break;
-            default:
-            case INTERNAL:
-                return PlaneConnections.of(false, false, false, false);
-        }
-
-        boolean left = false, right = false, down = false, up = false;
-
-        final IPartHost host = this.getHost();
-        if (host != null) {
-            final TileEntity te = host.getTile();
-
-            final BlockPos pos = te.getPos();
-
-            if (this.isAnnihilationPlane(te.getWorld().getTileEntity(pos.offset(facingRight.getOpposite())),
-                    this.getSide())) {
-                left = true;
-            }
-
-            if (this.isAnnihilationPlane(te.getWorld().getTileEntity(pos.offset(facingRight)), this.getSide())) {
-                right = true;
-            }
-
-            if (this.isAnnihilationPlane(te.getWorld().getTileEntity(pos.offset(facingUp.getOpposite())),
-                    this.getSide())) {
-                down = true;
-            }
-
-            if (this.isAnnihilationPlane(te.getWorld().getTileEntity(pos.offset(facingUp)), this.getSide())) {
-                up = true;
-            }
-        }
-
-        return PlaneConnections.of(up, right, down, left);
+        return connectionHelper.getConnections();
     }
 
     @Override
     public void onNeighborChanged(IBlockReader w, BlockPos pos, BlockPos neighbor) {
         if (pos.offset(this.getSide().getFacing()).equals(neighbor)) {
             this.refresh();
+        } else {
+            connectionHelper.updateConnections();
         }
     }
 
@@ -367,14 +277,6 @@ public class AnnihilationPlanePart extends BasicStatePart implements IGridTickab
         entityItem.getItem().setCount(newStackSize);
 
         return changed;
-    }
-
-    protected boolean isAnnihilationPlane(final TileEntity blockTileEntity, final AEPartLocation side) {
-        if (blockTileEntity instanceof IPartHost) {
-            final IPart p = ((IPartHost) blockTileEntity).getPart(side);
-            return p != null && p.getClass() == this.getClass();
-        }
-        return false;
     }
 
     @Override

--- a/src/main/java/appeng/parts/automation/IdentityAnnihilationPlanePart.java
+++ b/src/main/java/appeng/parts/automation/IdentityAnnihilationPlanePart.java
@@ -56,15 +56,6 @@ public class IdentityAnnihilationPlanePart extends AnnihilationPlanePart {
     }
 
     @Override
-    protected boolean isAnnihilationPlane(final TileEntity blockTileEntity, final AEPartLocation side) {
-        if (blockTileEntity instanceof IPartHost) {
-            final IPart p = ((IPartHost) blockTileEntity).getPart(side);
-            return p != null && p.getClass() == this.getClass();
-        }
-        return false;
-    }
-
-    @Override
     protected float calculateEnergyUsage(final ServerWorld w, final BlockPos pos, final List<ItemStack> items) {
         final float requiredEnergy = super.calculateEnergyUsage(w, pos, items);
 

--- a/src/main/java/appeng/parts/automation/PlaneConnectionHelper.java
+++ b/src/main/java/appeng/parts/automation/PlaneConnectionHelper.java
@@ -1,0 +1,160 @@
+package appeng.parts.automation;
+
+import javax.annotation.Nullable;
+
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.Direction;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+import appeng.api.parts.IPart;
+import appeng.api.parts.IPartCollisionHelper;
+import appeng.api.parts.IPartHost;
+import appeng.api.util.AEPartLocation;
+import appeng.parts.AEBasePart;
+
+/**
+ * Helps plane parts (annihilation, formation) with determining and checking for
+ * connections to adjacent plane parts of the same type to form a visually
+ * larger plane.
+ */
+public final class PlaneConnectionHelper {
+
+    private final AEBasePart part;
+
+    public PlaneConnectionHelper(AEBasePart part) {
+        this.part = part;
+    }
+
+    /**
+     * Gets on which sides this part has adjacent planes that it visually connects
+     * to
+     */
+    public PlaneConnections getConnections() {
+        TileEntity hostTileEntity = getHostTileEntity();
+        AEPartLocation side = part.getSide();
+
+        final Direction facingRight, facingUp;
+        switch (side) {
+            case UP:
+                facingRight = Direction.EAST;
+                facingUp = Direction.NORTH;
+                break;
+            case DOWN:
+                facingRight = Direction.WEST;
+                facingUp = Direction.NORTH;
+                break;
+            case NORTH:
+                facingRight = Direction.WEST;
+                facingUp = Direction.UP;
+                break;
+            case SOUTH:
+                facingRight = Direction.EAST;
+                facingUp = Direction.UP;
+                break;
+            case WEST:
+                facingRight = Direction.SOUTH;
+                facingUp = Direction.UP;
+                break;
+            case EAST:
+                facingRight = Direction.NORTH;
+                facingUp = Direction.UP;
+                break;
+            default:
+            case INTERNAL:
+                return PlaneConnections.of(false, false, false, false);
+        }
+
+        boolean left = false, right = false, down = false, up = false;
+
+        if (hostTileEntity != null) {
+            World world = hostTileEntity.getWorld();
+            BlockPos pos = hostTileEntity.getPos();
+
+            if (isCompatiblePlaneAdjacent(world.getTileEntity(pos.offset(facingRight.getOpposite())))) {
+                left = true;
+            }
+
+            if (isCompatiblePlaneAdjacent(world.getTileEntity(pos.offset(facingRight)))) {
+                right = true;
+            }
+
+            if (isCompatiblePlaneAdjacent(world.getTileEntity(pos.offset(facingUp.getOpposite())))) {
+                down = true;
+            }
+
+            if (isCompatiblePlaneAdjacent(world.getTileEntity(pos.offset(facingUp)))) {
+                up = true;
+            }
+        }
+
+        return PlaneConnections.of(up, right, down, left);
+    }
+
+    /**
+     * Get the bounding boxes of this plane parts components.
+     */
+    public void getBoxes(IPartCollisionHelper bch) {
+        int minX = 1;
+        int minY = 1;
+        int maxX = 15;
+        int maxY = 15;
+
+        TileEntity hostTile = getHostTileEntity();
+        if (hostTile != null) {
+            World world = hostTile.getWorld();
+
+            final BlockPos pos = hostTile.getPos();
+
+            final Direction e = bch.getWorldX();
+            final Direction u = bch.getWorldY();
+
+            if (isCompatiblePlaneAdjacent(world.getTileEntity(pos.offset(e.getOpposite())))) {
+                minX = 0;
+            }
+
+            if (isCompatiblePlaneAdjacent(world.getTileEntity(pos.offset(e)))) {
+                maxX = 16;
+            }
+
+            if (isCompatiblePlaneAdjacent(world.getTileEntity(pos.offset(u.getOpposite())))) {
+                minY = 0;
+            }
+
+            if (isCompatiblePlaneAdjacent(world.getTileEntity(pos.offset(u)))) {
+                maxY = 16;
+            }
+        }
+
+        bch.addBox(5, 5, 14, 11, 11, 15);
+        bch.addBox(minX, minY, 15, maxX, maxY, 16);
+    }
+
+    /**
+     * Call this when an adjacent block has changed since the connections need to be
+     * recalculated.
+     */
+    public void updateConnections() {
+        TileEntity hostTile = getHostTileEntity();
+        if (hostTile != null) {
+            hostTile.requestModelDataUpdate();
+        }
+    }
+
+    private boolean isCompatiblePlaneAdjacent(@Nullable TileEntity adjacentTileEntity) {
+        if (adjacentTileEntity instanceof IPartHost) {
+            final IPart p = ((IPartHost) adjacentTileEntity).getPart(part.getSide());
+            return p != null && p.getClass() == part.getClass();
+        }
+        return false;
+    }
+
+    private TileEntity getHostTileEntity() {
+        IPartHost host = part.getHost();
+        if (host != null) {
+            return host.getTile();
+        }
+        return null;
+    }
+
+}


### PR DESCRIPTION
* Refactors all plane parts to use a common helper for
calculating connections to adjacent planes.
Also fixes problems with updating these connections on neighbor updates.

* Fix conflicting GuiSync ID.

* Slightly refactor PlaneConnectionHelper, and fix an issue where the bounding box was calculated incorrectly by using the wrong up-direction.

(cherry picked from commit 8617dc8340ea1862662926562bc503260689303c)