### PR TITLE
Use invariant toLowerCase/toUpperCase

### DIFF
--- a/src/api/java/appeng/api/config/SecurityPermissions.java
+++ b/src/api/java/appeng/api/config/SecurityPermissions.java
@@ -23,6 +23,8 @@
 
 package appeng.api.config;
 
+import java.util.Locale;
+
 /**
  * Represent the security systems basic permissions, these are not for
  * anti-griefing, they are part of the mod as a gameplay feature.
@@ -58,7 +60,7 @@ public enum SecurityPermissions {
      */
     SECURITY;
 
-    private final String translationKey = "gui.appliedenergistics2.security." + this.name().toLowerCase();
+    private final String translationKey = "gui.appliedenergistics2.security." + this.name().toLowerCase(Locale.ROOT);
 
     public String getTranslatedName() {
         return this.translationKey + ".name";

--- a/src/main/java/appeng/block/networking/WirelessBlock.java
+++ b/src/main/java/appeng/block/networking/WirelessBlock.java
@@ -18,6 +18,8 @@
 
 package appeng.block.networking;
 
+import java.util.Locale;
+
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.player.PlayerEntity;
@@ -51,7 +53,7 @@ public class WirelessBlock extends AEBaseTileBlock<WirelessTileEntity> {
 
         @Override
         public String getString() {
-            return this.name().toLowerCase();
+            return this.name().toLowerCase(Locale.ROOT);
         }
     }
 

--- a/src/main/java/appeng/client/ActionKey.java
+++ b/src/main/java/appeng/client/ActionKey.java
@@ -1,6 +1,8 @@
 
 package appeng.client;
 
+import java.util.Locale;
+
 import org.lwjgl.glfw.GLFW;
 
 public enum ActionKey {
@@ -13,7 +15,7 @@ public enum ActionKey {
     }
 
     public String getTranslationKey() {
-        return "key." + this.name().toLowerCase() + ".desc";
+        return "key." + this.name().toLowerCase(Locale.ROOT) + ".desc";
     }
 
     public int getDefaultKey() {

--- a/src/main/java/appeng/client/render/FacingToRotation.java
+++ b/src/main/java/appeng/client/render/FacingToRotation.java
@@ -18,6 +18,8 @@
 
 package appeng.client.render;
 
+import java.util.Locale;
+
 import com.mojang.blaze3d.matrix.MatrixStack;
 
 import net.minecraft.util.Direction;
@@ -111,6 +113,6 @@ public enum FacingToRotation implements IStringSerializable {
 
     @Override
     public String getString() {
-        return name().toLowerCase();
+        return name().toLowerCase(Locale.ROOT);
     }
 }

--- a/src/main/java/appeng/client/render/cablebus/CableBuilder.java
+++ b/src/main/java/appeng/client/render/cablebus/CableBuilder.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.function.Function;
 
 import net.minecraft.client.renderer.model.BakedQuad;
@@ -100,7 +101,7 @@ class CableBuilder {
         }
 
         return new RenderMaterial(AtlasTexture.LOCATION_BLOCKS_TEXTURE,
-                new ResourceLocation(AppEng.MOD_ID, textureFolder + color.name().toLowerCase()));
+                new ResourceLocation(AppEng.MOD_ID, textureFolder + color.name().toLowerCase(Locale.ROOT)));
     }
 
     /**

--- a/src/main/java/appeng/client/render/cablebus/CableCoreType.java
+++ b/src/main/java/appeng/client/render/cablebus/CableCoreType.java
@@ -19,6 +19,7 @@
 package appeng.client.render.cablebus;
 
 import java.util.EnumMap;
+import java.util.Locale;
 import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
@@ -74,7 +75,7 @@ public enum CableCoreType {
 
     public RenderMaterial getTexture(AEColor color) {
         return new RenderMaterial(AtlasTexture.LOCATION_BLOCKS_TEXTURE,
-                new ResourceLocation(AppEng.MOD_ID, this.textureFolder + "/" + color.name().toLowerCase()));
+                new ResourceLocation(AppEng.MOD_ID, this.textureFolder + "/" + color.name().toLowerCase(Locale.ROOT)));
     }
 
 }

--- a/src/main/java/appeng/client/render/crafting/CraftingCubeModelLoader.java
+++ b/src/main/java/appeng/client/render/crafting/CraftingCubeModelLoader.java
@@ -18,6 +18,8 @@
 
 package appeng.client.render.crafting;
 
+import java.util.Locale;
+
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -48,7 +50,7 @@ public class CraftingCubeModelLoader implements IModelLoader<CraftingCubeModel> 
         if (typeEl != null) {
             String typeName = deserializationContext.deserialize(typeEl, String.class);
             if (typeName != null) {
-                unitType = AbstractCraftingUnitBlock.CraftingUnitType.valueOf(typeName.toUpperCase());
+                unitType = AbstractCraftingUnitBlock.CraftingUnitType.valueOf(typeName.toUpperCase(Locale.ROOT));
             }
         }
         if (unitType == null) {

--- a/src/main/java/appeng/client/render/effects/EnergyParticleData.java
+++ b/src/main/java/appeng/client/render/effects/EnergyParticleData.java
@@ -49,7 +49,7 @@ public class EnergyParticleData implements IParticleData {
             reader.expect(' ');
             boolean forItem = reader.readBoolean();
             reader.expect(' ');
-            AEPartLocation direction = AEPartLocation.valueOf(reader.readString().toUpperCase());
+            AEPartLocation direction = AEPartLocation.valueOf(reader.readString().toUpperCase(Locale.ROOT));
             return new EnergyParticleData(forItem, direction);
         }
 
@@ -74,7 +74,8 @@ public class EnergyParticleData implements IParticleData {
 
     @Override
     public String getParameters() {
-        return String.format(Locale.ROOT, "%s %s", forItem ? "true" : "false", direction.name().toLowerCase());
+        return String.format(Locale.ROOT, "%s %s", forItem ? "true" : "false",
+                direction.name().toLowerCase(Locale.ROOT));
     }
 
 }

--- a/src/main/java/appeng/client/render/spatial/SpatialPylonModel.java
+++ b/src/main/java/appeng/client/render/spatial/SpatialPylonModel.java
@@ -20,6 +20,7 @@ package appeng.client.render.spatial;
 
 import java.util.Arrays;
 import java.util.EnumMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -59,7 +60,7 @@ public class SpatialPylonModel implements BasicUnbakedModel<SpatialPylonModel> {
 
     private static RenderMaterial getTexturePath(SpatialPylonTextureType type) {
         return new RenderMaterial(AtlasTexture.LOCATION_BLOCKS_TEXTURE,
-                new ResourceLocation(AppEng.MOD_ID, "block/spatial_pylon/" + type.name().toLowerCase()));
+                new ResourceLocation(AppEng.MOD_ID, "block/spatial_pylon/" + type.name().toLowerCase(Locale.ROOT)));
     }
 
 }

--- a/src/main/java/appeng/integration/modules/theoneprobe/TheOneProbeText.java
+++ b/src/main/java/appeng/integration/modules/theoneprobe/TheOneProbeText.java
@@ -37,7 +37,7 @@ public enum TheOneProbeText {
     }
 
     public String getUnlocalized() {
-        return this.root + '.' + this.name().toLowerCase(Locale.ENGLISH);
+        return this.root + '.' + this.name().toLowerCase(Locale.ROOT);
     }
 
 }

--- a/src/main/java/appeng/server/AECommand.java
+++ b/src/main/java/appeng/server/AECommand.java
@@ -20,6 +20,8 @@ package appeng.server;
 
 import static net.minecraft.command.Commands.literal;
 
+import java.util.Locale;
+
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 
@@ -46,7 +48,7 @@ public final class AECommand {
 
     private void add(LiteralArgumentBuilder<net.minecraft.command.CommandSource> builder, Commands subCommand) {
 
-        LiteralArgumentBuilder<CommandSource> subCommandBuilder = literal(subCommand.name().toLowerCase())
+        LiteralArgumentBuilder<CommandSource> subCommandBuilder = literal(subCommand.name().toLowerCase(Locale.ROOT))
                 .requires(src -> src.hasPermissionLevel(subCommand.level));
         subCommand.command.addArguments(subCommandBuilder);
         subCommandBuilder.executes(ctx -> {


### PR DESCRIPTION
Fixes #4571: When not used for displaying localized text, specify Locale.ROOT for toLowerCase/toUpperCase to avoid issues with locale-specific non-ASCII lowercase conversions for ASCII uppercase characters (i.e. turkish lowercase i for uppercase I).