### PR TITLE
Only allow non-pure fluix crystals in the grinder [1.15]

### DIFF
--- a/src/main/resources/data/appliedenergistics2/recipes/grinder/fluix_dust.json
+++ b/src/main/resources/data/appliedenergistics2/recipes/grinder/fluix_dust.json
@@ -1,7 +1,7 @@
 {
   "type": "appliedenergistics2:grinder",
   "input": {
-    "tag": "appliedenergistics2:crystals/fluix"
+    "item": "appliedenergistics2:fluix_crystal"
   },
   "result": {
     "primary": {


### PR DESCRIPTION
Fixes #4574 by referencing only non-pure fluix crystals in the fluix dust grinder recipe.

For 1.15.