### PR TITLE
Fix ME Chest cell model lightmap

### DIFF
--- a/src/main/java/appeng/client/render/tesr/ChestTileEntityRenderer.java
+++ b/src/main/java/appeng/client/render/tesr/ChestTileEntityRenderer.java
@@ -142,7 +142,7 @@ public class ChestTileEntityRenderer extends TileEntityRenderer<ChestTileEntity>
         public List<BakedQuad> getQuads(@Nullable BlockState state, @Nullable Direction side, @Nonnull Random rand,
                 @Nonnull IModelData extraData) {
             if (side != null) {
-                side = r.rotate(side); // This fixes the incorrect lightmap position
+                side = r.resultingRotate(side); // This fixes the incorrect lightmap position
             }
             List<BakedQuad> quads = new ArrayList<>(super.getQuads(state, side, rand, extraData));
 


### PR DESCRIPTION
Fixes #4598: Incorrectly rotated face for determining block lightlevel in ME Chest renderer. (#4599)

(cherry picked from commit 954ce1442e155cd282a59039fa8b44844412e6a3)