### PR TITLE
Fix wrenches not harvesting blocks

### DIFF
--- a/src/main/java/appeng/items/tools/quartz/QuartzWrenchItem.java
+++ b/src/main/java/appeng/items/tools/quartz/QuartzWrenchItem.java
@@ -25,6 +25,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.ItemUseContext;
 import net.minecraft.util.ActionResultType;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IWorldReader;
 
 import appeng.api.implementations.items.IAEWrench;
 import appeng.api.util.DimensionalCoord;
@@ -59,6 +60,15 @@ public class QuartzWrenchItem extends AEBaseItem implements IAEWrench {
             }
         }
         return ActionResultType.PASS;
+    }
+
+    /**
+     * The actual wrenching is implemented by the wrenched block, so sneaking must
+     * not prevent the block from activating its use callback.
+     */
+    @Override
+    public boolean doesSneakBypassUse(ItemStack stack, IWorldReader world, BlockPos pos, PlayerEntity player) {
+        return true;
     }
 
     @Override


### PR DESCRIPTION
Fixes #4584: Wrench is not calling block use functions to harvest blocks

p.s.: Due to a change how Forge `onBlockHarvested` works, this will now play a block break sound + particles.