### PR TITLE
Replace SlotItemHandler with Slot

### DIFF
--- a/src/main/java/appeng/client/gui/Size1Slot.java
+++ b/src/main/java/appeng/client/gui/Size1Slot.java
@@ -8,19 +8,18 @@ import net.minecraft.inventory.container.Slot;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
-import net.minecraftforge.items.SlotItemHandler;
 
 /**
  * A proxy for a slot that will always return an itemstack with size 1, if there
  * is an item in the slot. Used to prevent the default item count from
  * rendering.
  */
-class Size1Slot extends SlotItemHandler {
+class Size1Slot extends Slot {
 
-    private final SlotItemHandler delegate;
+    private final Slot delegate;
 
-    public Size1Slot(SlotItemHandler delegate) {
-        super(delegate.getItemHandler(), delegate.getSlotIndex(), delegate.xPos, delegate.yPos);
+    public Size1Slot(Slot delegate) {
+        super(delegate.inventory, delegate.getSlotIndex(), delegate.xPos, delegate.yPos);
         this.delegate = delegate;
     }
 

--- a/src/main/java/appeng/client/me/FluidRepo.java
+++ b/src/main/java/appeng/client/me/FluidRepo.java
@@ -41,11 +41,6 @@ import appeng.fluids.util.FluidSorters;
 import appeng.util.Platform;
 import appeng.util.prioritylist.IPartitionList;
 
-/**
- * @author BrockWS
- * @version rv6 - 22/05/2018
- * @since rv6 22/05/2018
- */
 public class FluidRepo {
     private final IItemList<IAEFluidStack> list = Api.instance().storage().getStorageChannel(IFluidStorageChannel.class)
             .createList();

--- a/src/main/java/appeng/client/me/SlotFluidME.java
+++ b/src/main/java/appeng/client/me/SlotFluidME.java
@@ -21,23 +21,22 @@ package appeng.client.me;
 import javax.annotation.Nonnull;
 
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.Inventory;
+import net.minecraft.inventory.container.Slot;
 import net.minecraft.item.ItemStack;
-import net.minecraftforge.items.SlotItemHandler;
 
 import appeng.api.storage.data.IAEFluidStack;
 import appeng.fluids.container.slots.IMEFluidSlot;
 
-/**
- * @author BrockWS
- * @version rv6 - 22/05/2018
- * @since rv6 22/05/2018
- */
-public class SlotFluidME extends SlotItemHandler implements IMEFluidSlot {
+public class SlotFluidME extends Slot implements IMEFluidSlot {
 
-    private InternalFluidSlotME slot;
+    private static final IInventory EMPTY_INVENTORY = new Inventory(0);
+
+    private final InternalFluidSlotME slot;
 
     public SlotFluidME(InternalFluidSlotME slot) {
-        super(null, 0, slot.getxPosition(), slot.getyPosition());
+        super(EMPTY_INVENTORY, 0, slot.getxPosition(), slot.getyPosition());
         this.slot = slot;
     }
 
@@ -50,7 +49,7 @@ public class SlotFluidME extends SlotItemHandler implements IMEFluidSlot {
     }
 
     @Override
-    public boolean isItemValid(final ItemStack par1ItemStack) {
+    public boolean isItemValid(final ItemStack stack) {
         return false;
     }
 
@@ -69,7 +68,7 @@ public class SlotFluidME extends SlotItemHandler implements IMEFluidSlot {
     }
 
     @Override
-    public void putStack(final ItemStack par1ItemStack) {
+    public void putStack(final ItemStack stack) {
 
     }
 
@@ -85,7 +84,7 @@ public class SlotFluidME extends SlotItemHandler implements IMEFluidSlot {
     }
 
     @Override
-    public boolean canTakeStack(final PlayerEntity par1PlayerEntity) {
+    public boolean canTakeStack(final PlayerEntity player) {
         return false;
     }
 }

--- a/src/main/java/appeng/client/me/SlotME.java
+++ b/src/main/java/appeng/client/me/SlotME.java
@@ -19,23 +19,27 @@
 package appeng.client.me;
 
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.Inventory;
+import net.minecraft.inventory.container.Slot;
 import net.minecraft.item.ItemStack;
-import net.minecraftforge.items.SlotItemHandler;
 
 import appeng.api.storage.data.IAEItemStack;
 
-public class SlotME extends SlotItemHandler {
+public class SlotME extends Slot {
 
-    private final InternalSlotME mySlot;
+    private static final IInventory EMPTY_INVENTORY = new Inventory(0);
 
-    public SlotME(final InternalSlotME me) {
-        super(null, 0, me.getxPosition(), me.getyPosition());
-        this.mySlot = me;
+    private final InternalSlotME slot;
+
+    public SlotME(final InternalSlotME slot) {
+        super(EMPTY_INVENTORY, 0, slot.getxPosition(), slot.getyPosition());
+        this.slot = slot;
     }
 
     public IAEItemStack getAEStack() {
-        if (this.mySlot.hasPower()) {
-            return this.mySlot.getAEStack();
+        if (this.slot.hasPower()) {
+            return this.slot.getAEStack();
         }
         return null;
     }
@@ -47,15 +51,15 @@ public class SlotME extends SlotItemHandler {
 
     @Override
     public ItemStack getStack() {
-        if (this.mySlot.hasPower()) {
-            return this.mySlot.getStack();
+        if (this.slot.hasPower()) {
+            return this.slot.getStack();
         }
         return ItemStack.EMPTY;
     }
 
     @Override
     public boolean getHasStack() {
-        if (this.mySlot.hasPower()) {
+        if (this.slot.hasPower()) {
             return !this.getStack().isEmpty();
         }
         return false;


### PR DESCRIPTION
Remove the use of SlotItemHandler since we are using it in contexts where we don't actually have an item handler to begin with.

Instead, revert to using a Vanilla Slot and overriding all of its methods, but also inherit the empty inventory that Forge uses to fake a Vanilla slot that doesn't have an inventory.

This should also fix #4652.