### PR TITLE
Fix cached bounding box invalidation on Facade Changes

### DIFF
--- a/src/main/java/appeng/facade/FacadeContainer.java
+++ b/src/main/java/appeng/facade/FacadeContainer.java
@@ -37,15 +37,18 @@ public class FacadeContainer implements IFacadeContainer {
 
     private final int facades = 6;
     private final CableBusStorage storage;
+    private final Runnable changeCallback;
 
-    public FacadeContainer(final CableBusStorage cbs) {
+    public FacadeContainer(final CableBusStorage cbs, Runnable changeCallback) {
         this.storage = cbs;
+        this.changeCallback = changeCallback;
     }
 
     @Override
     public boolean addFacade(final IFacadePart a) {
         if (this.getFacade(a.getSide()) == null) {
             this.storage.setFacade(a.getSide().ordinal(), a);
+            this.notifyChange();
             return true;
         }
         return false;
@@ -56,6 +59,7 @@ public class FacadeContainer implements IFacadeContainer {
         if (side != null && side != AEPartLocation.INTERNAL) {
             if (this.storage.getFacade(side.ordinal()) != null) {
                 this.storage.setFacade(side.ordinal(), null);
+                this.notifyChange();
                 if (host != null) {
                     host.markForUpdate();
                 }
@@ -84,6 +88,7 @@ public class FacadeContainer implements IFacadeContainer {
         for (int x = 0; x < this.facades; x++) {
             this.storage.setFacade(x, newFacades[x]);
         }
+        this.notifyChange();
     }
 
     @Override
@@ -175,4 +180,9 @@ public class FacadeContainer implements IFacadeContainer {
         }
         return true;
     }
+
+    private void notifyChange() {
+        this.changeCallback.run();
+    }
+
 }

--- a/src/main/java/appeng/parts/CableBusContainer.java
+++ b/src/main/java/appeng/parts/CableBusContainer.java
@@ -125,7 +125,7 @@ public class CableBusContainer extends CableBusStorage implements AEMultiTile, I
 
     @Override
     public IFacadeContainer getFacadeContainer() {
-        return new FacadeContainer(this);
+        return new FacadeContainer(this, this::invalidateShapes);
     }
 
     @Override


### PR DESCRIPTION
Fixes removal of facades not invalidating the cached server-side collision boxes.

Fixes #4662 for 1.15