### PR TITLE
Remove GZipStreams from packets.

### DIFF
--- a/src/main/java/appeng/container/implementations/InterfaceTerminalContainer.java
+++ b/src/main/java/appeng/container/implementations/InterfaceTerminalContainer.java
@@ -42,7 +42,7 @@ import appeng.api.networking.security.IActionHost;
 import appeng.container.AEBaseContainer;
 import appeng.container.ContainerLocator;
 import appeng.core.sync.network.NetworkHandler;
-import appeng.core.sync.packets.CompressedNBTPacket;
+import appeng.core.sync.packets.MEInterfaceUpdatePacket;
 import appeng.helpers.DualityInterface;
 import appeng.helpers.IInterfaceHost;
 import appeng.helpers.InventoryAction;
@@ -177,7 +177,7 @@ public final class InterfaceTerminalContainer extends AEBaseContainer {
 
         if (!this.data.isEmpty()) {
             try {
-                NetworkHandler.instance().sendTo(new CompressedNBTPacket(this.data),
+                NetworkHandler.instance().sendTo(new MEInterfaceUpdatePacket(this.data),
                         (ServerPlayerEntity) this.getPlayerInv().player);
             } catch (final IOException e) {
                 // :P

--- a/src/main/java/appeng/core/sync/BasePacketHandler.java
+++ b/src/main/java/appeng/core/sync/BasePacketHandler.java
@@ -29,7 +29,6 @@ import appeng.core.sync.packets.BlockTransitionEffectPacket;
 import appeng.core.sync.packets.ClickPacket;
 import appeng.core.sync.packets.CompassRequestPacket;
 import appeng.core.sync.packets.CompassResponsePacket;
-import appeng.core.sync.packets.CompressedNBTPacket;
 import appeng.core.sync.packets.ConfigButtonPacket;
 import appeng.core.sync.packets.ConfigValuePacket;
 import appeng.core.sync.packets.CraftRequestPacket;
@@ -39,6 +38,7 @@ import appeng.core.sync.packets.ItemTransitionEffectPacket;
 import appeng.core.sync.packets.JEIRecipePacket;
 import appeng.core.sync.packets.LightningPacket;
 import appeng.core.sync.packets.MEFluidInventoryUpdatePacket;
+import appeng.core.sync.packets.MEInterfaceUpdatePacket;
 import appeng.core.sync.packets.MEInventoryUpdatePacket;
 import appeng.core.sync.packets.MatterCannonPacket;
 import appeng.core.sync.packets.MockExplosionPacket;
@@ -101,7 +101,7 @@ public class BasePacketHandler {
 
         PACKET_ASSEMBLER_ANIMATION(AssemblerAnimationPacket.class, AssemblerAnimationPacket::new),
 
-        PACKET_COMPRESSED_NBT(CompressedNBTPacket.class, CompressedNBTPacket::new),
+        PACKET_ME_INTERFACE_UPDATE(MEInterfaceUpdatePacket.class, MEInterfaceUpdatePacket::new),
 
         PACKET_PAINTED_ENTITY(PaintedEntityPacket.class, PaintedEntityPacket::new),
 

--- a/src/main/java/appeng/core/sync/packets/MEFluidInventoryUpdatePacket.java
+++ b/src/main/java/appeng/core/sync/packets/MEFluidInventoryUpdatePacket.java
@@ -19,13 +19,9 @@
 package appeng.core.sync.packets;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.nio.BufferOverflowException;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.zip.GZIPInputStream;
-import java.util.zip.GZIPOutputStream;
 
 import javax.annotation.Nullable;
 
@@ -41,7 +37,6 @@ import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.fml.network.NetworkDirection;
 
 import appeng.api.storage.data.IAEFluidStack;
-import appeng.core.AELog;
 import appeng.core.sync.BasePacket;
 import appeng.core.sync.network.INetworkInfo;
 import appeng.fluids.client.gui.FluidTerminalScreen;
@@ -55,8 +50,6 @@ import appeng.fluids.util.AEFluidStack;
 public class MEFluidInventoryUpdatePacket extends BasePacket {
     private static final int UNCOMPRESSED_PACKET_BYTE_LIMIT = 16 * 1024 * 1024;
     private static final int OPERATION_BYTE_LIMIT = 2 * 1024;
-    private static final int TEMP_BUFFER_SIZE = 1024;
-    private static final int STREAM_MASK = 0xff;
 
     // input.
     @Nullable
@@ -66,47 +59,18 @@ public class MEFluidInventoryUpdatePacket extends BasePacket {
 
     @Nullable
     private final PacketBuffer data;
-    @Nullable
-    private final GZIPOutputStream compressFrame;
 
     private int writtenBytes = 0;
     private boolean empty = true;
 
     public MEFluidInventoryUpdatePacket(final PacketBuffer stream) {
         this.data = null;
-        this.compressFrame = null;
         this.list = new LinkedList<>();
         this.ref = stream.readByte();
 
-        try (final GZIPInputStream gzReader = new GZIPInputStream(new InputStream() {
-            @Override
-            public int read() {
-                if (stream.readableBytes() <= 0) {
-                    return -1;
-                }
-
-                return stream.readByte() & STREAM_MASK;
-            }
-        })) {
-
-            final PacketBuffer uncompressed = new PacketBuffer(Unpooled.buffer(stream.readableBytes()));
-            final byte[] tmp = new byte[TEMP_BUFFER_SIZE];
-
-            while (gzReader.available() != 0) {
-                final int bytes = gzReader.read(tmp);
-
-                if (bytes > 0) {
-                    uncompressed.writeBytes(tmp, 0, bytes);
-                }
-            }
-
-            while (uncompressed.readableBytes() > 0) {
-                this.list.add(AEFluidStack.fromPacket(uncompressed));
-            }
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to decompress packet.", e);
+        while (stream.readableBytes() > 0) {
+            this.list.add(AEFluidStack.fromPacket(stream));
         }
-
         this.empty = this.list.isEmpty();
     }
 
@@ -121,14 +85,6 @@ public class MEFluidInventoryUpdatePacket extends BasePacket {
         this.data = new PacketBuffer(Unpooled.buffer(OPERATION_BYTE_LIMIT));
         this.data.writeInt(this.getPacketID());
         this.data.writeByte(this.ref);
-
-        this.compressFrame = new GZIPOutputStream(new OutputStream() {
-            @Override
-            public void write(final int value) {
-                MEFluidInventoryUpdatePacket.this.data.writeByte(value);
-            }
-        });
-
         this.list = null;
     }
 
@@ -145,28 +101,19 @@ public class MEFluidInventoryUpdatePacket extends BasePacket {
     @Nullable
     @Override
     public IPacket<?> toPacket(NetworkDirection direction) {
-        try {
-            this.compressFrame.close();
-
-            this.configureWrite(this.data);
-            return super.toPacket(direction);
-        } catch (final IOException e) {
-            AELog.debug(e);
-        }
-
-        return null;
+        this.configureWrite(this.data);
+        return super.toPacket(direction);
     }
 
     public void appendFluid(final IAEFluidStack fs) throws IOException, BufferOverflowException {
         final PacketBuffer tmp = new PacketBuffer(Unpooled.buffer(OPERATION_BYTE_LIMIT));
         fs.writeToPacket(tmp);
 
-        this.compressFrame.flush();
         if (this.writtenBytes + tmp.readableBytes() > UNCOMPRESSED_PACKET_BYTE_LIMIT) {
             throw new BufferOverflowException();
         } else {
             this.writtenBytes += tmp.readableBytes();
-            this.compressFrame.write(tmp.array(), 0, tmp.readableBytes());
+            this.data.writeBytes(tmp.array(), 0, tmp.readableBytes());
             this.empty = false;
         }
     }

--- a/src/main/java/appeng/core/sync/packets/MEInventoryUpdatePacket.java
+++ b/src/main/java/appeng/core/sync/packets/MEInventoryUpdatePacket.java
@@ -19,12 +19,10 @@
 package appeng.core.sync.packets;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.BufferOverflowException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
 import javax.annotation.Nullable;
@@ -45,7 +43,6 @@ import appeng.client.gui.implementations.CraftConfirmScreen;
 import appeng.client.gui.implementations.CraftingCPUScreen;
 import appeng.client.gui.implementations.MEMonitorableScreen;
 import appeng.client.gui.implementations.NetworkStatusScreen;
-import appeng.core.AELog;
 import appeng.core.sync.BasePacket;
 import appeng.core.sync.network.INetworkInfo;
 import appeng.util.item.AEItemStack;
@@ -53,8 +50,6 @@ import appeng.util.item.AEItemStack;
 public class MEInventoryUpdatePacket extends BasePacket {
     private static final int UNCOMPRESSED_PACKET_BYTE_LIMIT = 16 * 1024 * 1024;
     private static final int OPERATION_BYTE_LIMIT = 2 * 1024;
-    private static final int TEMP_BUFFER_SIZE = 1024;
-    private static final int STREAM_MASK = 0xff;
 
     // input.
     @Nullable
@@ -64,48 +59,18 @@ public class MEInventoryUpdatePacket extends BasePacket {
 
     @Nullable
     private final PacketBuffer data;
-    @Nullable
-    private final GZIPOutputStream compressFrame;
 
     private int writtenBytes = 0;
     private boolean empty = true;
 
     public MEInventoryUpdatePacket(final PacketBuffer stream) {
         this.data = null;
-        this.compressFrame = null;
         this.list = new ArrayList<>();
         this.ref = stream.readByte();
 
-        // int originalBytes = stream.readableBytes();
-
-        try (GZIPInputStream gzReader = new GZIPInputStream(new InputStream() {
-            @Override
-            public int read() {
-                if (stream.readableBytes() <= 0) {
-                    return -1;
-                }
-
-                return stream.readByte() & STREAM_MASK;
-            }
-        })) {
-            final PacketBuffer uncompressed = new PacketBuffer(Unpooled.buffer(stream.readableBytes()));
-            final byte[] tmp = new byte[TEMP_BUFFER_SIZE];
-
-            while (gzReader.available() != 0) {
-                final int bytes = gzReader.read(tmp);
-
-                if (bytes > 0) {
-                    uncompressed.writeBytes(tmp, 0, bytes);
-                }
-            }
-
-            while (uncompressed.readableBytes() > 0) {
-                this.list.add(AEItemStack.fromPacket(uncompressed));
-            }
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to decompress packet.", e);
+        while (stream.readableBytes() > 0) {
+            this.list.add(AEItemStack.fromPacket(stream));
         }
-
         this.empty = this.list.isEmpty();
     }
 
@@ -120,14 +85,6 @@ public class MEInventoryUpdatePacket extends BasePacket {
         this.data = new PacketBuffer(Unpooled.buffer(OPERATION_BYTE_LIMIT));
         this.data.writeInt(this.getPacketID());
         this.data.writeByte(this.ref);
-
-        this.compressFrame = new GZIPOutputStream(new OutputStream() {
-            @Override
-            public void write(final int value) {
-                MEInventoryUpdatePacket.this.data.writeByte(value);
-            }
-        });
-
         this.list = null;
     }
 
@@ -156,28 +113,19 @@ public class MEInventoryUpdatePacket extends BasePacket {
     @Nullable
     @Override
     public IPacket<?> toPacket(NetworkDirection direction) {
-        try {
-            this.compressFrame.close();
-
-            this.configureWrite(this.data);
-            return super.toPacket(direction);
-        } catch (final IOException e) {
-            AELog.debug(e);
-        }
-
-        return null;
+        this.configureWrite(this.data);
+        return super.toPacket(direction);
     }
 
     public void appendItem(final IAEItemStack is) throws IOException, BufferOverflowException {
         final PacketBuffer tmp = new PacketBuffer(Unpooled.buffer(OPERATION_BYTE_LIMIT));
         is.writeToPacket(tmp);
 
-        this.compressFrame.flush();
         if (this.writtenBytes + tmp.readableBytes() > UNCOMPRESSED_PACKET_BYTE_LIMIT) {
             throw new BufferOverflowException();
         } else {
             this.writtenBytes += tmp.readableBytes();
-            this.compressFrame.write(tmp.array(), 0, tmp.readableBytes());
+            this.data.writeBytes(tmp.array(), 0, tmp.readableBytes());
             this.empty = false;
         }
     }


### PR DESCRIPTION
This should now be handled by the normal network manager (hopefully).
Also renamed the `CompressedNBTPacket` to `MEInterfaceUpdatePacket` as that is the only use case.