### PR TITLE
Serialize the complete NBT data to avoid mismatches

### DIFF
--- a/src/main/java/appeng/util/item/AEItemStack.java
+++ b/src/main/java/appeng/util/item/AEItemStack.java
@@ -125,7 +125,7 @@ public final class AEItemStack extends AEStack<IAEItemStack> implements IAEItemS
         buffer.writeBoolean(this.isCraftable());
         buffer.writeVarLong(this.getStackSize());
         buffer.writeVarLong(this.getCountRequestable());
-        buffer.writeItemStack(getDefinition());
+        buffer.writeItemStack(getDefinition(), false);
     }
 
     @Override


### PR DESCRIPTION
This might increase the network traffic a bit, but the amount of mods actually using the share tag seems to be very limited.
For now it is worth the risk as it solves the problem. In case we run into actual issues, there might still be other solutions, which will be way more complex and can potentially introduce additional problems.