### PR TITLE
Guava-Cache for Cable Bus Quads

### DIFF
--- a/src/main/java/appeng/client/render/cablebus/CableBusModelLoader.java
+++ b/src/main/java/appeng/client/render/cablebus/CableBusModelLoader.java
@@ -18,7 +18,6 @@ public class CableBusModelLoader implements IModelLoader<CableBusModel> {
 
     @Override
     public void onResourceManagerReload(IResourceManager resourceManager) {
-        CableBusBakedModel.clearCache();
     }
 
     @Override


### PR DESCRIPTION
Implemented a cache with maximum quad-count it will cache for the cable bus,

which also fixes concurrent access to the hashmap.