### PR TITLE
Fix Creative Tab being empty in 1.15

### DIFF
--- a/src/main/java/appeng/core/AppEng.java
+++ b/src/main/java/appeng/core/AppEng.java
@@ -90,10 +90,10 @@ public final class AppEng {
         ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, AEConfig.CLIENT_SPEC);
         ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, AEConfig.COMMON_SPEC);
 
-        proxy = DistExecutor.safeRunForDist(() -> ClientHelper::new, () -> ServerHelper::new);
-
         CreativeTab.init();
         new FacadeItemGroup(); // This call has a side-effect (adding it to the creative screen)
+
+        proxy = DistExecutor.safeRunForDist(() -> ClientHelper::new, () -> ServerHelper::new);
 
         IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
         registration = new Registration();


### PR DESCRIPTION
Moving the model loader broke the creative tab since the model-loader accesses the API, which in turn requires the creative tab to be present.