### PR TITLE
Make players assume ownership of networks when they place security stations onto unsecured ones

### DIFF
--- a/src/api/java/appeng/api/networking/GridNotification.java
+++ b/src/api/java/appeng/api/networking/GridNotification.java
@@ -28,4 +28,9 @@ public enum GridNotification {
      * the visible connections for this node have changed, useful for cable.
      */
     CONNECTIONS_CHANGED,
+
+    /**
+     * the owner of the grid node has changed, and the node needs to be re-saved
+     */
+    OWNER_CHANGED
 }

--- a/src/api/java/appeng/api/networking/IGridBlock.java
+++ b/src/api/java/appeng/api/networking/IGridBlock.java
@@ -87,7 +87,8 @@ public interface IGridBlock {
     AEColor getGridColor();
 
     /**
-     * Notifies your IGridBlock that changes were made to your connections
+     * Called by the {@link IGridNode} to notify its {@link IGridBlock} about
+     * events.
      */
     void onGridNotification(@Nonnull GridNotification notification);
 

--- a/src/main/java/appeng/me/GridNode.java
+++ b/src/main/java/appeng/me/GridNode.java
@@ -327,8 +327,9 @@ public class GridNode implements IGridNode, IPathItem {
 
     @Override
     public void setPlayerID(final int playerID) {
-        if (playerID >= 0) {
+        if (playerID >= 0 && this.playerID != playerID) {
             this.playerID = playerID;
+            gridProxy.onGridNotification(GridNotification.OWNER_CHANGED);
         }
     }
 

--- a/src/main/java/appeng/me/cache/SecurityCache.java
+++ b/src/main/java/appeng/me/cache/SecurityCache.java
@@ -81,8 +81,16 @@ public class SecurityCache implements ISecurityGrid {
     private void updateSecurityKey() {
         final long lastCode = this.securityKey;
 
+        /**
+         * Placing a security station will propagate the security station's owner to all
+         * connected grid nodes to prevent the network from not reforming due to different
+         * owners later.
+         */
+        int newOwner = -1;
         if (this.securityProvider.size() == 1) {
-            this.securityKey = this.securityProvider.get(0).getSecurityKey();
+            ISecurityProvider securityProvider = this.securityProvider.get(0);
+            this.securityKey = securityProvider.getSecurityKey();
+            newOwner = securityProvider.getOwner();
         } else {
             this.securityKey = -1;
         }
@@ -90,7 +98,11 @@ public class SecurityCache implements ISecurityGrid {
         if (lastCode != this.securityKey) {
             this.getGrid().postEvent(new MENetworkSecurityChange());
             for (final IGridNode n : this.getGrid().getNodes()) {
-                ((GridNode) n).setLastSecurityKey(this.securityKey);
+                GridNode gridNode = (GridNode) n;
+                gridNode.setLastSecurityKey(this.securityKey);
+                if (gridNode.getPlayerID() != newOwner) {
+                    gridNode.setPlayerID(newOwner);
+                }
             }
         }
     }

--- a/src/main/java/appeng/me/cache/SecurityCache.java
+++ b/src/main/java/appeng/me/cache/SecurityCache.java
@@ -83,8 +83,8 @@ public class SecurityCache implements ISecurityGrid {
 
         /**
          * Placing a security station will propagate the security station's owner to all
-         * connected grid nodes to prevent the network from not reforming due to different
-         * owners later.
+         * connected grid nodes to prevent the network from not reforming due to
+         * different owners later.
          */
         int newOwner = -1;
         if (this.securityProvider.size() == 1) {

--- a/src/main/java/appeng/me/helpers/AENetworkProxy.java
+++ b/src/main/java/appeng/me/helpers/AENetworkProxy.java
@@ -167,7 +167,6 @@ public class AENetworkProxy implements IGridBlock {
      * short cut!
      *
      * @return grid of node
-     *
      * @throws GridAccessException of node or grid is null
      */
     public IGrid getGrid() throws GridAccessException {
@@ -280,6 +279,11 @@ public class AENetworkProxy implements IGridBlock {
 
     @Override
     public void onGridNotification(final GridNotification notification) {
+        if (notification == GridNotification.OWNER_CHANGED) {
+            gp.saveChanges();
+            return;
+        }
+
         if (this.gp instanceof CablePart) {
             ((CablePart) this.gp).markForUpdate();
         }

--- a/src/main/java/appeng/me/helpers/IGridProxyable.java
+++ b/src/main/java/appeng/me/helpers/IGridProxyable.java
@@ -28,4 +28,7 @@ public interface IGridProxyable extends IGridHost {
     DimensionalCoord getLocation();
 
     void gridChanged();
+
+    void saveChanges();
+
 }


### PR DESCRIPTION
Fixes #4712: When a security station is placed onto an unsecured network, the placer assumes ownership of the entire network. Otherwise the contiguous network would not necessarily reconnect in the same way when the chunk is reloaded due to differing player-ids throughout the network.

In addition, changes to the node's owner were not being persisted due to the host never being marked as dirty.