### PR TITLE
Fix needless looping over the same slot while simulating extraction to determine maximum amount

### DIFF
--- a/src/main/java/appeng/parts/misc/ItemHandlerAdapter.java
+++ b/src/main/java/appeng/parts/misc/ItemHandlerAdapter.java
@@ -69,8 +69,7 @@ class ItemHandlerAdapter implements IMEInventory<IAEItemStack>, IBaseMonitor<IAE
         int slotCount = this.itemHandler.getSlots();
         boolean simulate = (type == Actionable.SIMULATE);
 
-        // This uses a brute force approach and tries to jam it in every slot the
-        // inventory exposes.
+        // This uses a brute force approach and tries to jam it in every slot the inventory exposes.
         for (int i = 0; i < slotCount && !remaining.isEmpty(); i++) {
             remaining = this.itemHandler.insertItem(i, remaining, simulate);
         }
@@ -114,13 +113,19 @@ class ItemHandlerAdapter implements IMEInventory<IAEItemStack>, IBaseMonitor<IAE
             int stackSizeCurrentSlot = stackInInventorySlot.getCount();
             int remainingCurrentSlot = Math.min(remainingSize, stackSizeCurrentSlot);
 
-            // We have to loop here because according to the docs, the handler shouldn't
-            // return a stack with size >
-            // maxSize, even if we request more. So even if it returns a valid stack, it
-            // might have more stuff.
+            // We have to loop here because according to the docs, the handler shouldn't return a stack with
+            // size > maxSize, even if we request more. So even if it returns a valid stack, it might have more stuff.
             do {
                 extracted = this.itemHandler.extractItem(i, remainingCurrentSlot, simulate);
                 if (!extracted.isEmpty()) {
+                    // In order to guard against broken IItemHandler implementations, we'll try to guess if the returned
+                    // stack (especially in simulate mode) is the same that was returned by getStackInSlot. This is
+                    // obviously not a precise science, but it would catch the previous Forge bug:
+                    // https://github.com/MinecraftForge/MinecraftForge/pull/6580
+                    if (extracted == stackInInventorySlot) {
+                        extracted = extracted.copy();
+                    }
+
                     if (extracted.getCount() > remainingCurrentSlot) {
                         // Something broke. It should never return more than we requested...
                         // We're going to silently eat the remainder
@@ -130,19 +135,23 @@ class ItemHandlerAdapter implements IMEInventory<IAEItemStack>, IBaseMonitor<IAE
                         extracted.setCount(remainingCurrentSlot);
                     }
 
-                    // We're just gonna use the first stack we get our hands on as the template for
-                    // the rest.
-                    // In case some stupid itemhandler (aka forge) returns an internal state we have
-                    // to do a second
-                    // expensive copy again.
+                    // Heuristic for simulation: looping in case of simulations is pointless, since the state of the
+                    // underlying inventory does not change after a simulated extraction. To still support inventories
+                    // that report stacks that are larger than maxStackSize, we use this heuristic
+                    if (simulate && extracted.getCount() == extracted.getMaxStackSize()
+                            && remainingCurrentSlot > extracted.getMaxStackSize()) {
+                        extracted.setCount(remainingCurrentSlot);
+                    }
+
+                    // We're just gonna use the first stack we get our hands on as the template for the rest.
                     if (gathered.isEmpty()) {
-                        gathered = extracted.copy();
+                        gathered = extracted;
                     } else {
                         gathered.grow(extracted.getCount());
                     }
                     remainingCurrentSlot -= extracted.getCount();
                 }
-            } while (!extracted.isEmpty() && remainingCurrentSlot > 0);
+            } while (!simulate && !extracted.isEmpty() && remainingCurrentSlot > 0);
 
             remainingSize -= stackSizeCurrentSlot - remainingCurrentSlot;
 
@@ -296,15 +305,13 @@ class ItemHandlerAdapter implements IMEInventory<IAEItemStack>, IBaseMonitor<IAE
             // Completely different item
             this.cachedAeStacks[slot] = AEItemStack.fromItemStack(newIS);
 
-            // If we had a stack previously in this slot, notify the network about its
-            // disappearance
+            // If we had a stack previously in this slot, notify the network about its disappearance
             if (oldAeIS != null) {
                 oldAeIS.setStackSize(-oldAeIS.getStackSize());
                 changes.add(oldAeIS);
             }
 
-            // Notify the network about the new stack. Note that this is null if newIS was
-            // null
+            // Notify the network about the new stack. Note that this is null if newIS was null
             if (this.cachedAeStacks[slot] != null) {
                 changes.add(this.cachedAeStacks[slot]);
             }


### PR DESCRIPTION
Fixes #4768.

Be less defensive about copying item stacks in simulated extractions (but still catch obviously broken implementations).

Also fix looping over the same slot while simulating, and try to heuristically guess the maximum extraction from the slot given what getStackInSlot returned.