### PR TITLE
Allow memory cards to upload configurations to any valid machine

### DIFF
--- a/src/main/java/appeng/block/AEBaseTileBlock.java
+++ b/src/main/java/appeng/block/AEBaseTileBlock.java
@@ -230,7 +230,6 @@ public abstract class AEBaseTileBlock<T extends AEBaseTileEntity> extends AEBase
                         memoryCard.notifyUser(player, MemoryCardMessages.SETTINGS_SAVED);
                     }
                 } else {
-                    final String savedName = memoryCard.getSettingsName(heldItem);
                     final CompoundNBT data = memoryCard.getData(heldItem);
 
                     if (tileEntity.uploadSettings(SettingsFrom.MEMORY_CARD, data)) {

--- a/src/main/java/appeng/block/AEBaseTileBlock.java
+++ b/src/main/java/appeng/block/AEBaseTileBlock.java
@@ -233,8 +233,7 @@ public abstract class AEBaseTileBlock<T extends AEBaseTileEntity> extends AEBase
                     final String savedName = memoryCard.getSettingsName(heldItem);
                     final CompoundNBT data = memoryCard.getData(heldItem);
 
-                    if (this.getTranslationKey().equals(savedName)) {
-                        tileEntity.uploadSettings(SettingsFrom.MEMORY_CARD, data);
+                    if (tileEntity.uploadSettings(SettingsFrom.MEMORY_CARD, data)) {
                         memoryCard.notifyUser(player, MemoryCardMessages.SETTINGS_LOADED);
                     } else {
                         memoryCard.notifyUser(player, MemoryCardMessages.INVALID_MACHINE);

--- a/src/main/java/appeng/parts/AEBasePart.java
+++ b/src/main/java/appeng/parts/AEBasePart.java
@@ -396,7 +396,6 @@ public abstract class AEBasePart implements IPart, IGridProxyable, IActionHost, 
                     memoryCard.notifyUser(player, MemoryCardMessages.SETTINGS_SAVED);
                 }
             } else {
-                final String storedName = memoryCard.getSettingsName(memCardIS);
                 final CompoundNBT data = memoryCard.getData(memCardIS);
                 if (this.uploadSettings(SettingsFrom.MEMORY_CARD, data)) {
                     memoryCard.notifyUser(player, MemoryCardMessages.SETTINGS_LOADED);

--- a/src/main/java/appeng/tile/AEBaseTileEntity.java
+++ b/src/main/java/appeng/tile/AEBaseTileEntity.java
@@ -325,8 +325,14 @@ public class AEBaseTileEntity extends TileEntity implements IOrientable, ICommon
      *
      * @param from     source of settings
      * @param compound compound of source
+     *
+     * @return If the upload was successful
      */
-    public void uploadSettings(final SettingsFrom from, final CompoundNBT compound) {
+    public boolean uploadSettings(final SettingsFrom from, final CompoundNBT compound) {
+        boolean success = false;
+        final String priorityTag = "priority";
+        final String configTag = "config";
+
         if (this instanceof IConfigurableObject) {
             final IConfigManager cm = ((IConfigurableObject) this).getConfigManager();
             if (cm != null) {
@@ -334,22 +340,25 @@ public class AEBaseTileEntity extends TileEntity implements IOrientable, ICommon
             }
         }
 
-        if (this instanceof IPriorityHost) {
+        if (this instanceof IPriorityHost && compound.contains(priorityTag)) {
             final IPriorityHost pHost = (IPriorityHost) this;
             pHost.setPriority(compound.getInt("priority"));
+            success = true;
         }
 
         if (this instanceof ISegmentedInventory) {
-            final IItemHandler inv = ((ISegmentedInventory) this).getInventoryByName("config");
-            if (inv instanceof AppEngInternalAEInventory) {
+            final IItemHandler inv = ((ISegmentedInventory) this).getInventoryByName(configTag);
+            if (inv instanceof AppEngInternalAEInventory && compound.contains(configTag)) {
                 final AppEngInternalAEInventory target = (AppEngInternalAEInventory) inv;
                 final AppEngInternalAEInventory tmp = new AppEngInternalAEInventory(null, target.getSlots());
                 tmp.readFromNBT(compound, "config");
                 for (int x = 0; x < tmp.getSlots(); x++) {
                     target.setStackInSlot(x, tmp.getStackInSlot(x));
                 }
+                success = true;
             }
         }
+        return success;
     }
 
     /**

--- a/src/main/java/appeng/tile/networking/EnergyCellTileEntity.java
+++ b/src/main/java/appeng/tile/networking/EnergyCellTileEntity.java
@@ -111,10 +111,12 @@ public class EnergyCellTileEntity extends AENetworkTileEntity implements IAEPowe
     }
 
     @Override
-    public void uploadSettings(final SettingsFrom from, final CompoundNBT compound) {
+    public boolean uploadSettings(final SettingsFrom from, final CompoundNBT compound) {
         if (from == SettingsFrom.DISMANTLE_ITEM) {
             this.internalCurrentPower = compound.getDouble("internalCurrentPower");
+            return true;
         }
+        return false;
     }
 
     @Override


### PR DESCRIPTION
https://github.com/AppliedEnergistics/Applied-Energistics-2/issues/4727

Tested transferring configurations between a cell workbench, storage bus, and import bus with and without capacity cards.

(I tried to squash commit history but it only made them stronger, sorry)