### PR TITLE
Add CraftTweaker support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,7 @@ dependencies {
     // compile against provided APIs
     compileOnly "mezz.jei:jei-${jei_minecraft_version}:${jei_version}:api"
     compileOnly "mcjty.theoneprobe:TheOneProbe-${minecraft_release}:${minecraft_release}-${top_version}:api"
+    compileOnly fg.deobf("com.blamejared.crafttweaker:CraftTweaker-${minecraft_version}:${crt_version}")
 
     // Runtime, Mods
     runtimeOnly fg.deobf("mezz.jei:jei-${jei_minecraft_version}:${jei_version}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,6 +21,7 @@ forge_version_range=[35.0.1,36.0.0)
 jei_minecraft_version=1.16.4
 jei_version=7.6.0.53
 top_version=3.0.4-beta-7
+crt_version=7.1.0.69
 
 #########################################################
 # Deployment                                            #

--- a/src/main/java/appeng/integration/modules/crafttweaker/GrinderRecipeManager.java
+++ b/src/main/java/appeng/integration/modules/crafttweaker/GrinderRecipeManager.java
@@ -1,0 +1,61 @@
+package appeng.integration.modules.crafttweaker;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.blamejared.crafttweaker.api.CraftTweakerAPI;
+import com.blamejared.crafttweaker.api.annotations.ZenRegister;
+import com.blamejared.crafttweaker.api.item.IIngredient;
+import com.blamejared.crafttweaker.api.item.IItemStack;
+import com.blamejared.crafttweaker.api.managers.IRecipeManager;
+import com.blamejared.crafttweaker.impl.actions.recipes.ActionAddRecipe;
+import com.blamejared.crafttweaker.impl.item.MCWeightedItemStack;
+
+import org.openzen.zencode.java.ZenCodeType;
+
+import net.minecraft.item.crafting.IRecipeType;
+import net.minecraft.util.ResourceLocation;
+
+import appeng.api.features.InscriberProcessType;
+import appeng.recipes.handlers.GrinderOptionalResult;
+import appeng.recipes.handlers.GrinderRecipe;
+
+@ZenRegister
+@ZenCodeType.Name("mods.appliedenergistics2.Grinder")
+public class GrinderRecipeManager implements IRecipeManager {
+
+    @ZenCodeType.Method
+    public void addRecipe(String name, IItemStack output, IItemStack ingredient, int turns,
+            MCWeightedItemStack... optionalOutputs) {
+        name = fixRecipeName(name);
+        GrinderRecipe recipe = makeRecipe(name, output, ingredient, ingredient.getAmount(), turns, optionalOutputs);
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, recipe, InscriberProcessType.INSCRIBE.name()));
+    }
+
+    @ZenCodeType.Method
+    public void addRecipe(String name, IItemStack output, IIngredient ingredient, int ingredientCount, int turns,
+            MCWeightedItemStack... optionalOutputs) {
+        name = fixRecipeName(name);
+        GrinderRecipe recipe = makeRecipe(name, output, ingredient, ingredientCount, turns, optionalOutputs);
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, recipe, InscriberProcessType.INSCRIBE.name()));
+    }
+
+    private GrinderRecipe makeRecipe(String name, IItemStack output, IIngredient ingredient, int ingredientCount,
+            int turns, MCWeightedItemStack... optionalOutputs) {
+        ResourceLocation resourceLocation = new ResourceLocation("crafttweaker", name);
+        List<GrinderOptionalResult> optionalResults = Arrays.stream(optionalOutputs)
+                .map(mcWeightedItemStack -> new GrinderOptionalResult((float) mcWeightedItemStack.getWeight(),
+                        mcWeightedItemStack.getItemStack().getInternal()))
+                .collect(
+                        Collectors.toList());
+        return new GrinderRecipe(resourceLocation, "", ingredient.asVanillaIngredient(),
+                ingredientCount,
+                output.getInternal(), turns, optionalResults);
+    }
+
+    @Override
+    public IRecipeType<GrinderRecipe> getRecipeType() {
+        return GrinderRecipe.TYPE;
+    }
+}

--- a/src/main/java/appeng/integration/modules/crafttweaker/InscriberRecipeManager.java
+++ b/src/main/java/appeng/integration/modules/crafttweaker/InscriberRecipeManager.java
@@ -1,0 +1,60 @@
+package appeng.integration.modules.crafttweaker;
+
+import com.blamejared.crafttweaker.api.CraftTweakerAPI;
+import com.blamejared.crafttweaker.api.annotations.ZenRegister;
+import com.blamejared.crafttweaker.api.item.IIngredient;
+import com.blamejared.crafttweaker.api.item.IItemStack;
+import com.blamejared.crafttweaker.api.managers.IRecipeManager;
+import com.blamejared.crafttweaker.impl.actions.recipes.ActionAddRecipe;
+
+import org.openzen.zencode.java.ZenCodeType;
+
+import net.minecraft.item.crafting.IRecipeType;
+import net.minecraft.item.crafting.Ingredient;
+import net.minecraft.util.ResourceLocation;
+
+import appeng.api.features.InscriberProcessType;
+import appeng.recipes.handlers.InscriberRecipe;
+
+@ZenRegister
+@ZenCodeType.Name("mods.appliedenergistics2.Inscriber")
+public class InscriberRecipeManager implements IRecipeManager {
+
+    @ZenCodeType.Method
+    public void addInscribeRecipe(String name, IItemStack output, IIngredient middleInput,
+            @ZenCodeType.Optional IIngredient[] otherInputs) {
+        name = fixRecipeName(name);
+        InscriberRecipe recipe = makeRecipe(name, output, middleInput, otherInputs, InscriberProcessType.INSCRIBE);
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, recipe, InscriberProcessType.INSCRIBE.name()));
+    }
+
+    @ZenCodeType.Method
+    public void addPressRecipe(String name, IItemStack output, IIngredient middleInput,
+            @ZenCodeType.Optional IIngredient[] otherInputs) {
+        name = fixRecipeName(name);
+        InscriberRecipe recipe = makeRecipe(name, output, middleInput, otherInputs, InscriberProcessType.PRESS);
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, recipe, InscriberProcessType.PRESS.name()));
+    }
+
+    private InscriberRecipe makeRecipe(String name, IItemStack output, IIngredient middleInput,
+            IIngredient[] otherInputs, InscriberProcessType type) {
+        ResourceLocation resourceLocation = new ResourceLocation("crafttweaker", name);
+
+        Ingredient middleIngredient = middleInput.asVanillaIngredient();
+        Ingredient topIngredient = Ingredient.EMPTY;
+        Ingredient bottomIngredient = Ingredient.EMPTY;
+        if (otherInputs != null && otherInputs.length >= 1) {
+            topIngredient = otherInputs[0].asVanillaIngredient();
+            if (otherInputs.length == 2) {
+                bottomIngredient = otherInputs[1].asVanillaIngredient();
+            }
+        }
+        return new InscriberRecipe(resourceLocation, "", middleIngredient,
+                output.getInternal(), topIngredient, bottomIngredient, type);
+    }
+
+    @Override
+    public IRecipeType<InscriberRecipe> getRecipeType() {
+        return InscriberRecipe.TYPE;
+    }
+}


### PR DESCRIPTION
I figured since you guys used to have CraftTweaker support in 1.12 I would just PR it into 1.16 as well.

If you don't want the support anymore, just let me know and close this issue, and I'll just put it into a modtweaker-like mod or something like that.

Also if you ever add new recipes / change how current recipes work, just give me a ping and I'll update the support.

I put CraftTweaker as `compileOnly` because I doubt you actually want to load it every time you load the game when developing.

This is the script I used to test that it all worked, removals are all handled in the back-end, so you only need to worry about adding recipes.


```zenscript
import crafttweaker.api.item.IIngredient;

<recipetype:appliedenergistics2:inscriber>.removeRecipe(<item:appliedenergistics2:logic_processor>);
<recipetype:appliedenergistics2:inscriber>.addInscribeRecipe("inscriber_inscribe_test", <item:minecraft:diamond>, <item:minecraft:dirt>);
<recipetype:appliedenergistics2:inscriber>.addInscribeRecipe("inscriber_inscribe_test_top_input", <item:minecraft:dirt>, <item:minecraft:glass>, [<item:minecraft:dirt>] as IIngredient[]);
<recipetype:appliedenergistics2:inscriber>.addInscribeRecipe("inscriber_inscribe_test_bottom_input", <item:minecraft:glass>, <item:minecraft:stick>, [<item:minecraft:air>, <item:minecraft:stick>] as IIngredient[]);
<recipetype:appliedenergistics2:inscriber>.addInscribeRecipe("inscriber_inscribe_test_all_inputs", <item:minecraft:redstone>, <item:minecraft:apple>, [<item:minecraft:arrow>, <item:minecraft:stick>] as IIngredient[]);

<recipetype:appliedenergistics2:inscriber>.addInscribeRecipe("inscriber_press_test", <item:minecraft:scute>, <item:minecraft:lapis_lazuli>);
<recipetype:appliedenergistics2:inscriber>.addInscribeRecipe("inscriber_press_test_top_input", <item:minecraft:coal>, <item:minecraft:white_dye>, [<item:minecraft:white_wool>] as IIngredient[]);
<recipetype:appliedenergistics2:inscriber>.addInscribeRecipe("inscriber_press_test_bottom_input", <item:minecraft:iron_ingot>, <item:minecraft:orange_dye>, [<item:minecraft:air>, <item:minecraft:orange_wool>] as IIngredient[]);
<recipetype:appliedenergistics2:inscriber>.addInscribeRecipe("inscriber_press_test_all_inputs", <item:minecraft:gold_ingot>, <item:minecraft:magenta_dye>, [<item:minecraft:magenta_wool>, <item:minecraft:light_blue_wool>] as IIngredient[]);

<recipetype:appliedenergistics2:grinder>.removeRecipe(<item:minecraft:flint>);
<recipetype:appliedenergistics2:grinder>.addRecipe("grinder_test", <item:minecraft:apple>, <item:minecraft:arrow> * 4, 5);
<recipetype:appliedenergistics2:grinder>.addRecipe("grinder_test_optional_outputs", <item:minecraft:apple>, <item:minecraft:arrow> * 4, 5, [<item:minecraft:diamond> % 50]);
<recipetype:appliedenergistics2:grinder>.addRecipe("grinder_test_with_ingredient", <item:minecraft:redstone>, <item:minecraft:redstone_lamp>, 4, 5);
<recipetype:appliedenergistics2:grinder>.addRecipe("grinder_test_with_ingredient_and_optional_outputs", <item:minecraft:apple>, <tag:items:forge:dyes>, 4, 5, [<item:minecraft:glass> % 50]);
```