### PR TITLE
Allow substitions again for patterns

### DIFF
--- a/src/api/java/appeng/api/networking/crafting/ICraftingPatternDetails.java
+++ b/src/api/java/appeng/api/networking/crafting/ICraftingPatternDetails.java
@@ -116,6 +116,8 @@ public interface ICraftingPatternDetails {
      */
     boolean canSubstitute();
 
+    List<IAEItemStack> getSubstituteInputs(int slot);
+
     /**
      * Allow using this INSTANCE of the pattern details to preform the crafting action with performance enhancements.
      *

--- a/src/main/java/appeng/crafting/CraftingTreeNode.java
+++ b/src/main/java/appeng/crafting/CraftingTreeNode.java
@@ -120,7 +120,12 @@ public class CraftingTreeNode {
             final IItemList<IAEItemStack> inventoryList = inv.getItemList();
 
             if (this.parent.details.canSubstitute()) {
-                itemList = inventoryList.findFuzzy(this.what, FuzzyMode.IGNORE_ALL);
+                final List<IAEItemStack> substitutes = this.parent.details.getSubstituteInputs(this.slot);
+                itemList = new ArrayList<>(substitutes.size());
+
+                for (IAEItemStack stack : substitutes) {
+                    itemList.addAll(inventoryList.findFuzzy(stack, FuzzyMode.IGNORE_ALL));
+                }
             } else {
                 itemList = Lists.newArrayList();
 

--- a/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
+++ b/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
@@ -606,8 +606,13 @@ public final class CraftingCPUCluster implements IAECluster, ICraftingCPU {
                                         final Collection<IAEItemStack> itemList;
 
                                         if (details.canSubstitute()) {
-                                            itemList = this.inventory.getItemList().findFuzzy(input[x],
-                                                    FuzzyMode.IGNORE_ALL);
+                                            final List<IAEItemStack> substitutes = details.getSubstituteInputs(x);
+                                            itemList = new ArrayList<>(substitutes.size());
+
+                                            for (IAEItemStack stack : substitutes) {
+                                                itemList.addAll(this.inventory.getItemList().findFuzzy(stack,
+                                                        FuzzyMode.IGNORE_ALL));
+                                            }
                                         } else {
                                             itemList = new ArrayList<>(1);
 


### PR DESCRIPTION
This will now take matching stacks provided by the recipe into account for alternative inputs.