### PR TITLE
Fixes #4893: Fix autocrafting when substitutions are used

### DIFF
--- a/src/api/java/appeng/api/networking/crafting/ICraftingPatternDetails.java
+++ b/src/api/java/appeng/api/networking/crafting/ICraftingPatternDetails.java
@@ -116,6 +116,11 @@ public interface ICraftingPatternDetails {
      */
     boolean canSubstitute();
 
+    /**
+     * Get potential item substitutions based on the crafting recipe for a given slot.
+     *
+     * @param slot The slot to get the potential ingredients for, uses the indexing scheme of {@link #getSparseInputs()}
+     */
     List<IAEItemStack> getSubstituteInputs(int slot);
 
     /**

--- a/src/main/java/appeng/helpers/CraftingPatternDetails.java
+++ b/src/main/java/appeng/helpers/CraftingPatternDetails.java
@@ -19,7 +19,6 @@
 package appeng.helpers;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -41,8 +40,11 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.ICraftingRecipe;
 import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.item.crafting.IRecipeType;
+import net.minecraft.item.crafting.Ingredient;
+import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
+import net.minecraftforge.common.crafting.IShapedRecipe;
 
 import appeng.api.networking.crafting.ICraftingPatternDetails;
 import appeng.api.storage.channels.IItemStorageChannel;
@@ -55,7 +57,8 @@ import appeng.util.item.AEItemStack;
 
 public class CraftingPatternDetails implements ICraftingPatternDetails, Comparable<CraftingPatternDetails> {
 
-    private static final int ALL_INPUT_LIMIT = 9;
+    private static final int CRAFTING_GRID_DIMENSION = 3;
+    private static final int ALL_INPUT_LIMIT = CRAFTING_GRID_DIMENSION * CRAFTING_GRID_DIMENSION;
     private static final int CRAFTING_OUTPUT_LIMIT = 1;
     private static final int PROCESSING_OUTPUT_LIMIT = 3;
 
@@ -232,17 +235,88 @@ public class CraftingPatternDetails implements ICraftingPatternDetails, Comparab
     }
 
     public List<IAEItemStack> getSubstituteInputs(int slot) {
-        if (this.inputs.get(slot) == null) {
+        if (this.sparseInputs[slot] == null) {
             return Collections.emptyList();
         }
 
         return this.substituteInputs.computeIfAbsent(slot, value -> {
-            final List<IAEItemStack> itemList = Arrays
-                    .stream(this.standardRecipe.getIngredients().get(slot).getMatchingStacks())
-                    .map(AEItemStack::fromItemStack).collect(Collectors.toList());
+            ItemStack[] matchingStacks = getRecipeIngredient(slot).getMatchingStacks();
+            List<IAEItemStack> itemList = new ArrayList<>(matchingStacks.length + 1);
+            for (ItemStack matchingStack : matchingStacks) {
+                itemList.add(AEItemStack.fromItemStack(matchingStack));
+            }
+
+            // Ensure that the specific item put in by the user is at the beginning,
+            // so that it takes precedence over substitutions
             itemList.add(0, this.sparseInputs[slot]);
             return itemList;
         });
+    }
+
+    /**
+     * Gets the {@link Ingredient} from the actual used recipe for a given slot-index into {@link #getSparseInputs()}.
+     * <p/>
+     * Conversion is needed for two reasons: our sparse ingredients are always organized in a 3x3 grid, while Vanilla's
+     * ingredient list will be condensed to the actual recipe's grid size. In addition, in our 3x3 grid, the user can
+     * shift the actual recipe input to the right and down.
+     */
+    private Ingredient getRecipeIngredient(int slot) {
+
+        if (standardRecipe instanceof IShapedRecipe) {
+            IShapedRecipe<?> shapedRecipe = (IShapedRecipe<?>) standardRecipe;
+
+            return getShapedRecipeIngredient(slot, shapedRecipe.getRecipeWidth());
+        } else {
+            return getShapelessRecipeIngredient(slot);
+        }
+    }
+
+    private Ingredient getShapedRecipeIngredient(int slot, int recipeWidth) {
+        // Compute the offset of the user's input vs. crafting grid origin
+        // Which is >0 if they have empty rows above or to the left of their input
+        int leftOffset = 0, topOffset = 0;
+        for (int i = 0; i < sparseInputs.length; i++) {
+            if (sparseInputs[i] != null) {
+                // Found the first non-null input
+                leftOffset = i % CRAFTING_GRID_DIMENSION;
+                topOffset = i / CRAFTING_GRID_DIMENSION;
+                break;
+            }
+        }
+
+        // Compute the x,y of the slot, as-if the recipe was anchored to 0,0
+        int slotX = (slot % CRAFTING_GRID_DIMENSION) - leftOffset;
+        int slotY = (slot / CRAFTING_GRID_DIMENSION) - topOffset;
+
+        // Compute the index into the recipe's ingredient list now
+        int ingredientIndex = slotY * recipeWidth + slotX;
+
+        NonNullList<Ingredient> ingredients = standardRecipe.getIngredients();
+
+        if (ingredientIndex < 0 || ingredientIndex > ingredients.size()) {
+            return Ingredient.EMPTY;
+        }
+
+        return ingredients.get(ingredientIndex);
+    }
+
+    private Ingredient getShapelessRecipeIngredient(int slot) {
+        // We map the list of *filled* sparse inputs to the shapeless (ergo unordered)
+        // ingredients. While these do not actually correspond to each other,
+        // since both lists have the same length, the mapping is at least stable.
+        int ingredientIndex = 0;
+        for (int i = 0; i < slot; i++) {
+            if (sparseInputs[i] != null) {
+                ingredientIndex++;
+            }
+        }
+
+        NonNullList<Ingredient> ingredients = standardRecipe.getIngredients();
+        if (ingredientIndex < ingredients.size()) {
+            return ingredients.get(ingredientIndex);
+        }
+
+        return Ingredient.EMPTY;
     }
 
     @Override
@@ -327,12 +401,10 @@ public class CraftingPatternDetails implements ICraftingPatternDetails, Comparab
 
     /**
      * Merges all equal entries into a single one while adding their total stack sizes.
-     * 
-     * @throws IllegalStateException if the result would be empty.
-     * 
+     *
      * @param collection the collection to condense
-     * 
      * @return a non empty list of condensed stacks.
+     * @throws IllegalStateException if the result would be empty.
      */
     private List<IAEItemStack> condenseStacks(Collection<IAEItemStack> collection) {
         final List<IAEItemStack> merged = collection.stream().filter(Objects::nonNull)

--- a/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
+++ b/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
@@ -443,38 +443,86 @@ public final class CraftingCPUCluster implements IAECluster, ICraftingCPU {
         return null;
     }
 
-    private boolean canCraft(final ICraftingPatternDetails details, final Collection<IAEItemStack> condensedInputs) {
-        for (IAEItemStack g : condensedInputs) {
+    private boolean canCraft(final ICraftingPatternDetails details) {
 
-            if (details.isCraftable()) {
+        if (!details.isCraftable()) {
+            // Processing patterns are relatively easy
+            for (IAEItemStack input : details.getInputs()) {
+                final IAEItemStack ais = this.inventory.extractItems(input.copy(), Actionable.SIMULATE,
+                        this.machineSrc);
+                final ItemStack is = ais == null ? ItemStack.EMPTY : ais.createItemStack();
+
+                if (is.isEmpty() || is.getCount() < input.getStackSize()) {
+                    return false;
+                }
+            }
+        } else if (details.canSubstitute()) {
+
+            // When substitutions are allowed, we have to keep track of which items we've reserved
+            IAEItemStack[] sparseInputs = details.getSparseInputs();
+            Map<IAEItemStack, Integer> consumedCount = new HashMap<>();
+            for (int i = 0; i < sparseInputs.length; i++) {
+                List<IAEItemStack> substitutes = details.getSubstituteInputs(i);
+                if (substitutes.isEmpty()) {
+                    continue;
+                }
+
                 boolean found = false;
+                for (IAEItemStack substitute : substitutes) {
+                    for (IAEItemStack fuzz : this.inventory.getItemList().findFuzzy(substitute, FuzzyMode.IGNORE_ALL)) {
+                        int alreadyConsumed = consumedCount.getOrDefault(fuzz, 0);
+                        if (fuzz.getStackSize() - alreadyConsumed <= 0) {
+                            continue; // Already fully consumed by a previous slot of this recipe
+                        }
 
-                for (IAEItemStack fuzz : this.inventory.getItemList().findFuzzy(g, FuzzyMode.IGNORE_ALL)) {
-                    fuzz = fuzz.copy();
-                    fuzz.setStackSize(g.getStackSize());
-                    final IAEItemStack ais = this.inventory.extractItems(fuzz, Actionable.SIMULATE, this.machineSrc);
-                    final ItemStack is = ais == null ? ItemStack.EMPTY : ais.createItemStack();
+                        fuzz = fuzz.copy();
+                        fuzz.setStackSize(1); // We're iterating over SPARSE inputs which means there's 1 of each needed
+                        final IAEItemStack ais = this.inventory.extractItems(fuzz, Actionable.SIMULATE,
+                                this.machineSrc);
 
-                    if (!is.isEmpty() && is.getCount() == g.getStackSize()) {
-                        found = true;
+                        if (ais != null && ais.getStackSize() > 0) {
+                            // Mark 1 of the stack as consumed
+                            consumedCount.merge(fuzz, 1, Integer::sum);
+                            found = true;
+                            break;
+                        }
+                    }
+                    if (found) {
                         break;
-                    } else if (!is.isEmpty()) {
-                        g = g.copy();
-                        g.decStackSize(is.getCount());
                     }
                 }
 
                 if (!found) {
                     return false;
                 }
-            } else {
-                final IAEItemStack ais = this.inventory.extractItems(g.copy(), Actionable.SIMULATE, this.machineSrc);
-                final ItemStack is = ais == null ? ItemStack.EMPTY : ais.createItemStack();
+            }
 
-                if (is.isEmpty() || is.getCount() < g.getStackSize()) {
+        } else {
+
+            // When no substitutions can occur, we can simply check that all items are accounted since
+            // each type of item should only occur once
+            for (IAEItemStack g : details.getInputs()) {
+                boolean found = false;
+
+                for (IAEItemStack fuzz : this.inventory.getItemList().findFuzzy(g, FuzzyMode.IGNORE_ALL)) {
+                    fuzz = fuzz.copy();
+                    fuzz.setStackSize(g.getStackSize());
+                    final IAEItemStack ais = this.inventory.extractItems(fuzz, Actionable.SIMULATE, this.machineSrc);
+
+                    if (ais != null && ais.getStackSize() >= g.getStackSize()) {
+                        found = true;
+                        break;
+                    } else if (ais != null) {
+                        g = g.copy();
+                        g.decStackSize(ais.getStackSize());
+                    }
+                }
+
+                if (!found) {
                     return false;
                 }
             }
+
         }
 
         return true;
@@ -571,7 +619,7 @@ public final class CraftingCPUCluster implements IAECluster, ICraftingCPU {
 
             final ICraftingPatternDetails details = e.getKey();
 
-            if (this.canCraft(details, details.getInputs())) {
+            if (this.canCraft(details)) {
                 CraftingInventory ic = null;
 
                 for (final ICraftingMedium m : cc.getMediums(e.getKey())) {

--- a/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
+++ b/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
@@ -450,9 +450,8 @@ public final class CraftingCPUCluster implements IAECluster, ICraftingCPU {
             for (IAEItemStack input : details.getInputs()) {
                 final IAEItemStack ais = this.inventory.extractItems(input.copy(), Actionable.SIMULATE,
                         this.machineSrc);
-                final ItemStack is = ais == null ? ItemStack.EMPTY : ais.createItemStack();
 
-                if (is.isEmpty() || is.getCount() < input.getStackSize()) {
+                if (ais == null || ais.getStackSize() < input.getStackSize()) {
                     return false;
                 }
             }


### PR DESCRIPTION
I did some superficial testing of this with the cable anchor and crafting table recipes, and both cases seemed to work. But I'd say this needs more testing. However, it should at least not crash anymore. When substitutions break down, it should simply stall the crafting job now.

Fix retrieval of substitutions from a crafting pattern. Map indices from our sparse inputs to the probable indices of the crafting pattern and more gracefully handle mismatches.

When checking whether the inventory of a crafting CPU is sufficient to craft an autocrafting job, account for the new substitutions.

Fixes #4893