### PR TITLE
Fixes #4890 : Kill CompassService when server is closed, and not when closing.

### DIFF
--- a/src/main/java/appeng/core/worlddata/WorldData.java
+++ b/src/main/java/appeng/core/worlddata/WorldData.java
@@ -110,12 +110,13 @@ public final class WorldData implements IWorldData {
 
     @Override
     public void onServerStopping() {
-        compassData.service().kill();
+
     }
 
     @Override
     public void onServerStoppped() {
         Preconditions.checkNotNull(server);
+        compassData.service().kill();
         instance = null;
         WorldData.server = null;
     }


### PR DESCRIPTION
This is done in order to ensure that specified TEs, specifically CraftingTileEntity do not submit requests to the CompassService after it has already been killed.

If the better way to fix this issue is to instead make sure that no TEs submit requests after the CompassService has closed, then I am unable to help with that.