### PR TITLE
Work around Vanilla chunk lighting problem that leads to Worldgen deadlocks

### DIFF
--- a/src/main/java/appeng/mixins/feature/WorldLightManagerMixin.java
+++ b/src/main/java/appeng/mixins/feature/WorldLightManagerMixin.java
@@ -1,0 +1,30 @@
+package appeng.mixins.feature;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.lighting.WorldLightManager;
+
+/**
+ * This fixes a bug in the Minecraft light-update code that runs after world-generation for
+ * {@link net.minecraft.world.chunk.ChunkPrimer}. If a chunk-section contains a light-emitting block, and we clear the
+ * entire chunk-section (i.e. as part of meteorite worldgen), the lighting-update will assume that the chunk section
+ * exists when it runs through {@link WorldLightManager#onBlockEmissionIncrease(net.minecraft.util.math.BlockPos, int)},
+ * even though the light-level is now 0 for the block.
+ * <p/>
+ * This mixin will cancel the now useless block-update and prevent the crash from occurring.
+ * <p/>
+ * See: https://github.com/AppliedEnergistics/Applied-Energistics-2/issues/4891
+ */
+@Mixin(WorldLightManager.class)
+public class WorldLightManagerMixin {
+    @Inject(method = "onBlockEmissionIncrease", at = @At("HEAD"), cancellable = true)
+    public void onBlockEmissionIncrease(BlockPos blockPos, int lightLevel, CallbackInfo ci) {
+        if (lightLevel == 0) {
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/resources/appliedenergistics2.mixins.json
+++ b/src/main/resources/appliedenergistics2.mixins.json
@@ -10,7 +10,8 @@
     "spatial.BiomesMixin",
     "structure.DimensionStructuresSettingsMixin",
     "structure.ConfiguredStructureFeaturesAccessor",
-    "feature.ConfiguredFeaturesAccessor"
+    "feature.ConfiguredFeaturesAccessor",
+    "feature.WorldLightManagerMixin"
   ],
   "client": [
     "spatial.SkyRenderMixin",


### PR DESCRIPTION
Work around a bug in the Vanilla light update code that is triggered when our meteorite spawner clears entire chunk sections that previously contained lights.

Fixes #4891