### PR TITLE
Delay onReady for AE tile entities until they would normally tick

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -150,6 +150,8 @@ minecraft {
     runs {
         client {
             property 'forge.logging.console.level', 'debug'
+            // See https://github.com/Vazkii/Patchouli#mixin-troubleshooting
+            property 'mixin.env.disableRefMap', 'true'
             workingDirectory project.file('run')
             property "mixin.debug.export", "true"
             mods {

--- a/src/main/java/appeng/fluids/parts/SharedFluidBusPart.java
+++ b/src/main/java/appeng/fluids/parts/SharedFluidBusPart.java
@@ -24,7 +24,6 @@ import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Hand;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.ChunkPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.vector.Vector3d;
 import net.minecraft.world.IBlockReader;
@@ -115,7 +114,7 @@ public abstract class SharedFluidBusPart extends UpgradeablePart implements IGri
     private TileEntity getTileEntity(final TileEntity self, final BlockPos pos) {
         final World w = self.getWorld();
 
-        if (w.getChunkProvider().isChunkLoaded(new ChunkPos(pos))) {
+        if (w.getChunkProvider().canTick(pos)) {
             return w.getTileEntity(pos);
         }
 

--- a/src/main/java/appeng/me/cache/TickManagerCache.java
+++ b/src/main/java/appeng/me/cache/TickManagerCache.java
@@ -35,6 +35,7 @@ import appeng.api.networking.ticking.IGridTickable;
 import appeng.api.networking.ticking.ITickManager;
 import appeng.api.networking.ticking.TickRateModulation;
 import appeng.api.networking.ticking.TickingRequest;
+import appeng.core.AELog;
 import appeng.me.cache.helpers.TickTracker;
 
 public class TickManagerCache implements ITickManager {
@@ -202,7 +203,6 @@ public class TickManagerCache implements ITickManager {
             final TickTracker gt = this.awake.get(node);
             this.awake.remove(node);
             this.sleeping.put(node, gt);
-
             return true;
         }
 

--- a/src/main/java/appeng/parts/automation/SharedItemBusPart.java
+++ b/src/main/java/appeng/parts/automation/SharedItemBusPart.java
@@ -21,7 +21,6 @@ package appeng.parts.automation;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.IBlockReader;
 import net.minecraft.world.World;
 import net.minecraftforge.items.IItemHandler;
@@ -90,7 +89,7 @@ public abstract class SharedItemBusPart extends UpgradeablePart implements IGrid
     private TileEntity getTileEntity(final TileEntity self, final BlockPos pos) {
         final World w = self.getWorld();
 
-        if (w.getChunkProvider().isChunkLoaded(new ChunkPos(pos))) {
+        if (w.getChunkProvider().canTick(pos)) {
             return w.getTileEntity(pos);
         }
 
@@ -129,7 +128,7 @@ public abstract class SharedItemBusPart extends UpgradeablePart implements IGrid
         final BlockPos selfPos = self.getPos().offset(this.getSide().getFacing());
         final World world = self.getWorld();
 
-        return world != null && world.getChunkProvider().isChunkLoaded(new ChunkPos(selfPos));
+        return world != null && world.getChunkProvider().canTick(selfPos);
     }
 
     private void updateState() {

--- a/src/main/java/appeng/spatial/DefaultSpatialHandler.java
+++ b/src/main/java/appeng/spatial/DefaultSpatialHandler.java
@@ -47,7 +47,7 @@ public class DefaultSpatialHandler implements IMovableHandler {
         final Chunk c = w.getChunkAt(newPosition);
         c.addTileEntity(newPosition, te);
 
-        if (w.getChunkProvider().isChunkLoaded(c.getPos())) {
+        if (w.getChunkProvider().canTick(newPosition)) {
             final BlockState state = w.getBlockState(newPosition);
             w.addTileEntity(te);
             w.notifyBlockUpdate(newPosition, state, state, 1);

--- a/src/main/java/appeng/tile/networking/ControllerTileEntity.java
+++ b/src/main/java/appeng/tile/networking/ControllerTileEntity.java
@@ -183,7 +183,7 @@ public class ControllerTileEntity extends AENetworkPowerTileEntity {
      * @return true if there is a loaded controller
      */
     private boolean checkController(final BlockPos pos) {
-        if (this.world.getChunkProvider().isChunkLoaded(new ChunkPos(pos.getX() >> 4, pos.getZ() >> 4))) {
+        if (this.world.getChunkProvider().canTick(pos)) {
             return this.world.getTileEntity(pos) instanceof ControllerTileEntity;
         }
 


### PR DESCRIPTION
Fixes #4940: Fix AE tile entities starting up too early - before the chunks are fully loaded and other tile entities begin ticking.

Also use the same method that vanilla uses to determine whether tile entities in a chunk should tick or not, instead of checking whether entities would tick.