### PR TITLE
Allow cables to be placed underwater

### DIFF
--- a/src/api/java/appeng/api/parts/IFacadePart.java
+++ b/src/api/java/appeng/api/parts/IFacadePart.java
@@ -44,10 +44,10 @@ public interface IFacadePart {
     /**
      * used to collide, and pick the part
      *
-     * @param ch           collision helper
-     * @param livingEntity collision with a living entity?
+     * @param ch         collision helper
+     * @param itemEntity collision with an item entity?
      */
-    void getBoxes(IPartCollisionHelper ch, boolean livingEntity);
+    void getBoxes(IPartCollisionHelper ch, boolean itemEntity);
 
     /**
      * @return side the facade is in

--- a/src/main/java/appeng/block/misc/QuartzFixtureBlock.java
+++ b/src/main/java/appeng/block/misc/QuartzFixtureBlock.java
@@ -27,8 +27,10 @@ import javax.annotation.Nullable;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
+import net.minecraft.block.IWaterLoggable;
 import net.minecraft.block.SoundType;
-import net.minecraft.block.material.Material;
+import net.minecraft.fluid.FluidState;
+import net.minecraft.fluid.Fluids;
 import net.minecraft.item.BlockItemUseContext;
 import net.minecraft.state.BooleanProperty;
 import net.minecraft.state.DirectionProperty;
@@ -53,9 +55,10 @@ import appeng.block.AEBaseBlock;
 import appeng.client.render.effects.ParticleTypes;
 import appeng.core.AEConfig;
 import appeng.core.AppEng;
+import appeng.helpers.AEMaterials;
 import appeng.helpers.MetaRotation;
 
-public class QuartzFixtureBlock extends AEBaseBlock implements IOrientableBlock {
+public class QuartzFixtureBlock extends AEBaseBlock implements IOrientableBlock, IWaterLoggable {
 
     // Cache VoxelShapes for each facing
     private static final Map<Direction, VoxelShape> SHAPES;
@@ -79,16 +82,19 @@ public class QuartzFixtureBlock extends AEBaseBlock implements IOrientableBlock 
     // Used to alternate between two variants of the fixture on adjacent blocks
     public static final BooleanProperty ODD = BooleanProperty.create("odd");
 
-    public QuartzFixtureBlock() {
-        super(defaultProps(Material.MISCELLANEOUS).doesNotBlockMovement().hardnessAndResistance(0)
-                .setLightLevel((b) -> 14).sound(SoundType.GLASS).notSolid());
+    public static final BooleanProperty WATERLOGGED = BlockStateProperties.WATERLOGGED;
 
-        this.setDefaultState(getDefaultState().with(FACING, Direction.UP).with(ODD, false));
+    public QuartzFixtureBlock() {
+        super(defaultProps(
+                AEMaterials.FIXTURE).doesNotBlockMovement().notSolid().hardnessAndResistance(0)
+                        .setLightLevel((b) -> 14).sound(SoundType.GLASS));
+
+        this.setDefaultState(getDefaultState().with(FACING, Direction.UP).with(ODD, false).with(WATERLOGGED, false));
     }
 
     @Override
     protected void fillStateContainer(StateContainer.Builder<Block, BlockState> builder) {
-        builder.add(FACING, ODD);
+        builder.add(FACING, ODD, WATERLOGGED);
     }
 
     // For reference, see WallTorchBlock
@@ -97,10 +103,11 @@ public class QuartzFixtureBlock extends AEBaseBlock implements IOrientableBlock 
     public BlockState getStateForPlacement(BlockItemUseContext context) {
         BlockState blockstate = super.getStateForPlacement(context);
         BlockPos pos = context.getPos();
+        FluidState fluidState = context.getWorld().getFluidState(pos);
 
         // Set the even/odd property
         boolean oddPlacement = ((pos.getX() + pos.getY() + pos.getZ()) % 2) != 0;
-        blockstate = blockstate.with(ODD, oddPlacement);
+        blockstate = blockstate.with(ODD, oddPlacement).with(WATERLOGGED, fluidState.getFluid() == Fluids.WATER);
 
         IWorldReader iworldreader = context.getWorld();
         Direction[] adirection = context.getNearestLookingDirections();
@@ -117,13 +124,18 @@ public class QuartzFixtureBlock extends AEBaseBlock implements IOrientableBlock 
     // Break the fixture if the block it is attached to is changed so that it could
     // no longer be placed
     @Override
-    public BlockState updatePostPlacement(BlockState state, Direction facing, BlockState facingState, IWorld worldIn,
-            BlockPos pos, BlockPos facingPos) {
-        Direction fixtureFacing = state.get(FACING);
-        if (facing.getOpposite() == fixtureFacing && !canPlaceAt(worldIn, pos, facing)) {
+    public BlockState updatePostPlacement(BlockState blockState, Direction facing, BlockState facingState, IWorld world,
+            BlockPos currentPos, BlockPos facingPos) {
+        if (blockState.get(WATERLOGGED).booleanValue()) {
+            world.getPendingFluidTicks().scheduleTick(currentPos, Fluids.WATER,
+                    Fluids.WATER.getTickRate(world));
+        }
+
+        Direction fixtureFacing = blockState.get(FACING);
+        if (facing.getOpposite() == fixtureFacing && !canPlaceAt(world, currentPos, facing)) {
             return Blocks.AIR.getDefaultState();
         }
-        return state;
+        return blockState;
     }
 
     @Override
@@ -197,6 +209,12 @@ public class QuartzFixtureBlock extends AEBaseBlock implements IOrientableBlock 
     @Override
     public IOrientable getOrientable(final IBlockReader w, final BlockPos pos) {
         return new MetaRotation(w, pos, FACING);
+    }
+
+    public FluidState getFluidState(BlockState blockState) {
+        return blockState.get(WATERLOGGED).booleanValue()
+                ? Fluids.WATER.getStillFluidState(false)
+                : super.getFluidState(blockState);
     }
 
 }

--- a/src/main/java/appeng/block/networking/CableBusBlock.java
+++ b/src/main/java/appeng/block/networking/CableBusBlock.java
@@ -421,14 +421,14 @@ public class CableBusBlock extends AEBaseTileBlock<CableBusTileEntity> implement
                 : super.getFluidState(blockState);
     }
 
-    public BlockState updatePostPlacement(BlockState blockState1, Direction direction, BlockState blockState2,
-            IWorld world, BlockPos blockPos1, BlockPos blockPos2) {
-        if (blockState1.get(WATERLOGGED).booleanValue()) {
-            world.getPendingFluidTicks().scheduleTick(blockPos1, Fluids.WATER,
+    public BlockState updatePostPlacement(BlockState blockState, Direction facing, BlockState facingState, IWorld world,
+            BlockPos currentPos, BlockPos facingPos) {
+        if (blockState.get(WATERLOGGED)) {
+            world.getPendingFluidTicks().scheduleTick(currentPos, Fluids.WATER,
                     Fluids.WATER.getTickRate(world));
         }
 
-        return super.updatePostPlacement(blockState1, direction, blockState2, world, blockPos1, blockPos2);
+        return super.updatePostPlacement(blockState, facing, facingState, world, currentPos, facingPos);
     }
 
 }

--- a/src/main/java/appeng/block/storage/SkyChestBlock.java
+++ b/src/main/java/appeng/block/storage/SkyChestBlock.java
@@ -23,10 +23,18 @@ import java.util.Map;
 
 import javax.annotation.Nullable;
 
+import net.minecraft.block.Block;
 import net.minecraft.block.BlockRenderType;
 import net.minecraft.block.BlockState;
+import net.minecraft.block.IWaterLoggable;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.fluid.FluidState;
+import net.minecraft.fluid.Fluids;
+import net.minecraft.item.BlockItemUseContext;
 import net.minecraft.item.ItemStack;
+import net.minecraft.state.BooleanProperty;
+import net.minecraft.state.StateContainer;
+import net.minecraft.state.properties.BlockStateProperties;
 import net.minecraft.util.ActionResultType;
 import net.minecraft.util.Direction;
 import net.minecraft.util.Hand;
@@ -37,6 +45,7 @@ import net.minecraft.util.math.shapes.ISelectionContext;
 import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.util.math.shapes.VoxelShapes;
 import net.minecraft.world.IBlockReader;
+import net.minecraft.world.IWorld;
 import net.minecraft.world.World;
 
 import appeng.block.AEBaseTileBlock;
@@ -46,7 +55,7 @@ import appeng.container.implementations.SkyChestContainer;
 import appeng.tile.storage.SkyChestTileEntity;
 import appeng.util.Platform;
 
-public class SkyChestBlock extends AEBaseTileBlock<SkyChestTileEntity> {
+public class SkyChestBlock extends AEBaseTileBlock<SkyChestTileEntity> implements IWaterLoggable {
 
     private static final double AABB_OFFSET_BOTTOM = 0.00;
     private static final double AABB_OFFSET_SIDES = 0.06;
@@ -55,6 +64,8 @@ public class SkyChestBlock extends AEBaseTileBlock<SkyChestTileEntity> {
     // Precomputed bounding boxes of the chest, sorted into the map by the UP
     // direction
     private static final Map<Direction, VoxelShape> SHAPES = new EnumMap<>(Direction.class);
+
+    private static final BooleanProperty WATERLOGGED = BlockStateProperties.WATERLOGGED;
 
     static {
         for (Direction up : Direction.values()) {
@@ -72,6 +83,13 @@ public class SkyChestBlock extends AEBaseTileBlock<SkyChestTileEntity> {
     public SkyChestBlock(final SkyChestType type, Properties props) {
         super(props);
         this.type = type;
+        setDefaultState(getDefaultState().with(WATERLOGGED, false));
+    }
+
+    @Override
+    protected void fillStateContainer(StateContainer.Builder<Block, BlockState> builder) {
+        super.fillStateContainer(builder);
+        builder.add(WATERLOGGED);
     }
 
     @Override
@@ -127,5 +145,31 @@ public class SkyChestBlock extends AEBaseTileBlock<SkyChestTileEntity> {
                 1.0 - offsetZ - (up.getZOffset() < 0 ? AABB_OFFSET_TOP : (up.getZOffset() * AABB_OFFSET_BOTTOM)));
 
         return new AxisAlignedBB(minX, minY, minZ, maxX, maxY, maxZ);
+    }
+
+    @Nullable
+    public BlockState getStateForPlacement(BlockItemUseContext context) {
+        BlockPos pos = context.getPos();
+        FluidState fluidState = context.getWorld().getFluidState(pos);
+        BlockState blockState = this.getDefaultState()
+                .with(WATERLOGGED, fluidState.getFluid() == Fluids.WATER);
+
+        return blockState;
+    }
+
+    public FluidState getFluidState(BlockState blockState) {
+        return blockState.get(WATERLOGGED).booleanValue()
+                ? Fluids.WATER.getStillFluidState(false)
+                : super.getFluidState(blockState);
+    }
+
+    public BlockState updatePostPlacement(BlockState blockState, Direction facing, BlockState facingState, IWorld world,
+            BlockPos currentPos, BlockPos facingPos) {
+        if (blockState.get(WATERLOGGED)) {
+            world.getPendingFluidTicks().scheduleTick(currentPos, Fluids.WATER,
+                    Fluids.WATER.getTickRate(world));
+        }
+
+        return super.updatePostPlacement(blockState, facing, facingState, world, currentPos, facingPos);
     }
 }

--- a/src/main/java/appeng/facade/FacadePart.java
+++ b/src/main/java/appeng/facade/FacadePart.java
@@ -48,13 +48,13 @@ public class FacadePart implements IFacadePart {
     }
 
     @Override
-    public void getBoxes(final IPartCollisionHelper ch, boolean livingEntity) {
-        if (livingEntity || !ch.isBBCollision()) {
+    public void getBoxes(final IPartCollisionHelper ch, boolean itemEntity) {
+        if (itemEntity || ch.isBBCollision()) {
+            // the box is 15.9 for annihilation planes to pick up collision events.
+            ch.addBox(0.0, 0.0, 14, 16.0, 16.0, 15.9);
+        } else {
             // prevent weird snag behavior
             ch.addBox(0.0, 0.0, 14, 16.0, 16.0, 16.0);
-        } else {
-            // the box is 15.9 for transition planes to pick up collision events.
-            ch.addBox(0.0, 0.0, 14, 16.0, 16.0, 15.9);
         }
     }
 

--- a/src/main/java/appeng/helpers/AEMaterials.java
+++ b/src/main/java/appeng/helpers/AEMaterials.java
@@ -27,6 +27,9 @@ public class AEMaterials {
     public static final Material GLASS = make(MaterialColor.AIR, false, false, true, false, false, false,
             PushReaction.NORMAL);
 
+    public static final Material FIXTURE = make(MaterialColor.IRON, false, false, false, false, false, false,
+            PushReaction.DESTROY);
+
     /**
      * Small factory helper with named parameters.
      * 

--- a/src/main/java/appeng/parts/CableBusContainer.java
+++ b/src/main/java/appeng/parts/CableBusContainer.java
@@ -30,6 +30,7 @@ import javax.annotation.Nullable;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.item.ItemEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -1057,9 +1058,9 @@ public class CableBusContainer extends CableBusStorage implements AEMultiTile, I
      */
     public VoxelShape getCollisionShape(Entity entity) {
         // This is a hack for facades
-        boolean livingEntity = entity instanceof LivingEntity;
+        boolean itemEntity = entity instanceof ItemEntity;
 
-        if (livingEntity) {
+        if (itemEntity) {
             if (cachedCollisionShapeLiving == null) {
                 cachedCollisionShapeLiving = createShape(true, true);
             }
@@ -1072,7 +1073,7 @@ public class CableBusContainer extends CableBusStorage implements AEMultiTile, I
         }
     }
 
-    private VoxelShape createShape(boolean forCollision, boolean forLivingEntity) {
+    private VoxelShape createShape(boolean forCollision, boolean forItemEntity) {
         final List<AxisAlignedBB> boxes = new ArrayList<>();
 
         final IFacadeContainer fc = this.getFacadeContainer();
@@ -1088,7 +1089,7 @@ public class CableBusContainer extends CableBusStorage implements AEMultiTile, I
                 if (s != AEPartLocation.INTERNAL) {
                     final IFacadePart fp = fc.getFacade(s);
                     if (fp != null) {
-                        fp.getBoxes(bch, forLivingEntity);
+                        fp.getBoxes(bch, forItemEntity);
                     }
                 }
             }


### PR DESCRIPTION
This adds waterlogging to

* Cables
* Fixtures (charged and light detecting)
* Both skystone chests

Stairs, slabs, etc are already reusing the vanilla classes and therefore support it out of the box

A couple other non full blocks are for now not added and probably will not. This includes for example

* Chargers
* Inscribers
* Cranks
* Wireless Access Point
* Meteor compass