### PR TITLE
Update to Forge 1.16.5

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,24 +9,24 @@ artifact_basename=appliedenergistics2
 # Minecraft Versions                                    #
 #########################################################
 minecraft_release=1.16
-minecraft_version=1.16.4
-minecraft_version_range=[1.16.2,1.17.0)
+minecraft_version=1.16.5
+minecraft_version_range=[1.16.5,1.17.0)
 mcp_mappings=20201028-1.16.3
-forge_version=35.1.4
-forge_version_range=[35.1.4,36.0.0)
+forge_version=36.0.15
+forge_version_range=[36.0.15,37.0.0)
 
 #########################################################
 # Provided APIs                                         #
 #########################################################
 jei_minecraft_version=1.16.4
-jei_version=7.6.0.53
-top_version=3.0.4-beta-7
+jei_version=7.6.1.71
+top_version=3.0.6-8
 
 #########################################################
 # Deployment                                            #
 #########################################################
-website_version=1.16.4
-curse_versions=1.16.4
+website_version=1.16.5
+curse_versions=1.16.5
 curseforge_project=223794
 
 #########################################################


### PR DESCRIPTION
Also raises the required forge and minecraft versions to 1.16.5 or
equivalent as there is already a discrepancy.
Also updated other dependencies.