### PR TITLE
Fixes #4625: Prevents magnets from picking up crystal seeds.

### DIFF
--- a/src/main/java/appeng/entity/GrowingCrystalEntity.java
+++ b/src/main/java/appeng/entity/GrowingCrystalEntity.java
@@ -132,6 +132,11 @@ public final class GrowingCrystalEntity extends AEBaseItemEntity {
                 } while (this.progress_1000 >= 1000 && newItem.getItem() == is.getItem());
 
                 this.setItem(newItem);
+
+                if (is.getItem() != newItem.getItem()
+                        && this.getPersistentData().contains(CrystalSeedItem.TAG_PREVENT_MAGNET)) {
+                    this.getPersistentData().remove(CrystalSeedItem.TAG_PREVENT_MAGNET);
+                }
             }
         }
     }

--- a/src/main/java/appeng/items/misc/CrystalSeedItem.java
+++ b/src/main/java/appeng/items/misc/CrystalSeedItem.java
@@ -61,6 +61,8 @@ public class CrystalSeedItem extends AEBaseItem implements IGrowableCrystal {
      */
     private static final String TAG_GROWTH_TICKS = "p";
 
+    public static final String TAG_PREVENT_MAGNET = "PreventRemoteMovement";
+
     /**
      * The number of growth ticks required to finish growing.
      */
@@ -154,6 +156,7 @@ public class CrystalSeedItem extends AEBaseItem implements IGrowableCrystal {
         // Cannot read the pickup delay of the original item, so we
         // use the pickup delay used for items dropped by a player instead
         egc.setPickupDelay(40);
+        egc.getPersistentData().putBoolean(TAG_PREVENT_MAGNET, true);
 
         return egc;
     }


### PR DESCRIPTION
Crystal seeds are now tagged with `PreventRemoteMovement` when being
spawned to prevent magnets, which respect this flag, from picking them
up while growing.
Once they grow into a crystal, the flag is removed and magnets should
try to pick them up again.