### PR TITLE
Fixes #5004: Prevent AEBaseTileEntity#saveChanges() leaking client TEs

### DIFF
--- a/src/main/java/appeng/hooks/TickHandler.java
+++ b/src/main/java/appeng/hooks/TickHandler.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.TimeUnit;
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.Multimap;
@@ -104,7 +105,20 @@ public class TickHandler {
         return this.cliPlayerColors;
     }
 
+    /**
+     * Add a server or world callback which gets called the next time the queue is ticked.
+     * 
+     * Callbacks on the client are not support.
+     * <p>
+     * Using null as world will queue it into the global {@link ServerTickEvent}, otherwise it will be ticked with the
+     * corresponding {@link WorldTickEvent}.
+     * 
+     * @param w null or the specific {@link World}
+     * @param c the callback
+     */
     public void addCallable(final IWorld w, final IWorldCallable<?> c) {
+        Preconditions.checkArgument(w == null || !w.isRemote(), "Can only register serverside callbacks");
+
         if (w == null) {
             this.serverQueue.add(c);
         } else {

--- a/src/main/java/appeng/tile/AEBaseTileEntity.java
+++ b/src/main/java/appeng/tile/AEBaseTileEntity.java
@@ -450,7 +450,16 @@ public class AEBaseTileEntity extends TileEntity implements IOrientable, ICommon
     }
 
     public void saveChanges() {
-        if (this.world != null) {
+        if (this.world == null) {
+            return;
+        }
+
+        // Clientside is marked immediately as dirty as there is no queue processing
+        // Serverside is only queued once per tick to avoid costly operations
+        // TODO: Evaluate if this is still necessary
+        if (this.world.isRemote) {
+            this.markDirty();
+        } else {
             this.world.markChunkDirty(this.pos, this);
             if (!this.markDirtyQueued) {
                 TickHandler.instance().addCallable(null, this::markDirtyAtEndOfTick);


### PR DESCRIPTION
There was a chance that it would leak the clientside `TileEntity` into
the serverside callback queue.