### PR TITLE
Closes #4983 and cleans up `TickHandler` sided logic

### DIFF
--- a/src/main/java/appeng/client/AppEngClient.java
+++ b/src/main/java/appeng/client/AppEngClient.java
@@ -166,6 +166,8 @@ public final class AppEngClient extends AppEngBase {
 
     private final MinecraftClient client;
 
+    private IntegratedServer server = null;
+
     private final ClientNetworkHandler networkHandler;
 
     private final ClientTickHandler tickHandler;
@@ -200,6 +202,8 @@ public final class AppEngClient extends AppEngBase {
         // each time the integrated server starts&stops
         ServerLifecycleEvents.SERVER_STARTING.register(WorldData::onServerStarting);
         ServerLifecycleEvents.SERVER_STOPPED.register(WorldData::onServerStoppped);
+        ServerLifecycleEvents.SERVER_STARTED.register(server -> this.server = (IntegratedServer) server);
+        ServerLifecycleEvents.SERVER_STOPPED.register(server -> this.server = null);
 
         this.bindings = new EnumMap<>(ActionKey.class);
         for (ActionKey key : ActionKey.values()) {
@@ -211,7 +215,6 @@ public final class AppEngClient extends AppEngBase {
 
     @Override
     public MinecraftServer getServer() {
-        IntegratedServer server = client.getServer();
         if (server != null) {
             return server;
         }
@@ -221,7 +224,6 @@ public final class AppEngClient extends AppEngBase {
 
     @Override
     public boolean isOnServerThread() {
-        IntegratedServer server = client.getServer();
         return server != null && server.isOnThread();
     }
 

--- a/src/main/java/appeng/hooks/TickHandler.java
+++ b/src/main/java/appeng/hooks/TickHandler.java
@@ -36,6 +36,7 @@ import com.google.common.base.Stopwatch;
 import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.Multimap;
 
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerWorldEvents;
 import net.minecraft.server.MinecraftServer;
@@ -75,6 +76,7 @@ public class TickHandler {
         ServerTickEvents.START_WORLD_TICK.register(this::onBeforeWorldTick);
         ServerTickEvents.END_WORLD_TICK.register(this::onAfterWorldTick);
         ServerWorldEvents.UNLOAD.register(this::onUnloadWorld);
+        ServerLifecycleEvents.SERVER_STOPPED.register(server -> serverRepo.clear());
     }
 
     public static TickHandler instance() {
@@ -277,6 +279,25 @@ public class TickHandler {
 
             this.networks.addAll(this.toAdd);
             this.toAdd.clear();
+        }
+
+        private synchronized void clear() {
+            if (!tiles.isEmpty()) {
+                tiles.clear();
+                AELog.warn("tiles should be empty at server shutdown.");
+            }
+            if (!networks.isEmpty()) {
+                networks.clear();
+                AELog.warn("networks should be empty at server shutdown.");
+            }
+            if (!toAdd.isEmpty()) {
+                toAdd.clear();
+                AELog.warn("toAdd should be empty at server shutdown.");
+            }
+            if (!toRemove.isEmpty()) {
+                toRemove.clear();
+                AELog.warn("toRemove should be empty at server shutdown.");
+            }
         }
     }
 

--- a/src/main/java/appeng/hooks/TickHandler.java
+++ b/src/main/java/appeng/hooks/TickHandler.java
@@ -103,8 +103,8 @@ public class TickHandler {
 
     public void addInit(final AEBaseBlockEntity tile) {
         // for no there is no reason to care about this on the client...
-        if (Platform.isServer()) {
-            this.getRepo().tiles.add(tile);
+        if (!tile.isClient()) {
+            this.server.tiles.add(tile);
         }
     }
 


### PR DESCRIPTION
Closes #4983 and cleans up `TickHandler` sided logic.

A bigger cleanup involving the complete removal of `Platform#isClient` and `Platform#isServer` checks in favor of more robust checks would be great, but I don't want to break something by mistake (e.g. `world.isClient()` aka `world.isRemote()` when available).

Please make sure to test this a bit because I'm not 100% sure of what I am doing. 😄