### PR TITLE
Don't drop parts and facades in creative mode

### DIFF
--- a/src/main/java/appeng/block/networking/CableBusBlock.java
+++ b/src/main/java/appeng/block/networking/CableBusBlock.java
@@ -176,7 +176,7 @@ public class CableBusBlock extends AEBaseTileBlock<CableBusBlockEntity> implemen
             bus.getCableBus().appendPartStacks(drops);
             return drops;
         } else {
-            AELog.warn("The block entity was either null or of the wrong type! Skipped cable bus drops!");
+            AELog.debug("The block entity was either null or of the wrong type! Skipped cable bus drops!");
             return Collections.emptyList();
         }
     }

--- a/src/main/java/appeng/parts/CableBusContainer.java
+++ b/src/main/java/appeng/parts/CableBusContainer.java
@@ -874,12 +874,27 @@ public class CableBusContainer extends CableBusStorage implements AEMultiTile, I
         this.getFacadeContainer().readFromNBT(data);
     }
 
-    public List<ItemStack> getDrops(final List<ItemStack> drops) {
+    /**
+     * Append the contents of the parts to the drop list, e.g. crafting patterns but not the parts or facades
+     * themselves.
+     */
+    public void appendPartContentDrops(final List<ItemStack> drops) {
+        for (final AEPartLocation s : AEPartLocation.values()) {
+            final IPart part = this.getPart(s);
+            if (part != null) {
+                part.getDrops(drops, false);
+            }
+        }
+    }
+
+    /**
+     * Append the parts and facades to the drop list, but not their contents.
+     */
+    public void appendPartStacks(final List<ItemStack> drops) {
         for (final AEPartLocation s : AEPartLocation.values()) {
             final IPart part = this.getPart(s);
             if (part != null) {
                 drops.add(part.getItemStack(PartItemStack.BREAK));
-                part.getDrops(drops, false);
             }
 
             if (s != AEPartLocation.INTERNAL) {
@@ -889,19 +904,6 @@ public class CableBusContainer extends CableBusStorage implements AEMultiTile, I
                 }
             }
         }
-
-        return drops;
-    }
-
-    public List<ItemStack> getNoDrops(final List<ItemStack> drops) {
-        for (final AEPartLocation s : AEPartLocation.values()) {
-            final IPart part = this.getPart(s);
-            if (part != null) {
-                part.getDrops(drops, false);
-            }
-        }
-
-        return drops;
     }
 
     @Override

--- a/src/main/java/appeng/tile/networking/CableBusBlockEntity.java
+++ b/src/main/java/appeng/tile/networking/CableBusBlockEntity.java
@@ -163,13 +163,14 @@ public class CableBusBlockEntity extends AEBaseBlockEntity implements AEMultiTil
     }
 
     @Override
-    public void getDrops(final World w, final BlockPos pos, final List drops) {
-        this.getCableBus().getDrops(drops);
+    public void getDrops(final World w, final BlockPos pos, final List<ItemStack> drops) {
+        // the parts and facades are handled by CableBusBlock#getDroppedStacks
+        this.getCableBus().appendPartContentDrops(drops);
     }
 
     @Override
     public void getNoDrops(final World w, final BlockPos pos, final List<ItemStack> drops) {
-        this.getCableBus().getNoDrops(drops);
+        this.getCableBus().appendPartContentDrops(drops);
     }
 
     @Override


### PR DESCRIPTION
Part contents are dropped by the BE, parts and facades are dropped in `getDroppedStacks`.
I tested that explosions still drop everything.
Closes #5016.