### PR TITLE
Set molecular assembler output max stack size to 64

### DIFF
--- a/src/main/java/appeng/tile/crafting/MolecularAssemblerBlockEntity.java
+++ b/src/main/java/appeng/tile/crafting/MolecularAssemblerBlockEntity.java
@@ -117,6 +117,7 @@ public class MolecularAssemblerBlockEntity extends AENetworkInvBlockEntity
         this.upgrades = new DefinitionUpgradeInventory(assembler, this, this.getUpgradeSlots());
         this.craftingInv = new CraftingInventory(new ContainerNull(), 3, 3);
 
+        gridInv.setMaxStackSize(9, 64);
         gridInvExt = gridInv.createLimitedFixedInv();
         // Limit the input slots to 1 of the respective crafting ingredient
         for (int i = 0; i < 9; i++) {


### PR DESCRIPTION
Otherwise the output gets voided if the resulting stack size would be > 1.

Place a log into a powered molecular assembler with a planks crafting pattern and the output will get voided. Same if there are > 1 leftover items after extraction into adjacent inventories.