### PR TITLE
Fixes #5040: Fixes to chest closing sound timings.

### DIFF
--- a/src/main/java/appeng/tile/storage/SkyChestTileEntity.java
+++ b/src/main/java/appeng/tile/storage/SkyChestTileEntity.java
@@ -28,6 +28,7 @@ import net.minecraft.tileentity.IChestLid;
 import net.minecraft.tileentity.ITickableTileEntity;
 import net.minecraft.tileentity.TileEntityType;
 import net.minecraft.util.SoundCategory;
+import net.minecraft.util.SoundEvent;
 import net.minecraft.util.SoundEvents;
 import net.minecraft.util.math.MathHelper;
 import net.minecraftforge.api.distmarker.Dist;
@@ -58,16 +59,16 @@ public class SkyChestTileEntity extends AEBaseInvTileEntity implements ITickable
     @Override
     protected void writeToStream(final PacketBuffer data) throws IOException {
         super.writeToStream(data);
-        data.writeBoolean(this.getPlayerOpen() > 0);
+        data.writeBoolean(this.numPlayersUsing > 0);
     }
 
     @Override
     protected boolean readFromStream(final PacketBuffer data) throws IOException {
         final boolean c = super.readFromStream(data);
-        final int wasOpen = this.getPlayerOpen();
-        this.setPlayerOpen(data.readBoolean() ? 1 : 0);
+        final int wasOpen = this.numPlayersUsing;
+        this.numPlayersUsing = data.readBoolean() ? 1 : 0;
 
-        if (wasOpen != this.getPlayerOpen()) {
+        if (wasOpen != this.numPlayersUsing) {
             this.setLastEvent(System.currentTimeMillis());
         }
 
@@ -80,34 +81,20 @@ public class SkyChestTileEntity extends AEBaseInvTileEntity implements ITickable
     }
 
     public void openInventory(final PlayerEntity player) {
-        if (!player.isSpectator()) {
-            this.setPlayerOpen(this.getPlayerOpen() + 1);
+        // Ignore calls to this function on the client, since the server is responsible for
+        // calculating the numPlayersUsing count.
+        if (!player.isSpectator() && !player.getEntityWorld().isRemote()) {
+            this.numPlayersUsing++;
             onOpenOrClose();
-
-            if (this.getPlayerOpen() == 1) {
-                this.getWorld().playSound(player, this.pos.getX() + 0.5D, this.pos.getY() + 0.5D,
-                        this.pos.getZ() + 0.5D, SoundEvents.BLOCK_CHEST_OPEN, SoundCategory.BLOCKS, 0.5F,
-                        this.getWorld().rand.nextFloat() * 0.1F + 0.9F);
-                this.markForUpdate();
-            }
         }
     }
 
     public void closeInventory(final PlayerEntity player) {
-        if (!player.isSpectator()) {
-            this.setPlayerOpen(this.getPlayerOpen() - 1);
+        // Ignore calls to this function on the client, since the server is responsible for
+        // calculating the numPlayersUsing count.
+        if (!player.isSpectator() && !player.getEntityWorld().isRemote()) {
+            this.numPlayersUsing = Math.max(this.numPlayersUsing - 1, 0);
             onOpenOrClose();
-
-            if (this.getPlayerOpen() < 0) {
-                this.setPlayerOpen(0);
-            }
-
-            if (this.getPlayerOpen() == 0) {
-                this.getWorld().playSound(player, this.pos.getX() + 0.5D, this.pos.getY() + 0.5D,
-                        this.pos.getZ() + 0.5D, SoundEvents.BLOCK_CHEST_CLOSE, SoundCategory.BLOCKS, 0.5F,
-                        this.getWorld().rand.nextFloat() * 0.1F + 0.9F);
-                this.markForUpdate();
-            }
         }
     }
 
@@ -118,36 +105,49 @@ public class SkyChestTileEntity extends AEBaseInvTileEntity implements ITickable
             this.world.addBlockEvent(this.pos, block, 1, this.numPlayersUsing);
             this.world.notifyNeighborsOfStateChange(this.pos, block);
             // FIXME: Uhm, we are we doing this?
-            this.world.notifyNeighborsOfStateChange(this.pos.down(), block);
+            // this.world.notifyNeighborsOfStateChange(this.pos.down(), block);
         }
     }
 
     @Override
     public void tick() {
         this.prevLidAngle = this.lidAngle;
-        if (this.numPlayersUsing == 0 && this.lidAngle > 0.0F || this.numPlayersUsing > 0 && this.lidAngle < 1.0F) {
-            if (this.numPlayersUsing > 0) {
-                this.lidAngle += 0.1F;
-            } else {
-                this.lidAngle -= 0.1F;
-            }
-
-            this.lidAngle = MathHelper.clamp(this.lidAngle, 0, 1);
+        // Play a sound on initial opening.
+        if (this.numPlayersUsing > 0 && this.lidAngle == 0.0F) {
+            this.playSound(SoundEvents.BLOCK_CHEST_OPEN);
         }
+
+        if (this.numPlayersUsing == 0 && this.lidAngle > 0.0F) {
+            this.lidAngle = Math.max(this.lidAngle - 0.1F, 0);
+            // Play a sound on the way down.
+            if (this.lidAngle < 0.5F && this.prevLidAngle >= 0.5F) {
+                this.playSound(SoundEvents.BLOCK_CHEST_CLOSE);
+            }
+        } else if (this.numPlayersUsing > 0 && this.lidAngle < 1.0F) {
+            this.lidAngle = Math.min(this.lidAngle + 0.1F, 1);
+        }
+    }
+
+    private void playSound(SoundEvent soundIn) {
+        double d0 = (double) this.pos.getX() + 0.5D;
+        double d1 = (double) this.pos.getY() + 0.5D;
+        double d2 = (double) this.pos.getZ() + 0.5D;
+        this.world.playSound((PlayerEntity) null, d0, d1, d2, soundIn, SoundCategory.BLOCKS, 0.5F,
+                this.world.rand.nextFloat() * 0.1F + 0.9F);
+    }
+
+    public boolean receiveClientEvent(int id, int type) {
+        if (id == 1) {
+            this.numPlayersUsing = type;
+            return true;
+        }
+        return super.receiveClientEvent(id, type);
     }
 
     @Override
     public void onChangeInventory(final IItemHandler inv, final int slot, final InvOperation mc,
             final ItemStack removed, final ItemStack added) {
 
-    }
-
-    public int getPlayerOpen() {
-        return this.numPlayersUsing;
-    }
-
-    private void setPlayerOpen(final int playerOpen) {
-        this.numPlayersUsing = playerOpen;
     }
 
     public long getLastEvent() {


### PR DESCRIPTION
- Only track users on the server side.
- Only play the closing sound when the becomes halfway closed (like native MC).

(Also we should prefer not to use public getters and setters inside the class.)