### PR TITLE
Make networked parts cleanup the part host in securityBreak()

### DIFF
--- a/src/api/java/appeng/api/networking/IGridHost.java
+++ b/src/api/java/appeng/api/networking/IGridHost.java
@@ -29,6 +29,7 @@ import javax.annotation.Nullable;
 import net.minecraft.tileentity.TileEntity;
 
 import appeng.api.parts.IPart;
+import appeng.api.parts.IPartHost;
 import appeng.api.util.AECableType;
 import appeng.api.util.AEPartLocation;
 
@@ -58,7 +59,10 @@ public interface IGridHost {
     AECableType getCableConnectionType(@Nonnull AEPartLocation dir);
 
     /**
-     * break this host, its violating security rules, just break your block, or part.
+     * Break this host, it's violating security rules, just break your block, or part.
+     *
+     * If it's a part, make sure to check if the host is empty using {@link IPartHost#isEmpty}, and if that's the case
+     * clean it up using {@link IPartHost#cleanup}.
      */
     void securityBreak();
 }

--- a/src/main/java/appeng/parts/AEBasePart.java
+++ b/src/main/java/appeng/parts/AEBasePart.java
@@ -123,6 +123,11 @@ public abstract class AEBasePart implements IPart, IGridProxyable, IActionHost, 
             this.host.removePart(this.side, false);
             Platform.spawnDrops(this.tile.getWorld(), this.tile.getPos(), items);
             this.is.setCount(0);
+
+            // Remove the host if it's now empty
+            if (this.host.isEmpty()) {
+                this.host.cleanup();
+            }
         }
     }
 


### PR DESCRIPTION
Closes #5120. Take 3. 😄