### PR TITLE
Fixes #5120: Always remove a cable bus once empty.

### DIFF
--- a/src/main/java/appeng/parts/CableBusContainer.java
+++ b/src/main/java/appeng/parts/CableBusContainer.java
@@ -316,6 +316,12 @@ public class CableBusContainer extends CableBusStorage implements AEMultiTile, I
             this.markForUpdate();
             this.markForSave();
             this.partChanged();
+
+            // Cleanup the cable bus once it is no longer containing any parts.
+            // Also only when the cable bus actually exists, otherwise it might perform a cleanup during initialization.
+            if (this.isInWorld() && this.isEmpty()) {
+                this.cleanup();
+            }
         }
     }
 

--- a/src/main/java/appeng/parts/PartPlacement.java
+++ b/src/main/java/appeng/parts/PartPlacement.java
@@ -106,20 +106,18 @@ public class PartPlacement {
                         final SelectedPart sp = selectPart(player, host,
                                 mop.getHitVec().add(-mop.getPos().getX(), -mop.getPos().getY(), -mop.getPos().getZ()));
 
+                        // SelectedPart contains either a facade or a part. Never both.
                         if (sp.part != null) {
                             is.add(sp.part.getItemStack(PartItemStack.WRENCH));
                             sp.part.getDrops(is, true);
                             host.removePart(sp.side, false);
                         }
 
+                        // A facade cannot exist without a cable part, no host cleanup needed.
                         if (sp.facade != null) {
                             is.add(sp.facade.getItemStack());
                             host.getFacadeContainer().removeFacade(host, sp.side);
                             Platform.notifyBlocksOfNeighbors(world, pos);
-                        }
-
-                        if (host.isEmpty()) {
-                            host.cleanup();
                         }
 
                         if (!is.isEmpty()) {


### PR DESCRIPTION
The tile entity for a cable bus will now be removed once all parts are
removed through whatever means. This needs to be limited to only ones
existing in a world, otherwise it can accidentally remove cable buses
which are currently loaded. Further it should avoid cases where it is
replacing the last part as this will leave it shortly without a single
part.