### PR TITLE
Downgraded JEI missing slots error to a warning.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -230,7 +230,8 @@ processResources {
     exclude '.cache'
 
     filesMatching("META-INF/mods.toml") {
-        expand 'version': version, 'minecraft_version': project.minecraft_version_range, 'forge_version': project.forge_version_range
+        expand 'version': version, 'minecraft_version': project.minecraft_version_range, 'forge_version': project.forge_version_range,
+            'jei_version': project.jei_version_range, 'top_version': project.top_version_range
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,15 +13,17 @@ minecraft_version=1.16.5
 minecraft_version_range=[1.16.5,1.17.0)
 mcp_channel=snapshot
 mcp_mappings=20210309-1.16.5
-forge_version=36.1.0
-forge_version_range=[36.1.0,37.0.0)
+forge_version=36.1.10
+forge_version_range=[36.1.10,37.0.0)
 
 #########################################################
 # Provided APIs                                         #
 #########################################################
 jei_minecraft_version=1.16.5
-jei_version=7.6.4.90
+jei_version=7.7.0.98
+jei_version_range=[7.7.0.98,8.0.0)
 top_version=3.0.8-14
+top_version_range=[1.16-3.0.0,1.16-4.0.0)
 
 #########################################################
 # Deployment                                            #

--- a/src/main/java/appeng/integration/modules/jei/CraftingRecipeTransferHandler.java
+++ b/src/main/java/appeng/integration/modules/jei/CraftingRecipeTransferHandler.java
@@ -24,12 +24,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.mojang.blaze3d.matrix.MatrixStack;
+
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.TranslationTextComponent;
 
 import mezz.jei.api.gui.IRecipeLayout;
 import mezz.jei.api.gui.ingredient.IGuiIngredient;
@@ -70,9 +73,9 @@ public class CraftingRecipeTransferHandler extends RecipeTransferHandler<Craftin
             // Find every "slot" (in JEI parlance) that has no equivalent item in the item repo or player inventory
             List<Integer> missingSlots = new ArrayList<>();
 
-            // We need to track how many of a given item stack we've already used for other slots in
-            // the recipe. Otherwise recipes that need 4x<item> will not correctly show missing
-            // items if at least 1 of <item> is in the grid.
+            // We need to track how many of a given item stack we've already used for other slots in the recipe.
+            // Otherwise recipes that need 4x<item> will not correctly show missing items if at least 1 of <item> is in
+            // the grid.
             Map<IAEItemStack, Integer> reservedGridAmounts = new HashMap<>();
 
             for (Map.Entry<Integer, ? extends IGuiIngredient<ItemStack>> entry : recipeLayout.getItemStacks()
@@ -112,8 +115,8 @@ public class CraftingRecipeTransferHandler extends RecipeTransferHandler<Craftin
             }
 
             if (!missingSlots.isEmpty()) {
-                String tooltip = I18n.format("jei.appliedenergistics2.missing_items");
-                return helper.createUserErrorForSlots(tooltip, missingSlots);
+                ITextComponent message = new TranslationTextComponent("jei.appliedenergistics2.missing_items");
+                return new TransferWarning(helper.createUserErrorForSlots(message, missingSlots));
             }
         }
 
@@ -123,6 +126,27 @@ public class CraftingRecipeTransferHandler extends RecipeTransferHandler<Craftin
     @Override
     protected boolean isCrafting() {
         return true;
+    }
+
+    private static class TransferWarning implements IRecipeTransferError {
+
+        private final IRecipeTransferError parent;
+
+        public TransferWarning(IRecipeTransferError parent) {
+            this.parent = parent;
+        }
+
+        @Override
+        public Type getType() {
+            return Type.COSMETIC;
+        }
+
+        @Override
+        public void showError(MatrixStack matrixStack, int mouseX, int mouseY, IRecipeLayout recipeLayout, int recipeX,
+                int recipeY) {
+            this.parent.showError(matrixStack, mouseX, mouseY, recipeLayout, recipeX, recipeY);
+        }
+
     }
 
 }

--- a/src/main/java/appeng/integration/modules/jei/JEIPlugin.java
+++ b/src/main/java/appeng/integration/modules/jei/JEIPlugin.java
@@ -36,6 +36,8 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.RecipeManager;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.StringTextComponent;
 
 import mezz.jei.api.IModPlugin;
 import mezz.jei.api.JeiPlugin;
@@ -137,44 +139,46 @@ public class JEIPlugin implements IModPlugin {
     private void registerDescriptions(IDefinitions definitions, IRecipeRegistration registry) {
         IMaterials materials = definitions.materials();
 
-        final String[] message;
+        final ITextComponent[] message;
         if (AEConfig.instance().isFeatureEnabled(AEFeature.CERTUS_QUARTZ_WORLD_GEN)) {
-            message = new String[] { GuiText.ChargedQuartz.getTranslationKey(), "",
-                    GuiText.ChargedQuartzFind.getTranslationKey() };
+            // " " Used to enforce a new paragraph
+            message = new ITextComponent[] { GuiText.ChargedQuartz.text(), new StringTextComponent(" "),
+                    GuiText.ChargedQuartzFind.text() };
         } else {
-            message = new String[] { GuiText.ChargedQuartzFind.getTranslationKey() };
+            message = new ITextComponent[] { GuiText.ChargedQuartz.text() };
         }
         this.addDescription(registry, materials.certusQuartzCrystalCharged(), message);
 
         if (AEConfig.instance().isFeatureEnabled(AEFeature.METEORITE_WORLD_GEN)) {
             this.addDescription(registry, materials.logicProcessorPress(),
-                    GuiText.inWorldCraftingPresses.getTranslationKey());
+                    GuiText.inWorldCraftingPresses.text());
             this.addDescription(registry, materials.calcProcessorPress(),
-                    GuiText.inWorldCraftingPresses.getTranslationKey());
+                    GuiText.inWorldCraftingPresses.text());
             this.addDescription(registry, materials.engProcessorPress(),
-                    GuiText.inWorldCraftingPresses.getTranslationKey());
+                    GuiText.inWorldCraftingPresses.text());
         }
 
         if (AEConfig.instance().isFeatureEnabled(AEFeature.IN_WORLD_FLUIX)) {
-            this.addDescription(registry, materials.fluixCrystal(), GuiText.inWorldFluix.getTranslationKey());
+            this.addDescription(registry, materials.fluixCrystal(), GuiText.inWorldFluix.text());
         }
 
         if (AEConfig.instance().isFeatureEnabled(AEFeature.IN_WORLD_SINGULARITY)) {
-            this.addDescription(registry, materials.qESingularity(), GuiText.inWorldSingularity.getTranslationKey());
+            this.addDescription(registry, materials.qESingularity(), GuiText.inWorldSingularity.text());
         }
 
         if (AEConfig.instance().isFeatureEnabled(AEFeature.IN_WORLD_PURIFICATION)) {
             this.addDescription(registry, materials.purifiedCertusQuartzCrystal(),
-                    GuiText.inWorldPurificationCertus.getTranslationKey());
+                    GuiText.inWorldPurificationCertus.text());
             this.addDescription(registry, materials.purifiedNetherQuartzCrystal(),
-                    GuiText.inWorldPurificationNether.getTranslationKey());
+                    GuiText.inWorldPurificationNether.text());
             this.addDescription(registry, materials.purifiedFluixCrystal(),
-                    GuiText.inWorldPurificationFluix.getTranslationKey());
+                    GuiText.inWorldPurificationFluix.text());
         }
 
     }
 
-    private void addDescription(IRecipeRegistration registry, IItemDefinition itemDefinition, String... message) {
+    private void addDescription(IRecipeRegistration registry, IItemDefinition itemDefinition,
+            ITextComponent... message) {
         registry.addIngredientInfo(itemDefinition.stack(1), VanillaTypes.ITEM, message);
     }
 
@@ -206,8 +210,8 @@ public class JEIPlugin implements IModPlugin {
             @Nullable
             @Override
             public Object getIngredientUnderMouse(ContainerScreen<?> containerScreen, double mouseX, double mouseY) {
-                // The following code allows the player to show recipes involving fluids in AE fluid terminals or
-                // AE fluid tanks shown in fluid interfaces and other UI.
+                // The following code allows the player to show recipes involving fluids in AE fluid terminals or AE
+                // fluid tanks shown in fluid interfaces and other UI.
                 if (containerScreen instanceof AEBaseScreen) {
                     AEBaseScreen<?> baseScreen = (AEBaseScreen<?>) containerScreen;
                     return baseScreen.getIngredientUnderMouse(mouseX, mouseY);
@@ -244,8 +248,7 @@ public class JEIPlugin implements IModPlugin {
     private void hideDebugTools(IJeiRuntime jeiRuntime) {
         Collection<ItemStack> toRemove = new ArrayList<>();
 
-        // We use the internal API here as exception as debug tools are not part of the
-        // public one by design.
+        // We use the internal API here as exception as debug tools are not part of the public one by design.
         toRemove.add(Api.INSTANCE.definitions().items().dummyFluidItem().maybeStack(1).orElse(null));
 
         if (!AEConfig.instance().isFeatureEnabled(AEFeature.UNSUPPORTED_DEVELOPER_TOOLS)) {

--- a/src/main/java/appeng/integration/modules/jei/PatternRecipeTransferHandler.java
+++ b/src/main/java/appeng/integration/modules/jei/PatternRecipeTransferHandler.java
@@ -18,9 +18,9 @@
 
 package appeng.integration.modules.jei;
 
-import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.util.text.TranslationTextComponent;
 
 import mezz.jei.api.constants.VanillaRecipeCategoryUid;
 import mezz.jei.api.gui.IRecipeLayout;
@@ -41,11 +41,13 @@ public class PatternRecipeTransferHandler extends RecipeTransferHandler<PatternT
         if (container.isCraftingMode()
                 && recipeLayout.getRecipeCategory().getUid() != VanillaRecipeCategoryUid.CRAFTING) {
             return this.helper
-                    .createUserErrorWithTooltip(I18n.format("jei.appliedenergistics2.requires_processing_mode"));
+                    .createUserErrorWithTooltip(
+                            new TranslationTextComponent("jei.appliedenergistics2.requires_processing_mode"));
         }
 
         if (recipe.getRecipeOutput().isEmpty()) {
-            return this.helper.createUserErrorWithTooltip(I18n.format("jei.appliedenergistics2.no_output"));
+            return this.helper
+                    .createUserErrorWithTooltip(new TranslationTextComponent("jei.appliedenergistics2.no_output"));
         }
 
         return null;

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -27,3 +27,17 @@ description="A Mod about Matter, Energy and using them to conquer the world.."
     versionRange="${minecraft_version}"
     ordering="NONE"
     side="BOTH"
+
+[[dependencies.appliedenergistics2]]
+    modId="jei"
+    mandatory=false
+    versionRange="${jei_version}"
+    ordering="AFTER"
+    side="CLIENT"
+
+[[dependencies.appliedenergistics2]]
+    modId="theoneprobe"
+    mandatory=false
+    versionRange="${top_version}"
+    ordering="AFTER"
+    side="BOTH"

--- a/src/main/resources/assets/appliedenergistics2/lang/en_us.json
+++ b/src/main/resources/assets/appliedenergistics2/lang/en_us.json
@@ -730,7 +730,7 @@
   "jei.appliedenergistics2.recipe_too_large": "Recipe larger than 3x3",
   "jei.appliedenergistics2.requires_processing_mode": "Requires processing mode",
   "jei.appliedenergistics2.no_output": "Recipe has no output",
-  "jei.appliedenergistics2.missing_items": "Missing Items",
+  "jei.appliedenergistics2.missing_items": "Missing items will be skipped",
   "gui.appliedenergistics2.ConfirmCraftCpuStatus": "Storage: %s : Co Processors: %s",
   "gui.appliedenergistics2.ConfirmCraftNoCpu": "Storage: N/A : Co Processors: N/A"
 }


### PR DESCRIPTION
Now using the new JEI feature added in 7.7.0.98 to indicate a warning by tinting the `+` button yellow/orange instead of a hard fail.
Update to using the new methods using `ITextCompoment` instead of `String`
Fixed a wrong text entry for charged certus quartz when the worldgen is disabled.

Updated to JEI 7.7.0.98 as minimum requirement
Updated to Forge 36.1.10 as minimum requirement to fix it ignoring minimum requirements for non mandatory dependencies.