### PR TITLE
Add missing getInput() calls in FE P2P tunnels

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,9 +18,9 @@
 
 buildscript {
     repositories {
+        mavenCentral()
         maven { url = 'https://files.minecraftforge.net/maven' }
         maven { url = 'https://repo.spongepowered.org/maven' }
-        mavenCentral()
     }
     dependencies {
         classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '4.1.+', changing: true

--- a/src/main/java/appeng/parts/p2p/FEP2PTunnelPart.java
+++ b/src/main/java/appeng/parts/p2p/FEP2PTunnelPart.java
@@ -174,7 +174,8 @@ public class FEP2PTunnelPart extends P2PTunnelPart<FEP2PTunnelPart> {
     private class OutputEnergyStorage implements IEnergyStorage {
         @Override
         public int extractEnergy(int maxExtract, boolean simulate) {
-            final int total = FEP2PTunnelPart.this.getAttachedEnergyStorage().extractEnergy(maxExtract, simulate);
+            final int total = FEP2PTunnelPart.this.getInput().getAttachedEnergyStorage().extractEnergy(maxExtract,
+                    simulate);
 
             if (!simulate) {
                 FEP2PTunnelPart.this.queueTunnelDrain(PowerUnits.RF, total);
@@ -190,7 +191,7 @@ public class FEP2PTunnelPart extends P2PTunnelPart<FEP2PTunnelPart> {
 
         @Override
         public boolean canExtract() {
-            return FEP2PTunnelPart.this.getAttachedEnergyStorage().canExtract();
+            return FEP2PTunnelPart.this.getInput().getAttachedEnergyStorage().canExtract();
         }
 
         @Override
@@ -200,12 +201,12 @@ public class FEP2PTunnelPart extends P2PTunnelPart<FEP2PTunnelPart> {
 
         @Override
         public int getMaxEnergyStored() {
-            return FEP2PTunnelPart.this.getAttachedEnergyStorage().getMaxEnergyStored();
+            return FEP2PTunnelPart.this.getInput().getAttachedEnergyStorage().getMaxEnergyStored();
         }
 
         @Override
         public int getEnergyStored() {
-            return FEP2PTunnelPart.this.getAttachedEnergyStorage().getEnergyStored();
+            return FEP2PTunnelPart.this.getInput().getAttachedEnergyStorage().getEnergyStored();
         }
     }
 


### PR DESCRIPTION
I suspect this is an issue, not yet tested though. (I need to find a FE producer that doesn't auto-push, might have to write it myself xD).

I moved the `mavenCentral()` in the buildscript above the forge maven cause they were interfering for some reason, preventing spotless from running.