### PR TITLE
Fix item P2P tunnels. Closes #5249.

### DIFF
--- a/src/main/java/appeng/parts/PartPlacement.java
+++ b/src/main/java/appeng/parts/PartPlacement.java
@@ -288,7 +288,7 @@ public class PartPlacement {
                 if (sp.part != null) {
                     if (!InteractionUtil.isInAlternateUseMode(player)
                             && sp.part.onActivate(player, hand, mop.getHitVec())) {
-                        return ActionResultType.FAIL;
+                        return ActionResultType.CONSUME;
                     }
                 }
             }

--- a/src/main/java/appeng/parts/p2p/CapabilityP2PTunnelPart.java
+++ b/src/main/java/appeng/parts/p2p/CapabilityP2PTunnelPart.java
@@ -21,7 +21,7 @@ public abstract class CapabilityP2PTunnelPart<P extends CapabilityP2PTunnelPart<
     // Prevents recursive access to the adjacent capability in case P2P input/output faces touch
     private int accessDepth = 0;
     private final CapabilityGuard capabilityGuard = new CapabilityGuard();
-    private final EmptyCapabilityGuard emptyAdjCapability = new EmptyCapabilityGuard();
+    private final EmptyCapabilityGuard emptyCapabilityGuard = new EmptyCapabilityGuard();
     protected C inputHandler;
     protected C outputHandler;
     protected C emptyHandler;
@@ -64,7 +64,7 @@ public abstract class CapabilityP2PTunnelPart<P extends CapabilityP2PTunnelPart<
      */
     protected final CapabilityGuard getInputCapability() {
         P input = getInput();
-        return input == null ? emptyAdjCapability : input.getAdjacentCapability();
+        return input == null ? emptyCapabilityGuard : input.getAdjacentCapability();
     }
 
     protected class CapabilityGuard implements AutoCloseable {

--- a/src/main/java/appeng/parts/p2p/CapabilityP2PTunnelPart.java
+++ b/src/main/java/appeng/parts/p2p/CapabilityP2PTunnelPart.java
@@ -1,9 +1,14 @@
 package appeng.parts.p2p;
 
+import net.minecraft.block.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockReader;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.util.LazyOptional;
+
+import appeng.me.GridAccessException;
 
 /**
  * Base class for simple capability-based p2p tunnels. Don't forget to set the 3 handlers in the constructor of the
@@ -11,9 +16,14 @@ import net.minecraftforge.common.util.LazyOptional;
  */
 public abstract class CapabilityP2PTunnelPart<P extends CapabilityP2PTunnelPart<P, C>, C> extends P2PTunnelPart<P> {
     private final Capability<C> capability;
+    // Prevents recursive block updates.
+    private boolean inBlockUpdate = false;
+    // Prevents recursive capability queries.
+    private int insertionNesting = 0;
+    private final InputCapability inputCapability = new InputCapability();
     protected C inputHandler;
     protected C outputHandler;
-    protected C nullHandler;
+    protected C emptyHandler;
 
     public CapabilityP2PTunnelPart(ItemStack is, Capability<C> capability) {
         super(is);
@@ -49,11 +59,76 @@ public abstract class CapabilityP2PTunnelPart<P extends CapabilityP2PTunnelPart<
             }
         }
 
-        return adjacentCapability == null ? nullHandler : adjacentCapability;
+        return adjacentCapability == null ? emptyHandler : adjacentCapability;
     }
 
-    protected C getInputCapability() {
-        P input = getInput();
-        return input == null ? nullHandler : input.getAdjacentCapability();
+    protected InputCapability inputCapability() {
+        insertionNesting++;
+        return inputCapability;
+    }
+
+    protected class InputCapability implements AutoCloseable {
+        @Override
+        public void close() {
+            insertionNesting--;
+        }
+
+        /**
+         * Return the capability connected to the input side of this P2P connection, or the empty handler if it's not
+         * available. The RAII guard will prevent infinite recursion.
+         */
+        protected C get() {
+            if (insertionNesting == 0) {
+                throw new IllegalStateException("This should be at least 1.");
+            } else if (insertionNesting == 1) {
+                P input = getInput();
+                return input == null ? emptyHandler : input.getAdjacentCapability();
+            } else {
+                return emptyHandler;
+            }
+        }
+    }
+
+    // Send a block update on p2p status change, or any update on another endpoint.
+    // Prevent recursive block updates.
+
+    protected void sendBlockUpdate() {
+        if (!inBlockUpdate) {
+            inBlockUpdate = true;
+            // getHost().notifyNeighbors() would queue a callback, but we want to do an update synchronously!
+            // (otherwise we can't detect infinite recursion, it would just queue updates endlessly)
+            TileEntity self = getTile();
+            self.getWorld().notifyNeighborsOfStateChange(self.getPos(), Blocks.AIR);
+            inBlockUpdate = false;
+        }
+    }
+
+    @Override
+    public void onTunnelNetworkChange() {
+        sendBlockUpdate();
+    }
+
+    @Override
+    public void onNeighborChanged(IBlockReader w, BlockPos pos, BlockPos neighbor) {
+        if (!inBlockUpdate) {
+            inBlockUpdate = true;
+
+            if (isOutput()) {
+                P input = getInput();
+
+                if (input != null) {
+                    input.sendBlockUpdate();
+                }
+            } else {
+                try {
+                    for (P output : getOutputs()) {
+                        output.sendBlockUpdate();
+                    }
+                } catch (GridAccessException ignored) {
+                    // :-P
+                }
+            }
+            inBlockUpdate = false;
+        }
     }
 }

--- a/src/main/java/appeng/parts/p2p/CapabilityP2PTunnelPart.java
+++ b/src/main/java/appeng/parts/p2p/CapabilityP2PTunnelPart.java
@@ -1,0 +1,59 @@
+package appeng.parts.p2p;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.util.LazyOptional;
+
+/**
+ * Base class for simple capability-based p2p tunnels. Don't forget to set the 3 handlers in the constructor of the
+ * child class!
+ */
+public abstract class CapabilityP2PTunnelPart<P extends CapabilityP2PTunnelPart<P, C>, C> extends P2PTunnelPart<P> {
+    private final Capability<C> capability;
+    protected C inputHandler;
+    protected C outputHandler;
+    protected C nullHandler;
+
+    public CapabilityP2PTunnelPart(ItemStack is, Capability<C> capability) {
+        super(is);
+        this.capability = capability;
+    }
+
+    @Override
+    protected float getPowerDrainPerTick() {
+        return 2.0f;
+    }
+
+    public final <T> LazyOptional<T> getCapability(Capability<T> capabilityClass) {
+        if (capabilityClass == capability) {
+            if (isOutput()) {
+                return LazyOptional.of(() -> outputHandler).cast();
+            } else {
+                return LazyOptional.of(() -> inputHandler).cast();
+            }
+        }
+        return LazyOptional.empty();
+    }
+
+    protected C getAdjacentCapability() {
+        C adjacentCapability = null;
+
+        if (this.isActive()) {
+            final TileEntity self = this.getTile();
+            final TileEntity te = self.getWorld().getTileEntity(self.getPos().offset(this.getSide().getFacing()));
+
+            if (te != null) {
+                adjacentCapability = te.getCapability(capability, this.getSide().getOpposite().getFacing())
+                        .orElse(null);
+            }
+        }
+
+        return adjacentCapability == null ? nullHandler : adjacentCapability;
+    }
+
+    protected C getInputCapability() {
+        P input = getInput();
+        return input == null ? nullHandler : input.getAdjacentCapability();
+    }
+}

--- a/src/main/java/appeng/parts/p2p/FEP2PTunnelPart.java
+++ b/src/main/java/appeng/parts/p2p/FEP2PTunnelPart.java
@@ -172,9 +172,15 @@ public class FEP2PTunnelPart extends P2PTunnelPart<FEP2PTunnelPart> {
     }
 
     private class OutputEnergyStorage implements IEnergyStorage {
+        private IEnergyStorage getInputStorage() {
+            @Nullable
+            FEP2PTunnelPart input = getInput();
+            return input != null ? input.getAttachedEnergyStorage() : NULL_ENERGY_STORAGE;
+        }
+
         @Override
         public int extractEnergy(int maxExtract, boolean simulate) {
-            final int total = FEP2PTunnelPart.this.getAttachedEnergyStorage().extractEnergy(maxExtract, simulate);
+            final int total = getInputStorage().extractEnergy(maxExtract, simulate);
 
             if (!simulate) {
                 FEP2PTunnelPart.this.queueTunnelDrain(PowerUnits.RF, total);
@@ -190,7 +196,7 @@ public class FEP2PTunnelPart extends P2PTunnelPart<FEP2PTunnelPart> {
 
         @Override
         public boolean canExtract() {
-            return FEP2PTunnelPart.this.getAttachedEnergyStorage().canExtract();
+            return getInputStorage().canExtract();
         }
 
         @Override
@@ -200,12 +206,12 @@ public class FEP2PTunnelPart extends P2PTunnelPart<FEP2PTunnelPart> {
 
         @Override
         public int getMaxEnergyStored() {
-            return FEP2PTunnelPart.this.getAttachedEnergyStorage().getMaxEnergyStored();
+            return getInputStorage().getMaxEnergyStored();
         }
 
         @Override
         public int getEnergyStored() {
-            return FEP2PTunnelPart.this.getAttachedEnergyStorage().getEnergyStored();
+            return getInputStorage().getEnergyStored();
         }
     }
 

--- a/src/main/java/appeng/parts/p2p/FEP2PTunnelPart.java
+++ b/src/main/java/appeng/parts/p2p/FEP2PTunnelPart.java
@@ -42,7 +42,7 @@ public class FEP2PTunnelPart extends CapabilityP2PTunnelPart<FEP2PTunnelPart, IE
         super(is, CapabilityEnergy.ENERGY);
         inputHandler = new InputEnergyStorage();
         outputHandler = new OutputEnergyStorage();
-        nullHandler = NULL_ENERGY_STORAGE;
+        emptyHandler = NULL_ENERGY_STORAGE;
     }
 
     @Override
@@ -132,13 +132,15 @@ public class FEP2PTunnelPart extends CapabilityP2PTunnelPart<FEP2PTunnelPart, IE
     private class OutputEnergyStorage implements IEnergyStorage {
         @Override
         public int extractEnergy(int maxExtract, boolean simulate) {
-            final int total = getInputCapability().extractEnergy(maxExtract, simulate);
+            try (InputCapability input = inputCapability()) {
+                final int total = input.get().extractEnergy(maxExtract, simulate);
 
-            if (!simulate) {
-                FEP2PTunnelPart.this.queueTunnelDrain(PowerUnits.RF, total);
+                if (!simulate) {
+                    FEP2PTunnelPart.this.queueTunnelDrain(PowerUnits.RF, total);
+                }
+
+                return total;
             }
-
-            return total;
         }
 
         @Override
@@ -148,7 +150,9 @@ public class FEP2PTunnelPart extends CapabilityP2PTunnelPart<FEP2PTunnelPart, IE
 
         @Override
         public boolean canExtract() {
-            return getInputCapability().canExtract();
+            try (InputCapability input = inputCapability()) {
+                return input.get().canExtract();
+            }
         }
 
         @Override
@@ -158,12 +162,16 @@ public class FEP2PTunnelPart extends CapabilityP2PTunnelPart<FEP2PTunnelPart, IE
 
         @Override
         public int getMaxEnergyStored() {
-            return getInputCapability().getMaxEnergyStored();
+            try (InputCapability input = inputCapability()) {
+                return input.get().getMaxEnergyStored();
+            }
         }
 
         @Override
         public int getEnergyStored() {
-            return getInputCapability().getEnergyStored();
+            try (InputCapability input = inputCapability()) {
+                return input.get().getEnergyStored();
+            }
         }
     }
 

--- a/src/main/java/appeng/parts/p2p/FEP2PTunnelPart.java
+++ b/src/main/java/appeng/parts/p2p/FEP2PTunnelPart.java
@@ -71,12 +71,14 @@ public class FEP2PTunnelPart extends CapabilityP2PTunnelPart<FEP2PTunnelPart, IE
                 int overflow = amountPerOutput == 0 ? maxReceive : maxReceive % amountPerOutput;
 
                 for (FEP2PTunnelPart target : FEP2PTunnelPart.this.getOutputs()) {
-                    final IEnergyStorage output = target.getAdjacentCapability();
-                    final int toSend = amountPerOutput + overflow;
-                    final int received = output.receiveEnergy(toSend, simulate);
+                    try (AdjCapability adjCapability = target.getAdjacentCapability()) {
+                        final IEnergyStorage output = adjCapability.get();
+                        final int toSend = amountPerOutput + overflow;
+                        final int received = output.receiveEnergy(toSend, simulate);
 
-                    overflow = toSend - received;
-                    total += received;
+                        overflow = toSend - received;
+                        total += received;
+                    }
                 }
 
                 if (!simulate) {
@@ -104,7 +106,9 @@ public class FEP2PTunnelPart extends CapabilityP2PTunnelPart<FEP2PTunnelPart, IE
 
             try {
                 for (FEP2PTunnelPart t : FEP2PTunnelPart.this.getOutputs()) {
-                    total += t.getAdjacentCapability().getMaxEnergyStored();
+                    try (AdjCapability adjCapability = t.getAdjacentCapability()) {
+                        total += adjCapability.get().getMaxEnergyStored();
+                    }
                 }
             } catch (GridAccessException e) {
                 return 0;
@@ -119,7 +123,9 @@ public class FEP2PTunnelPart extends CapabilityP2PTunnelPart<FEP2PTunnelPart, IE
 
             try {
                 for (FEP2PTunnelPart t : FEP2PTunnelPart.this.getOutputs()) {
-                    total += t.getAdjacentCapability().getEnergyStored();
+                    try (AdjCapability adjCapability = t.getAdjacentCapability()) {
+                        total += adjCapability.get().getEnergyStored();
+                    }
                 }
             } catch (GridAccessException e) {
                 return 0;
@@ -132,7 +138,7 @@ public class FEP2PTunnelPart extends CapabilityP2PTunnelPart<FEP2PTunnelPart, IE
     private class OutputEnergyStorage implements IEnergyStorage {
         @Override
         public int extractEnergy(int maxExtract, boolean simulate) {
-            try (InputCapability input = inputCapability()) {
+            try (AdjCapability input = inputCapability()) {
                 final int total = input.get().extractEnergy(maxExtract, simulate);
 
                 if (!simulate) {
@@ -150,7 +156,7 @@ public class FEP2PTunnelPart extends CapabilityP2PTunnelPart<FEP2PTunnelPart, IE
 
         @Override
         public boolean canExtract() {
-            try (InputCapability input = inputCapability()) {
+            try (AdjCapability input = inputCapability()) {
                 return input.get().canExtract();
             }
         }
@@ -162,14 +168,14 @@ public class FEP2PTunnelPart extends CapabilityP2PTunnelPart<FEP2PTunnelPart, IE
 
         @Override
         public int getMaxEnergyStored() {
-            try (InputCapability input = inputCapability()) {
+            try (AdjCapability input = inputCapability()) {
                 return input.get().getMaxEnergyStored();
             }
         }
 
         @Override
         public int getEnergyStored() {
-            try (InputCapability input = inputCapability()) {
+            try (AdjCapability input = inputCapability()) {
                 return input.get().getEnergyStored();
             }
         }

--- a/src/main/java/appeng/parts/p2p/FEP2PTunnelPart.java
+++ b/src/main/java/appeng/parts/p2p/FEP2PTunnelPart.java
@@ -71,8 +71,8 @@ public class FEP2PTunnelPart extends CapabilityP2PTunnelPart<FEP2PTunnelPart, IE
                 int overflow = amountPerOutput == 0 ? maxReceive : maxReceive % amountPerOutput;
 
                 for (FEP2PTunnelPart target : FEP2PTunnelPart.this.getOutputs()) {
-                    try (AdjCapability adjCapability = target.getAdjacentCapability()) {
-                        final IEnergyStorage output = adjCapability.get();
+                    try (CapabilityGuard capabilityGuard = target.getAdjacentCapability()) {
+                        final IEnergyStorage output = capabilityGuard.get();
                         final int toSend = amountPerOutput + overflow;
                         final int received = output.receiveEnergy(toSend, simulate);
 
@@ -106,8 +106,8 @@ public class FEP2PTunnelPart extends CapabilityP2PTunnelPart<FEP2PTunnelPart, IE
 
             try {
                 for (FEP2PTunnelPart t : FEP2PTunnelPart.this.getOutputs()) {
-                    try (AdjCapability adjCapability = t.getAdjacentCapability()) {
-                        total += adjCapability.get().getMaxEnergyStored();
+                    try (CapabilityGuard capabilityGuard = t.getAdjacentCapability()) {
+                        total += capabilityGuard.get().getMaxEnergyStored();
                     }
                 }
             } catch (GridAccessException e) {
@@ -123,8 +123,8 @@ public class FEP2PTunnelPart extends CapabilityP2PTunnelPart<FEP2PTunnelPart, IE
 
             try {
                 for (FEP2PTunnelPart t : FEP2PTunnelPart.this.getOutputs()) {
-                    try (AdjCapability adjCapability = t.getAdjacentCapability()) {
-                        total += adjCapability.get().getEnergyStored();
+                    try (CapabilityGuard capabilityGuard = t.getAdjacentCapability()) {
+                        total += capabilityGuard.get().getEnergyStored();
                     }
                 }
             } catch (GridAccessException e) {
@@ -138,7 +138,7 @@ public class FEP2PTunnelPart extends CapabilityP2PTunnelPart<FEP2PTunnelPart, IE
     private class OutputEnergyStorage implements IEnergyStorage {
         @Override
         public int extractEnergy(int maxExtract, boolean simulate) {
-            try (AdjCapability input = inputCapability()) {
+            try (CapabilityGuard input = getInputCapability()) {
                 final int total = input.get().extractEnergy(maxExtract, simulate);
 
                 if (!simulate) {
@@ -156,7 +156,7 @@ public class FEP2PTunnelPart extends CapabilityP2PTunnelPart<FEP2PTunnelPart, IE
 
         @Override
         public boolean canExtract() {
-            try (AdjCapability input = inputCapability()) {
+            try (CapabilityGuard input = getInputCapability()) {
                 return input.get().canExtract();
             }
         }
@@ -168,14 +168,14 @@ public class FEP2PTunnelPart extends CapabilityP2PTunnelPart<FEP2PTunnelPart, IE
 
         @Override
         public int getMaxEnergyStored() {
-            try (AdjCapability input = inputCapability()) {
+            try (CapabilityGuard input = getInputCapability()) {
                 return input.get().getMaxEnergyStored();
             }
         }
 
         @Override
         public int getEnergyStored() {
-            try (AdjCapability input = inputCapability()) {
+            try (CapabilityGuard input = getInputCapability()) {
                 return input.get().getEnergyStored();
             }
         }

--- a/src/main/java/appeng/parts/p2p/FluidP2PTunnelPart.java
+++ b/src/main/java/appeng/parts/p2p/FluidP2PTunnelPart.java
@@ -93,15 +93,17 @@ public class FluidP2PTunnelPart extends CapabilityP2PTunnelPart<FluidP2PTunnelPa
                 int overflow = amountPerOutput == 0 ? amount : amount % amountPerOutput;
 
                 for (FluidP2PTunnelPart target : FluidP2PTunnelPart.this.getOutputs()) {
-                    final IFluidHandler output = target.getAdjacentCapability();
-                    final int toSend = amountPerOutput + overflow;
-                    final FluidStack fillWithFluidStack = resource.copy();
-                    fillWithFluidStack.setAmount(toSend);
+                    try (AdjCapability adjCapability = target.getAdjacentCapability()) {
+                        final IFluidHandler output = adjCapability.get();
+                        final int toSend = amountPerOutput + overflow;
+                        final FluidStack fillWithFluidStack = resource.copy();
+                        fillWithFluidStack.setAmount(toSend);
 
-                    final int received = output.fill(fillWithFluidStack, action);
+                        final int received = output.fill(fillWithFluidStack, action);
 
-                    overflow = toSend - received;
-                    total += received;
+                        overflow = toSend - received;
+                        total += received;
+                    }
                 }
 
                 if (action == FluidAction.EXECUTE) {
@@ -130,7 +132,7 @@ public class FluidP2PTunnelPart extends CapabilityP2PTunnelPart<FluidP2PTunnelPa
     private class OutputFluidHandler implements IFluidHandler {
         @Override
         public int getTanks() {
-            try (InputCapability input = inputCapability()) {
+            try (AdjCapability input = inputCapability()) {
                 return input.get().getTanks();
             }
         }
@@ -138,21 +140,21 @@ public class FluidP2PTunnelPart extends CapabilityP2PTunnelPart<FluidP2PTunnelPa
         @Override
         @Nonnull
         public FluidStack getFluidInTank(int tank) {
-            try (InputCapability input = inputCapability()) {
+            try (AdjCapability input = inputCapability()) {
                 return input.get().getFluidInTank(tank);
             }
         }
 
         @Override
         public int getTankCapacity(int tank) {
-            try (InputCapability input = inputCapability()) {
+            try (AdjCapability input = inputCapability()) {
                 return input.get().getTankCapacity(tank);
             }
         }
 
         @Override
         public boolean isFluidValid(int tank, @Nonnull FluidStack stack) {
-            try (InputCapability input = inputCapability()) {
+            try (AdjCapability input = inputCapability()) {
                 return input.get().isFluidValid(tank, stack);
             }
         }
@@ -165,7 +167,7 @@ public class FluidP2PTunnelPart extends CapabilityP2PTunnelPart<FluidP2PTunnelPa
         @Override
         @Nonnull
         public FluidStack drain(FluidStack resource, FluidAction action) {
-            try (InputCapability input = inputCapability()) {
+            try (AdjCapability input = inputCapability()) {
                 FluidStack result = input.get().drain(resource, action);
 
                 if (action.execute()) {
@@ -179,7 +181,7 @@ public class FluidP2PTunnelPart extends CapabilityP2PTunnelPart<FluidP2PTunnelPa
         @Override
         @Nonnull
         public FluidStack drain(int maxDrain, FluidAction action) {
-            try (InputCapability input = inputCapability()) {
+            try (AdjCapability input = inputCapability()) {
                 FluidStack result = input.get().drain(maxDrain, action);
 
                 if (action.execute()) {

--- a/src/main/java/appeng/parts/p2p/FluidP2PTunnelPart.java
+++ b/src/main/java/appeng/parts/p2p/FluidP2PTunnelPart.java
@@ -93,8 +93,8 @@ public class FluidP2PTunnelPart extends CapabilityP2PTunnelPart<FluidP2PTunnelPa
                 int overflow = amountPerOutput == 0 ? amount : amount % amountPerOutput;
 
                 for (FluidP2PTunnelPart target : FluidP2PTunnelPart.this.getOutputs()) {
-                    try (AdjCapability adjCapability = target.getAdjacentCapability()) {
-                        final IFluidHandler output = adjCapability.get();
+                    try (CapabilityGuard capabilityGuard = target.getAdjacentCapability()) {
+                        final IFluidHandler output = capabilityGuard.get();
                         final int toSend = amountPerOutput + overflow;
                         final FluidStack fillWithFluidStack = resource.copy();
                         fillWithFluidStack.setAmount(toSend);
@@ -132,7 +132,7 @@ public class FluidP2PTunnelPart extends CapabilityP2PTunnelPart<FluidP2PTunnelPa
     private class OutputFluidHandler implements IFluidHandler {
         @Override
         public int getTanks() {
-            try (AdjCapability input = inputCapability()) {
+            try (CapabilityGuard input = getInputCapability()) {
                 return input.get().getTanks();
             }
         }
@@ -140,21 +140,21 @@ public class FluidP2PTunnelPart extends CapabilityP2PTunnelPart<FluidP2PTunnelPa
         @Override
         @Nonnull
         public FluidStack getFluidInTank(int tank) {
-            try (AdjCapability input = inputCapability()) {
+            try (CapabilityGuard input = getInputCapability()) {
                 return input.get().getFluidInTank(tank);
             }
         }
 
         @Override
         public int getTankCapacity(int tank) {
-            try (AdjCapability input = inputCapability()) {
+            try (CapabilityGuard input = getInputCapability()) {
                 return input.get().getTankCapacity(tank);
             }
         }
 
         @Override
         public boolean isFluidValid(int tank, @Nonnull FluidStack stack) {
-            try (AdjCapability input = inputCapability()) {
+            try (CapabilityGuard input = getInputCapability()) {
                 return input.get().isFluidValid(tank, stack);
             }
         }
@@ -167,7 +167,7 @@ public class FluidP2PTunnelPart extends CapabilityP2PTunnelPart<FluidP2PTunnelPa
         @Override
         @Nonnull
         public FluidStack drain(FluidStack resource, FluidAction action) {
-            try (AdjCapability input = inputCapability()) {
+            try (CapabilityGuard input = getInputCapability()) {
                 FluidStack result = input.get().drain(resource, action);
 
                 if (action.execute()) {
@@ -181,7 +181,7 @@ public class FluidP2PTunnelPart extends CapabilityP2PTunnelPart<FluidP2PTunnelPa
         @Override
         @Nonnull
         public FluidStack drain(int maxDrain, FluidAction action) {
-            try (AdjCapability input = inputCapability()) {
+            try (CapabilityGuard input = getInputCapability()) {
                 FluidStack result = input.get().drain(maxDrain, action);
 
                 if (action.execute()) {

--- a/src/main/java/appeng/parts/p2p/FluidP2PTunnelPart.java
+++ b/src/main/java/appeng/parts/p2p/FluidP2PTunnelPart.java
@@ -46,7 +46,7 @@ public class FluidP2PTunnelPart extends CapabilityP2PTunnelPart<FluidP2PTunnelPa
         super(is, CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY);
         inputHandler = new InputFluidHandler();
         outputHandler = new OutputFluidHandler();
-        nullHandler = NULL_FLUID_HANDLER;
+        emptyHandler = NULL_FLUID_HANDLER;
     }
 
     @Override
@@ -130,23 +130,31 @@ public class FluidP2PTunnelPart extends CapabilityP2PTunnelPart<FluidP2PTunnelPa
     private class OutputFluidHandler implements IFluidHandler {
         @Override
         public int getTanks() {
-            return getInputCapability().getTanks();
+            try (InputCapability input = inputCapability()) {
+                return input.get().getTanks();
+            }
         }
 
         @Override
         @Nonnull
         public FluidStack getFluidInTank(int tank) {
-            return getInputCapability().getFluidInTank(tank);
+            try (InputCapability input = inputCapability()) {
+                return input.get().getFluidInTank(tank);
+            }
         }
 
         @Override
         public int getTankCapacity(int tank) {
-            return getInputCapability().getTankCapacity(tank);
+            try (InputCapability input = inputCapability()) {
+                return input.get().getTankCapacity(tank);
+            }
         }
 
         @Override
         public boolean isFluidValid(int tank, @Nonnull FluidStack stack) {
-            return getInputCapability().isFluidValid(tank, stack);
+            try (InputCapability input = inputCapability()) {
+                return input.get().isFluidValid(tank, stack);
+            }
         }
 
         @Override
@@ -157,25 +165,29 @@ public class FluidP2PTunnelPart extends CapabilityP2PTunnelPart<FluidP2PTunnelPa
         @Override
         @Nonnull
         public FluidStack drain(FluidStack resource, FluidAction action) {
-            FluidStack result = getInputCapability().drain(resource, action);
+            try (InputCapability input = inputCapability()) {
+                FluidStack result = input.get().drain(resource, action);
 
-            if (action.execute()) {
-                queueTunnelDrain(PowerUnits.RF, result.getAmount());
+                if (action.execute()) {
+                    queueTunnelDrain(PowerUnits.RF, result.getAmount());
+                }
+
+                return result;
             }
-
-            return result;
         }
 
         @Override
         @Nonnull
         public FluidStack drain(int maxDrain, FluidAction action) {
-            FluidStack result = getInputCapability().drain(maxDrain, action);
+            try (InputCapability input = inputCapability()) {
+                FluidStack result = input.get().drain(maxDrain, action);
 
-            if (action.execute()) {
-                queueTunnelDrain(PowerUnits.RF, result.getAmount());
+                if (action.execute()) {
+                    queueTunnelDrain(PowerUnits.RF, result.getAmount());
+                }
+
+                return result;
             }
-
-            return result;
         }
     }
 

--- a/src/main/java/appeng/parts/p2p/ItemP2PTunnelPart.java
+++ b/src/main/java/appeng/parts/p2p/ItemP2PTunnelPart.java
@@ -46,7 +46,7 @@ public class ItemP2PTunnelPart extends CapabilityP2PTunnelPart<ItemP2PTunnelPart
         super(is, CapabilityItemHandler.ITEM_HANDLER_CAPABILITY);
         inputHandler = new InputItemHandler();
         outputHandler = new OutputItemHandler();
-        nullHandler = NULL_ITEM_HANDLER;
+        emptyHandler = NULL_ITEM_HANDLER;
     }
 
     @Override
@@ -140,13 +140,17 @@ public class ItemP2PTunnelPart extends CapabilityP2PTunnelPart<ItemP2PTunnelPart
     private class OutputItemHandler implements IItemHandler {
         @Override
         public int getSlots() {
-            return getInputCapability().getSlots();
+            try (InputCapability input = inputCapability()) {
+                return input.get().getSlots();
+            }
         }
 
         @Override
         @Nonnull
         public ItemStack getStackInSlot(int slot) {
-            return getInputCapability().getStackInSlot(slot);
+            try (InputCapability input = inputCapability()) {
+                return input.get().getStackInSlot(slot);
+            }
         }
 
         @Override
@@ -158,23 +162,29 @@ public class ItemP2PTunnelPart extends CapabilityP2PTunnelPart<ItemP2PTunnelPart
         @Override
         @Nonnull
         public ItemStack extractItem(int slot, int amount, boolean simulate) {
-            ItemStack result = getInputCapability().extractItem(slot, amount, simulate);
+            try (InputCapability input = inputCapability()) {
+                ItemStack result = input.get().extractItem(slot, amount, simulate);
 
-            if (!simulate) {
-                queueTunnelDrain(PowerUnits.RF, result.getCount());
+                if (!simulate) {
+                    queueTunnelDrain(PowerUnits.RF, result.getCount());
+                }
+
+                return result;
             }
-
-            return result;
         }
 
         @Override
         public int getSlotLimit(int slot) {
-            return getInputCapability().getSlotLimit(slot);
+            try (InputCapability input = inputCapability()) {
+                return input.get().getSlotLimit(slot);
+            }
         }
 
         @Override
         public boolean isItemValid(int slot, @Nonnull ItemStack stack) {
-            return getInputCapability().isItemValid(slot, stack);
+            try (InputCapability input = inputCapability()) {
+                return input.get().isItemValid(slot, stack);
+            }
         }
     }
 

--- a/src/main/java/appeng/parts/p2p/ItemP2PTunnelPart.java
+++ b/src/main/java/appeng/parts/p2p/ItemP2PTunnelPart.java
@@ -84,8 +84,8 @@ public class ItemP2PTunnelPart extends CapabilityP2PTunnelPart<ItemP2PTunnelPart
                 int overflow = amountPerOutput == 0 ? amount : amount % amountPerOutput;
 
                 for (ItemP2PTunnelPart target : ItemP2PTunnelPart.this.getOutputs()) {
-                    try (AdjCapability adjCapability = target.getAdjacentCapability()) {
-                        final IItemHandler output = adjCapability.get();
+                    try (CapabilityGuard capabilityGuard = target.getAdjacentCapability()) {
+                        final IItemHandler output = capabilityGuard.get();
                         final int toSend = amountPerOutput + overflow;
 
                         if (toSend <= 0) {
@@ -144,7 +144,7 @@ public class ItemP2PTunnelPart extends CapabilityP2PTunnelPart<ItemP2PTunnelPart
     private class OutputItemHandler implements IItemHandler {
         @Override
         public int getSlots() {
-            try (AdjCapability input = inputCapability()) {
+            try (CapabilityGuard input = getInputCapability()) {
                 return input.get().getSlots();
             }
         }
@@ -152,7 +152,7 @@ public class ItemP2PTunnelPart extends CapabilityP2PTunnelPart<ItemP2PTunnelPart
         @Override
         @Nonnull
         public ItemStack getStackInSlot(int slot) {
-            try (AdjCapability input = inputCapability()) {
+            try (CapabilityGuard input = getInputCapability()) {
                 return input.get().getStackInSlot(slot);
             }
         }
@@ -166,7 +166,7 @@ public class ItemP2PTunnelPart extends CapabilityP2PTunnelPart<ItemP2PTunnelPart
         @Override
         @Nonnull
         public ItemStack extractItem(int slot, int amount, boolean simulate) {
-            try (AdjCapability input = inputCapability()) {
+            try (CapabilityGuard input = getInputCapability()) {
                 ItemStack result = input.get().extractItem(slot, amount, simulate);
 
                 if (!simulate) {
@@ -179,14 +179,14 @@ public class ItemP2PTunnelPart extends CapabilityP2PTunnelPart<ItemP2PTunnelPart
 
         @Override
         public int getSlotLimit(int slot) {
-            try (AdjCapability input = inputCapability()) {
+            try (CapabilityGuard input = getInputCapability()) {
                 return input.get().getSlotLimit(slot);
             }
         }
 
         @Override
         public boolean isItemValid(int slot, @Nonnull ItemStack stack) {
-            try (AdjCapability input = inputCapability()) {
+            try (CapabilityGuard input = getInputCapability()) {
                 return input.get().isItemValid(slot, stack);
             }
         }

--- a/src/main/java/appeng/parts/p2p/ItemP2PTunnelPart.java
+++ b/src/main/java/appeng/parts/p2p/ItemP2PTunnelPart.java
@@ -105,7 +105,6 @@ public class ItemP2PTunnelPart extends P2PTunnelPart<ItemP2PTunnelPart> {
         @Override
         @Nonnull
         public ItemStack insertItem(int slot, @Nonnull ItemStack stack, boolean simulate) {
-            final ItemStack testStack = stack.copy();
             int remainder = stack.getCount();
 
             try {
@@ -128,9 +127,10 @@ public class ItemP2PTunnelPart extends P2PTunnelPart<ItemP2PTunnelPart> {
                         break;
                     }
 
-                    // So in theory copying the stack should not be necessary because it is not supposed to be stored
-                    // or modifed by insertItem. However, ItemStackHandler will gladly store the stack so we need to do
-                    // a defensive copy.
+                    // So the documentation says that copying the stack should not be necessary because it is not
+                    // supposed to be stored or modifed by insertItem. However, ItemStackHandler will gladly store the
+                    // stack so we need to do a defensive copy. Forgecord says this is the intended behavior, and the
+                    // documentation is wrong.
                     ItemStack stackCopy = stack.copy();
                     stackCopy.setCount(toSend);
                     final int sent = toSend - ItemHandlerHelper.insertItem(output, stackCopy, simulate).getCount();
@@ -145,8 +145,13 @@ public class ItemP2PTunnelPart extends P2PTunnelPart<ItemP2PTunnelPart> {
             } catch (GridAccessException ignored) {
             }
 
-            testStack.setCount(remainder);
-            return testStack;
+            if (remainder == stack.getCount()) {
+                return stack;
+            } else {
+                ItemStack copy = stack.copy();
+                copy.setCount(remainder);
+                return copy;
+            }
         }
 
         @Override

--- a/src/main/java/appeng/parts/p2p/ItemP2PTunnelPart.java
+++ b/src/main/java/appeng/parts/p2p/ItemP2PTunnelPart.java
@@ -21,6 +21,7 @@ package appeng.parts.p2p;
 import java.util.List;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
@@ -173,16 +174,21 @@ public class ItemP2PTunnelPart extends P2PTunnelPart<ItemP2PTunnelPart> {
     }
 
     private class OutputItemHandler implements IItemHandler {
+        private IItemHandler getInputHandler() {
+            @Nullable
+            ItemP2PTunnelPart input = getInput();
+            return input != null ? input.getAttachedItemHandler() : NULL_ITEM_HANDLER;
+        }
 
         @Override
         public int getSlots() {
-            return ItemP2PTunnelPart.this.getInput().getAttachedItemHandler().getSlots();
+            return getInputHandler().getSlots();
         }
 
         @Override
         @Nonnull
         public ItemStack getStackInSlot(int slot) {
-            return ItemP2PTunnelPart.this.getInput().getAttachedItemHandler().getStackInSlot(slot);
+            return getInputHandler().getStackInSlot(slot);
         }
 
         @Override
@@ -194,17 +200,23 @@ public class ItemP2PTunnelPart extends P2PTunnelPart<ItemP2PTunnelPart> {
         @Override
         @Nonnull
         public ItemStack extractItem(int slot, int amount, boolean simulate) {
-            return ItemP2PTunnelPart.this.getInput().getAttachedItemHandler().extractItem(slot, amount, simulate);
+            ItemStack result = getInputHandler().extractItem(slot, amount, simulate);
+
+            if (!simulate) {
+                queueTunnelDrain(PowerUnits.RF, result.getCount());
+            }
+
+            return result;
         }
 
         @Override
         public int getSlotLimit(int slot) {
-            return ItemP2PTunnelPart.this.getInput().getAttachedItemHandler().getSlotLimit(slot);
+            return getInputHandler().getSlotLimit(slot);
         }
 
         @Override
         public boolean isItemValid(int slot, @Nonnull ItemStack stack) {
-            return ItemP2PTunnelPart.this.getInput().getAttachedItemHandler().isItemValid(slot, stack);
+            return getInputHandler().isItemValid(slot, stack);
         }
     }
 

--- a/src/main/java/appeng/parts/p2p/ItemP2PTunnelPart.java
+++ b/src/main/java/appeng/parts/p2p/ItemP2PTunnelPart.java
@@ -112,6 +112,8 @@ public class ItemP2PTunnelPart extends CapabilityP2PTunnelPart<ItemP2PTunnelPart
 
             if (remainder == stack.getCount()) {
                 return stack;
+            } else if (remainder == 0) {
+                return ItemStack.EMPTY;
             } else {
                 ItemStack copy = stack.copy();
                 copy.setCount(remainder);

--- a/src/main/java/appeng/parts/p2p/P2PTunnelPart.java
+++ b/src/main/java/appeng/parts/p2p/P2PTunnelPart.java
@@ -258,7 +258,7 @@ public abstract class P2PTunnelPart<T extends P2PTunnelPart> extends BasicStateP
                 final boolean oldOutput = this.isOutput();
                 final short myFreq = this.getFrequency();
 
-                this.getHost().removePart(this.getSide(), false);
+                this.getHost().removePart(this.getSide(), true);
                 final AEPartLocation dir = this.getHost().addPart(newType, this.getSide(), player, hand);
                 final IPart newBus = this.getHost().getPart(dir);
 

--- a/src/main/java/appeng/parts/p2p/P2PTunnelPart.java
+++ b/src/main/java/appeng/parts/p2p/P2PTunnelPart.java
@@ -23,6 +23,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Optional;
 
+import javax.annotation.Nullable;
+
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundNBT;
@@ -78,6 +80,7 @@ public abstract class P2PTunnelPart<T extends P2PTunnelPart> extends BasicStateP
         return null;
     }
 
+    @Nullable
     public T getInput() {
         if (this.getFrequency() == 0) {
             return null;


### PR DESCRIPTION
TL;DR working with `ItemStack`s is much more error prone than working with `int`s. 

Additionally stops p2p tunnel attunement destroying it when it's the only part in the block.

Additionally use `ActionResultType.CONSUME` instead of `ActionResultType.FAIL` when a part activation succeeded server-side.

Additionally:
- Item and fluids: don't crash if `getInput` is null, and properly tax pulled items/fluids.
- Energy: correctly allow pulling energy.