### PR TITLE
Disable Gradle module metadata

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -390,3 +390,9 @@ if (System.getProperty("idea.sync.active") == "true") {
         }
     }
 }
+
+// See https://github.com/AppliedEnergistics/Applied-Energistics-2/issues/5259
+// Gradle module metadata contains mapped dependencies, making our artifacts unconsumable
+tasks.withType(GenerateModuleMetadata) {
+    enabled = false
+}


### PR DESCRIPTION
Fixes #5259

This should fix consuming our artifacts for addons.