### PR TITLE
Capability Wrench

### DIFF
--- a/src/main/java/appeng/capabilities/Capabilities.java
+++ b/src/main/java/appeng/capabilities/Capabilities.java
@@ -18,7 +18,6 @@
 
 package appeng.capabilities;
 
-import appeng.api.implementations.items.IAEWrench;
 import net.minecraft.nbt.INBT;
 import net.minecraft.util.Direction;
 import net.minecraftforge.common.capabilities.Capability;
@@ -26,6 +25,7 @@ import net.minecraftforge.common.capabilities.CapabilityInject;
 import net.minecraftforge.common.capabilities.CapabilityManager;
 import net.minecraftforge.energy.IEnergyStorage;
 
+import appeng.api.implementations.items.IAEWrench;
 import appeng.api.storage.IStorageMonitorableAccessor;
 
 /**

--- a/src/main/java/appeng/capabilities/Capabilities.java
+++ b/src/main/java/appeng/capabilities/Capabilities.java
@@ -18,6 +18,7 @@
 
 package appeng.capabilities;
 
+import appeng.api.implementations.items.IAEWrench;
 import net.minecraft.nbt.INBT;
 import net.minecraft.util.Direction;
 import net.minecraftforge.common.capabilities.Capability;
@@ -37,6 +38,8 @@ public final class Capabilities {
 
     public static Capability<IStorageMonitorableAccessor> STORAGE_MONITORABLE_ACCESSOR;
 
+    public static Capability<IAEWrench> WRENCH;
+
     public static Capability<IEnergyStorage> FORGE_ENERGY;
 
     /**
@@ -45,11 +48,17 @@ public final class Capabilities {
     public static void register() {
         CapabilityManager.INSTANCE.register(IStorageMonitorableAccessor.class, createNullStorage(),
                 NullMENetworkAccessor::new);
+        CapabilityManager.INSTANCE.register(IAEWrench.class, createNullStorage(), NullWrench::new);
     }
 
     @CapabilityInject(IStorageMonitorableAccessor.class)
     private static void capIStorageMonitorableAccessorRegistered(Capability<IStorageMonitorableAccessor> cap) {
         STORAGE_MONITORABLE_ACCESSOR = cap;
+    }
+
+    @CapabilityInject(IAEWrench.class)
+    private static void capIAEWrenchRegistered(Capability<IAEWrench> cap) {
+        WRENCH = cap;
     }
 
     @CapabilityInject(IEnergyStorage.class)
@@ -71,4 +80,5 @@ public final class Capabilities {
             }
         };
     }
+
 }

--- a/src/main/java/appeng/capabilities/NullWrench.java
+++ b/src/main/java/appeng/capabilities/NullWrench.java
@@ -1,0 +1,15 @@
+package appeng.capabilities;
+
+import appeng.api.implementations.items.IAEWrench;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.BlockPos;
+
+public class NullWrench implements IAEWrench {
+
+    @Override
+    public boolean canWrench(ItemStack wrench, PlayerEntity player, BlockPos pos) {
+        return false;
+    }
+
+}

--- a/src/main/java/appeng/capabilities/NullWrench.java
+++ b/src/main/java/appeng/capabilities/NullWrench.java
@@ -1,9 +1,10 @@
 package appeng.capabilities;
 
-import appeng.api.implementations.items.IAEWrench;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
+
+import appeng.api.implementations.items.IAEWrench;
 
 public class NullWrench implements IAEWrench {
 

--- a/src/main/java/appeng/util/InteractionUtil.java
+++ b/src/main/java/appeng/util/InteractionUtil.java
@@ -20,13 +20,10 @@ package appeng.util;
 
 import java.util.List;
 
-import appeng.capabilities.Capabilities;
-import appeng.datagen.AE2DataGenerators;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.ItemEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.EntityRayTraceResult;
@@ -38,11 +35,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.ForgeMod;
 
 import appeng.api.implementations.items.IAEWrench;
-import net.minecraftforge.common.capabilities.Capability;
-import net.minecraftforge.common.capabilities.CapabilityInject;
-import net.minecraftforge.common.util.LazyOptional;
-
-import javax.annotation.Nonnull;
+import appeng.capabilities.Capabilities;
 
 /**
  * Utility functions revolving around using or placing items.

--- a/src/main/java/appeng/util/InteractionUtil.java
+++ b/src/main/java/appeng/util/InteractionUtil.java
@@ -20,10 +20,13 @@ package appeng.util;
 
 import java.util.List;
 
+import appeng.capabilities.Capabilities;
+import appeng.datagen.AE2DataGenerators;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.ItemEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.EntityRayTraceResult;
@@ -35,6 +38,11 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.ForgeMod;
 
 import appeng.api.implementations.items.IAEWrench;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.CapabilityInject;
+import net.minecraftforge.common.util.LazyOptional;
+
+import javax.annotation.Nonnull;
 
 /**
  * Utility functions revolving around using or placing items.
@@ -66,6 +74,11 @@ public final class InteractionUtil {
                 final IAEWrench wrench = (IAEWrench) eq.getItem();
                 return wrench.canWrench(eq, player, pos);
             }
+
+            return eq.getCapability(Capabilities.WRENCH)
+                    .filter(w -> w.canWrench(eq, player, pos))
+                    .isPresent();
+
         }
         return false;
     }


### PR DESCRIPTION
Implementation for #5266

Make the `IAEWrench` interface an item capability, allowing mods to implement it without requiring AE2 as a hard dependency.
Implementing the interface still works, but you can now alternativly provide it as a capability.