### PR TITLE
Fixes #5226: Correctly apply stored NBT when placing the last block.

### DIFF
--- a/src/main/java/appeng/block/AEBaseBlockItem.java
+++ b/src/main/java/appeng/block/AEBaseBlockItem.java
@@ -74,6 +74,9 @@ public class AEBaseBlockItem extends BlockItem {
         return this.blockType.getTranslationKey();
     }
 
+    /**
+     * TODO: 1.17 Refactor to use Block#onBlockPlacedBy(), BlockItem#setTileEntityNBT() or equivalent.
+     */
     @Override
     public ActionResultType tryPlace(BlockItemUseContext context) {
 
@@ -149,8 +152,6 @@ public class AEBaseBlockItem extends BlockItem {
             if (tile instanceof IGridProxyable) {
                 ((IGridProxyable) tile).getProxy().setOwner(player);
             }
-
-            tile.onPlacement(context);
         } else if (this.blockType instanceof IOrientableBlock) {
             ori.setOrientation(forward, up);
         }

--- a/src/main/java/appeng/block/AEBaseTileBlock.java
+++ b/src/main/java/appeng/block/AEBaseTileBlock.java
@@ -159,17 +159,22 @@ public abstract class AEBaseTileBlock<T extends AEBaseTileEntity> extends AEBase
     @Override
     public void onBlockPlacedBy(final World w, final BlockPos pos, final BlockState state, final LivingEntity placer,
             final ItemStack is) {
-        // Inherit the item stack's display name, but only if it's a user defined string
-        // rather
-        // than a translation component, since our custom naming cannot handle
-        // untranslated
-        // I18N strings and we would translate it using the server's locale :-(
+        // Inherit the item stack's display name, but only if it's a user defined string rather than a translation
+        // component, since our custom naming cannot handle untranslated I18N strings and we would translate it using
+        // the server's locale :-(
         AEBaseTileEntity te = this.getTileEntity(w, pos);
-        if (te != null && is.hasDisplayName()) {
-            ITextComponent displayName = is.getDisplayName();
-            if (displayName instanceof StringTextComponent) {
-                te.setName(((StringTextComponent) displayName).getText());
-            }
+
+        if (te == null) {
+            return;
+        }
+
+        ITextComponent displayName = is.getDisplayName();
+        if (displayName instanceof StringTextComponent) {
+            te.setName(((StringTextComponent) displayName).getText());
+        }
+
+        if (is.hasTag()) {
+            te.uploadSettings(SettingsFrom.DISMANTLE_ITEM, is.getTag());
         }
     }
 

--- a/src/main/java/appeng/tile/AEBaseTileEntity.java
+++ b/src/main/java/appeng/tile/AEBaseTileEntity.java
@@ -30,7 +30,6 @@ import javax.annotation.Nullable;
 import io.netty.buffer.Unpooled;
 
 import net.minecraft.block.BlockState;
-import net.minecraft.item.BlockItemUseContext;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.network.NetworkManager;
@@ -310,13 +309,6 @@ public class AEBaseTileEntity extends TileEntity implements IOrientable, ICommon
         this.markForUpdate();
         Platform.notifyBlocksOfNeighbors(this.world, this.pos);
         this.saveChanges();
-    }
-
-    public void onPlacement(BlockItemUseContext context) {
-        ItemStack stack = context.getItem();
-        if (stack.hasTag()) {
-            this.uploadSettings(SettingsFrom.DISMANTLE_ITEM, stack.getTag());
-        }
     }
 
     /**


### PR DESCRIPTION
Closes #5226. Before this PR, the stored NBT is applied after the stack is decremented, which doesn't work when the last block of the stack is placed in survival mode, as the resulting stack is then empty.

**This is a temporary fix for 8.4 only**

Vanilla itself provides helpers like `net.minecraft.item.BlockItem.setTileEntityNBT(World, PlayerEntity, BlockPos, ItemStack)` which can apply NBT directly but need a different NBT structure, which would break every existing itemstack in 1.16.