### PR TITLE
Reduce ItemStack creations in ItemHandlerAdapter#extract

### DIFF
--- a/src/main/java/appeng/parts/misc/ItemHandlerAdapter.java
+++ b/src/main/java/appeng/parts/misc/ItemHandlerAdapter.java
@@ -25,6 +25,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import com.google.common.primitives.Ints;
+
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.items.IItemHandler;
 
@@ -42,7 +44,6 @@ import appeng.core.Api;
 import appeng.me.GridAccessException;
 import appeng.me.helpers.IGridProxyable;
 import appeng.me.storage.ITickingMonitor;
-import appeng.util.Platform;
 import appeng.util.item.AEItemStack;
 
 /**
@@ -93,9 +94,7 @@ class ItemHandlerAdapter implements IMEInventory<IAEItemStack>, IBaseMonitor<IAE
 
     @Override
     public IAEItemStack extractItems(IAEItemStack request, Actionable mode, IActionSource src) {
-
-        ItemStack requestedItemStack = request.createItemStack();
-        int remainingSize = requestedItemStack.getCount();
+        int remainingSize = Ints.saturatedCast(request.getStackSize());
 
         // Use this to gather the requested items
         ItemStack gathered = ItemStack.EMPTY;
@@ -105,7 +104,7 @@ class ItemHandlerAdapter implements IMEInventory<IAEItemStack>, IBaseMonitor<IAE
         for (int i = 0; i < this.itemHandler.getSlots(); i++) {
             ItemStack stackInInventorySlot = this.itemHandler.getStackInSlot(i);
 
-            if (!Platform.itemComparisons().isSameItem(stackInInventorySlot, requestedItemStack)) {
+            if (!request.isSameType(stackInInventorySlot)) {
                 continue;
             }
 


### PR DESCRIPTION
Close #5296.

This PR does that in two ways:
- Do not use a new stack to compare in `extractItems`. We can compare with the IAEItemStack directly (internally it uses the shared item stack for the comparison).
- ~~Cache the stack used by `insertItems`. This is especially useful when there are a lot of storage busses to iterate through for an injection. Most of those return the stack unmodified, and we can just reuse it for the next time, possibly adjusting the count.~~ Somewhat risky, reverted for now.