### PR TITLE
Add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,8 @@
+
+# Use via git config --local --add blame.ignoreRevsFile .git-blame-ignore-revs
+
+# Big Reformat of 2020
+5225ea426beb873ab4d1906da352b5dde4b45067
+
+# The great rename of 2020
+b4471b1abb2fea14f331d74bf3f2487a2d35c7c3

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ src/generated
 !.gitmodules
 !.gitignore
 !.gitattributes
+!.git-blame-ignore-revs
 
 # code format to reduce noise in git commits
 !codeformat/


### PR DESCRIPTION
Should probably extend this file over time as we rediscover various big, automated renames/reformats.

p.s.: Everyone still needs to activate it locally via the git config command that's in the files comment.