### PR TITLE
Rework storage bus caching

### DIFF
--- a/src/main/java/appeng/parts/misc/FluidStorageBusPart.java
+++ b/src/main/java/appeng/parts/misc/FluidStorageBusPart.java
@@ -18,17 +18,13 @@
 
 package appeng.parts.misc;
 
-import java.util.Objects;
-
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 
@@ -49,7 +45,7 @@ import appeng.util.fluid.AEFluidInventory;
 import appeng.util.fluid.IAEFluidTank;
 import appeng.util.inv.IAEFluidInventory;
 
-public class FluidStorageBusPart extends AbstractStorageBusPart<IAEFluidStack>
+public class FluidStorageBusPart extends AbstractStorageBusPart<IAEFluidStack, IFluidHandler>
         implements IAEFluidInventory, IConfigurableFluidInventory {
     public static final ResourceLocation MODEL_BASE = new ResourceLocation(AppEng.MOD_ID,
             "part/fluid_storage_bus_base");
@@ -66,7 +62,7 @@ public class FluidStorageBusPart extends AbstractStorageBusPart<IAEFluidStack>
     private final AEFluidInventory config = new AEFluidInventory(this, 63);
 
     public FluidStorageBusPart(ItemStack is) {
-        super(TickRates.FluidStorageBus, is);
+        super(TickRates.FluidStorageBus, is, CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY);
     }
 
     @Override
@@ -76,33 +72,13 @@ public class FluidStorageBusPart extends AbstractStorageBusPart<IAEFluidStack>
 
     @Nullable
     @Override
-    protected IMEInventory<IAEFluidStack> getHandlerAdapter(BlockEntity target, Direction targetSide,
-            Runnable alertDevice) {
-        var handlerExtOpt = target
-                .getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, targetSide);
-        if (handlerExtOpt.isPresent()) {
-            return new FluidHandlerAdapter(handlerExtOpt.orElse(null)) {
-                @Override
-                protected void onInjectOrExtract() {
-                    alertDevice.run();
-                }
-            };
-        }
-
-        return null;
-    }
-
-    @Override
-    protected int getHandlerHash(BlockEntity target, Direction targetSide) {
-        var fluidHandlerOpt = target
-                .getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, targetSide);
-
-        if (fluidHandlerOpt.isPresent()) {
-            var itemHandler = fluidHandlerOpt.orElse(null);
-            return Objects.hash(target, itemHandler, itemHandler.getTanks());
-        } else {
-            return 0;
-        }
+    protected IMEInventory<IAEFluidStack> getHandlerAdapter(IFluidHandler handler, Runnable alertDevice) {
+        return new FluidHandlerAdapter(handler) {
+            @Override
+            protected void onInjectOrExtract() {
+                alertDevice.run();
+            }
+        };
     }
 
     @Override

--- a/src/main/java/appeng/parts/misc/ItemStorageBusPart.java
+++ b/src/main/java/appeng/parts/misc/ItemStorageBusPart.java
@@ -18,16 +18,12 @@
 
 package appeng.parts.misc;
 
-import java.util.Objects;
-
 import javax.annotation.Nullable;
 
-import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
 
@@ -46,7 +42,7 @@ import appeng.menu.implementations.ItemStorageBusMenu;
 import appeng.parts.PartModel;
 import appeng.util.inv.InvOperation;
 
-public class ItemStorageBusPart extends AbstractStorageBusPart<IAEItemStack> {
+public class ItemStorageBusPart extends AbstractStorageBusPart<IAEItemStack, IItemHandler> {
 
     public static final ResourceLocation MODEL_BASE = new ResourceLocation(AppEng.MOD_ID, "part/item_storage_bus_base");
 
@@ -65,7 +61,7 @@ public class ItemStorageBusPart extends AbstractStorageBusPart<IAEItemStack> {
     private final AppEngInternalAEInventory config = new AppEngInternalAEInventory(this, 63);
 
     public ItemStorageBusPart(final ItemStack is) {
-        super(TickRates.ItemStorageBus, is);
+        super(TickRates.ItemStorageBus, is, CapabilityItemHandler.ITEM_HANDLER_CAPABILITY);
     }
 
     @Override
@@ -75,33 +71,13 @@ public class ItemStorageBusPart extends AbstractStorageBusPart<IAEItemStack> {
 
     @Nullable
     @Override
-    protected IMEInventory<IAEItemStack> getHandlerAdapter(BlockEntity target, Direction targetSide,
-            Runnable alertDevice) {
-        var itemHandlerOpt = target
-                .getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, targetSide);
-        if (itemHandlerOpt.isPresent()) {
-            return new ItemHandlerAdapter(itemHandlerOpt.orElse(null)) {
-                @Override
-                protected void onInjectOrExtract() {
-                    alertDevice.run();
-                }
-            };
-        }
-
-        return null;
-    }
-
-    @Override
-    protected int getHandlerHash(BlockEntity target, Direction targetSide) {
-        var itemHandlerOpt = target
-                .getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, targetSide);
-
-        if (itemHandlerOpt.isPresent()) {
-            var itemHandler = itemHandlerOpt.orElse(null);
-            return Objects.hash(target, itemHandler, itemHandler.getSlots());
-        } else {
-            return 0;
-        }
+    protected IMEInventory<IAEItemStack> getHandlerAdapter(IItemHandler handler, Runnable alertDevice) {
+        return new ItemHandlerAdapter(handler) {
+            @Override
+            protected void onInjectOrExtract() {
+                alertDevice.run();
+            }
+        };
     }
 
     @Override


### PR DESCRIPTION
Removed the hash to avoid a small chance of collision.
We now use the `IMEMonitor` object instead of the `IStorageMonitorableAccessor` for comparison to make sure that changes to the exposed monitor properly trigger a cache update (e.g. when you change an interface next to a storage bus from "passthrough" to "inventory config" mode).