### PR TITLE
Use long for storage disks, and clamp storage adapter value

### DIFF
--- a/src/main/java/appeng/me/storage/AbstractCellInventory.java
+++ b/src/main/java/appeng/me/storage/AbstractCellInventory.java
@@ -47,7 +47,7 @@ public abstract class AbstractCellInventory<T extends IAEStack> implements ICell
     protected final ISaveProvider container;
     private int maxItemTypes;
     private short storedItems;
-    private int storedItemCount;
+    private long storedItemCount;
     protected IItemList<T> cellItems;
     private final ItemStack i;
     protected final IStorageCell<T> cellType;
@@ -77,7 +77,7 @@ public abstract class AbstractCellInventory<T extends IAEStack> implements ICell
         this.container = container;
         this.tagCompound = o.getOrCreateTag();
         this.storedItems = this.tagCompound.getShort(ITEM_TYPE_TAG);
-        this.storedItemCount = this.tagCompound.getInt(ITEM_COUNT_TAG);
+        this.storedItemCount = this.tagCompound.getLong(ITEM_COUNT_TAG);
         this.cellItems = null;
     }
 
@@ -96,7 +96,7 @@ public abstract class AbstractCellInventory<T extends IAEStack> implements ICell
             return;
         }
 
-        int itemCount = 0;
+        long itemCount = 0;
 
         // add new pretty stuff...
         int x = 0;
@@ -106,7 +106,7 @@ public abstract class AbstractCellInventory<T extends IAEStack> implements ICell
             final CompoundTag g = new CompoundTag();
             v.writeToNBT(g);
             this.tagCompound.put(ITEM_SLOT_KEYS[x], g);
-            this.tagCompound.putInt(ITEM_SLOT_COUNT_KEYS[x], (int) v.getStackSize());
+            this.tagCompound.putLong(ITEM_SLOT_COUNT_KEYS[x], v.getStackSize());
 
             x++;
         }
@@ -124,7 +124,7 @@ public abstract class AbstractCellInventory<T extends IAEStack> implements ICell
         if (itemCount == 0) {
             this.tagCompound.remove(ITEM_COUNT_TAG);
         } else {
-            this.tagCompound.putInt(ITEM_COUNT_TAG, itemCount);
+            this.tagCompound.putLong(ITEM_COUNT_TAG, itemCount);
         }
 
         // clean any old crusty stuff...
@@ -165,7 +165,7 @@ public abstract class AbstractCellInventory<T extends IAEStack> implements ICell
 
         for (int slot = 0; slot < types; slot++) {
             CompoundTag compoundTag = this.tagCompound.getCompound(ITEM_SLOT_KEYS[slot]);
-            int stackSize = this.tagCompound.getInt(ITEM_SLOT_COUNT_KEYS[slot]);
+            long stackSize = this.tagCompound.getLong(ITEM_SLOT_COUNT_KEYS[slot]);
             needsUpdate |= !this.loadCellItem(compoundTag, stackSize);
         }
 
@@ -179,7 +179,7 @@ public abstract class AbstractCellInventory<T extends IAEStack> implements ICell
      * 
      * @return true when successfully loaded
      */
-    protected abstract boolean loadCellItem(CompoundTag compoundTag, int stackSize);
+    protected abstract boolean loadCellItem(CompoundTag compoundTag, long stackSize);
 
     @Override
     public IItemList<T> getAvailableItems(final IItemList<T> out) {

--- a/src/main/java/appeng/me/storage/BasicCellInventory.java
+++ b/src/main/java/appeng/me/storage/BasicCellInventory.java
@@ -157,8 +157,8 @@ public class BasicCellInventory<T extends IAEStack> extends AbstractCellInventor
 
         if (this.canHoldNewItem()) // room for new type, and for at least one item!
         {
-            final int remainingItemCount = (int) this.getRemainingItemCount()
-                    - this.getBytesPerType() * this.itemsPerByte;
+            long remainingItemCount = this.getRemainingItemCount()
+                    - (long) this.getBytesPerType() * this.itemsPerByte;
             if (remainingItemCount > 0) {
                 if (input.getStackSize() > remainingItemCount) {
                     final T toReturn = IAEStack.copy(input);
@@ -223,7 +223,7 @@ public class BasicCellInventory<T extends IAEStack> extends AbstractCellInventor
     }
 
     @Override
-    protected boolean loadCellItem(CompoundTag compoundTag, int stackSize) {
+    protected boolean loadCellItem(CompoundTag compoundTag, long stackSize) {
         // Now load the item stack
         final T t;
         try {

--- a/src/main/java/appeng/me/storage/StorageAdapter.java
+++ b/src/main/java/appeng/me/storage/StorageAdapter.java
@@ -20,6 +20,10 @@ import appeng.util.Platform;
 
 public abstract class StorageAdapter<V extends TransferVariant<?>, T extends IAEStack>
         implements IMEInventory<T>, IBaseMonitor<T>, ITickingMonitor {
+    /**
+     * Clamp reported values to avoid overflows when amounts get too close to Long.MAX_VALUE.
+     */
+    private static final long MAX_REPORTED_AMOUNT = 1L << 42;
     private final Map<IMEMonitorHandlerReceiver<T>, Object> listeners = new HashMap<>();
     private IActionSource source;
     private final IVariantConversion<V, T> conversion;
@@ -177,7 +181,8 @@ public abstract class StorageAdapter<V extends TransferVariant<?>, T extends IAE
                         }
                     }
 
-                    frontBuffer.addStorage(conversion.createStack(view.getResource(), view.getAmount()));
+                    long amount = Math.min(view.getAmount(), MAX_REPORTED_AMOUNT);
+                    frontBuffer.addStorage(conversion.createStack(view.getResource(), amount));
                 }
             }
 


### PR DESCRIPTION
This fixes the overflow with 64k fluid storage disks not accepting anything on Fabric, and also clamps the value reported by the storage adapter. The threshold is pretty much arbitrary. If add-on authors make disks that are too big, we might have to clamp their reported size too, TBD.