### PR TITLE
Fix controller initialization

### DIFF
--- a/src/main/java/appeng/blockentity/networking/ControllerBlockEntity.java
+++ b/src/main/java/appeng/blockentity/networking/ControllerBlockEntity.java
@@ -67,8 +67,8 @@ public class ControllerBlockEntity extends AENetworkPowerBlockEntity {
 
     @Override
     public void onReady() {
-        this.onNeighborChange(true);
         super.onReady();
+        this.onNeighborChange(true);
     }
 
     @Override
@@ -90,8 +90,7 @@ public class ControllerBlockEntity extends AENetworkPowerBlockEntity {
 
         final boolean oldValid = this.isValid;
 
-        this.isValid = xx && !yy && !zz || !xx && yy && !zz || !xx && !yy && zz
-                || (xx ? 1 : 0) + (yy ? 1 : 0) + (zz ? 1 : 0) <= 1;
+        this.isValid = (xx ? 1 : 0) + (yy ? 1 : 0) + (zz ? 1 : 0) <= 1;
 
         if (oldValid != this.isValid || force) {
             if (this.isValid) {


### PR DESCRIPTION
Fix these issues:
![image](https://user-images.githubusercontent.com/13494793/136024553-a9f906ea-8b54-4243-9111-71afc97bda01.png)

To reproduce, place a controller block next to a powered controller black, and observe that it fails to turn on visually.
This is because the controller has to query the network controller status when it is placed.
Obviously, that needs to be done after the node is placed in the world, otherwise `this.getMainNode().isReady()` is `false` and `updateState()` immediately returns without doing anything.

Draft because I just found more issues...