### PR TITLE
Fix Item Transfer API Snapshots not being independent of the actual inventory

### DIFF
--- a/src/main/java/appeng/api/inventories/InternalInventoryStorage.java
+++ b/src/main/java/appeng/api/inventories/InternalInventoryStorage.java
@@ -98,7 +98,7 @@ class InternalInventoryStorage extends SnapshotParticipant<List<ItemStack>> impl
         // TODO FABRIC 117: DISGUSTING.
         List<ItemStack> snapshot = new ArrayList<>(inventory.size());
         for (int i = 0; i < inventory.size(); i++) {
-            snapshot.add(inventory.getStackInSlot(i));
+            snapshot.add(inventory.getStackInSlot(i).copy());
         }
         return snapshot;
     }


### PR DESCRIPTION
Fixes #5480

Snapshots are still disgustingly slow. This just fixes that snapshots made are not resilient against changes to the stacks themselves, even though that "shouldn't" happen (tm).

What this doesn't really solve is that item-identity for items is not preserved. This might be troublesome for Vanilla interactions in the UI, but those don't use transactions or snapshots anyway.