### PR TITLE
Fix custom block entity names

### DIFF
--- a/src/main/java/appeng/block/AEBaseEntityBlock.java
+++ b/src/main/java/appeng/block/AEBaseEntityBlock.java
@@ -28,7 +28,6 @@ import com.google.common.collect.Lists;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.network.chat.TextComponent;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.LivingEntity;
@@ -177,9 +176,8 @@ public abstract class AEBaseEntityBlock<T extends AEBaseBlockEntity> extends AEB
             return;
         }
 
-        var displayName = is.getDisplayName();
-        if (displayName instanceof TextComponent) {
-            blockEntity.setName(((TextComponent) displayName).getText());
+        if (is.hasCustomHoverName()) {
+            blockEntity.setName(is.getHoverName());
         }
 
         if (is.hasTag()) {

--- a/src/main/java/appeng/blockentity/AEBaseBlockEntity.java
+++ b/src/main/java/appeng/blockentity/AEBaseBlockEntity.java
@@ -78,7 +78,7 @@ public class AEBaseBlockEntity extends BlockEntity
     private static final Map<BlockEntityType<?>, Item> REPRESENTATIVE_ITEMS = new HashMap<>();
     private int renderFragment = 0;
     @Nullable
-    private String customName;
+    private Component customName;
     private Direction forward = Direction.NORTH;
     private Direction up = Direction.UP;
     private boolean setChangedQueued = false;
@@ -119,7 +119,7 @@ public class AEBaseBlockEntity extends BlockEntity
         super.load(data);
 
         if (data.contains("customName")) {
-            this.customName = data.getString("customName");
+            this.customName = Component.Serializer.fromJson(data.getString("customName"));
         } else {
             this.customName = null;
         }
@@ -143,7 +143,7 @@ public class AEBaseBlockEntity extends BlockEntity
         }
 
         if (this.customName != null) {
-            data.putString("customName", this.customName);
+            data.putString("customName", Component.Serializer.toJson(this.customName));
         }
 
         return data;
@@ -304,7 +304,7 @@ public class AEBaseBlockEntity extends BlockEntity
 
         if (this.hasCustomInventoryName()) {
             final CompoundTag dsp = new CompoundTag();
-            dsp.putString("Name", this.customName);
+            dsp.putString("Name", Component.Serializer.toJson(this.customName));
             output.put("display", dsp);
         }
 
@@ -384,13 +384,12 @@ public class AEBaseBlockEntity extends BlockEntity
 
     @Override
     public Component getCustomInventoryName() {
-        return new TextComponent(
-                this.hasCustomInventoryName() ? this.customName : this.getClass().getSimpleName());
+        return this.hasCustomInventoryName() ? this.customName : new TextComponent(this.getClass().getSimpleName());
     }
 
     @Override
     public boolean hasCustomInventoryName() {
-        return this.customName != null && !this.customName.isEmpty();
+        return this.customName != null;
     }
 
     public void securityBreak() {
@@ -435,7 +434,7 @@ public class AEBaseBlockEntity extends BlockEntity
         return null;
     }
 
-    public void setName(final String name) {
+    public void setName(Component name) {
         this.customName = name;
     }
 

--- a/src/main/java/appeng/blockentity/crafting/CraftingBlockEntity.java
+++ b/src/main/java/appeng/blockentity/crafting/CraftingBlockEntity.java
@@ -30,6 +30,7 @@ import com.google.common.collect.Iterators;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.BlockGetter;
@@ -87,7 +88,7 @@ public class CraftingBlockEntity extends AENetworkBlockEntity
     }
 
     @Override
-    public void setName(final String name) {
+    public void setName(Component name) {
         super.setName(name);
         if (this.cluster != null) {
             this.cluster.updateName();

--- a/src/main/java/appeng/helpers/iface/DualityPatternProvider.java
+++ b/src/main/java/appeng/helpers/iface/DualityPatternProvider.java
@@ -69,7 +69,6 @@ import appeng.api.storage.data.MixedStackList;
 import appeng.api.util.IConfigManager;
 import appeng.core.settings.TickRates;
 import appeng.crafting.execution.GenericStackHelper;
-import appeng.helpers.ICustomNameObject;
 import appeng.me.helpers.MachineSource;
 import appeng.util.ConfigManager;
 import appeng.util.inv.AppEngInternalInventory;
@@ -384,8 +383,8 @@ public class DualityPatternProvider implements InternalInventoryHost, ICraftingP
         final BlockEntity host = this.host.getBlockEntity();
         final Level hostWorld = host.getLevel();
 
-        if (((ICustomNameObject) this.host).hasCustomInventoryName()) {
-            return ((ICustomNameObject) this.host).getCustomInventoryName();
+        if (this.host.hasCustomInventoryName()) {
+            return this.host.getCustomInventoryName();
         }
 
         for (var direction : this.host.getTargets()) {

--- a/src/main/java/appeng/helpers/iface/IPatternProviderHost.java
+++ b/src/main/java/appeng/helpers/iface/IPatternProviderHost.java
@@ -28,10 +28,11 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 
 import appeng.api.util.IConfigManager;
 import appeng.api.util.IConfigurableObject;
+import appeng.helpers.ICustomNameObject;
 import appeng.helpers.IPriorityHost;
 import appeng.menu.implementations.PatternProviderMenu;
 
-public interface IPatternProviderHost extends IConfigurableObject, IPriorityHost {
+public interface IPatternProviderHost extends IConfigurableObject, IPriorityHost, ICustomNameObject {
     DualityPatternProvider getDuality();
 
     /**


### PR DESCRIPTION
Hmmm, now I realize that changing `getDisplayName` to `getHoverName` in `AEBaseEntityBlock` would have probably been enough, but this should be better in the long run anyway. (In mojmap, the display name is the chat display name, enclosed by `[]`, which is not a `TextComponent`).