### PR TITLE
Fix QNB

### DIFF
--- a/src/main/java/appeng/blockentity/qnb/QuantumBridgeBlockEntity.java
+++ b/src/main/java/appeng/blockentity/qnb/QuantumBridgeBlockEntity.java
@@ -130,6 +130,11 @@ public class QuantumBridgeBlockEntity extends AENetworkInvBlockEntity
     }
 
     @Override
+    public void onMainNodeGridChanged() {
+        this.updateStatus = true;
+    }
+
+    @Override
     public void onChunkUnloaded() {
         this.disconnect(false);
         super.onChunkUnloaded();

--- a/src/main/java/appeng/me/GridConnection.java
+++ b/src/main/java/appeng/me/GridConnection.java
@@ -133,7 +133,9 @@ public class GridConnection implements IGridConnection, IPathItem {
             final GridNode tmp = this.sideA;
             this.sideA = this.sideB;
             this.sideB = tmp;
-            this.fromAtoB = this.fromAtoB.getOpposite();
+            if (this.fromAtoB != null) {
+                this.fromAtoB = this.fromAtoB.getOpposite();
+            }
         }
     }
 

--- a/src/main/java/appeng/me/helpers/BlockEntityNodeListener.java
+++ b/src/main/java/appeng/me/helpers/BlockEntityNodeListener.java
@@ -42,4 +42,8 @@ public class BlockEntityNodeListener<T extends IGridConnectedBlockEntity> implem
         nodeOwner.onMainNodeStateChanged(state);
     }
 
+    @Override
+    public void onGridChanged(T nodeOwner, IGridNode node) {
+        nodeOwner.onMainNodeGridChanged();
+    }
 }

--- a/src/main/java/appeng/me/helpers/IGridConnectedBlockEntity.java
+++ b/src/main/java/appeng/me/helpers/IGridConnectedBlockEntity.java
@@ -77,4 +77,6 @@ public interface IGridConnectedBlockEntity extends IActionHost, IOwnerAwareBlock
         getMainNode().setOwningPlayer(owner);
     }
 
+    default void onMainNodeGridChanged() {
+    }
 }


### PR DESCRIPTION
Fix two issues introduced by the grid refactor:
- Stop NPEs when pathing through an internal node.
- Ensure the QNB correctly updates the link when the grid changes. Otherwise, there were some issues where the link would not properly be set.