### PR TITLE
Fix moving JEI Recipes to Crafting Terminal

### DIFF
--- a/src/main/java/appeng/core/sync/packets/JEIRecipePacket.java
+++ b/src/main/java/appeng/core/sync/packets/JEIRecipePacket.java
@@ -55,7 +55,6 @@ import appeng.core.sync.network.INetworkInfo;
 import appeng.helpers.IMenuCraftingPacket;
 import appeng.items.storage.ViewCellItem;
 import appeng.menu.me.items.PatternTermMenu;
-import appeng.parts.reporting.PatternTerminalPart;
 import appeng.util.Platform;
 import appeng.util.item.AEItemStack;
 import appeng.util.prioritylist.IPartitionList;
@@ -79,10 +78,8 @@ public class JEIRecipePacket extends BasePacket {
      */
     @Nullable
     private Recipe<?> recipe;
-    private boolean crafting;
 
     public JEIRecipePacket(final FriendlyByteBuf stream) {
-        this.crafting = stream.readBoolean();
         this.recipeId = new ResourceLocation(stream.readUtf());
 
         int inlineRecipeType = stream.readVarInt();
@@ -100,8 +97,8 @@ public class JEIRecipePacket extends BasePacket {
     /**
      * Sends a recipe identified by the given recipe ID to the server for either filling a crafting grid or a pattern.
      */
-    public JEIRecipePacket(final ResourceLocation recipeId, final boolean crafting) {
-        FriendlyByteBuf data = createCommonHeader(recipeId, crafting, INLINE_RECIPE_NONE);
+    public JEIRecipePacket(ResourceLocation recipeId) {
+        FriendlyByteBuf data = createCommonHeader(recipeId, INLINE_RECIPE_NONE);
         this.configureWrite(data);
     }
 
@@ -110,17 +107,16 @@ public class JEIRecipePacket extends BasePacket {
      * <p>
      * Prefer the id-based constructor above whereever possible.
      */
-    public JEIRecipePacket(final ShapedRecipe recipe, final boolean crafting) {
-        FriendlyByteBuf data = createCommonHeader(recipe.getId(), crafting, INLINE_RECIPE_SHAPED);
+    public JEIRecipePacket(ShapedRecipe recipe) {
+        FriendlyByteBuf data = createCommonHeader(recipe.getId(), INLINE_RECIPE_SHAPED);
         RecipeSerializer.SHAPED_RECIPE.toNetwork(data, recipe);
         this.configureWrite(data);
     }
 
-    private FriendlyByteBuf createCommonHeader(ResourceLocation recipeId, boolean crafting, int inlineRecipeType) {
+    private FriendlyByteBuf createCommonHeader(ResourceLocation recipeId, int inlineRecipeType) {
         final FriendlyByteBuf data = new FriendlyByteBuf(Unpooled.buffer());
 
         data.writeInt(this.getPacketID());
-        data.writeBoolean(crafting);
         data.writeResourceLocation(recipeId);
         data.writeVarInt(inlineRecipeType);
 
@@ -164,12 +160,11 @@ public class JEIRecipePacket extends BasePacket {
 
         var energy = grid.getService(IEnergyService.class);
         var crafting = grid.getService(ICraftingService.class);
-        var craftMatrix = cct.getSubInventory(PatternTerminalPart.INV_CRAFTING);
+        var craftMatrix = cct.getCraftingMatrix();
 
-        final IMEMonitor<IAEItemStack> storage = inv
-                .getInventory(StorageChannels.items());
-        final IPartitionList<IAEItemStack> filter = ViewCellItem.createFilter(cct.getViewCells());
-        final NonNullList<Ingredient> ingredients = this.ensure3by3CraftingMatrix(recipe);
+        var storage = inv.getInventory(StorageChannels.items());
+        var filter = ViewCellItem.createFilter(cct.getViewCells());
+        var ingredients = this.ensure3by3CraftingMatrix(recipe);
 
         // Handle each slot
         for (int x = 0; x < craftMatrix.size(); x++) {
@@ -243,9 +238,7 @@ public class JEIRecipePacket extends BasePacket {
             craftMatrix.setItemDirect(x, currentItem);
         }
 
-        if (!this.crafting) {
-            this.handleProcessing(con, cct, recipe);
-        }
+        handleProcessing(con, recipe);
 
         con.slotsChanged(craftMatrix.toContainer());
     }
@@ -341,13 +334,10 @@ public class JEIRecipePacket extends BasePacket {
                 .orElse(null);
     }
 
-    private void handleProcessing(AbstractContainerMenu con, IMenuCraftingPacket cct, Recipe<?> recipe) {
+    private void handleProcessing(AbstractContainerMenu con, Recipe<?> recipe) {
         if (con instanceof PatternTermMenu patternTerm) {
             if (!patternTerm.craftingMode) {
-                var output = cct.getSubInventory(PatternTerminalPart.INV_OUTPUT);
-                output.setItemDirect(0, recipe.getResultItem());
-                output.setItemDirect(1, ItemStack.EMPTY);
-                output.setItemDirect(2, ItemStack.EMPTY);
+                patternTerm.setProcessingResult(recipe.getResultItem());
             }
         }
     }

--- a/src/main/java/appeng/helpers/IMenuCraftingPacket.java
+++ b/src/main/java/appeng/helpers/IMenuCraftingPacket.java
@@ -20,7 +20,6 @@ package appeng.helpers;
 
 import java.util.List;
 
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 
 import appeng.api.inventories.InternalInventory;
@@ -34,10 +33,9 @@ public interface IMenuCraftingPacket {
     IGridNode getNetworkNode();
 
     /**
-     * @param string name of inventory
-     * @return the inventory of the part/block entity by name.
+     * @return the inventory used for the crafting matrix.
      */
-    InternalInventory getSubInventory(ResourceLocation id);
+    InternalInventory getCraftingMatrix();
 
     /**
      * @return who are we?

--- a/src/main/java/appeng/integration/modules/jei/CraftingRecipeTransferHandler.java
+++ b/src/main/java/appeng/integration/modules/jei/CraftingRecipeTransferHandler.java
@@ -33,9 +33,4 @@ public class CraftingRecipeTransferHandler extends RecipeTransferHandler<Craftin
         return null;
     }
 
-    @Override
-    protected boolean isCrafting() {
-        return true;
-    }
-
 }

--- a/src/main/java/appeng/integration/modules/jei/PatternRecipeTransferHandler.java
+++ b/src/main/java/appeng/integration/modules/jei/PatternRecipeTransferHandler.java
@@ -44,9 +44,4 @@ public class PatternRecipeTransferHandler extends RecipeTransferHandler<PatternT
         return null;
     }
 
-    @Override
-    protected boolean isCrafting() {
-        return false;
-    }
-
 }

--- a/src/main/java/appeng/integration/modules/jei/RecipeTransferHandler.java
+++ b/src/main/java/appeng/integration/modules/jei/RecipeTransferHandler.java
@@ -80,7 +80,7 @@ abstract class RecipeTransferHandler<T extends AbstractContainerMenu & IMenuCraf
 
         if (context.isActuallyCrafting()) {
             if (canSendReference) {
-                NetworkHandler.instance().sendToServer(new JEIRecipePacket(recipeId, isCrafting()));
+                NetworkHandler.instance().sendToServer(new JEIRecipePacket(recipeId));
             } else {
                 // To avoid earlier problems of too large packets being sent that crashed the
                 // client,
@@ -114,7 +114,7 @@ abstract class RecipeTransferHandler<T extends AbstractContainerMenu & IMenuCraf
                 }
 
                 ShapedRecipe fallbackRecipe = new ShapedRecipe(recipeId, "", 3, 3, flatIngredients, output);
-                NetworkHandler.instance().sendToServer(new JEIRecipePacket(fallbackRecipe, isCrafting()));
+                NetworkHandler.instance().sendToServer(new JEIRecipePacket(fallbackRecipe));
             }
         }
 
@@ -123,6 +123,4 @@ abstract class RecipeTransferHandler<T extends AbstractContainerMenu & IMenuCraf
 
     protected abstract Result doTransferRecipe(T container, Display recipe,
             TransferHandler.Context context);
-
-    protected abstract boolean isCrafting();
 }

--- a/src/main/java/appeng/menu/me/items/CraftingTermMenu.java
+++ b/src/main/java/appeng/menu/me/items/CraftingTermMenu.java
@@ -20,7 +20,6 @@ package appeng.menu.me.items;
 
 import com.google.common.base.Preconditions;
 
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.Container;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.inventory.CraftingContainer;
@@ -110,8 +109,8 @@ public class CraftingTermMenu extends ItemTerminalMenu implements IMenuCraftingP
     }
 
     @Override
-    public InternalInventory getSubInventory(ResourceLocation id) {
-        return this.craftingInventoryHost.getSubInventory(id);
+    public InternalInventory getCraftingMatrix() {
+        return this.craftingInventoryHost.getSubInventory(CraftingTerminalPart.INV_CRAFTING);
     }
 
     @Override

--- a/src/main/java/appeng/menu/me/items/PatternTermMenu.java
+++ b/src/main/java/appeng/menu/me/items/PatternTermMenu.java
@@ -18,14 +18,9 @@
 
 package appeng.menu.me.items;
 
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.inventory.CraftingContainer;
-import net.minecraft.world.inventory.MenuType;
-import net.minecraft.world.inventory.ResultContainer;
-import net.minecraft.world.inventory.ResultSlot;
-import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.inventory.*;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.CraftingRecipe;
 import net.minecraft.world.item.crafting.Recipe;
@@ -56,12 +51,7 @@ import appeng.menu.NullMenu;
 import appeng.menu.SlotSemantic;
 import appeng.menu.guisync.GuiSync;
 import appeng.menu.implementations.MenuTypeBuilder;
-import appeng.menu.slot.FakeCraftingMatrixSlot;
-import appeng.menu.slot.IOptionalSlotHost;
-import appeng.menu.slot.OptionalFakeSlot;
-import appeng.menu.slot.PatternOutputsSlot;
-import appeng.menu.slot.PatternTermSlot;
-import appeng.menu.slot.RestrictedInputSlot;
+import appeng.menu.slot.*;
 import appeng.parts.reporting.PatternTerminalPart;
 import appeng.util.Platform;
 import appeng.util.inv.CarriedItemInventory;
@@ -436,8 +426,8 @@ public class PatternTermMenu extends ItemTerminalMenu implements IOptionalSlotHo
     }
 
     @Override
-    public InternalInventory getSubInventory(ResourceLocation id) {
-        return this.getPatternTerminal().getSubInventory(id);
+    public InternalInventory getCraftingMatrix() {
+        return this.getPatternTerminal().getSubInventory(PatternTerminalPart.INV_CRAFTING);
     }
 
     @Override
@@ -521,4 +511,13 @@ public class PatternTermMenu extends ItemTerminalMenu implements IOptionalSlotHo
         return FluidContainerHelper.getContainedFluid(slot.getItem()) != null;
     }
 
+    public void setProcessingResult(ItemStack resultItem) {
+        for (int i = 0; i < processingOutputSlots.length; i++) {
+            if (i == 0) {
+                processingOutputSlots[i].set(resultItem);
+            } else {
+                processingOutputSlots[i].set(ItemStack.EMPTY);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Fixes #5518: Consider crafting terminals when obtaining inventory for moving recipe from JEI to crafting grid.