### PR TITLE
Stop Upgrade Cards from "dropping" when taking them out

### DIFF
--- a/src/main/java/appeng/client/gui/AEBaseScreen.java
+++ b/src/main/java/appeng/client/gui/AEBaseScreen.java
@@ -566,6 +566,17 @@ public abstract class AEBaseScreen<T extends AEBaseMenu> extends AbstractContain
     }
 
     @Override
+    protected boolean hasClickedOutside(double mouseX, double mouseY, int screenX, int screenY, int button) {
+        // Consider clicks within attached compound widgets as still inside the screen
+        var mousePos = new Point((int) Math.round(mouseX - screenX), (int) Math.round(mouseY - screenY));
+        if (widgets.hitTest(mousePos)) {
+            return false;
+        }
+
+        return super.hasClickedOutside(mouseX, mouseY, screenX, screenY, button);
+    }
+
+    @Override
     protected boolean checkHotbarKeyPressed(int keyCode, int scanCode) {
         return checkHotbarKeys(InputConstants.getKey(keyCode, scanCode));
     }

--- a/src/main/java/appeng/client/gui/WidgetContainer.java
+++ b/src/main/java/appeng/client/gui/WidgetContainer.java
@@ -307,6 +307,18 @@ public class WidgetContainer {
         return null;
     }
 
+    /**
+     * Check if there's any content or compound widget at the given screen-relative mouse position.
+     */
+    public boolean hitTest(Point mousePos) {
+        for (var widget : compositeWidgets.values()) {
+            if (mousePos.isIn(widget.getBounds())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     // NOTE: Vanilla's implementation of Rect2i is broken since it uses less-than-equal to compare against x+width,
     // rather than less-than.
     private static boolean contains(Rect2i area, int mouseX, int mouseY) {


### PR DESCRIPTION
Fixes #5517: Clicks on attached widgets are not considered "in bounds" and cause the click-type to be set to throw.