### PR TITLE
Fix Network Tool Dupe Bug

### DIFF
--- a/src/main/java/appeng/util/inv/AppEngInternalInventory.java
+++ b/src/main/java/appeng/util/inv/AppEngInternalInventory.java
@@ -163,6 +163,7 @@ public class AppEngInternalInventory extends BaseInternalInventory {
 
     public void writeToNBT(CompoundTag data, String name) {
         if (isEmpty()) {
+            data.remove(name);
             return;
         }
 


### PR DESCRIPTION
Fixes #5521: Correctly save empty inventories, instead of completely skipping saving (which leads to dupes if the last item was removed).