### PR TITLE
Fix Iron and Gold Nuggets as Matter Cannon Ammo

### DIFF
--- a/src/main/java/appeng/datagen/providers/recipes/MatterCannonAmmoProvider.java
+++ b/src/main/java/appeng/datagen/providers/recipes/MatterCannonAmmoProvider.java
@@ -30,6 +30,7 @@ import net.minecraft.world.level.ItemLike;
 
 import appeng.core.AppEng;
 import appeng.core.definitions.AEItems;
+import appeng.datagen.providers.tags.ConventionTags;
 
 public class MatterCannonAmmoProvider extends AE2RecipeProvider {
     public MatterCannonAmmoProvider(DataGenerator generator) {
@@ -65,8 +66,8 @@ public class MatterCannonAmmoProvider extends AE2RecipeProvider {
         registerAmmoTag(consumer, "nuggets/titanium", new ResourceLocation("c:titanium_nuggets"), 47.867f);
         registerAmmoTag(consumer, "nuggets/vanadium", new ResourceLocation("c:vanadium_nuggets"), 50.9415f);
         registerAmmoTag(consumer, "nuggets/manganese", new ResourceLocation("c:manganese_nuggets"), 54.938f);
-        registerAmmoTag(consumer, "nuggets/iron", new ResourceLocation("c:iron_nuggets"), 55.845f);
-        registerAmmoTag(consumer, "nuggets/gold", new ResourceLocation("c:gold_nuggets"), 196.96655f);
+        registerAmmoTag(consumer, "nuggets/iron", ConventionTags.IRON_NUGGET.getName(), 55.845f);
+        registerAmmoTag(consumer, "nuggets/gold", ConventionTags.GOLD_NUGGET.getName(), 196.96655f);
         registerAmmoTag(consumer, "nuggets/nickel", new ResourceLocation("c:nickel_nuggets"), 58.6934f);
         registerAmmoTag(consumer, "nuggets/cobalt", new ResourceLocation("c:cobalt_nuggets"), 58.9332f);
         registerAmmoTag(consumer, "nuggets/copper", new ResourceLocation("c:copper_nuggets"), 63.546f);

--- a/src/main/java/appeng/datagen/providers/tags/ConventionTags.java
+++ b/src/main/java/appeng/datagen/providers/tags/ConventionTags.java
@@ -68,9 +68,11 @@ public final class ConventionTags {
     public static Tag.Named<Item> FLUIX_DUST = tag("c:fluix_dusts");
     public static Tag.Named<Item> FLUIX_CRYSTAL = tag("c:fluix");
 
+    public static Tag.Named<Item> GOLD_NUGGET = tag("c:gold_nuggets");
     public static Tag.Named<Item> GOLD_INGOT = tag("c:gold_ingots");
     public static Tag.Named<Item> GOLD_ORE = tag("c:gold_ores");
 
+    public static Tag.Named<Item> IRON_NUGGET = tag("c:iron_nuggets");
     public static Tag.Named<Item> IRON_INGOT = tag("c:iron_ingots");
     public static Tag.Named<Item> IRON_ORE = tag("c:iron_ores");
 

--- a/src/main/java/appeng/datagen/providers/tags/ItemTagsProvider.java
+++ b/src/main/java/appeng/datagen/providers/tags/ItemTagsProvider.java
@@ -139,11 +139,17 @@ public class ItemTagsProvider extends net.minecraft.data.tags.ItemTagsProvider i
         tag(ConventionTags.NETHER_QUARTZ_ORE)
                 .add(Items.NETHER_QUARTZ_ORE);
 
+        tag(ConventionTags.GOLD_NUGGET)
+                .add(Items.GOLD_NUGGET);
+
         tag(ConventionTags.GOLD_INGOT)
                 .add(Items.GOLD_INGOT);
 
         tag(ConventionTags.GOLD_ORE)
                 .addOptionalTag(ItemTags.GOLD_ORES.getName());
+
+        tag(ConventionTags.IRON_NUGGET)
+                .add(Items.IRON_NUGGET);
 
         tag(ConventionTags.IRON_INGOT)
                 .add(Items.IRON_INGOT);


### PR DESCRIPTION
Fixes #5524: Provide convention tags for iron and gold nuggets to make both valid matter cannon ammo even when no other mod adds these convention tags.