### PR TITLE
Fix Matter Cannon on Ender Dragon causing an Infinite Loop

### DIFF
--- a/src/main/java/appeng/items/tools/powered/MatterCannonItem.java
+++ b/src/main/java/appeng/items/tools/powered/MatterCannonItem.java
@@ -349,7 +349,7 @@ public class MatterCannonItem extends AEBasePoweredItem implements IStorageCell<
                         hasDestroyed = true;
                         entityHit.discard();
                     } else if (entityHit.hurt(dmgSrc, dmg)) {
-                        hasDestroyed = true;
+                        hasDestroyed = !entityHit.isAlive();
                     }
                 } else if (pos instanceof BlockHitResult blockResult) {
 


### PR DESCRIPTION
Fixes #5349: Attacking non-living, killable entities (-> Ender Dragon) with the Matter Cannon causes an infinite loop.