### PR TITLE
Fix Screen Bounds for Security Station Encoding Panel

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ loader_version=0.11.6
 # Provided APIs                                         #
 #########################################################
 fabric_version=0.40.1+1.17
-rei_version=6.0.279-alpha
+rei_version=6.0.296-alpha
 wthit_version=3.8.1
 tr_energy_version=2.0.0-beta1
 

--- a/src/main/java/appeng/client/gui/WidgetContainer.java
+++ b/src/main/java/appeng/client/gui/WidgetContainer.java
@@ -40,6 +40,7 @@ import net.minecraft.network.chat.Component;
 import appeng.client.Point;
 import appeng.client.gui.style.ScreenStyle;
 import appeng.client.gui.style.WidgetStyle;
+import appeng.client.gui.widgets.BackgroundPanel;
 import appeng.client.gui.widgets.Scrollbar;
 import appeng.client.gui.widgets.TabButton;
 import appeng.core.localization.GuiText;
@@ -126,6 +127,17 @@ public class WidgetContainer {
         Scrollbar scrollbar = new Scrollbar();
         add(id, scrollbar);
         return scrollbar;
+    }
+
+    /**
+     * Adds a panel to the screen, which takes its background from the style's "images" section, and it's position from
+     * the widget section.
+     * 
+     * @param id The id used to look up the background image and bounds in the style.
+     */
+    public void addBackgroundPanel(String id) {
+        var background = style.getImage(id).copy();
+        add(id, new BackgroundPanel(background));
     }
 
     void populateScreen(Consumer<AbstractWidget> addWidget, Rect2i bounds, AEBaseScreen<?> screen) {

--- a/src/main/java/appeng/client/gui/implementations/SecurityStationScreen.java
+++ b/src/main/java/appeng/client/gui/implementations/SecurityStationScreen.java
@@ -18,11 +18,6 @@
 
 package appeng.client.gui.implementations;
 
-import java.util.List;
-
-import com.mojang.blaze3d.vertex.PoseStack;
-
-import net.minecraft.client.renderer.Rect2i;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Inventory;
 
@@ -30,7 +25,6 @@ import appeng.api.config.SecurityPermissions;
 import appeng.api.config.SortOrder;
 import appeng.client.gui.Icon;
 import appeng.client.gui.me.items.ItemTerminalScreen;
-import appeng.client.gui.style.Blitter;
 import appeng.client.gui.style.ScreenStyle;
 import appeng.client.gui.widgets.ToggleButton;
 import appeng.menu.implementations.SecurityStationMenu;
@@ -43,13 +37,11 @@ public class SecurityStationScreen extends ItemTerminalScreen<SecurityStationMen
     private final ToggleButton build;
     private final ToggleButton security;
 
-    private final Blitter encodingBg;
-
     public SecurityStationScreen(SecurityStationMenu menu,
             Inventory playerInventory, Component title, ScreenStyle style) {
         super(menu, playerInventory, title, style);
 
-        encodingBg = style.getImage("encoding");
+        widgets.addBackgroundPanel("encodingPanel");
 
         this.inject = new ToggleButton(Icon.PERMISSION_INJECT, Icon.PERMISSION_INJECT_DISABLED,
                 SecurityPermissions.INJECT.getDisplayName(), SecurityPermissions.INJECT.getDisplayHint(),
@@ -86,26 +78,7 @@ public class SecurityStationScreen extends ItemTerminalScreen<SecurityStationMen
     }
 
     @Override
-    public void drawBG(PoseStack poseStack, int offsetX, int offsetY, int mouseX, int mouseY, float partialTicks) {
-        super.drawBG(poseStack, offsetX, offsetY, mouseX, mouseY, partialTicks);
-
-        // Draw the encoding-box on the right
-        encodingBg.dest(offsetX + imageWidth + 3, offsetY).blit(poseStack, getBlitOffset());
-    }
-
-    @Override
     public SortOrder getSortBy() {
         return SortOrder.NAME;
-    }
-
-    @Override
-    public List<Rect2i> getExclusionZones() {
-        List<Rect2i> result = super.getExclusionZones();
-        result.add(new Rect2i(
-                leftPos + imageWidth + 3,
-                topPos,
-                encodingBg.getSrcWidth(),
-                encodingBg.getSrcHeight()));
-        return result;
     }
 }

--- a/src/main/java/appeng/client/gui/widgets/BackgroundPanel.java
+++ b/src/main/java/appeng/client/gui/widgets/BackgroundPanel.java
@@ -1,0 +1,45 @@
+package appeng.client.gui.widgets;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+
+import net.minecraft.client.renderer.Rect2i;
+
+import appeng.client.Point;
+import appeng.client.gui.ICompositeWidget;
+import appeng.client.gui.style.Blitter;
+
+/**
+ * Renders a simple panel with a background an no interactivity.
+ */
+public class BackgroundPanel implements ICompositeWidget {
+    private final Blitter background;
+
+    // Relative to current screen origin (not window)
+    private int x;
+    private int y;
+
+    public BackgroundPanel(Blitter background) {
+        this.background = background;
+    }
+
+    @Override
+    public void setPosition(Point position) {
+        x = position.getX();
+        y = position.getY();
+    }
+
+    @Override
+    public void setSize(int width, int height) {
+        // Size of panels is implied by the background
+    }
+
+    @Override
+    public Rect2i getBounds() {
+        return new Rect2i(x, y, background.getSrcWidth(), background.getSrcHeight());
+    }
+
+    @Override
+    public void drawBackgroundLayer(PoseStack poseStack, int zIndex, Rect2i bounds, Point mouse) {
+        background.dest(bounds.getX() + x, bounds.getY() + y).blit(poseStack, zIndex);
+    }
+}

--- a/src/main/resources/assets/appliedenergistics2/screens/terminals/security_station.json
+++ b/src/main/resources/assets/appliedenergistics2/screens/terminals/security_station.json
@@ -59,7 +59,7 @@
     }
   },
   "images": {
-    "encoding": {
+    "encodingPanel": {
       "texture": "guis/security_station.png",
       "srcRect": [198, 0, 44, 98]
     }
@@ -84,6 +84,10 @@
     "permissionSecurity": {
       "left": 128,
       "bottom": 116
+    },
+    "encodingPanel": {
+      "right": -3,
+      "top": 0
     }
   }
 }


### PR DESCRIPTION
Fixes #5533: Security Station Encoding Panel wasn't considered to be inside the screen when clicked.