### PR TITLE
Fix Quantum Network Bridge Duping when Breaking Multiblock

### DIFF
--- a/src/main/java/appeng/block/qnb/QuantumBaseBlock.java
+++ b/src/main/java/appeng/block/qnb/QuantumBaseBlock.java
@@ -83,7 +83,7 @@ public abstract class QuantumBaseBlock extends AEBaseEntityBlock<QuantumBridgeBl
 
         final QuantumBridgeBlockEntity bridge = this.getBlockEntity(level, pos);
         if (bridge != null) {
-            bridge.breakCluster();
+            bridge.breakClusterOnRemove();
         }
 
         super.onRemove(state, level, pos, newState, isMoving);

--- a/src/main/java/appeng/blockentity/qnb/QuantumBridgeBlockEntity.java
+++ b/src/main/java/appeng/blockentity/qnb/QuantumBridgeBlockEntity.java
@@ -258,8 +258,11 @@ public class QuantumBridgeBlockEntity extends AENetworkInvBlockEntity
         return (this.constructed & this.hasSingularity) == this.hasSingularity;
     }
 
-    public void breakCluster() {
+    public void breakClusterOnRemove() {
         if (this.cluster != null) {
+            // Prevents cluster.destroy() from changing the block state back to an unformed QNB,
+            // because that would undo the removal.
+            this.remove = true;
             this.cluster.destroy();
         }
     }

--- a/src/main/java/appeng/me/cluster/implementations/QuantumCluster.java
+++ b/src/main/java/appeng/me/cluster/implementations/QuantumCluster.java
@@ -235,7 +235,7 @@ public class QuantumCluster implements IAECluster, IActionHost {
 
             this.center.updateStatus(null, (byte) -1, this.isUpdateStatus());
 
-            for (final QuantumBridgeBlockEntity r : this.getRing()) {
+            for (var r : this.getRing()) {
                 r.updateStatus(null, (byte) -1, this.isUpdateStatus());
             }
 


### PR DESCRIPTION
Fixes #5566: When breaking a QNB block, the block-state would be reset back to an unformed QNB when breaking up the cluster, which would undo the block removal, resulting in a dupe.