### PR TITLE
Fix #5534: Never return null from toClientTag

### DIFF
--- a/src/main/java/appeng/blockentity/AEBaseBlockEntity.java
+++ b/src/main/java/appeng/blockentity/AEBaseBlockEntity.java
@@ -201,7 +201,10 @@ public class AEBaseBlockEntity extends BlockEntity
      */
     @Override
     public CompoundTag toClientTag(CompoundTag tag) {
-        return this.writeUpdateData(tag);
+        this.writeUpdateData(tag);
+        // Fabric: return `tag` instead of the result of writeUpdateData, as we must always return the data that is
+        // passed to us even if no additional data is added by us (in which case writeUpdateData returns null).
+        return tag;
     }
 
     /**


### PR DESCRIPTION
If null is returned, vanilla NPEs when it tries to read `x`, `y` and `z` from the tag, which causes it to miss the data of subsequent block entities. Not sure this is the cleanest fix, I'm not sure why `writeUpdateData` is allowed to return `null` in the first place - maybe it makes sense on Forge?