### PR TITLE
Fix #5300: IO Port copies isCraftable to target cell

### DIFF
--- a/src/main/java/appeng/api/storage/data/IAEStack.java
+++ b/src/main/java/appeng/api/storage/data/IAEStack.java
@@ -60,10 +60,11 @@ public interface IAEStack {
     }
 
     /**
-     * Copies a stack and sets the stack size of the copy.
+     * Copies a stack and sets the stack size of the copy. Also clears craftable and requestable.
      */
     static <T extends IAEStack> T copy(@Nonnull T stack, long newStackSize) {
         var result = IAEStack.copy(stack);
+        result.reset();
         result.setStackSize(newStackSize);
         return result;
     }

--- a/src/main/java/appeng/crafting/execution/CraftingCpuHelper.java
+++ b/src/main/java/appeng/crafting/execution/CraftingCpuHelper.java
@@ -177,8 +177,6 @@ public class CraftingCpuHelper {
             for (var fuzz : inv.findFuzzyTemplates(stack)) {
                 // Set the correct amount, it has to match that of the template!
                 var fuzzCopy = IAEStack.copy(fuzz, stack.getStackSize());
-                // Craftable flag is true in the ICraftingInventory to avoid cleanup, but we don't want to leak it.
-                fuzzCopy.setCraftable(false);
                 substitutes.add(fuzzCopy);
             }
         }


### PR DESCRIPTION
I changed `IAEStack.copy` with an explicit size to clear the craftable flag. This should be better behavior in the long run, and I don't think it introduces bugs because that function was only introduced and used by me in the fluid autocrafting PR.
Also cleaned up the IO port to remove some rawtypes.