### PR TITLE
Fix crafting jobs not resuming after world or chunk unload/reload

### DIFF
--- a/src/main/java/appeng/api/crafting/IPatternDetails.java
+++ b/src/main/java/appeng/api/crafting/IPatternDetails.java
@@ -32,6 +32,9 @@ import appeng.api.storage.data.IAEStack;
 
 /**
  * Information about a pattern for use by the autocrafting system.
+ * <p/>
+ * <strong>Implementing classes need to properly implement equals/hashCode for crafting jobs to resume properly after
+ * world or chunk reloads.</strong>
  */
 public interface IPatternDetails {
     /**

--- a/src/main/java/appeng/crafting/pattern/AECraftingPattern.java
+++ b/src/main/java/appeng/crafting/pattern/AECraftingPattern.java
@@ -48,7 +48,7 @@ import appeng.util.item.AEItemStack;
 public class AECraftingPattern implements IAEPatternDetails {
     private static final int CRAFTING_GRID_DIMENSION = 3;
 
-    private final CompoundTag definition;
+    private final IAEItemStack definition;
     public final boolean canSubstitute;
     private final CraftingRecipe recipe;
     private final CraftingContainer testFrame;
@@ -63,7 +63,11 @@ public class AECraftingPattern implements IAEPatternDetails {
     private final Map<Item, Boolean>[] isValidCache = new Map[9];
 
     public AECraftingPattern(CompoundTag definition, Level level) {
-        this.definition = definition;
+        // We use an IAEItemStack as the definition here to achieve interning so that equals/hashCode is fast
+        var definitionStack = AEItems.CRAFTING_PATTERN.stack();
+        definitionStack.setTag(definition);
+        this.definition = IAEItemStack.of(definitionStack);
+
         this.canSubstitute = AEPatternHelper.canSubstitute(definition);
         this.sparseInputs = AEPatternHelper.getCraftingInputs(definition);
 
@@ -105,10 +109,18 @@ public class AECraftingPattern implements IAEPatternDetails {
     }
 
     @Override
+    public int hashCode() {
+        return definition.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj != null && obj.getClass() == getClass() && ((AECraftingPattern) obj).definition.equals(definition);
+    }
+
+    @Override
     public ItemStack copyDefinition() {
-        var result = new ItemStack(AEItems.CRAFTING_PATTERN);
-        result.setTag(definition.copy());
-        return result;
+        return definition.createItemStack();
     }
 
     @Override


### PR DESCRIPTION
Implement equals/hashCode for AECraftingPattern and AEProcessingPattern based on IAEItemStack interning. Also fixes loading issues for ongoing crafting in molecular assemblers.

This should allow ongoing crafting jobs to properly resume when the world or chunk reloads.