### PR TITLE
Fix molecular assembler crafting animation/particles not being visible

### DIFF
--- a/src/main/java/appeng/client/render/crafting/MolecularAssemblerRenderer.java
+++ b/src/main/java/appeng/client/render/crafting/MolecularAssemblerRenderer.java
@@ -89,9 +89,11 @@ public class MolecularAssemblerRenderer implements BlockEntityRenderer<Molecular
             return;
         }
 
-        VertexConsumer buffer = bufferIn.getBuffer(RenderType.translucent());
+        // tripwire layer has the shader-property we're looking for:
+        // alpha testing
+        // translucency
+        VertexConsumer buffer = bufferIn.getBuffer(RenderType.tripwire());
 
-        // TODO 1.17: Verify that the custom render type is no longer needed. The shader used for the translucent layer
         // certainly doesn't use alpha testing, making it look like it will not work.
         minecraft.getBlockRenderer().getModelRenderer().renderModel(ms.last(), buffer, null,
                 lightsModel, 1, 1, 1, combinedLightIn, combinedOverlayIn);


### PR DESCRIPTION
Fixes #5607:  Use different render layer for molecular assembler power-lights to make the crafting particles visible again.