### PR TITLE
Reporting parts (level emitters, storage monitor) no longer require channels

### DIFF
--- a/src/main/java/appeng/api/networking/IManagedGridNode.java
+++ b/src/main/java/appeng/api/networking/IManagedGridNode.java
@@ -121,7 +121,7 @@ public interface IManagedGridNode {
         return node.getGrid();
     }
 
-    IManagedGridNode setFlags(GridFlags... requireChannel);
+    IManagedGridNode setFlags(GridFlags... flags);
 
     /**
      * Changes the sides of the node's host this node is exposed on.

--- a/src/main/java/appeng/me/ManagedGridNode.java
+++ b/src/main/java/appeng/me/ManagedGridNode.java
@@ -236,10 +236,10 @@ public class ManagedGridNode implements IManagedGridNode {
     }
 
     @Override
-    public ManagedGridNode setFlags(final GridFlags... requireChannel) {
-        var flags = EnumSet.noneOf(GridFlags.class);
-        Collections.addAll(flags, requireChannel);
-        getInitData().flags = flags;
+    public ManagedGridNode setFlags(GridFlags... flags) {
+        var flagSet = EnumSet.noneOf(GridFlags.class);
+        Collections.addAll(flagSet, flags);
+        getInitData().flags = flagSet;
         return this;
     }
 

--- a/src/main/java/appeng/parts/automation/AbstractLevelEmitterPart.java
+++ b/src/main/java/appeng/parts/automation/AbstractLevelEmitterPart.java
@@ -48,6 +48,9 @@ public abstract class AbstractLevelEmitterPart extends UpgradeablePart {
     public AbstractLevelEmitterPart(ItemStack is) {
         super(is);
 
+        // Level emitters do not require a channel to function
+        getMainNode().setFlags();
+
         this.getConfigManager().registerSetting(Settings.REDSTONE_EMITTER, RedstoneMode.HIGH_SIGNAL);
     }
 

--- a/src/main/java/appeng/parts/reporting/AbstractDisplayPart.java
+++ b/src/main/java/appeng/parts/reporting/AbstractDisplayPart.java
@@ -52,8 +52,8 @@ public abstract class AbstractDisplayPart extends AbstractReportingPart {
     protected static final ResourceLocation MODEL_STATUS_HAS_CHANNEL = new ResourceLocation(AppEng.MOD_ID,
             "part/display_status_has_channel");
 
-    public AbstractDisplayPart(final ItemStack is) {
-        super(is, true);
+    public AbstractDisplayPart(ItemStack is, boolean requireChannel) {
+        super(is, requireChannel);
     }
 
     @Override

--- a/src/main/java/appeng/parts/reporting/AbstractMonitorPart.java
+++ b/src/main/java/appeng/parts/reporting/AbstractMonitorPart.java
@@ -72,8 +72,8 @@ public abstract class AbstractMonitorPart extends AbstractDisplayPart
     private boolean isLocked;
     private IStackWatcher myWatcher;
 
-    public AbstractMonitorPart(final ItemStack is) {
-        super(is);
+    public AbstractMonitorPart(ItemStack is, boolean requireChannel) {
+        super(is, requireChannel);
 
         getMainNode().addService(IStackWatcherNode.class, this);
     }

--- a/src/main/java/appeng/parts/reporting/AbstractTerminalPart.java
+++ b/src/main/java/appeng/parts/reporting/AbstractTerminalPart.java
@@ -63,7 +63,7 @@ public abstract class AbstractTerminalPart extends AbstractDisplayPart
     private final AppEngInternalInventory viewCell = new AppEngInternalInventory(this, 5);
 
     public AbstractTerminalPart(final ItemStack is) {
-        super(is);
+        super(is, true);
 
         this.cm.registerSetting(Settings.SORT_BY, SortOrder.NAME);
         this.cm.registerSetting(Settings.VIEW_MODE, ViewItems.ALL);

--- a/src/main/java/appeng/parts/reporting/ConversionMonitorPart.java
+++ b/src/main/java/appeng/parts/reporting/ConversionMonitorPart.java
@@ -63,7 +63,7 @@ public class ConversionMonitorPart extends AbstractMonitorPart {
             MODEL_STATUS_HAS_CHANNEL);
 
     public ConversionMonitorPart(final ItemStack is) {
-        super(is);
+        super(is, true);
     }
 
     @Override

--- a/src/main/java/appeng/parts/reporting/InterfaceTerminalPart.java
+++ b/src/main/java/appeng/parts/reporting/InterfaceTerminalPart.java
@@ -44,7 +44,7 @@ public class InterfaceTerminalPart extends AbstractDisplayPart {
     public static final IPartModel MODELS_HAS_CHANNEL = new PartModel(MODEL_BASE, MODEL_ON, MODEL_STATUS_HAS_CHANNEL);
 
     public InterfaceTerminalPart(final ItemStack is) {
-        super(is);
+        super(is, true);
     }
 
     @Override

--- a/src/main/java/appeng/parts/reporting/StorageMonitorPart.java
+++ b/src/main/java/appeng/parts/reporting/StorageMonitorPart.java
@@ -55,8 +55,8 @@ public class StorageMonitorPart extends AbstractMonitorPart {
     public static final IPartModel MODELS_LOCKED_HAS_CHANNEL = new PartModel(MODEL_BASE, MODEL_LOCKED_ON,
             MODEL_STATUS_HAS_CHANNEL);
 
-    public StorageMonitorPart(final ItemStack is) {
-        super(is);
+    public StorageMonitorPart(ItemStack is) {
+        super(is, false);
     }
 
     @Override


### PR DESCRIPTION
Fixes #5616: Reporting parts (level emitters, storage monitor) no longer require a channel to function.