### PR TITLE
Improve meteorite generation when not enough vertical space is available (i.e. in flat worlds)

### DIFF
--- a/src/main/java/appeng/worldgen/meteorite/MeteoriteStructurePiece.java
+++ b/src/main/java/appeng/worldgen/meteorite/MeteoriteStructurePiece.java
@@ -96,9 +96,9 @@ public class MeteoriteStructurePiece extends StructurePiece {
     }
 
     @Override
-    public boolean postProcess(WorldGenLevel level, StructureFeatureManager p_230383_2_,
+    public boolean postProcess(WorldGenLevel level, StructureFeatureManager featureManager,
             ChunkGenerator chunkGeneratorIn,
-            Random rand, BoundingBox bounds, ChunkPos chunkPos, BlockPos p_230383_7_) {
+            Random rand, BoundingBox bounds, ChunkPos chunkPos, BlockPos centerPos) {
         MeteoritePlacer placer = new MeteoritePlacer(level, settings, bounds, rand);
         placer.place();
 

--- a/src/main/java/appeng/worldgen/meteorite/MeteoriteStructureStart.java
+++ b/src/main/java/appeng/worldgen/meteorite/MeteoriteStructureStart.java
@@ -82,11 +82,12 @@ public class MeteoriteStructureStart extends StructureStart<NoneFeatureConfigura
 
         // Offset caused by the meteorsize
         centerY -= yOffset;
-        // Limit to not spawn below y32
-        centerY = Math.max(32, centerY);
+
+        // If we seemingly don't have enough space to spawn (as can happen in flat chunks generators)
+        // we snugly generate it on bedrock.
+        centerY = Math.max(heightAccessor.getMinBuildHeight() + yOffset, centerY);
 
         BlockPos actualPos = new BlockPos(centerX, centerY, centerZ);
-
         boolean craterLake = this.locateWaterAroundTheCrater(generator, actualPos, meteoriteRadius, heightAccessor);
         CraterType craterType = this.determineCraterType(spawnBiome);
         boolean pureCrater = this.random.nextFloat() > .9f;


### PR DESCRIPTION
Related to fix of #5618 causing meteorites to generate, but to look bad, because they were clamped to minimum y=32.