### PR TITLE
Fixes not being able to pick up items from ME terminals when the network inventory is recalculated each tick for other reasons

### DIFF
--- a/src/main/java/appeng/menu/me/common/IncrementalUpdateHelper.java
+++ b/src/main/java/appeng/menu/me/common/IncrementalUpdateHelper.java
@@ -74,10 +74,24 @@ public class IncrementalUpdateHelper<T extends IAEStack> implements Iterable<T> 
         return mapping.inverse().get(serial);
     }
 
+    /**
+     * Clear pending changes and prepare for a full update.
+     * <p/>
+     * Mappings are kept because even in case of a full update, many items are usually still present and should keep
+     * their serial.
+     */
     public void clear() {
-        this.mapping.clear();
         this.changes.clear();
         fullUpdate = true;
+    }
+
+    /**
+     * Fully resets this helper into its initial state. This will also clear any serial mapping.
+     */
+    public void reset() {
+        clear();
+        this.serial = 0;
+        this.mapping.clear();
     }
 
     public void addChange(T entry) {

--- a/src/main/java/appeng/menu/me/crafting/CraftingCPUMenu.java
+++ b/src/main/java/appeng/menu/me/crafting/CraftingCPUMenu.java
@@ -93,7 +93,7 @@ public class CraftingCPUMenu extends AEBaseMenu {
             this.cpu.craftingLogic.removeListener(cpuChangeListener);
         }
 
-        this.incrementalUpdateHelper.clear();
+        this.incrementalUpdateHelper.reset();
 
         if (c instanceof CraftingCPUCluster) {
             this.cpu = (CraftingCPUCluster) c;


### PR DESCRIPTION
Don't reset the item-serials in case of a full update because they can happen once per tick (i.e. in case of storage cell reset). Keeping the serials will greatly reduce traffic and still allow interactions with items while this is happening each tick.

Should fix #5584