### PR TITLE
Fix #5638: Crash when starting a crafting job with items that are not in the network anymore

### DIFF
--- a/src/main/java/appeng/crafting/execution/CraftingCpuHelper.java
+++ b/src/main/java/appeng/crafting/execution/CraftingCpuHelper.java
@@ -35,7 +35,6 @@ import appeng.api.networking.IGrid;
 import appeng.api.networking.crafting.ICraftingPlan;
 import appeng.api.networking.energy.IEnergyService;
 import appeng.api.networking.security.IActionSource;
-import appeng.api.storage.IMEMonitor;
 import appeng.api.storage.data.IAEStack;
 import appeng.api.storage.data.MixedStackList;
 import appeng.crafting.inv.ICraftingInventory;
@@ -50,15 +49,14 @@ public class CraftingCpuHelper {
         var storageService = grid.getStorageService();
 
         for (var toExtract : plan.usedItems()) {
-            IMEMonitor networkMonitor = storageService.getInventory(toExtract.getChannel());
-            var extracted = networkMonitor.extractItems(toExtract, Actionable.MODULATE, src);
+            var extracted = GenericStackHelper.extractMonitorable(storageService, toExtract, Actionable.MODULATE, src);
             cpuInventory.injectItems(extracted, Actionable.MODULATE);
 
-            if (extracted == null || extracted.getStackSize() < toExtract.getStackSize()) {
+            if (IAEStack.getStackSizeOrZero(extracted) < toExtract.getStackSize()) {
                 // Failed to extract everything, reinject and hope for the best.
                 // TODO: maybe voiding items that fail to re-insert is not the best thing to do?
                 for (var stored : cpuInventory.list) {
-                    networkMonitor.injectItems(stored, Actionable.MODULATE, src);
+                    GenericStackHelper.injectMonitorable(storageService, stored, Actionable.MODULATE, src);
                     stored.reset();
                 }
 

--- a/src/main/java/appeng/crafting/inv/ListCraftingInventory.java
+++ b/src/main/java/appeng/crafting/inv/ListCraftingInventory.java
@@ -38,7 +38,7 @@ public class ListCraftingInventory implements ICraftingInventory {
 
     @Override
     public void injectItems(IAEStack input, Actionable mode) {
-        if (mode == Actionable.MODULATE) {
+        if (input != null && mode == Actionable.MODULATE) {
             list.addStorage(input);
             postChange(input, -input.getStackSize());
         }


### PR DESCRIPTION
Also cleaned up some rawtypes.

This should probably be go into a new release 9.0.0-beta.2. Do we want to create a `fabric/9.0.x` branch? We'll also need a matching forge branch.