### PR TITLE
Allow JEI Recipe/Usages/Bookmark on crafting status and confirm screens

### DIFF
--- a/src/main/java/appeng/client/gui/me/crafting/AbstractTableRenderer.java
+++ b/src/main/java/appeng/client/gui/me/crafting/AbstractTableRenderer.java
@@ -56,6 +56,7 @@ public abstract class AbstractTableRenderer<T> {
     private final float lineHeight;
     private final int x;
     private final int y;
+    private IAEStack hoveredStack;
 
     public AbstractTableRenderer(AEBaseScreen<?> screen, int x, int y) {
         this.screen = screen;
@@ -71,6 +72,7 @@ public abstract class AbstractTableRenderer<T> {
 
         final int textColor = screen.getStyle().getColor(PaletteColor.DEFAULT_TEXT_COLOR).toARGB();
         List<Component> tooltipLines = null;
+        IAEStack hovered = null;
 
         for (int row = 0; row < ROWS; row++) {
             for (int col = 0; col < COLS; col++) {
@@ -125,13 +127,19 @@ public abstract class AbstractTableRenderer<T> {
                 if (mouseX >= cellX && mouseX <= cellX + CELL_WIDTH
                         && mouseY >= cellY && mouseY <= cellY + CELL_HEIGHT) {
                     tooltipLines = getEntryTooltip(entry);
+                    hovered = entryStack;
                 }
             }
         }
+        hoveredStack = hovered;
 
         if (tooltipLines != null) {
             screen.drawTooltip(poseStack, mouseX, mouseY, tooltipLines);
         }
+    }
+
+    public IAEStack getHoveredStack() {
+        return hoveredStack;
     }
 
     /**

--- a/src/main/java/appeng/client/gui/me/crafting/CraftConfirmScreen.java
+++ b/src/main/java/appeng/client/gui/me/crafting/CraftConfirmScreen.java
@@ -20,6 +20,8 @@ package appeng.client.gui.me.crafting;
 
 import java.text.NumberFormat;
 
+import javax.annotation.Nullable;
+
 import com.mojang.blaze3d.platform.InputConstants;
 import com.mojang.blaze3d.vertex.PoseStack;
 
@@ -30,6 +32,9 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TextComponent;
 import net.minecraft.world.entity.player.Inventory;
 
+import appeng.api.storage.data.IAEFluidStack;
+import appeng.api.storage.data.IAEItemStack;
+import appeng.api.storage.data.IAEStack;
 import appeng.client.gui.AEBaseScreen;
 import appeng.client.gui.style.ScreenStyle;
 import appeng.client.gui.widgets.Scrollbar;
@@ -125,6 +130,18 @@ public class CraftConfirmScreen extends AEBaseScreen<CraftConfirmMenu> {
             this.table.render(poseStack, mouseX, mouseY, plan.getEntries(), scrollbar.getCurrentScroll());
         }
 
+    }
+
+    @Nullable
+    @Override
+    public Object getIngredientUnderMouse(double mouseX, double mouseY) {
+        IAEStack hovered = table.getHoveredStack();
+        if (hovered instanceof IAEItemStack) {
+            return ((IAEItemStack) hovered).getDefinition();
+        } else if (hovered instanceof IAEFluidStack) {
+            return ((IAEFluidStack) hovered).getFluidStack();
+        }
+        return null;
     }
 
     // Allow players to confirm a craft via the enter key

--- a/src/main/java/appeng/client/gui/me/crafting/CraftingCPUScreen.java
+++ b/src/main/java/appeng/client/gui/me/crafting/CraftingCPUScreen.java
@@ -25,6 +25,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import javax.annotation.Nullable;
+
 import com.mojang.blaze3d.vertex.PoseStack;
 
 import org.apache.commons.lang3.time.DurationFormatUtils;
@@ -33,6 +35,9 @@ import net.minecraft.client.gui.components.Button;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Inventory;
 
+import appeng.api.storage.data.IAEFluidStack;
+import appeng.api.storage.data.IAEItemStack;
+import appeng.api.storage.data.IAEStack;
 import appeng.client.gui.AEBaseScreen;
 import appeng.client.gui.style.ScreenStyle;
 import appeng.client.gui.widgets.Scrollbar;
@@ -108,6 +113,18 @@ public class CraftingCPUScreen<T extends CraftingCPUMenu> extends AEBaseScreen<T
         if (status != null) {
             this.table.render(poseStack, mouseX, mouseY, status.getEntries(), scrollbar.getCurrentScroll());
         }
+    }
+
+    @Nullable
+    @Override
+    public Object getIngredientUnderMouse(double mouseX, double mouseY) {
+        IAEStack hovered = table.getHoveredStack();
+        if (hovered instanceof IAEItemStack) {
+            return ((IAEItemStack) hovered).getDefinition();
+        } else if (hovered instanceof IAEFluidStack) {
+            return ((IAEFluidStack) hovered).getFluidStack();
+        }
+        return null;
     }
 
     public void postUpdate(CraftingStatus status) {


### PR DESCRIPTION
This pull request the allows entry stacks shown on the crafting status and confirm screens to be used for JEI integration

Since theses screens do not use custom slots or widgets, this does not make use of IIngredientSupplier