### PR TITLE
Always allow network access for server operators

### DIFF
--- a/src/main/java/appeng/api/networking/security/ISecurityService.java
+++ b/src/main/java/appeng/api/networking/security/ISecurityService.java
@@ -24,7 +24,6 @@
 package appeng.api.networking.security;
 
 import javax.annotation.Nonnegative;
-import javax.annotation.Nonnull;
 
 import net.minecraft.world.entity.player.Player;
 
@@ -49,7 +48,7 @@ public interface ISecurityService extends IGridService {
      * @param perm   The permission to check.
      * @return True if the player has permission.
      */
-    boolean hasPermission(@Nonnull Player player, @Nonnull SecurityPermissions perm);
+    boolean hasPermission(Player player, SecurityPermissions perm);
 
     /**
      * Check if a player has the specified permissions on this grid.
@@ -60,7 +59,7 @@ public interface ISecurityService extends IGridService {
      * @param perm     The permission to check.
      * @return True if the player has permission.
      */
-    boolean hasPermission(@Nonnegative int playerId, @Nonnull SecurityPermissions perm);
+    boolean hasPermission(@Nonnegative int playerId, SecurityPermissions perm);
 
     /**
      * @return PlayerID of the admin, or owner, this is the person who placed the security block.

--- a/src/main/java/appeng/core/AEConfig.java
+++ b/src/main/java/appeng/core/AEConfig.java
@@ -105,7 +105,6 @@ public final class AEConfig {
     }
 
     // Misc
-    private boolean removeCrashingItemsOnLoad;
     private int formationPlaneEntityLimit;
     private boolean enableEffects;
     private boolean useLargeFonts;
@@ -190,8 +189,6 @@ public final class AEConfig {
 
         this.craftingCalculationTimePerTick = COMMON.craftingCalculationTimePerTick.get();
 
-        this.removeCrashingItemsOnLoad = COMMON.removeCrashingItemsOnLoad.get();
-
         AEWorldGenInternal.setConfigBlacklists(
                 COMMON.quartzOresBiomeBlacklist.get().stream().map(ResourceLocation::new)
                         .collect(Collectors.toList()),
@@ -254,7 +251,6 @@ public final class AEConfig {
             case LEVEL_ITEM_COUNT -> levelByStacks;
             case LEVEL_FLUID_VOLUME -> levelByMillibuckets;
             case LEVEL_ENERGY_AMOUNT -> levelByStacks;
-            default -> throw new IllegalArgumentException("Unknown number entry: " + type);
         };
     }
 
@@ -262,7 +258,6 @@ public final class AEConfig {
         return this.CLIENT.selectedPowerUnit.get();
     }
 
-    @SuppressWarnings("unchecked")
     public void nextPowerUnit(final boolean backwards) {
         PowerUnits selectedPowerUnit = EnumCycler.rotateEnum(getSelectedPowerUnit(), backwards,
                 Settings.POWER_UNITS.getValues());
@@ -270,10 +265,6 @@ public final class AEConfig {
     }
 
     // Getters
-    public boolean isRemoveCrashingItemsOnLoad() {
-        return this.removeCrashingItemsOnLoad;
-    }
-
     public boolean isBlockEntityFacadesEnabled() {
         return COMMON.allowBlockEntityFacades.get();
     }
@@ -336,14 +327,6 @@ public final class AEConfig {
 
     public DoubleSupplier getChargedStaffBattery() {
         return () -> this.chargedStaffBattery;
-    }
-
-    public double getPowerTransactionLimitTechReborn() {
-        return COMMON.powerTransactionLimitTechReborn.get();
-    }
-
-    public float getSpawnChargedChance() {
-        return (float) COMMON.spawnChargedChance.get();
     }
 
     public int getQuartzOresPerCluster() {
@@ -419,6 +402,10 @@ public final class AEConfig {
         return COMMON.chunkLoggerTrace.get();
     }
 
+    public boolean serverOpsIgnoreSecurity() {
+        return COMMON.serverOpsIgnoreSecurity.get();
+    }
+
     // Setters keep visibility as low as possible.
 
     private static class ClientConfig {
@@ -479,13 +466,13 @@ public final class AEConfig {
     private static class CommonConfig {
 
         // Misc
-        public final BooleanOption removeCrashingItemsOnLoad;
         public final IntegerOption formationPlaneEntityLimit;
         public final IntegerOption craftingCalculationTimePerTick;
         public final BooleanOption allowBlockEntityFacades;
         public final BooleanOption debugTools;
         public final BooleanOption matterCannonBlockDamage;
         public final BooleanOption tinyTntBlockDamage;
+        public final BooleanOption serverOpsIgnoreSecurity;
 
         // Crafting
         public final BooleanOption inWorldSingularity;
@@ -514,7 +501,6 @@ public final class AEConfig {
         public final IntegerOption chargedStaffBattery;
 
         // Certus quartz
-        public final DoubleOption spawnChargedChance;
         public final IntegerOption quartzOresPerCluster;
         public final IntegerOption quartzOresClusterAmount;
         public final BooleanOption generateQuartzOre;
@@ -538,9 +524,6 @@ public final class AEConfig {
         public final DoubleOption powerRatioTechReborn;
         public final DoubleOption powerUsageMultiplier;
 
-        // How much TR energy can be transfered at most in one operation
-        public final DoubleOption powerTransactionLimitTechReborn;
-
         // Condenser Power Requirement
         public final IntegerOption condenserMatterBallsPower;
         public final IntegerOption condenserSingularityPower;
@@ -556,13 +539,13 @@ public final class AEConfig {
         public CommonConfig(ConfigSection root) {
 
             ConfigSection general = root.subsection("general");
-            removeCrashingItemsOnLoad = general.addBoolean("removeCrashingItemsOnLoad", false,
-                    "Will auto-remove items that crash when being loaded from storage. This will destroy those items instead of crashing the game!");
             debugTools = general.addBoolean("unsupportedDeveloperTools", false);
             matterCannonBlockDamage = general.addBoolean("matterCannonBlockDamage", true,
                     "Enables the ability of the Matter Cannon to break blocks.");
             tinyTntBlockDamage = general.addBoolean("tinyTntBlockDamage", true,
                     "Enables the ability of Tiny TNT to break blocks.");
+            serverOpsIgnoreSecurity = general.addBoolean("serverOpsIgnoreSecurity", true,
+                    "Server operators are not restricted by ME security terminal settings.");
 
             ConfigSection automation = root.subsection("automation");
             formationPlaneEntityLimit = automation.addInt("formationPlaneEntityLimit", 128);
@@ -606,7 +589,6 @@ public final class AEConfig {
 
             ConfigSection worldGen = root.subsection("worldGen");
 
-            this.spawnChargedChance = worldGen.addDouble("spawnChargedChance", 0.08, 0.0, 1.0);
             this.generateMeteorites = worldGen.addBoolean("generateMeteorites", true);
             this.meteoriteBiomeBlacklist = worldGen.addStringList("meteoriteBiomeBlacklist", new ArrayList<>(),
                     "Biome IDs in which meteorites should NOT be generated (i.e. minecraft:plains).");
@@ -630,10 +612,6 @@ public final class AEConfig {
             ConfigSection PowerRatios = root.subsection("PowerRatios");
             powerRatioTechReborn = PowerRatios.addDouble("TechReborn", DEFAULT_TR_EXCHANGE);
             powerUsageMultiplier = PowerRatios.addDouble("UsageMultiplier", 1.0, 0.01, Double.MAX_VALUE);
-
-            ConfigSection integration = root.subsection("Integration");
-            powerTransactionLimitTechReborn = integration.addDouble("MaxTechRebornEnergyPerTransaction", 10000.0, 0.1,
-                    1000000.0, "The maximum amount of TechReborn energy units that can be transfered per operation.");
 
             ConfigSection Condenser = root.subsection("Condenser");
             condenserMatterBallsPower = Condenser.addInt("MatterBalls", 256);

--- a/src/main/java/appeng/me/GridNode.java
+++ b/src/main/java/appeng/me/GridNode.java
@@ -40,6 +40,7 @@ import com.google.common.collect.MutableClassToInstanceMap;
 
 import net.minecraft.CrashReportCategory;
 import net.minecraft.core.Direction;
+import net.minecraft.core.Registry;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.server.level.ServerLevel;
@@ -637,7 +638,12 @@ public class GridNode implements IGridNode, IPathItem {
 
     @Override
     public String toString() {
-        return "node hosted by " + getOwner().getClass().getName();
+        if (getOwner() instanceof BlockEntity blockEntity) {
+            var beType = Registry.BLOCK_ENTITY_TYPE.getKey(blockEntity.getType());
+            return "node hosted by " + beType;
+        } else {
+            return "node hosted by " + getOwner().getClass().getName();
+        }
     }
 
     @Override

--- a/src/main/java/appeng/me/service/SecurityService.java
+++ b/src/main/java/appeng/me/service/SecurityService.java
@@ -36,6 +36,7 @@ import appeng.api.networking.IGridServiceProvider;
 import appeng.api.networking.events.GridSecurityChange;
 import appeng.api.networking.security.ISecurityProvider;
 import appeng.api.networking.security.ISecurityService;
+import appeng.core.AEConfig;
 import appeng.me.GridNode;
 
 public class SecurityService implements ISecurityService, IGridServiceProvider {
@@ -124,9 +125,13 @@ public class SecurityService implements ISecurityService, IGridServiceProvider {
     }
 
     @Override
-    public boolean hasPermission(final Player player, final SecurityPermissions perm) {
+    public boolean hasPermission(Player player, SecurityPermissions perm) {
         Objects.requireNonNull(player);
         Objects.requireNonNull(perm);
+
+        if (AEConfig.instance().serverOpsIgnoreSecurity() && player.hasPermissions(4)) {
+            return true;
+        }
 
         if (player instanceof ServerPlayer serverPlayer) {
             var playerID = IPlayerRegistry.getPlayerId(serverPlayer);

--- a/src/main/java/appeng/me/storage/NetworkStorage.java
+++ b/src/main/java/appeng/me/storage/NetworkStorage.java
@@ -28,10 +28,7 @@ import java.util.TreeMap;
 
 import appeng.api.config.Actionable;
 import appeng.api.config.SecurityPermissions;
-import appeng.api.networking.IGrid;
-import appeng.api.networking.IGridNode;
 import appeng.api.networking.security.IActionSource;
-import appeng.api.networking.security.ISecurityService;
 import appeng.api.storage.IMEInventory;
 import appeng.api.storage.IStorageChannel;
 import appeng.api.storage.data.AEKey;
@@ -134,16 +131,16 @@ public class NetworkStorage<T extends AEKey> implements IMEInventory<T> {
                 return true;
             }
         } else if (src.machine().isPresent() && this.security.isAvailable()) {
-            final IGridNode n = src.machine().get().getActionableNode();
+            var n = src.machine().get().getActionableNode();
             if (n == null) {
                 return true;
             }
 
-            final IGrid gn = n.getGrid();
+            var gn = n.getGrid();
             if (gn != this.security.getGrid()) {
 
-                final ISecurityService sg = gn.getSecurityService();
-                final int playerID = sg.getOwner();
+                var sg = gn.getSecurityService();
+                var playerID = sg.getOwner();
 
                 if (!this.security.hasPermission(playerID, permission)) {
                     return true;

--- a/src/main/java/appeng/menu/implementations/MenuTypeBuilder.java
+++ b/src/main/java/appeng/menu/implementations/MenuTypeBuilder.java
@@ -41,6 +41,7 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import appeng.api.config.SecurityPermissions;
 import appeng.api.implementations.menuobjects.IMenuItem;
 import appeng.api.implementations.menuobjects.ItemMenuHost;
+import appeng.api.networking.security.IActionHost;
 import appeng.api.parts.IPart;
 import appeng.api.parts.IPartHost;
 import appeng.core.AELog;
@@ -313,8 +314,8 @@ public final class MenuTypeBuilder<M extends AEBaseMenu, I> {
 
     private boolean checkPermission(Player player, Object accessInterface) {
 
-        if (requiredPermission != null) {
-            return Platform.checkPermissions(player, accessInterface, requiredPermission, true);
+        if (requiredPermission != null && accessInterface instanceof IActionHost actionHost) {
+            return Platform.checkPermissions(player, actionHost, requiredPermission, false, true);
         }
 
         return true;

--- a/src/main/java/appeng/parts/reporting/CraftingTerminalPart.java
+++ b/src/main/java/appeng/parts/reporting/CraftingTerminalPart.java
@@ -84,7 +84,7 @@ public class CraftingTerminalPart extends AbstractTerminalPart {
 
     @Override
     public MenuType<?> getMenuType(final Player p) {
-        if (Platform.checkPermissions(p, this, SecurityPermissions.CRAFT, false)) {
+        if (Platform.checkPermissions(p, this, SecurityPermissions.CRAFT, false, false)) {
             return CraftingTermMenu.TYPE;
         }
         return ItemTerminalMenu.TYPE;

--- a/src/main/java/appeng/parts/reporting/PatternTerminalPart.java
+++ b/src/main/java/appeng/parts/reporting/PatternTerminalPart.java
@@ -99,7 +99,7 @@ public class PatternTerminalPart extends AbstractTerminalPart implements IPatter
 
     @Override
     public MenuType<?> getMenuType(final Player p) {
-        if (Platform.checkPermissions(p, this, SecurityPermissions.CRAFT, false)) {
+        if (Platform.checkPermissions(p, this, SecurityPermissions.CRAFT, false, false)) {
             return PatternTermMenu.TYPE;
         }
         return ItemTerminalMenu.TYPE;


### PR DESCRIPTION
Server operators can now always access ME GUIs, ignoring the security terminal. This does not extend to grids owned by operators, only the logged in player.

Fixes #101