### PR TITLE
Fixes inscriber always showing stack size 1 in UI

### DIFF
--- a/src/main/java/appeng/server/testworld/PlotBuilder.java
+++ b/src/main/java/appeng/server/testworld/PlotBuilder.java
@@ -5,8 +5,10 @@ import java.util.function.Function;
 
 import net.minecraft.core.Direction;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.ItemLike;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.HopperBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
@@ -83,6 +85,30 @@ public interface PlotBuilder {
         customizeBlockEntity(bb, BlockEntityType.CHEST, chest -> {
             for (int i = 0; i < stacks.length; i++) {
                 chest.setItem(i, stacks[i]);
+            }
+        });
+    }
+
+    default void filledHopper(String bb, Direction direction, ItemLike item) {
+        var stack = new ItemStack(item);
+        stack.setCount(stack.getMaxStackSize());
+        filledHopper(bb, direction, stack);
+    }
+
+    default void filledHopper(String bb, Direction direction, ItemStack stack) {
+        blockState(bb, Blocks.HOPPER.defaultBlockState().setValue(HopperBlock.FACING, direction));
+        customizeBlockEntity(bb, BlockEntityType.HOPPER, hopper -> {
+            for (int i = 0; i < hopper.getContainerSize(); i++) {
+                hopper.setItem(i, stack.copy());
+            }
+        });
+    }
+
+    default void hopper(String bb, Direction direction, ItemStack... stacks) {
+        blockState(bb, Blocks.HOPPER.defaultBlockState().setValue(HopperBlock.FACING, direction));
+        customizeBlockEntity(bb, BlockEntityType.HOPPER, hopper -> {
+            for (int i = 0; i < stacks.length; i++) {
+                hopper.setItem(i, stacks[i]);
             }
         });
     }

--- a/src/main/java/appeng/server/testworld/TestPlots.java
+++ b/src/main/java/appeng/server/testworld/TestPlots.java
@@ -9,6 +9,7 @@ import net.minecraft.core.Registry;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.enchantment.Enchantments;
+import net.minecraft.world.level.ItemLike;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.levelgen.structure.BoundingBox;
 import net.minecraft.world.level.material.Fluids;
@@ -39,6 +40,7 @@ final class TestPlots {
                 skyCompassRendering(),
                 crystalGrowthAutoCrafting(),
                 importExportBus(),
+                inscriber(),
                 AutoCraftingTestPlot.create());
         return plots;
     }
@@ -271,5 +273,43 @@ final class TestPlots {
             drive.getInternalInventory().addItems(AEItems.ITEM_CELL_64K.stack());
         });
         return plot;
+    }
+
+    private static Plot inscriber() {
+        var plot = new Plot();
+
+        processorInscriber(plot.offset(0, 1, 2), AEItems.LOGIC_PROCESSOR_PRESS, Items.GOLD_INGOT);
+        processorInscriber(plot.offset(5, 1, 2), AEItems.ENGINEERING_PROCESSOR_PRESS, Items.DIAMOND);
+        processorInscriber(plot.offset(10, 1, 2), AEItems.CALCULATION_PROCESSOR_PRESS, AEItems.CERTUS_QUARTZ_CRYSTAL);
+
+        return plot;
+    }
+
+    private static void processorInscriber(PlotBuilder plot, ItemLike processorPress, ItemLike processorMaterial) {
+        // Set up the inscriber for the processor print
+        plot.filledHopper("-1 3 0", Direction.DOWN, processorMaterial);
+        plot.creativeEnergyCell("-1 2 1");
+        plot.blockEntity("-1 2 0", AEBlocks.INSCRIBER, inscriber -> {
+            inscriber.getInternalInventory().setItemDirect(0, new ItemStack(processorPress));
+            inscriber.setOrientation(Direction.NORTH, Direction.WEST);
+        });
+
+        // Set up the inscriber for the silicon print
+        plot.filledHopper("1 3 0", Direction.DOWN, AEItems.SILICON);
+        plot.creativeEnergyCell("1 2 1");
+        plot.blockEntity("1 2 0", AEBlocks.INSCRIBER, inscriber -> {
+            inscriber.getInternalInventory().setItemDirect(0, AEItems.SILICON_PRESS.stack());
+            inscriber.setOrientation(Direction.NORTH, Direction.WEST);
+        });
+
+        // Set up the inscriber for assembly
+        plot.hopper("1 1 0", Direction.WEST);
+        plot.hopper("-1 1 0", Direction.EAST);
+        plot.filledHopper("0 2 0", Direction.DOWN, Items.REDSTONE);
+        plot.creativeEnergyCell("0 1 1");
+        plot.blockEntity("0 1 0", AEBlocks.INSCRIBER, inscriber -> {
+            inscriber.setOrientation(Direction.NORTH, Direction.WEST);
+        });
+        plot.hopper("0 0 0", Direction.DOWN);
     }
 }


### PR DESCRIPTION
Fixes #5747: Do not overwrite client-side BE inventory with items only suitable for rendering. Fixes that the output slot is overwritten with stack size 1 visually while observing the inscribers UI.