### PR TITLE
Fix Terminals / Chests crashing the game when being opened (obfuscation issue)

### DIFF
--- a/src/main/java/appeng/client/gui/WidgetContainer.java
+++ b/src/main/java/appeng/client/gui/WidgetContainer.java
@@ -72,15 +72,13 @@ public class WidgetContainer {
 
         // Size the widget, as this doesn't change when the parent is resized
         WidgetStyle widgetStyle = style.getWidget(id);
-        if (widgetStyle.getWidth() != 0) {
-            widget.setWidth(widgetStyle.getWidth());
-        }
-        if (widgetStyle.getHeight() != 0) {
-            if (widget instanceof IResizableWidget resizableWidget) {
-                resizableWidget.setHeight(widgetStyle.getHeight());
-            } else {
-                widget.height = widgetStyle.getHeight();
-            }
+        int width = widgetStyle.getWidth() != 0 ? widgetStyle.getWidth() : widget.getWidth();
+        int height = widgetStyle.getHeight() != 0 ? widgetStyle.getHeight() : widget.getHeight();
+        if (widget instanceof IResizableWidget resizableWidget) {
+            resizableWidget.resize(width, height);
+        } else {
+            widget.setWidth(width);
+            widget.height = height;
         }
 
         if (widget instanceof TabButton) {
@@ -157,8 +155,7 @@ public class WidgetContainer {
             WidgetStyle widgetStyle = style.getWidget(entry.getKey());
             Point pos = widgetStyle.resolve(bounds);
             if (widget instanceof IResizableWidget resizableWidget) {
-                resizableWidget.setX(pos.getX());
-                resizableWidget.setY(pos.getY());
+                resizableWidget.move(pos);
             } else {
                 widget.x = pos.getX();
                 widget.y = pos.getY();

--- a/src/main/java/appeng/client/gui/widgets/AETextField.java
+++ b/src/main/java/appeng/client/gui/widgets/AETextField.java
@@ -33,6 +33,8 @@ import net.minecraft.client.gui.components.EditBox;
 import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.network.chat.TextComponent;
 
+import appeng.client.Point;
+
 /**
  * A modified version of the Minecraft text field. You can initialize it over the full element span. The mouse click
  * area is increased to the full element subtracted with the defined padding.
@@ -75,23 +77,15 @@ public class AETextField extends EditBox implements IResizableWidget {
     }
 
     @Override
-    public void setX(int x) {
-        super.setX(x + PADDING);
+    public void move(Point pos) {
+        super.setX(pos.getX() + PADDING);
+        this.y = pos.getY() + PADDING;
     }
 
     @Override
-    public void setY(int y) {
-        this.y = y + PADDING;
-    }
-
-    @Override
-    public void setHeight(int height) {
-        this.height = height - 2 * PADDING;
-    }
-
-    @Override
-    public void setWidth(int width) {
+    public void resize(int width, int height) {
         super.setWidth(width - 2 * PADDING - _fontPad);
+        this.height = height - 2 * PADDING;
     }
 
     public void selectAll() {

--- a/src/main/java/appeng/client/gui/widgets/IResizableWidget.java
+++ b/src/main/java/appeng/client/gui/widgets/IResizableWidget.java
@@ -1,13 +1,11 @@
 package appeng.client.gui.widgets;
 
+import appeng.client.Point;
+
 public interface IResizableWidget {
 
-    void setX(int x);
+    void move(Point pos);
 
-    void setY(int y);
-
-    void setHeight(int height);
-
-    void setWidth(int width);
+    void resize(int width, int height);
 
 }


### PR DESCRIPTION
Fixes #5755: Method was obfuscated by Forge, but not Fabric due to a name-clash, which lead to terminals crashing the game when being opened.