### PR TITLE
Fix Annihilation Plane not returning to accepting items if the network ever can't accept them

### DIFF
--- a/src/main/java/appeng/parts/automation/AnnihilationPlanePart.java
+++ b/src/main/java/appeng/parts/automation/AnnihilationPlanePart.java
@@ -165,7 +165,11 @@ public class AnnihilationPlanePart extends BasicStatePart implements IGridTickab
         };
 
         if (capture) {
-            strategy.pickUpEntity(grid.getEnergyService(), this::insertIntoGrid, entity);
+            if (!strategy.pickUpEntity(grid.getEnergyService(), this::insertIntoGrid, entity)) {
+                // we need to wake up the block entity in case an entity pickup fails
+                // to reset the "blocked" flags internal to the pickup strategy.
+                getMainNode().ifPresent((g, n) -> g.getTickManager().alertDevice(n));
+            }
         }
     }
 


### PR DESCRIPTION
Wake up the annihilation plane if an entity collides with it but the pickup fails. This is required to retry the pickup later if the annihilation plane isn't otherwise woken up for an unrelated reason.

Fixes #5764