### PR TITLE
Fixes #5783: Crafting monitor can now display fluids correctly

### DIFF
--- a/src/main/java/appeng/api/client/AEStackRendering.java
+++ b/src/main/java/appeng/api/client/AEStackRendering.java
@@ -38,6 +38,7 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.network.chat.Component;
 
 import appeng.api.stacks.AEKey;
@@ -89,8 +90,13 @@ public class AEStackRendering {
     }
 
     @SuppressWarnings("unchecked")
-    public static void drawRepresentation(Minecraft minecraft, PoseStack poseStack, int x, int y, int z, AEKey stack) {
-        getUnchecked(stack).drawRepresentation(minecraft, poseStack, x, y, z, stack);
+    public static void drawInGui(Minecraft minecraft, PoseStack poseStack, int x, int y, int z, AEKey what) {
+        getUnchecked(what).drawInGui(minecraft, poseStack, x, y, z, what);
+    }
+
+    public static void drawOnBlockFace(PoseStack poseStack, MultiBufferSource buffers, AEKey what, float scale,
+            int combinedLightIn) {
+        getUnchecked(what).drawOnBlockFace(poseStack, buffers, what, scale, combinedLightIn);
     }
 
     @SuppressWarnings("unchecked")
@@ -107,4 +113,5 @@ public class AEStackRendering {
     public static String formatAmount(AEKey what, long amount, AmountFormat format) {
         return getUnchecked(what).formatAmount(amount, format);
     }
+
 }

--- a/src/main/java/appeng/api/client/IAEStackRenderHandler.java
+++ b/src/main/java/appeng/api/client/IAEStackRenderHandler.java
@@ -30,6 +30,7 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TextComponent;
 
@@ -44,7 +45,12 @@ public interface IAEStackRenderHandler<T extends AEKey> {
     /**
      * Draw the stack, for example the item or the fluid sprite, but not the amount.
      */
-    void drawRepresentation(Minecraft minecraft, PoseStack poseStack, int x, int y, int zIndex, T stack);
+    void drawInGui(Minecraft minecraft, PoseStack poseStack, int x, int y, int zIndex, T stack);
+
+    /**
+     * Draw the representation of a key in-world on the face of a block. Used for displaying it on screens and monitors.
+     */
+    void drawOnBlockFace(PoseStack poseStack, MultiBufferSource buffers, T what, float scale, int combinedLight);
 
     /**
      * Name of the stack, ignoring the amount.

--- a/src/main/java/appeng/api/implementations/parts/IStorageMonitorPart.java
+++ b/src/main/java/appeng/api/implementations/parts/IStorageMonitorPart.java
@@ -23,6 +23,8 @@
 
 package appeng.api.implementations.parts;
 
+import javax.annotation.Nullable;
+
 import appeng.api.parts.IPart;
 import appeng.api.stacks.AEKey;
 import appeng.api.util.INetworkToolAware;
@@ -35,6 +37,7 @@ public interface IStorageMonitorPart extends IMonitorPart, IPart, INetworkToolAw
     /**
      * @return what is being shown on the storage monitor
      */
+    @Nullable
     AEKey getDisplayed();
 
     /**

--- a/src/main/java/appeng/client/gui/me/common/MEStorageScreen.java
+++ b/src/main/java/appeng/client/gui/me/common/MEStorageScreen.java
@@ -450,7 +450,7 @@ public class MEStorageScreen<C extends MEStorageMenu>
                 GridInventoryEntry entry = repoSlot.getEntry();
                 if (entry != null) {
                     try {
-                        AEStackRendering.drawRepresentation(
+                        AEStackRendering.drawInGui(
                                 minecraft,
                                 poseStack,
                                 s.x,

--- a/src/main/java/appeng/client/gui/me/crafting/AbstractTableRenderer.java
+++ b/src/main/java/appeng/client/gui/me/crafting/AbstractTableRenderer.java
@@ -118,7 +118,7 @@ public abstract class AbstractTableRenderer<T> {
                 var entryStack = getEntryStack(entry);
 
                 int itemY = cellY + (CELL_HEIGHT - 16) / 2;
-                AEStackRendering.drawRepresentation(Minecraft.getInstance(), poseStack, itemX, itemY,
+                AEStackRendering.drawInGui(Minecraft.getInstance(), poseStack, itemX, itemY,
                         screen.getBlitOffset(), entryStack);
 
                 int overlay = getEntryOverlayColor(entry);

--- a/src/main/java/appeng/client/render/crafting/CraftingMonitorRenderer.java
+++ b/src/main/java/appeng/client/render/crafting/CraftingMonitorRenderer.java
@@ -22,21 +22,22 @@ import com.mojang.blaze3d.vertex.PoseStack;
 
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
+import net.minecraft.client.renderer.LightTexture;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
 import net.minecraft.core.Direction;
 
 import appeng.blockentity.crafting.CraftingMonitorBlockEntity;
-import appeng.client.render.TesrRenderHelper;
+import appeng.client.render.BlockEntityRenderHelper;
 
 /**
  * Renders the item currently being crafted
  */
 @Environment(EnvType.CLIENT)
-public class CraftingMonitorTESR implements BlockEntityRenderer<CraftingMonitorBlockEntity> {
+public class CraftingMonitorRenderer implements BlockEntityRenderer<CraftingMonitorBlockEntity> {
 
-    public CraftingMonitorTESR(BlockEntityRendererProvider.Context context) {
+    public CraftingMonitorRenderer(BlockEntityRendererProvider.Context context) {
     }
 
     @Override
@@ -51,14 +52,17 @@ public class CraftingMonitorTESR implements BlockEntityRenderer<CraftingMonitorB
             poseStack.pushPose();
             poseStack.translate(0.5, 0.5, 0.5); // Move to the center of the block
 
-            TesrRenderHelper.rotateToFace(poseStack, facing, (byte) 0);
+            BlockEntityRenderHelper.rotateToFace(poseStack, facing, (byte) 0);
             poseStack.translate(0, 0.08, 0.5);
-            var what = jobProgress.what();
-            var itemToShow = what.wrapForDisplayOrFilter();
 
-            TesrRenderHelper.renderItem2dWithAmount(poseStack, buffers, itemToShow, jobProgress.amount(), 0.3f, -0.18f,
-                    15728880,
-                    combinedOverlay);
+            BlockEntityRenderHelper.renderItem2dWithAmount(
+                    poseStack,
+                    buffers,
+                    jobProgress.what(),
+                    jobProgress.amount(),
+                    0.3f,
+                    -0.18f,
+                    LightTexture.FULL_BRIGHT);
 
             poseStack.popPose();
         }

--- a/src/main/java/appeng/hooks/ItemRendererHooks.java
+++ b/src/main/java/appeng/hooks/ItemRendererHooks.java
@@ -67,7 +67,7 @@ public final class ItemRendererHooks {
 
         var unwrapped = GenericStack.unwrapItemStack(stack);
         if (unwrapped != null) {
-            AEStackRendering.drawRepresentation(
+            AEStackRendering.drawInGui(
                     Minecraft.getInstance(),
                     new PoseStack(),
                     x,

--- a/src/main/java/appeng/init/client/InitBlockEntityRenderers.java
+++ b/src/main/java/appeng/init/client/InitBlockEntityRenderers.java
@@ -26,7 +26,7 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 
 import appeng.blockentity.networking.CableBusTESR;
-import appeng.client.render.crafting.CraftingMonitorTESR;
+import appeng.client.render.crafting.CraftingMonitorRenderer;
 import appeng.client.render.crafting.MolecularAssemblerRenderer;
 import appeng.client.render.tesr.ChargerBlockEntityRenderer;
 import appeng.client.render.tesr.ChestBlockEntityRenderer;
@@ -49,7 +49,7 @@ public final class InitBlockEntityRenderers {
         register(AEBlockEntities.CHARGER, ChargerBlockEntityRenderer.FACTORY);
         register(AEBlockEntities.DRIVE, DriveLedBlockEntityRenderer::new);
         register(AEBlockEntities.CHEST, ChestBlockEntityRenderer::new);
-        register(AEBlockEntities.CRAFTING_MONITOR, CraftingMonitorTESR::new);
+        register(AEBlockEntities.CRAFTING_MONITOR, CraftingMonitorRenderer::new);
         register(AEBlockEntities.MOLECULAR_ASSEMBLER, MolecularAssemblerRenderer::new);
         register(AEBlockEntities.CABLE_BUS, CableBusTESR::new);
         register(AEBlockEntities.SKY_COMPASS, SkyCompassTESR::new);

--- a/src/main/java/appeng/parts/reporting/AbstractMonitorPart.java
+++ b/src/main/java/appeng/parts/reporting/AbstractMonitorPart.java
@@ -25,8 +25,8 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.Util;
+import net.minecraft.client.renderer.LightTexture;
 import net.minecraft.client.renderer.MultiBufferSource;
-import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.InteractionHand;
@@ -42,7 +42,7 @@ import appeng.api.networking.storage.IStorageWatcherNode;
 import appeng.api.parts.IPartModel;
 import appeng.api.stacks.AEItemKey;
 import appeng.api.stacks.AEKey;
-import appeng.client.render.TesrRenderHelper;
+import appeng.client.render.BlockEntityRenderHelper;
 import appeng.core.localization.PlayerMessages;
 import appeng.util.IWideReadableNumberConverter;
 import appeng.util.Platform;
@@ -220,14 +220,12 @@ public abstract class AbstractMonitorPart extends AbstractDisplayPart
         poseStack.pushPose();
         poseStack.translate(0.5, 0.5, 0.5); // Move into the center of the block
 
-        Direction facing = this.getSide();
-
-        TesrRenderHelper.rotateToFace(poseStack, facing, this.getSpin());
+        BlockEntityRenderHelper.rotateToFace(poseStack, getSide(), this.getSpin());
 
         poseStack.translate(0, 0.05, 0.5);
 
-        TesrRenderHelper.renderItem2dWithAmount(poseStack, buffers, configuredItem.wrapForDisplayOrFilter(), amount,
-                0.4f, -0.23f, 15728880, combinedOverlayIn);
+        BlockEntityRenderHelper.renderItem2dWithAmount(poseStack, buffers, getDisplayed(), amount,
+                0.4f, -0.23f, LightTexture.FULL_BRIGHT);
 
         poseStack.popPose();
 
@@ -238,14 +236,10 @@ public abstract class AbstractMonitorPart extends AbstractDisplayPart
         return true;
     }
 
+    @Nullable
     @Override
     public AEKey getDisplayed() {
         return this.configuredItem;
-    }
-
-    @Nullable
-    public AEKey getConfiguredItem() {
-        return configuredItem;
     }
 
     public void setConfiguredItem(@Nullable AEKey configuredItem) {


### PR DESCRIPTION
This technically enables the storage monitor to do the same, but there's no way to configure a fluid for it yet.