### PR TITLE
Fix #96: optionally reduce amount in crafting calculations on failure

### DIFF
--- a/src/main/java/appeng/api/networking/crafting/CalculationStrategy.java
+++ b/src/main/java/appeng/api/networking/crafting/CalculationStrategy.java
@@ -1,0 +1,13 @@
+package appeng.api.networking.crafting;
+
+public enum CalculationStrategy {
+    /**
+     * If the exact requested amount cannot be crafted, create a {@link ICraftingPlan} containing the missing items.
+     */
+    REPORT_MISSING_ITEMS,
+    /**
+     * Try to craft less items than requested. Will try to craft as many items as possible. If even {@code 1} cannot be
+     * crafted, fall back to {@link #REPORT_MISSING_ITEMS}.
+     */
+    CRAFT_LESS,
+}

--- a/src/main/java/appeng/api/networking/crafting/ICraftingService.java
+++ b/src/main/java/appeng/api/networking/crafting/ICraftingService.java
@@ -78,12 +78,13 @@ public interface ICraftingService extends IGridService {
      * @param level        crafting level
      * @param simRequester source
      * @param craftWhat    result
+     * @param strategy     usually {@link CalculationStrategy#REPORT_MISSING_ITEMS} for player requests
      *
      * @return a future which will at an undetermined point in the future get you the {@link ICraftingPlan} do not wait
      *         on this, your be waiting forever.
      */
     Future<ICraftingPlan> beginCraftingCalculation(Level level, ICraftingSimulationRequester simRequester,
-            AEKey craftWhat, long amount);
+            AEKey craftWhat, long amount, CalculationStrategy strategy);
 
     /**
      * Submit the job to the Crafting system for processing.

--- a/src/main/java/appeng/crafting/CraftingCalculation.java
+++ b/src/main/java/appeng/crafting/CraftingCalculation.java
@@ -18,13 +18,20 @@
 
 package appeng.crafting;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import com.google.common.base.Stopwatch;
 
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.Nullable;
+
 import net.minecraft.world.level.Level;
 
 import appeng.api.networking.IGrid;
+import appeng.api.networking.crafting.CalculationStrategy;
+import appeng.api.networking.crafting.ICraftingPlan;
 import appeng.api.networking.crafting.ICraftingSimulationRequester;
 import appeng.api.stacks.AEKey;
 import appeng.api.stacks.GenericStack;
@@ -36,50 +43,50 @@ import appeng.crafting.inv.NetworkCraftingSimulationState;
 import appeng.hooks.ticking.TickHandler;
 
 public class CraftingCalculation {
-    private static final String LOG_CRAFTING_JOB = "CraftingCalculation (%s) issued by %s requesting [%s] using %s bytes took %s ms";
-    private static final String LOG_MACHINE_SOURCE_DETAILS = "Machine[object=%s, %s, %s]";
-
     private final NetworkCraftingSimulationState networkInv;
     private final Level level;
     private final KeyCounter missing = new KeyCounter();
     private final Object monitor = new Object();
     private final Stopwatch watch = Stopwatch.createUnstarted();
     private final CraftingTreeNode tree;
-    private final GenericStack output;
+    private final AEKey output;
+    private final long requestedAmount;
+    private final CalculationStrategy strategy;
     private boolean simulate = false;
     final ICraftingSimulationRequester simRequester;
     private boolean running = false;
     private boolean done = false;
     private int time = 5;
     private int incTime = Integer.MAX_VALUE;
+    private final List<CraftAttempt> attempts = AELog.isCraftingLogEnabled() ? new ArrayList<>() : null;
 
     public CraftingCalculation(Level level, IGrid grid, ICraftingSimulationRequester simRequester,
-            GenericStack output) {
+            GenericStack output, CalculationStrategy strategy) {
         this.level = level;
-        this.output = output;
+        this.output = output.what();
+        this.requestedAmount = output.amount();
+        this.strategy = strategy;
         this.simRequester = simRequester;
 
         var storage = grid.getStorageService();
         var craftingService = grid.getCraftingService();
         this.networkInv = new NetworkCraftingSimulationState(storage, simRequester.getActionSource());
 
-        this.tree = new CraftingTreeNode(craftingService, this, output.what(), 1, null, -1);
+        this.tree = new CraftingTreeNode(craftingService, this, this.output, 1, null, -1);
     }
 
     void addMissing(AEKey what, long amount) {
         missing.add(what, amount);
     }
 
-    public CraftingPlan run() {
+    public ICraftingPlan run() {
         try {
             TickHandler.instance().registerCraftingSimulation(this.level, this);
             this.handlePausing();
 
-            try {
-                return computeCraft(false);
-            } catch (CraftBranchFailure e) {
-                return computeCraft(true);
-            }
+            var plan = computePlan();
+            this.logCraftingJob(plan);
+            return plan;
         } catch (Exception ex) {
             AELog.info(ex, "Exception during crafting calculation.");
             throw new RuntimeException(ex);
@@ -88,16 +95,61 @@ public class CraftingCalculation {
         }
     }
 
-    private CraftingPlan computeCraft(boolean simulate) throws CraftBranchFailure, InterruptedException {
+    private ICraftingPlan computePlan() throws InterruptedException {
+        var fullAmountPlan = runCraftAttempt(false, requestedAmount);
+        if (fullAmountPlan != null) {
+            // Success with full amount!
+            return fullAmountPlan;
+        }
+
+        if (strategy == CalculationStrategy.CRAFT_LESS) {
+            // Try crafting less if possible using binary search.
+            long successfulAmount = 0;
+            ICraftingPlan successfulPlan = null;
+            for (long increment = Long.highestOneBit(requestedAmount); increment > 0; increment /= 2) {
+                long testAmount = successfulAmount + increment;
+                if (testAmount < requestedAmount) {
+                    var plan = runCraftAttempt(false, testAmount);
+                    if (plan != null) {
+                        // Success! :)
+                        successfulAmount = testAmount;
+                        successfulPlan = plan;
+                    }
+                }
+            }
+
+            // Found a successful plan! :)
+            if (successfulPlan != null) {
+                return successfulPlan;
+            }
+        }
+
+        // Couldn't find a successful plan -> simulate.
+        return runCraftAttempt(true, requestedAmount);
+    }
+
+    /**
+     * @return null on failure
+     */
+    @Nullable
+    @Contract("true, _ -> !null") // the calculation can't fail if simulated
+    private CraftingPlan runCraftAttempt(boolean simulate, long amount) throws InterruptedException {
         this.simulate = simulate;
 
         final Stopwatch timer = Stopwatch.createStarted();
 
         ChildCraftingSimulationState craftingInventory = new ChildCraftingSimulationState(networkInv);
-        craftingInventory.ignore(this.output.what());
+        craftingInventory.ignore(this.output);
 
         // Do the crafting. Throws in case of failure.
-        this.tree.request(craftingInventory, output.amount(), null);
+        try {
+            this.tree.request(craftingInventory, amount, null);
+        } catch (CraftBranchFailure failure) {
+            if (AELog.isCraftingLogEnabled()) {
+                this.attempts.add(new CraftAttempt(amount + " failed", timer));
+            }
+            return null;
+        }
         // Add bytes for the tree size.
         craftingInventory.addBytes(this.tree.getNodeCount() * 8);
 
@@ -107,8 +159,11 @@ public class CraftingCalculation {
         // AELog.crafting(s + " * " + ti.times + " = " + ti.perOp * ti.times);
         // }
 
-        var plan = CraftingSimulationState.buildCraftingPlan(craftingInventory, this);
-        this.logCraftingJob(plan, timer);
+        var plan = CraftingSimulationState.buildCraftingPlan(craftingInventory, this, amount);
+        if (AELog.isCraftingLogEnabled()) {
+            String type = simulate ? "simulated" : "succeeded";
+            this.attempts.add(new CraftAttempt("%d %s (%d bytes)".formatted(amount, type, plan.bytes()), timer));
+        }
         return plan;
     }
 
@@ -153,8 +208,8 @@ public class CraftingCalculation {
         return this.simulate;
     }
 
-    public GenericStack getOutput() {
-        return this.output;
+    public AEKey getOutput() {
+        return output;
     }
 
     public KeyCounter getMissingItems() {
@@ -200,10 +255,9 @@ public class CraftingCalculation {
         return true;
     }
 
-    private void logCraftingJob(CraftingPlan plan, Stopwatch timer) {
+    private void logCraftingJob(ICraftingPlan plan) {
         if (AELog.isCraftingLogEnabled()) {
-            String itemToOutput = this.output.toString();
-            long elapsedTime = timer.elapsed(TimeUnit.MILLISECONDS);
+            ;
             var actionSource = this.simRequester.getActionSource();
             String actionSourceName;
 
@@ -218,12 +272,23 @@ public class CraftingCalculation {
                 actionSourceName = "[unknown source]";
             }
 
-            String type = plan.simulation() ? "simulation" : "real";
-            AELog.crafting(LOG_CRAFTING_JOB, type, actionSourceName, itemToOutput, plan.bytes(), elapsedTime);
+            StringBuilder message = new StringBuilder();
+            message.append("CraftingCalculation issued by %s requesting [%dx%s] breakdown:\n".formatted(
+                    actionSourceName, this.requestedAmount, this.output));
+            for (var attempt : this.attempts) {
+                message.append(" - %s in %d ms\n".formatted(
+                        attempt.description, attempt.stopwatch.elapsed(TimeUnit.MILLISECONDS)));
+            }
+            message.append(" - final plan: %d (%d bytes)".formatted(plan.finalOutput().amount(), plan.bytes()));
+
+            AELog.crafting(message.toString());
         }
     }
 
     public boolean hasMultiplePaths() {
         return this.tree.hasMultiplePaths();
+    }
+
+    private record CraftAttempt(String description, Stopwatch stopwatch) {
     }
 }

--- a/src/main/java/appeng/crafting/CraftingCalculation.java
+++ b/src/main/java/appeng/crafting/CraftingCalculation.java
@@ -50,6 +50,7 @@ public class CraftingCalculation {
     private final Stopwatch watch = Stopwatch.createUnstarted();
     private final CraftingTreeNode tree;
     private final AEKey output;
+    // The initially requested amount of "output", may be reduced depending on the strategy used
     private final long requestedAmount;
     private final CalculationStrategy strategy;
     private boolean simulate = false;

--- a/src/main/java/appeng/crafting/inv/CraftingSimulationState.java
+++ b/src/main/java/appeng/crafting/inv/CraftingSimulationState.java
@@ -30,6 +30,7 @@ import appeng.api.config.Actionable;
 import appeng.api.config.FuzzyMode;
 import appeng.api.crafting.IPatternDetails;
 import appeng.api.stacks.AEKey;
+import appeng.api.stacks.GenericStack;
 import appeng.api.stacks.KeyCounter;
 import appeng.crafting.CraftingCalculation;
 import appeng.crafting.CraftingPlan;
@@ -194,9 +195,9 @@ public abstract class CraftingSimulationState implements ICraftingSimulationStat
     }
 
     public static CraftingPlan buildCraftingPlan(CraftingSimulationState state,
-            CraftingCalculation calculation) {
+            CraftingCalculation calculation, long calculatedAmount) {
         return new CraftingPlan(
-                calculation.getOutput(),
+                new GenericStack(calculation.getOutput(), calculatedAmount),
                 (long) Math.ceil(state.bytes),
                 calculation.isSimulation(),
                 calculation.hasMultiplePaths(),

--- a/src/main/java/appeng/helpers/MultiCraftingTracker.java
+++ b/src/main/java/appeng/helpers/MultiCraftingTracker.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableSet;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.level.Level;
 
+import appeng.api.networking.crafting.CalculationStrategy;
 import appeng.api.networking.crafting.ICraftingLink;
 import appeng.api.networking.crafting.ICraftingPlan;
 import appeng.api.networking.crafting.ICraftingRequester;
@@ -102,7 +103,8 @@ public class MultiCraftingTracker {
                 // :P
             }
         } else if (this.getLink(x) == null) {
-            this.setJob(x, cg.beginCraftingCalculation(level, () -> mySrc, what, amount));
+            this.setJob(x,
+                    cg.beginCraftingCalculation(level, () -> mySrc, what, amount, CalculationStrategy.CRAFT_LESS));
         }
         return false;
     }

--- a/src/main/java/appeng/me/service/CraftingService.java
+++ b/src/main/java/appeng/me/service/CraftingService.java
@@ -249,13 +249,13 @@ public class CraftingService implements ICraftingService, IGridServiceProvider {
 
     @Override
     public Future<ICraftingPlan> beginCraftingCalculation(Level level, ICraftingSimulationRequester simRequester,
-            AEKey what, long amount) {
+            AEKey what, long amount, CalculationStrategy strategy) {
         if (level == null || simRequester == null) {
             throw new IllegalArgumentException("Invalid Crafting Job Request");
         }
 
         final CraftingCalculation job = new CraftingCalculation(level, grid, simRequester,
-                new GenericStack(what, amount));
+                new GenericStack(what, amount), strategy);
 
         return CRAFTING_POOL.submit(job::run);
     }

--- a/src/main/java/appeng/menu/me/crafting/CraftAmountMenu.java
+++ b/src/main/java/appeng/menu/me/crafting/CraftAmountMenu.java
@@ -32,6 +32,7 @@ import net.minecraft.world.level.Level;
 import appeng.api.config.SecurityPermissions;
 import appeng.api.networking.IGrid;
 import appeng.api.networking.IGridNode;
+import appeng.api.networking.crafting.CalculationStrategy;
 import appeng.api.networking.crafting.ICraftingPlan;
 import appeng.api.networking.security.IActionHost;
 import appeng.api.networking.security.IActionSource;
@@ -147,7 +148,8 @@ public class CraftAmountMenu extends AEBaseMenu implements ISubMenu {
             try {
                 var cg = g.getCraftingService();
                 var actionSource = getActionSrc();
-                futureJob = cg.beginCraftingCalculation(getLevel(), () -> actionSource, whatToCraft, amount);
+                futureJob = cg.beginCraftingCalculation(getLevel(), () -> actionSource, whatToCraft, amount,
+                        CalculationStrategy.REPORT_MISSING_ITEMS);
 
                 var locator = getLocator();
                 if (locator != null) {

--- a/src/test/java/appeng/crafting/simulation/helpers/SimulationEnv.java
+++ b/src/test/java/appeng/crafting/simulation/helpers/SimulationEnv.java
@@ -39,7 +39,6 @@ import appeng.api.storage.AEKeyFilter;
 import appeng.api.storage.IStorageProvider;
 import appeng.api.storage.MEStorage;
 import appeng.crafting.CraftingCalculation;
-import appeng.crafting.CraftingPlan;
 import appeng.me.helpers.BaseActionSource;
 
 public class SimulationEnv {
@@ -83,8 +82,8 @@ public class SimulationEnv {
         return copy;
     }
 
-    public CraftingPlan runSimulation(GenericStack what) {
-        var calculation = new CraftingCalculation(mock(Level.class), gridMock, simulationRequester, what);
+    public ICraftingPlan runSimulation(GenericStack what, CalculationStrategy strategy) {
+        var calculation = new CraftingCalculation(mock(Level.class), gridMock, simulationRequester, what, strategy);
         try {
             var calculationFuture = Executors.newSingleThreadExecutor().submit(calculation::run);
             calculation.simulateFor(1000000000);
@@ -141,7 +140,8 @@ public class SimulationEnv {
 
             @Override
             public Future<ICraftingPlan> beginCraftingCalculation(Level level,
-                    ICraftingSimulationRequester simRequester, AEKey craftWhat, long amount) {
+                    ICraftingSimulationRequester simRequester, AEKey craftWhat, long amount,
+                    CalculationStrategy strat) {
                 throw new UnsupportedOperationException();
             }
 


### PR DESCRIPTION
Only enabled for MultiCraftingTracker requests (interfaces and export busses) for now. Might look into offering the option to players one day?