### PR TITLE
Fix cable dupe bug in weird interaction between cable anchor and security terminal

### DIFF
--- a/src/main/java/appeng/me/GridNode.java
+++ b/src/main/java/appeng/me/GridNode.java
@@ -229,9 +229,11 @@ public class GridNode implements IGridNode, IPathItem {
     }
 
     public void setExposedOnSides(Set<Direction> directions) {
-        exposedOnSides.clear();
-        exposedOnSides.addAll(directions);
-        updateState();
+        if (!exposedOnSides.equals(directions)) {
+            exposedOnSides.clear();
+            exposedOnSides.addAll(directions);
+            updateState();
+        }
     }
 
     /**

--- a/src/main/java/appeng/parts/AEBasePart.java
+++ b/src/main/java/appeng/parts/AEBasePart.java
@@ -326,12 +326,15 @@ public abstract class AEBasePart implements IPart, IActionHost, ICustomNameObjec
 
         @Override
         public void onSecurityBreak(T nodeOwner, IGridNode node) {
-            var items = new ArrayList<ItemStack>();
-            nodeOwner.getDrops(items, false);
-            nodeOwner.getHost().removePart(nodeOwner.getSide());
-            if (!items.isEmpty()) {
-                var be = nodeOwner.getHost().getBlockEntity();
-                Platform.spawnDrops(be.getLevel(), be.getBlockPos(), items);
+            // Only drop items if the part is still attached at that side
+            if (nodeOwner.getHost().getPart(nodeOwner.getSide()) == nodeOwner) {
+                var items = new ArrayList<ItemStack>();
+                nodeOwner.getDrops(items, false);
+                nodeOwner.getHost().removePart(nodeOwner.getSide());
+                if (!items.isEmpty()) {
+                    var be = nodeOwner.getHost().getBlockEntity();
+                    Platform.spawnDrops(be.getLevel(), be.getBlockPos(), items);
+                }
             }
         }
 


### PR DESCRIPTION
And be smarter about trying to connect grid nodes with their surrounding multiple times during placements.

Fixes #5858: