### PR TITLE
Fix Pattern-Provider Blocking into Storage-Bus with Co-Processors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ plugins {
     id "com.diffplug.spotless" version "5.12.4"
     id "com.matthewprenger.cursegradle" version "1.4.0"
     id "com.modrinth.minotaur" version "1.2.1"
+    id 'io.github.juuxel.loom-quiltflower-mini' version '1.2.1'
 }
 
 repositories {

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,6 +5,10 @@ pluginManagement {
             name = 'Fabric'
             url = 'https://maven.fabricmc.net/'
         }
+        maven {
+            name = 'Cotton'
+            url = 'https://server.bbkr.space/artifactory/libs-release/'
+        }
         gradlePluginPortal()
     }
 }

--- a/src/main/java/appeng/api/networking/crafting/ICraftingService.java
+++ b/src/main/java/appeng/api/networking/crafting/ICraftingService.java
@@ -27,9 +27,9 @@ import java.util.Collection;
 import java.util.Set;
 import java.util.concurrent.Future;
 
-import javax.annotation.Nullable;
-
 import com.google.common.collect.ImmutableSet;
+
+import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.world.level.Level;
 
@@ -102,7 +102,8 @@ public interface ICraftingService extends IGridService {
      *         {@link ICraftingRequester} methods. if you send null, this object should be discarded after verifying the
      *         return state.
      */
-    ICraftingLink submitJob(ICraftingPlan job, ICraftingRequester requestingMachine, ICraftingCPU target,
+    ICraftingLink submitJob(ICraftingPlan job, @Nullable ICraftingRequester requestingMachine,
+            @Nullable ICraftingCPU target,
             boolean prioritizePower, IActionSource src);
 
     /**

--- a/src/main/java/appeng/me/storage/CompositeStorage.java
+++ b/src/main/java/appeng/me/storage/CompositeStorage.java
@@ -14,7 +14,7 @@ import appeng.api.stacks.AEKeyType;
 import appeng.api.stacks.KeyCounter;
 import appeng.api.storage.MEStorage;
 import appeng.core.localization.GuiText;
-import appeng.helpers.iface.PatternProviderLogic;
+import appeng.helpers.iface.PatternProviderLogicHost;
 
 /**
  * Combines several ME storages that each handle only a given key-space.
@@ -65,8 +65,8 @@ public class CompositeStorage implements MEStorage, ITickingMonitor {
             return false;
         }
         var machineNode = source.machine().get().getActionableNode();
-        if (machineNode != null && machineNode.getOwner() instanceof PatternProviderLogic logic) {
-            return logic.isBlocking();
+        if (machineNode != null && machineNode.getOwner() instanceof PatternProviderLogicHost host) {
+            return host.getLogic().isBlocking();
         }
         return false;
     }

--- a/src/main/java/appeng/me/storage/CompositeStorage.java
+++ b/src/main/java/appeng/me/storage/CompositeStorage.java
@@ -14,6 +14,7 @@ import appeng.api.stacks.AEKeyType;
 import appeng.api.stacks.KeyCounter;
 import appeng.api.storage.MEStorage;
 import appeng.core.localization.GuiText;
+import appeng.helpers.iface.PatternProviderLogic;
 
 /**
  * Combines several ME storages that each handle only a given key-space.
@@ -22,6 +23,8 @@ public class CompositeStorage implements MEStorage, ITickingMonitor {
     private final InventoryCache cache;
 
     private Map<AEKeyType, MEStorage> storages;
+
+    private boolean forceCacheRebuild;
 
     public CompositeStorage(Map<AEKeyType, MEStorage> storages) {
         this.storages = storages;
@@ -41,7 +44,31 @@ public class CompositeStorage implements MEStorage, ITickingMonitor {
     @Override
     public long insert(AEKey what, long amount, Actionable mode, IActionSource source) {
         var storage = storages.get(what.getType());
-        return storage != null ? storage.insert(what, amount, mode, source) : 0;
+        var inserted = storage != null ? storage.insert(what, amount, mode, source) : 0;
+
+        // If a pattern provider in blocking mode successfully inserts its input into this storage bus,
+        // and we do not currently report that item as being in this storage, we have to refresh
+        // the cache the next time it's queried. Otherwise, the pattern provider would not correctly
+        // detect the pattern input to already be stored here.
+        if (inserted > 0
+                && !forceCacheRebuild
+                && isPatternProviderInBlockingMode(source)
+                && !cache.contains(what)) {
+            forceCacheRebuild = true;
+        }
+
+        return inserted;
+    }
+
+    private static boolean isPatternProviderInBlockingMode(IActionSource source) {
+        if (source.machine().isEmpty()) {
+            return false;
+        }
+        var machineNode = source.machine().get().getActionableNode();
+        if (machineNode != null && machineNode.getOwner() instanceof PatternProviderLogic logic) {
+            return logic.isBlocking();
+        }
+        return false;
     }
 
     @Override
@@ -71,6 +98,7 @@ public class CompositeStorage implements MEStorage, ITickingMonitor {
 
     @Override
     public TickRateModulation onTick() {
+        forceCacheRebuild = false;
         boolean changed = this.cache.update();
         if (changed) {
             return TickRateModulation.URGENT;
@@ -81,6 +109,10 @@ public class CompositeStorage implements MEStorage, ITickingMonitor {
 
     @Override
     public void getAvailableStacks(KeyCounter out) {
+        if (forceCacheRebuild) {
+            forceCacheRebuild = false;
+            cache.update();
+        }
         this.cache.getAvailableKeys(out);
     }
 
@@ -122,6 +154,10 @@ public class CompositeStorage implements MEStorage, ITickingMonitor {
 
         public void getAvailableKeys(KeyCounter out) {
             out.addAll(frontBuffer);
+        }
+
+        public boolean contains(AEKey what) {
+            return frontBuffer.get(what) > 0;
         }
     }
 }

--- a/src/main/java/appeng/server/testworld/DriveBuilder.java
+++ b/src/main/java/appeng/server/testworld/DriveBuilder.java
@@ -1,0 +1,124 @@
+package appeng.server.testworld;
+
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.ItemLike;
+import net.minecraft.world.level.material.Fluid;
+
+import appeng.api.config.Actionable;
+import appeng.api.stacks.AEFluidKey;
+import appeng.api.stacks.AEItemKey;
+import appeng.api.stacks.AEKey;
+import appeng.api.stacks.GenericStack;
+import appeng.api.storage.MEStorage;
+import appeng.core.definitions.AEItems;
+import appeng.me.cells.BasicCellInventory;
+import appeng.me.helpers.BaseActionSource;
+import appeng.util.ConfigInventory;
+
+/**
+ * A helper class for quickly and succintly building the contents of a drive for test plots and tests.
+ */
+public class DriveBuilder {
+    private final List<ItemStack> cells;
+
+    DriveBuilder(List<ItemStack> cells) {
+        this.cells = cells;
+    }
+
+    public CreativeCellBuilder addCreativeCell() {
+        var cell = AEItems.ITEM_CELL_CREATIVE.stack();
+        var configInv = AEItems.ITEM_CELL_CREATIVE.asItem().getConfigInventory(cell);
+        cells.add(cell);
+        return new CreativeCellBuilder(configInv);
+    }
+
+    public ItemCellBuilder addItemCell64k() {
+        var cell = AEItems.ITEM_CELL_64K.stack();
+        var cellInv = BasicCellInventory.createInventory(cell, null);
+        cells.add(cell);
+        return new ItemCellBuilder(cellInv);
+    }
+
+    public FluidCellBuilder addFluidCell64k() {
+        var cell = AEItems.FLUID_CELL_64K.stack();
+        var cellInv = BasicCellInventory.createInventory(cell, null);
+        cells.add(cell);
+        return new FluidCellBuilder(cellInv);
+    }
+
+    public class CellBuilder {
+        protected final MEStorage inv;
+
+        public CellBuilder(MEStorage inv) {
+            this.inv = inv;
+        }
+
+        public void add(GenericStack stack) {
+            add(stack.what(), stack.amount());
+        }
+
+        public void add(AEKey what, long amount) {
+            if (inv.insert(what, amount, Actionable.MODULATE, new BaseActionSource()) != amount) {
+                throw new IllegalArgumentException("Couldn't insert " + amount + " of " + what);
+            }
+        }
+
+        public DriveBuilder and() {
+            return DriveBuilder.this;
+        }
+    }
+
+    public class FluidCellBuilder extends CellBuilder {
+        public FluidCellBuilder(BasicCellInventory inv) {
+            super(inv);
+        }
+
+        public void addBuckets(Fluid fluid, double buckets) {
+            add(AEFluidKey.of(fluid), (long) (buckets * AEFluidKey.AMOUNT_BUCKET));
+        }
+    }
+
+    public class ItemCellBuilder extends CellBuilder {
+        public ItemCellBuilder(BasicCellInventory inv) {
+            super(inv);
+        }
+
+        public void add(ItemLike what, long amount) {
+            add(AEItemKey.of(what.asItem()), amount);
+        }
+    }
+
+    public class CreativeCellBuilder {
+        private final ConfigInventory inv;
+
+        public CreativeCellBuilder(ConfigInventory inv) {
+            this.inv = inv;
+        }
+
+        public void add(ItemLike item) {
+            add(AEItemKey.of(item.asItem()));
+        }
+
+        public void add(Fluid fluid) {
+            add(AEFluidKey.of(fluid));
+        }
+
+        public void add(@Nullable GenericStack stack) {
+            if (stack != null) {
+                add(stack.what());
+            }
+        }
+
+        public void add(AEKey key) {
+            inv.insert(key, 1, Actionable.MODULATE, new BaseActionSource());
+        }
+
+        public DriveBuilder and() {
+            return DriveBuilder.this;
+        }
+    }
+}

--- a/src/main/java/appeng/server/testworld/PlotBuilder.java
+++ b/src/main/java/appeng/server/testworld/PlotBuilder.java
@@ -1,5 +1,6 @@
 package appeng.server.testworld;
 
+import java.util.ArrayList;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -267,6 +268,22 @@ public interface PlotBuilder {
             cells.addItems(AEItems.ITEM_CELL_64K.stack());
             cells.addItems(AEItems.FLUID_CELL_64K.stack());
         });
+    }
+
+    /**
+     * Creates a drive with an empty item and fluid cell.
+     */
+    default DriveBuilder drive(BlockPos pos) {
+        var cells = new ArrayList<ItemStack>(10);
+
+        blockEntity(posToBb(pos), AEBlocks.DRIVE, drive -> {
+            var cellInv = drive.getInternalInventory();
+            for (ItemStack cell : cells) {
+                cellInv.addItems(cell);
+            }
+        });
+
+        return new DriveBuilder(cells);
     }
 
     Test test(Consumer<PlotTestHelper> assertion);

--- a/src/main/java/appeng/server/testworld/PlotTestHelper.java
+++ b/src/main/java/appeng/server/testworld/PlotTestHelper.java
@@ -11,11 +11,14 @@ import net.minecraft.world.phys.Vec3;
 import appeng.api.config.Actionable;
 import appeng.api.networking.IGrid;
 import appeng.api.networking.IInWorldGridNodeHost;
+import appeng.api.parts.IPartHost;
 import appeng.api.stacks.AEItemKey;
 import appeng.api.stacks.AEKey;
 import appeng.api.storage.MEStorage;
 import appeng.me.helpers.BaseActionSource;
 import appeng.me.helpers.IGridConnectedBlockEntity;
+import appeng.parts.AEBasePart;
+import appeng.util.Platform;
 
 public class PlotTestHelper extends GameTestHelper {
     private final BlockPos plotTranslation;
@@ -53,6 +56,8 @@ public class PlotTestHelper extends GameTestHelper {
      * Find all grids in the area and return the biggest one.
      */
     public IGrid getGrid(BlockPos pos) {
+        checkAllInitialized();
+
         var be = getBlockEntity(pos);
         if (be instanceof IGridConnectedBlockEntity gridConnectedBlockEntity) {
             return gridConnectedBlockEntity.getMainNode().getGrid();
@@ -65,6 +70,26 @@ public class PlotTestHelper extends GameTestHelper {
             }
         }
         throw new GameTestAssertException("No grid @ " + pos);
+    }
+
+    /**
+     * Checks that everything is initialized
+     */
+    public void checkAllInitialized() {
+        forEveryBlockInStructure(blockPos -> {
+            var be = getBlockEntity(blockPos);
+            if (be instanceof IGridConnectedBlockEntity gridConnectedBlockEntity) {
+                check(gridConnectedBlockEntity.getMainNode().isReady(), "BE " + be + " is not ready");
+            } else if (be instanceof IPartHost partHost) {
+                for (var side : Platform.DIRECTIONS_WITH_NULL) {
+                    var part = partHost.getPart(side);
+                    if (part instanceof AEBasePart basePart) {
+                        var mainNode = basePart.getMainNode();
+                        check(mainNode.isReady(), "Part " + part + " is not ready");
+                    }
+                }
+            }
+        });
     }
 
     public void assertContains(IGrid grid, Item item) {

--- a/src/main/java/appeng/server/testworld/PlotTestHelper.java
+++ b/src/main/java/appeng/server/testworld/PlotTestHelper.java
@@ -64,7 +64,7 @@ public class PlotTestHelper extends GameTestHelper {
                 }
             }
         }
-        throw new IllegalStateException("No grid @ " + pos);
+        throw new GameTestAssertException("No grid @ " + pos);
     }
 
     public void assertContains(IGrid grid, Item item) {
@@ -88,6 +88,12 @@ public class PlotTestHelper extends GameTestHelper {
         var counter = storage.getAvailableStacks();
         for (var key : counter.keySet()) {
             storage.extract(key, Long.MAX_VALUE, Actionable.MODULATE, new BaseActionSource());
+        }
+    }
+
+    public void check(boolean test, String errorMessage) throws GameTestAssertException {
+        if (!test) {
+            throw new GameTestAssertException(errorMessage);
         }
     }
 }

--- a/src/main/java/appeng/server/testworld/TestCraftingJob.java
+++ b/src/main/java/appeng/server/testworld/TestCraftingJob.java
@@ -1,0 +1,78 @@
+package appeng.server.testworld;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import javax.annotation.Nullable;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.gametest.framework.GameTestAssertException;
+
+import appeng.api.networking.crafting.CalculationStrategy;
+import appeng.api.networking.crafting.ICraftingLink;
+import appeng.api.networking.crafting.ICraftingPlan;
+import appeng.api.networking.crafting.ICraftingSimulationRequester;
+import appeng.api.stacks.AEKey;
+import appeng.core.AELog;
+import appeng.me.helpers.BaseActionSource;
+import appeng.me.helpers.MachineSource;
+
+public class TestCraftingJob {
+    private final PlotTestHelper helper;
+    private final BlockPos gridOrigin;
+    private final AEKey what;
+    private final long amount;
+    private final CalculationStrategy strategy;
+    @Nullable
+    private Future<ICraftingPlan> planFuture;
+    @Nullable
+    private ICraftingPlan plan;
+    @Nullable
+    private ICraftingLink link;
+
+    public TestCraftingJob(PlotTestHelper helper, BlockPos gridOrigin, AEKey what, long amount) {
+        this(helper, gridOrigin, what, amount, CalculationStrategy.REPORT_MISSING_ITEMS);
+    }
+
+    public TestCraftingJob(PlotTestHelper helper, BlockPos gridOrigin, AEKey what, long amount,
+            CalculationStrategy strategy) {
+        this.what = what;
+        this.amount = amount;
+        this.strategy = strategy;
+        this.helper = helper;
+        this.gridOrigin = gridOrigin;
+    }
+
+    /**
+     * Use this with {@link net.minecraft.gametest.framework.GameTestSequence#thenWaitUntil(Runnable)} to wait until the
+     * job has been planned and started.
+     */
+    public void tickUntilStarted() {
+        if (planFuture == null) {
+            var grid = helper.getGrid(gridOrigin);
+            var src = new MachineSource(grid::getPivot);
+            var craftingService = grid.getCraftingService();
+            ICraftingSimulationRequester simRequester = () -> src;
+            planFuture = craftingService.beginCraftingCalculation(grid.getPivot().getLevel(), simRequester,
+                    what, amount, strategy);
+        }
+        if (plan == null) {
+            try {
+                plan = planFuture.get(0, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException | ExecutionException e) {
+                AELog.error(e);
+                throw new GameTestAssertException("Crafting job planning failed: " + e);
+            } catch (TimeoutException e) {
+                throw new GameTestAssertException("Crafting job planning did not complete");
+            }
+        }
+        if (link == null) {
+            var grid = helper.getGrid(BlockPos.ZERO);
+            link = grid.getCraftingService().submitJob(plan, null, null, true,
+                    new BaseActionSource());
+            helper.check(link != null, "failed to submit job");
+        }
+    }
+}

--- a/src/main/java/appeng/server/testworld/TestPlots.java
+++ b/src/main/java/appeng/server/testworld/TestPlots.java
@@ -7,20 +7,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 import java.util.function.Consumer;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 
-import org.apache.commons.lang3.mutable.MutableObject;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Registry;
-import net.minecraft.gametest.framework.GameTestAssertException;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.item.Item;
@@ -42,9 +38,6 @@ import appeng.api.config.RedstoneMode;
 import appeng.api.config.Settings;
 import appeng.api.config.YesNo;
 import appeng.api.crafting.PatternDetailsHelper;
-import appeng.api.networking.crafting.CalculationStrategy;
-import appeng.api.networking.crafting.ICraftingPlan;
-import appeng.api.networking.crafting.ICraftingSimulationRequester;
 import appeng.api.networking.pathing.ChannelMode;
 import appeng.api.parts.PartHelper;
 import appeng.api.stacks.AEFluidKey;
@@ -62,7 +55,6 @@ import appeng.items.storage.CreativeCellItem;
 import appeng.items.tools.powered.MatterCannonItem;
 import appeng.me.cells.BasicCellInventory;
 import appeng.me.helpers.BaseActionSource;
-import appeng.me.helpers.MachineSource;
 import appeng.me.service.PathingService;
 import appeng.parts.crafting.PatternProviderPart;
 import appeng.util.CraftingRecipeUtil;
@@ -728,13 +720,9 @@ public final class TestPlots {
                                     new GenericStack[] { output }));
                     pp.getLogic().getConfigManager().putSetting(Settings.BLOCKING_MODE, YesNo.YES);
                 });
-        plot.blockEntity("2 0 -1", AEBlocks.DRIVE, drive -> {
-            var creativeCell = AEItems.ITEM_CELL_CREATIVE.stack();
-            var configInventory = AEItems.ITEM_CELL_CREATIVE.asItem().getConfigInventory(creativeCell);
-            configInventory.setStack(0, input);
-
-            drive.getInternalInventory().addItems(creativeCell);
-        });
+        plot.drive(new BlockPos(2, 0, -1))
+                .addCreativeCell()
+                .add(input);
         // Subnetwork
         plot.creativeEnergyCell("3 -1 0");
         plot.cable("3 0 0")
@@ -743,47 +731,18 @@ public final class TestPlots {
         plot.block("4 0 0", Blocks.CHEST);
         // Crafting operation
         plot.test(helper -> {
-            var craftingJob = new MutableObject<Future<ICraftingPlan>>();
+            var craftingJob = new TestCraftingJob(helper, BlockPos.ZERO, output.what(), 64);
             helper.startSequence()
-                    .thenIdle(5)
-                    .thenExecute(() -> {
-                        var grid = helper.getGrid(BlockPos.ZERO);
-                        helper.check(!grid.getStorageService().getCachedInventory().isEmpty(), "storage is empty");
-                        var src = new MachineSource(grid::getPivot);
-                        var craftingService = grid.getCraftingService();
-                        ICraftingSimulationRequester simRequester = () -> src;
-                        var future = craftingService.beginCraftingCalculation(grid.getPivot().getLevel(), simRequester,
-                                output.what(), 64, CalculationStrategy.REPORT_MISSING_ITEMS);
-                        craftingJob.setValue(future);
-                    })
-                    // Wait until the crafting job plan has arrived
-                    .thenWaitUntil(() -> {
-                        helper.check(craftingJob.getValue() != null && craftingJob.getValue().isDone(),
-                                "crafting job not done");
-                    })
-                    // Submit job
-                    .thenExecute(() -> {
-                        try {
-                            var plan = craftingJob.getValue().get();
-                            var grid = helper.getGrid(BlockPos.ZERO);
-                            var link = grid.getCraftingService().submitJob(plan, null, null, true,
-                                    new BaseActionSource());
-                            helper.check(link != null, "failed to submit job");
-                        } catch (InterruptedException | ExecutionException e) {
-                            throw new GameTestAssertException("failed to get crafting plan: " + e.getMessage());
-                        }
-                    })
+                    .thenWaitUntil(craftingJob::tickUntilStarted)
                     .thenWaitUntil(() -> {
                         var grid = helper.getGrid(BlockPos.ZERO);
-                        long requesting = grid.getCraftingService().getRequestedAmount(output.what());
+                        var requesting = grid.getCraftingService().getRequestedAmount(output.what());
                         helper.check(requesting > 0, "not yet requesting items");
-                        if (requesting == 1) {
-                            helper.succeed(); // blocking mode succeeded
-                        } else {
-                            helper.testInfo.fail(
-                                    new GameTestAssertException("blocking mode failed, requesting: " + requesting));
+                        if (requesting != 1) {
+                            helper.fail("blocking mode failed, requesting: " + requesting);
                         }
-                    });
+                    })
+                    .thenSucceed();
         });
     }
 }


### PR DESCRIPTION
Fixes #5860: Refresh storage bus inventory cache the next time it's queried if a pattern provider with blocking mode inerts items. Otherwise the test for "does this contain pattern input X" will be based on an outdated cache if the CPU tries to insert multiple patterns per tick (with co-processors).