### PR TITLE
Fix JEI integration not working on the crafting status and confirm screens

### DIFF
--- a/src/main/java/appeng/integration/modules/jei/JEIPlugin.java
+++ b/src/main/java/appeng/integration/modules/jei/JEIPlugin.java
@@ -212,9 +212,9 @@ public class JEIPlugin implements IModPlugin {
                             var stack = baseScreen.getStackUnderMouse(mouseX, mouseY);
                             if (stack != null) {
                                 if (stack.what() instanceof AEItemKey itemKey) {
-                                    return itemKey.toStack(Ints.saturatedCast(stack.amount()));
+                                    return itemKey.toStack();
                                 } else if (stack.what() instanceof AEFluidKey fluidKey) {
-                                    return fluidKey.toStack(Ints.saturatedCast(stack.amount()));
+                                    return fluidKey.toStack(1);
                                 }
                             }
                         }


### PR DESCRIPTION
Behavior is now a bit closer to the REI plugin implementation.
It cant be the same as JEI needs a FluidStack and the REI works with a Fluid.