### PR TITLE
Change crafting recipes for portable cells

### DIFF
--- a/src/main/java/appeng/datagen/providers/recipes/CraftingRecipes.java
+++ b/src/main/java/appeng/datagen/providers/recipes/CraftingRecipes.java
@@ -11,6 +11,7 @@ import net.minecraft.tags.ItemTags;
 import net.minecraft.world.item.Items;
 
 import appeng.api.ids.AETags;
+import appeng.api.stacks.AEKeyType;
 import appeng.api.util.AEColor;
 import appeng.core.AppEng;
 import appeng.core.definitions.AEBlocks;
@@ -18,6 +19,7 @@ import appeng.core.definitions.AEItems;
 import appeng.core.definitions.AEParts;
 import appeng.core.definitions.ItemDefinition;
 import appeng.datagen.providers.tags.ConventionTags;
+import appeng.items.tools.powered.PortableCellItem;
 
 public class CraftingRecipes extends AE2RecipeProvider {
     public CraftingRecipes(DataGenerator generator) {
@@ -827,14 +829,14 @@ public class CraftingRecipes extends AE2RecipeProvider {
                 .unlockedBy("has_engineering_processor", has(AEItems.ENGINEERING_PROCESSOR))
                 .save(consumer, AppEng.makeId("tools/misctools_entropy_manipulator"));
 
-        portableCell(consumer, AEItems.PORTABLE_ITEM_CELL1K, AEItems.ITEM_CELL_1K);
-        portableCell(consumer, AEItems.PORTABLE_ITEM_CELL4k, AEItems.ITEM_CELL_4K);
-        portableCell(consumer, AEItems.PORTABLE_ITEM_CELL16K, AEItems.ITEM_CELL_16K);
-        portableCell(consumer, AEItems.PORTABLE_ITEM_CELL64K, AEItems.ITEM_CELL_64K);
-        portableCell(consumer, AEItems.PORTABLE_FLUID_CELL1K, AEItems.FLUID_CELL_1K);
-        portableCell(consumer, AEItems.PORTABLE_FLUID_CELL4k, AEItems.FLUID_CELL_4K);
-        portableCell(consumer, AEItems.PORTABLE_FLUID_CELL16K, AEItems.FLUID_CELL_16K);
-        portableCell(consumer, AEItems.PORTABLE_FLUID_CELL64K, AEItems.FLUID_CELL_64K);
+        portableCell(consumer, AEItems.PORTABLE_ITEM_CELL1K);
+        portableCell(consumer, AEItems.PORTABLE_ITEM_CELL4k);
+        portableCell(consumer, AEItems.PORTABLE_ITEM_CELL16K);
+        portableCell(consumer, AEItems.PORTABLE_ITEM_CELL64K);
+        portableCell(consumer, AEItems.PORTABLE_FLUID_CELL1K);
+        portableCell(consumer, AEItems.PORTABLE_FLUID_CELL4k);
+        portableCell(consumer, AEItems.PORTABLE_FLUID_CELL16K);
+        portableCell(consumer, AEItems.PORTABLE_FLUID_CELL64K);
 
         ShapedRecipeBuilder.shaped(AEItems.BIOMETRIC_CARD)
                 .pattern("abb")
@@ -878,15 +880,23 @@ public class CraftingRecipes extends AE2RecipeProvider {
 
     }
 
-    private void portableCell(Consumer<FinishedRecipe> consumer,
-            ItemDefinition<?> cell,
-            ItemDefinition<?> component) {
-        ShapedRecipeBuilder.shaped(cell)
-                .pattern("abc")
-                .define('a', AEBlocks.CHEST)
-                .define('b', component)
-                .define('c', AEBlocks.ENERGY_CELL)
-                .unlockedBy("has_" + component.id().getPath(), has(component))
+    private void portableCell(Consumer<FinishedRecipe> consumer, ItemDefinition<PortableCellItem> cell) {
+        ItemDefinition<?> housing;
+        if (cell.asItem().getKeyType() == AEKeyType.items()) {
+            housing = AEItems.ITEM_CELL_HOUSING;
+        } else if (cell.asItem().getKeyType() == AEKeyType.fluids()) {
+            housing = AEItems.FLUID_CELL_HOUSING;
+        } else {
+            throw new RuntimeException("No housing known for " + cell.asItem().getKeyType());
+        }
+
+        var component = cell.asItem().getTier().componentSupplier().get();
+        ShapelessRecipeBuilder.shapeless(cell)
+                .requires(AEBlocks.CHEST)
+                .requires(component)
+                .requires(AEBlocks.ENERGY_CELL)
+                .requires(housing)
+                .unlockedBy("has_" + housing.id().getPath(), has(housing))
                 .unlockedBy("has_energy_cell", has(AEBlocks.ENERGY_CELL))
                 .save(consumer, AppEng.makeId("tools/" + cell.id().getPath()));
     }

--- a/src/main/java/appeng/items/tools/powered/PortableCellItem.java
+++ b/src/main/java/appeng/items/tools/powered/PortableCellItem.java
@@ -19,10 +19,12 @@
 package appeng.items.tools.powered;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Registry;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
@@ -32,12 +34,14 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.ClickAction;
 import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.Level;
 
 import appeng.api.config.Actionable;
 import appeng.api.config.FuzzyMode;
+import appeng.api.ids.AEItemIds;
 import appeng.api.implementations.menuobjects.IMenuItem;
 import appeng.api.stacks.AEFluidKey;
 import appeng.api.stacks.AEItemKey;
@@ -61,10 +65,14 @@ import appeng.util.ConfigInventory;
 public class PortableCellItem extends AEBasePoweredItem
         implements IBasicCellItem, IMenuItem {
 
-    public static final StorageTier SIZE_1K = new StorageTier("1k", 512, 54, 8);
-    public static final StorageTier SIZE_4K = new StorageTier("4k", 2048, 45, 32);
-    public static final StorageTier SIZE_16K = new StorageTier("16k", 8192, 36, 128);
-    public static final StorageTier SIZE_64K = new StorageTier("64k", 16834, 27, 512);
+    public static final StorageTier SIZE_1K = new StorageTier("1k", 512, 54, 8,
+            () -> Registry.ITEM.get(AEItemIds.CELL_COMPONENT_1K));
+    public static final StorageTier SIZE_4K = new StorageTier("4k", 2048, 45, 32,
+            () -> Registry.ITEM.get(AEItemIds.CELL_COMPONENT_4K));
+    public static final StorageTier SIZE_16K = new StorageTier("16k", 8192, 36, 128,
+            () -> Registry.ITEM.get(AEItemIds.CELL_COMPONENT_16K));
+    public static final StorageTier SIZE_64K = new StorageTier("64k", 16834, 27, 512,
+            () -> Registry.ITEM.get(AEItemIds.CELL_COMPONENT_64K));
 
     private final StorageTier tier;
     private final AEKeyType keyType;
@@ -203,7 +211,8 @@ public class PortableCellItem extends AEBasePoweredItem
         return 0;
     }
 
-    public record StorageTier(String namePrefix, int bytes, int types, int bytesPerType) {
+    public record StorageTier(String namePrefix, int bytes, int types, int bytesPerType,
+            Supplier<Item> componentSupplier) {
     }
 
     @Override
@@ -285,4 +294,7 @@ public class PortableCellItem extends AEBasePoweredItem
         return true;
     }
 
+    public StorageTier getTier() {
+        return tier;
+    }
 }


### PR DESCRIPTION
Fixes #5890: 

Change crafting recipes for portable cells to use a housing+cell component separately to prevent players from accidentally using non-empty storage cells and voiding contained items.

![grafik](https://user-images.githubusercontent.com/1261399/147412284-ac36bca4-9c41-4064-a3a8-0a5b3c603431.png)
