### PR TITLE
Allow disassembly of portable cells into their components

### DIFF
--- a/src/main/java/appeng/core/AEConfig.java
+++ b/src/main/java/appeng/core/AEConfig.java
@@ -425,6 +425,10 @@ public final class AEConfig {
         return CLIENT.showPlacementPreview.get();
     }
 
+    public boolean isPortableCellDisassemblyEnabled() {
+        return COMMON.portableCellDisassembly.get();
+    }
+
     // Setters keep visibility as low as possible.
 
     private static class ClientConfig {
@@ -523,6 +527,9 @@ public final class AEConfig {
         public final DoubleOption wirelessBoosterExp;
         public final DoubleOption wirelessHighWirelessCount;
 
+        // Portable Cells
+        public final BooleanOption portableCellDisassembly;
+
         // Power Ratios
         public final DoubleOption powerRatioTechReborn;
         public final DoubleOption powerUsageMultiplier;
@@ -619,6 +626,10 @@ public final class AEConfig {
             this.wirelessBoosterExp = wireless.addDouble("wirelessBoosterExp", 1.5);
             this.wirelessHighWirelessCount = wireless.addDouble("wirelessHighWirelessCount", 64.0);
             this.wirelessTerminalDrainMultiplier = wireless.addDouble("wirelessTerminalDrainMultiplier", 1.0);
+
+            ConfigSection portableCells = root.subsection("PortableCells");
+            portableCellDisassembly = portableCells.addBoolean("allowDisassembly", true,
+                    "Allow disassembly of portable cells into the recipe ingredients using shift+right-click");
 
             ConfigSection PowerRatios = root.subsection("PowerRatios");
             powerRatioTechReborn = PowerRatios.addDouble("TechReborn", DEFAULT_TR_EXCHANGE);

--- a/src/main/java/appeng/core/localization/PlayerMessages.java
+++ b/src/main/java/appeng/core/localization/PlayerMessages.java
@@ -22,18 +22,39 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TranslatableComponent;
 
 public enum PlayerMessages {
-    ChestCannotReadStorageCell, InvalidMachine, LoadedSettings, SavedSettings, ResetSettings, MachineNotPowered,
-
-    isNowLocked, isNowUnlocked, AmmoDepleted, CommunicationError, OutOfRange, DeviceNotPowered,
-    DeviceNotWirelessTerminal, DeviceNotLinked, StationCanNotBeLocated, SettingCleared,
+    AmmoDepleted("Ammo Depleted."),
+    ChestCannotReadStorageCell("ME Chest cannot read storage cell."),
+    CommunicationError("Error Communicating with Network."),
+    DeviceNotLinked("Device is not linked."),
+    DeviceNotPowered("Device is low on power."),
+    InvalidMachine("Invalid Machine."),
+    LoadedSettings("Loaded device configuration from memory card."),
+    MachineNotPowered("Machine is not powered."),
+    OutOfRange("Wireless Out Of Range."),
+    ResetSettings("New device configuration created and copied to memory card."),
+    SavedSettings("Copied current device configuration to memory card."),
+    SettingCleared("Memory card cleared."),
+    StationCanNotBeLocated("Station can not be located."),
+    isNowLocked("Monitor is now Locked."),
+    isNowUnlocked("Monitor is now Unlocked."),
+    OnlyEmptyCellsCanBeDisassembled("Only empty storage cells can be disassembled."),
     ;
+
+    private final String englishText;
+
+    PlayerMessages(String englishText) {
+        this.englishText = englishText;
+    }
 
     public Component get() {
         return new TranslatableComponent(this.getTranslationKey());
     }
 
-    String getTranslationKey() {
-        return "chat.ae2." + this.toString();
+    public String getEnglishText() {
+        return englishText;
     }
 
+    public String getTranslationKey() {
+        return "chat.ae2." + name();
+    }
 }

--- a/src/main/java/appeng/datagen/providers/localization/LocalizationProvider.java
+++ b/src/main/java/appeng/datagen/providers/localization/LocalizationProvider.java
@@ -19,6 +19,7 @@ import appeng.core.definitions.AEBlocks;
 import appeng.core.definitions.AEItems;
 import appeng.core.localization.ButtonToolTips;
 import appeng.core.localization.GuiText;
+import appeng.core.localization.PlayerMessages;
 import appeng.datagen.providers.IAE2DataProvider;
 
 public class LocalizationProvider implements IAE2DataProvider {
@@ -48,6 +49,9 @@ public class LocalizationProvider implements IAE2DataProvider {
         for (var text : ButtonToolTips.values()) {
             add("gui.tooltips.ae2." + text.name(), text.getEnglishText());
         }
+        for (var text : PlayerMessages.values()) {
+            add(text.getTranslationKey(), text.getEnglishText());
+        }
 
         generateLocalizations();
 
@@ -69,21 +73,6 @@ public class LocalizationProvider implements IAE2DataProvider {
 
     private void generateLocalizations() {
         add("ae2.permission_denied", "You lack permission to access this.");
-        add("chat.ae2.AmmoDepleted", "Ammo Depleted.");
-        add("chat.ae2.ChestCannotReadStorageCell", "ME Chest cannot read storage cell.");
-        add("chat.ae2.CommunicationError", "Error Communicating with Network.");
-        add("chat.ae2.DeviceNotLinked", "Device is not linked.");
-        add("chat.ae2.DeviceNotPowered", "Device is low on power.");
-        add("chat.ae2.InvalidMachine", "Invalid Machine.");
-        add("chat.ae2.LoadedSettings", "Loaded device configuration from memory card.");
-        add("chat.ae2.MachineNotPowered", "Machine is not powered.");
-        add("chat.ae2.OutOfRange", "Wireless Out Of Range.");
-        add("chat.ae2.ResetSettings", "New device configuration created and copied to memory card.");
-        add("chat.ae2.SavedSettings", "Copied current device configuration to memory card.");
-        add("chat.ae2.SettingCleared", "Memory card cleared.");
-        add("chat.ae2.StationCanNotBeLocated", "Station can not be located.");
-        add("chat.ae2.isNowLocked", "Monitor is now Locked.");
-        add("chat.ae2.isNowUnlocked", "Monitor is now Unlocked.");
         add("commands.ae2.ChunkLoggerOff", "Chunk Logging is now off");
         add("commands.ae2.ChunkLoggerOn", "Chunk Logging is now on");
         add("commands.ae2.permissions", "You do not have adequate permissions to run this command.");

--- a/src/main/java/appeng/datagen/providers/recipes/CraftingRecipes.java
+++ b/src/main/java/appeng/datagen/providers/recipes/CraftingRecipes.java
@@ -898,7 +898,7 @@ public class CraftingRecipes extends AE2RecipeProvider {
                 .requires(housing)
                 .unlockedBy("has_" + housing.id().getPath(), has(housing))
                 .unlockedBy("has_energy_cell", has(AEBlocks.ENERGY_CELL))
-                .save(consumer, AppEng.makeId("tools/" + cell.id().getPath()));
+                .save(consumer, cell.asItem().getRecipeId());
     }
 
     private void addSpatialCells(Consumer<FinishedRecipe> consumer) {


### PR DESCRIPTION
Fixes #5889: Allow disassembly of portable cells into their components. Move chat localization to data generation.