### PR TITLE
Indicate when items are being hidden through JEI or REI search

### DIFF
--- a/src/main/java/appeng/client/gui/AEBaseScreen.java
+++ b/src/main/java/appeng/client/gui/AEBaseScreen.java
@@ -64,6 +64,7 @@ import appeng.client.gui.layout.SlotGridLayout;
 import appeng.client.gui.style.ScreenStyle;
 import appeng.client.gui.style.SlotPosition;
 import appeng.client.gui.style.Text;
+import appeng.client.gui.style.TextAlignment;
 import appeng.client.gui.widgets.ITickingWidget;
 import appeng.client.gui.widgets.ITooltip;
 import appeng.client.gui.widgets.VerticalButtonBar;
@@ -388,22 +389,40 @@ public abstract class AEBaseScreen<T extends AEBaseMenu> extends AbstractContain
         // Allow overrides for which content is shown
         Component content = text.getText();
         if (override != null && override.getContent() != null) {
-            content = override.getContent();
+            content = override.getContent().copy().withStyle(content.getStyle());
         }
 
         Point pos = text.getPosition().resolve(getBounds(false));
 
-        if (text.isCenterHorizontally()) {
-            int textWidth = this.font.width(content);
+        float scale = text.getScale();
+
+        if (text.getAlign() == TextAlignment.CENTER) {
+            int textWidth = Math.round(this.font.width(content) * scale);
             pos = pos.move(-textWidth / 2, 0);
+        } else if (text.getAlign() == TextAlignment.RIGHT) {
+            int textWidth = Math.round(this.font.width(content) * scale);
+            pos = pos.move(-textWidth, 0);
         }
 
-        this.font.draw(
-                poseStack,
-                content,
-                pos.getX(),
-                pos.getY(),
-                color);
+        if (text.getScale() == 1) {
+            this.font.draw(
+                    poseStack,
+                    content,
+                    pos.getX(),
+                    pos.getY(),
+                    color);
+        } else {
+            poseStack.pushPose();
+            poseStack.translate(pos.getX(), pos.getY(), 0);
+            poseStack.scale(text.getScale(), text.getScale(), 1);
+            this.font.draw(
+                    poseStack,
+                    content,
+                    0,
+                    0,
+                    color);
+            poseStack.popPose();
+        }
     }
 
     public void drawFG(PoseStack poseStack, int offsetX, int offsetY, int mouseX, int mouseY) {

--- a/src/main/java/appeng/client/gui/me/common/MEStorageScreen.java
+++ b/src/main/java/appeng/client/gui/me/common/MEStorageScreen.java
@@ -87,6 +87,8 @@ import appeng.util.prioritylist.IPartitionList;
 public class MEStorageScreen<C extends MEStorageMenu>
         extends AEBaseScreen<C> implements ISortSource, IConfigManagerListener {
 
+    private static final String TEXT_ID_ENTRIES_SHOWN = "entriesShown";
+
     private static final int MIN_ROWS = 3;
 
     private static String memoryText = "";
@@ -315,16 +317,7 @@ public class MEStorageScreen<C extends MEStorageMenu>
     protected void updateBeforeRender() {
         super.updateBeforeRender();
 
-        var searchMode = AEConfig.instance().getTerminalSearchMode();
-        if (searchMode.shouldUseExternalSearchBox()) {
-            this.searchField.setVisible(false);
-            var externalSearchText = Platform.getExternalSearchText(searchMode);
-            if (!Objects.equals(repo.getSearchString(), externalSearchText)) {
-                setSearchText(externalSearchText);
-            }
-        } else {
-            this.searchField.setVisible(true);
-        }
+        updateSearch();
 
         // Override the dialog title found in the screen JSON with the user-supplied name
         if (!this.title.getString().isEmpty()) {
@@ -332,6 +325,29 @@ public class MEStorageScreen<C extends MEStorageMenu>
         } else if (this.menu.getTarget() instanceof IMEChest) {
             // ME Chest uses Item Terminals, but overrides the title
             setTextContent(TEXT_ID_DIALOG_TITLE, GuiText.Chest.text());
+        }
+    }
+
+    private void updateSearch() {
+        var searchMode = AEConfig.instance().getTerminalSearchMode();
+        if (searchMode.shouldUseExternalSearchBox()) {
+            this.searchField.setVisible(false);
+            var externalSearchText = Platform.getExternalSearchText(searchMode);
+            if (!Objects.equals(repo.getSearchString(), externalSearchText)) {
+                setSearchText(externalSearchText);
+            }
+
+            var allEntries = repo.getAllEntries().size();
+            var visibleEntries = repo.size();
+            if (allEntries != visibleEntries) {
+                setTextHidden(TEXT_ID_ENTRIES_SHOWN, false);
+                setTextContent(TEXT_ID_ENTRIES_SHOWN, GuiText.ShowingOf.text(visibleEntries, allEntries));
+            } else {
+                setTextHidden(TEXT_ID_ENTRIES_SHOWN, true);
+            }
+        } else {
+            this.searchField.setVisible(true);
+            setTextHidden(TEXT_ID_ENTRIES_SHOWN, true);
         }
     }
 

--- a/src/main/java/appeng/client/gui/style/Text.java
+++ b/src/main/java/appeng/client/gui/style/Text.java
@@ -42,9 +42,14 @@ public class Text {
     private Position position;
 
     /**
-     * Center on the computed x position.
+     * Alignment relative to the computed x position.
      */
-    private boolean centerHorizontally;
+    private TextAlignment align = TextAlignment.LEFT;
+
+    /**
+     * Allows text to be scaled.
+     */
+    private float scale = 1.0f;
 
     public Component getText() {
         return text;
@@ -70,11 +75,24 @@ public class Text {
         this.position = position;
     }
 
-    public boolean isCenterHorizontally() {
-        return centerHorizontally;
+    public TextAlignment getAlign() {
+        return align;
     }
 
-    public void setCenterHorizontally(boolean centerHorizontally) {
-        this.centerHorizontally = centerHorizontally;
+    public void setAlign(TextAlignment align) {
+        this.align = align;
+    }
+
+    @Deprecated(forRemoval = true, since = "1.18")
+    public void setCenterHorizontally(boolean enable) {
+        align = enable ? TextAlignment.CENTER : TextAlignment.LEFT;
+    }
+
+    public float getScale() {
+        return scale;
+    }
+
+    public void setScale(float scale) {
+        this.scale = scale;
     }
 }

--- a/src/main/java/appeng/client/gui/style/TextAlignment.java
+++ b/src/main/java/appeng/client/gui/style/TextAlignment.java
@@ -1,0 +1,7 @@
+package appeng.client.gui.style;
+
+public enum TextAlignment {
+    LEFT,
+    CENTER,
+    RIGHT
+}

--- a/src/main/java/appeng/core/localization/GuiText.java
+++ b/src/main/java/appeng/core/localization/GuiText.java
@@ -150,6 +150,7 @@ public enum GuiText {
     SelectedCraftingCPU("Crafting CPU: %s"),
     SerialNumber("Serial Number: %s"),
     Set("Set"),
+    ShowingOf("Showing %d of %d"),
     SkyChest("Sky Stone Chest"),
     // Used in a terminal to indicate that an item is craftable
     SmallFontCraft("Craft"),

--- a/src/main/resources/assets/ae2/screens/craft_confirm.json
+++ b/src/main/resources/assets/ae2/screens/craft_confirm.json
@@ -17,7 +17,7 @@
         "left": 109,
         "top": 165
       },
-      "centerHorizontally": true
+      "align": "CENTER"
     }
   },
   "widgets": {

--- a/src/main/resources/assets/ae2/screens/schema.json
+++ b/src/main/resources/assets/ae2/screens/schema.json
@@ -359,9 +359,17 @@
           "position": {
             "$ref": "#/definitions/position"
           },
-          "centerHorizontally": {
-            "type": "boolean",
-            "default": false
+          "scale": {
+            "type": "number",
+            "default": 1,
+            "minimum": 0.1,
+            "maximum": 4,
+            "$comment": "Can be used to display smaller text, 0.5 works well, usually"
+          },
+          "align": {
+            "type": "string",
+            "default": "LEFT",
+            "enum": ["LEFT", "CENTER", "RIGHT"]
           }
         }
       }

--- a/src/main/resources/assets/ae2/screens/terminals/base_terminal.json
+++ b/src/main/resources/assets/ae2/screens/terminals/base_terminal.json
@@ -24,6 +24,17 @@
       "srcRect": [0, 71, 195, 97]
     }
   },
+  "text": {
+    "entriesShown": {
+      "color": "DEFAULT_TEXT_COLOR",
+      "align": "RIGHT",
+      "scale": 0.6,
+      "position": {
+        "right": 26,
+        "top": 8
+      }
+    }
+  },
   "widgets": {
     "scrollbar": {
       "left": 175,

--- a/src/main/resources/assets/ae2/screens/wireless.json
+++ b/src/main/resources/assets/ae2/screens/wireless.json
@@ -26,14 +26,14 @@
         "left": 88,
         "top": 20
       },
-      "centerHorizontally": true
+      "align": "CENTER"
     },
     "energy_use": {
       "position": {
         "left": 88,
         "top": 32
       },
-      "centerHorizontally": true
+      "align": "CENTER"
     }
   }
 }


### PR DESCRIPTION
Fixes #5902: Indicate when items are being hidden through JEI or REI search.

![grafik](https://user-images.githubusercontent.com/1261399/147422818-80149174-f70c-47b6-b6ad-facfb8dc9351.png)


Adds the ability to specify "scale" and "align" for texts in screen JSONs as well.