### PR TITLE
Fix ghost parts when seurity-checks fail for placed parts

### DIFF
--- a/src/main/java/appeng/parts/CableBusContainer.java
+++ b/src/main/java/appeng/parts/CableBusContainer.java
@@ -51,6 +51,7 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 
 import appeng.api.config.YesNo;
 import appeng.api.exceptions.FailedConnectionException;
+import appeng.api.exceptions.SecurityConnectionException;
 import appeng.api.implementations.parts.ICablePart;
 import appeng.api.networking.GridHelper;
 import appeng.api.networking.IGridNode;
@@ -188,7 +189,9 @@ public class CableBusContainer implements AEMultiBlockEntity, ICableBusContainer
                             try {
                                 GridConnection.create(cableNode, existingPartNode, null);
                             } catch (FailedConnectionException e) {
-                                AELog.warn(e);
+                                if (!(e instanceof SecurityConnectionException)) {
+                                    AELog.warn(e); // Security check failures are already logged in the security check
+                                }
 
                                 cablePart.removeFromWorld();
                                 this.storage.setCenter(null);
@@ -224,7 +227,9 @@ public class CableBusContainer implements AEMultiBlockEntity, ICableBusContainer
                     try {
                         GridConnection.create(cableNode, partNode, null);
                     } catch (FailedConnectionException e) {
-                        AELog.warn(e);
+                        if (!(e instanceof SecurityConnectionException)) {
+                            AELog.warn(e); // Security check failures are already logged in the security check
+                        }
 
                         part.removeFromWorld();
                         this.storage.removePart(side);

--- a/src/main/java/appeng/parts/PartPlacement.java
+++ b/src/main/java/appeng/parts/PartPlacement.java
@@ -17,6 +17,7 @@ import appeng.api.parts.IPartItem;
 import appeng.api.parts.PartHelper;
 import appeng.core.AELog;
 import appeng.core.definitions.AEBlocks;
+import appeng.util.Platform;
 import appeng.util.SettingsFrom;
 
 public class PartPlacement {
@@ -42,6 +43,10 @@ public class PartPlacement {
         // Then try to place it
         var part = placePart(player, level, partItem, partStack.getTag(), placement.pos(), placement.side());
         if (part == null) {
+            // Resend the host to the client. Failure to connect for security reasons is only possible to know
+            // server-side, and this will cause ghost parts on the client.
+            Platform.sendImmediateBlockEntityUpdate(player, pos);
+
             return InteractionResult.FAIL;
         }
 

--- a/src/main/java/appeng/util/Platform.java
+++ b/src/main/java/appeng/util/Platform.java
@@ -46,6 +46,7 @@ import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientboundLevelChunkWithLightPacket;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.CraftingContainer;
@@ -678,5 +679,21 @@ public class Platform {
         ItemStack copy = itemStack.copy();
         copy.setCount(size);
         return copy;
+    }
+
+    /**
+     * Send an update packet for the block entity at the given position to the player immediately, if they're a server
+     * player.
+     */
+    public static void sendImmediateBlockEntityUpdate(Player player, BlockPos pos) {
+        if (player instanceof ServerPlayer serverPlayer) {
+            var be = player.getLevel().getBlockEntity(pos);
+            if (be != null) {
+                var packet = be.getUpdatePacket();
+                if (packet != null) {
+                    serverPlayer.connection.send(packet);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #5885: Update the cable bus for the player placing a part if it fails only server-side to remove client-side ghost parts.