### PR TITLE
Disable rotation for network tool

### DIFF
--- a/src/main/java/appeng/blockentity/crafting/CraftingBlockEntity.java
+++ b/src/main/java/appeng/blockentity/crafting/CraftingBlockEntity.java
@@ -78,9 +78,7 @@ public class CraftingBlockEntity extends AENetworkBlockEntity
 
     @Override
     public boolean canBeRotated() {
-        return true;// return BlockCraftingUnit.checkType( level.getBlockMetadata( xCoord, yCoord,
-        // zCoord ),
-        // BlockCraftingUnit.BASE_MONITOR );
+        return false;
     }
 
     @Override

--- a/src/main/java/appeng/blockentity/crafting/CraftingMonitorBlockEntity.java
+++ b/src/main/java/appeng/blockentity/crafting/CraftingMonitorBlockEntity.java
@@ -22,8 +22,6 @@ import java.util.Objects;
 
 import javax.annotation.Nullable;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
@@ -40,12 +38,6 @@ import appeng.core.definitions.AEBlocks;
 
 public class CraftingMonitorBlockEntity extends CraftingBlockEntity implements IColorableBlockEntity {
 
-    @Environment(EnvType.CLIENT)
-    private Integer dspList;
-
-    @Environment(EnvType.CLIENT)
-    private boolean updateList;
-
     private GenericStack display;
     private AEColor paintedColor = AEColor.TRANSPARENT;
 
@@ -61,8 +53,7 @@ public class CraftingMonitorBlockEntity extends CraftingBlockEntity implements I
 
         this.display = GenericStack.readBuffer(data);
 
-        this.setUpdateList(true);
-        return oldPaintedColor != this.paintedColor || c; // tesr!
+        return oldPaintedColor != this.paintedColor || c; // Block Entity Renderer takes care of display
     }
 
     @Override
@@ -126,22 +117,6 @@ public class CraftingMonitorBlockEntity extends CraftingBlockEntity implements I
         return true;
     }
 
-    public Integer getDisplayList() {
-        return this.dspList;
-    }
-
-    public void setDisplayList(Integer dspList) {
-        this.dspList = dspList;
-    }
-
-    public boolean isUpdateList() {
-        return this.updateList;
-    }
-
-    public void setUpdateList(boolean updateList) {
-        this.updateList = updateList;
-    }
-
     @Override
     protected Item getItemFromBlockEntity() {
         return AEBlocks.CRAFTING_MONITOR.asItem();
@@ -152,4 +127,8 @@ public class CraftingMonitorBlockEntity extends CraftingBlockEntity implements I
         return new CraftingMonitorModelData(getUp(), getForward(), getConnections(), getColor());
     }
 
+    @Override
+    public boolean canBeRotated() {
+        return true;
+    }
 }

--- a/src/main/java/appeng/blockentity/networking/ControllerBlockEntity.java
+++ b/src/main/java/appeng/blockentity/networking/ControllerBlockEntity.java
@@ -144,4 +144,9 @@ public class ControllerBlockEntity extends AENetworkPowerBlockEntity {
     private boolean checkController(BlockPos pos) {
         return Platform.getTickingBlockEntity(getLevel(), pos) instanceof ControllerBlockEntity;
     }
+
+    @Override
+    public boolean canBeRotated() {
+        return false;
+    }
 }

--- a/src/main/java/appeng/util/InteractionUtil.java
+++ b/src/main/java/appeng/util/InteractionUtil.java
@@ -35,6 +35,7 @@ import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 
 import appeng.datagen.providers.tags.ConventionTags;
+import appeng.items.tools.NetworkToolItem;
 
 /**
  * Utility functions revolving around using or placing items.
@@ -57,6 +58,11 @@ public final class InteractionUtil {
      */
     public static boolean canWrenchRotate(ItemStack tool) {
         // TODO FABRIC 117 Currently Fabric cannot dynamically distinguish tools / tool actions
+        // Special case to stop the network tool from rotating things instead of opening the appropriate UI
+        if (tool.getItem() instanceof NetworkToolItem) {
+            return false;
+        }
+
         return ConventionTags.WRENCH.contains(tool.getItem());
     }
 


### PR DESCRIPTION
Fixes #5867: The network tool no longer counts as a wrench for the purposes of rotating blocks on Fabric.

Make controller and crafting CPU non-rotatable.