### PR TITLE
Fix Crafting Provider Possibly Receiving Items After Cancellation

### DIFF
--- a/src/main/java/appeng/crafting/CraftingLink.java
+++ b/src/main/java/appeng/crafting/CraftingLink.java
@@ -155,6 +155,11 @@ public class CraftingLink implements ICraftingLink {
             return 0;
         }
 
+        // The job was canceled. Don't insert more items. See issue #5919
+        if (tie.isCanceled()) {
+            return 0;
+        }
+
         return this.tie.getRequest().getRequester().insertCraftedItems(this.tie.getRequest(), what, amount, mode);
     }
 

--- a/src/main/java/appeng/server/testworld/AutoCraftingTestPlot.java
+++ b/src/main/java/appeng/server/testworld/AutoCraftingTestPlot.java
@@ -14,8 +14,6 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.material.Fluids;
 
 import appeng.api.config.Actionable;
-import appeng.api.config.Settings;
-import appeng.api.config.YesNo;
 import appeng.api.crafting.PatternDetailsHelper;
 import appeng.api.inventories.ISegmentedInventory;
 import appeng.api.stacks.AEFluidKey;
@@ -150,12 +148,7 @@ public final class AutoCraftingTestPlot {
                 .part(Direction.NORTH, AEParts.TOGGLE_BUS);
         plot.cable("0 1 0");
         plot.cable("0 1 1")
-                .part(Direction.DOWN, AEParts.LEVEL_EMITTER, levelEmitter -> {
-                    levelEmitter.getConfig().insert(0, AEFluidKey.of(Fluids.WATER), 1, Actionable.MODULATE);
-                    levelEmitter.getUpgrades().addItems(AEItems.CRAFTING_CARD.stack());
-                    // Set it to emit and craft on redstone
-                    levelEmitter.getConfigManager().putSetting(Settings.CRAFT_VIA_REDSTONE, YesNo.YES);
-                })
+                .craftingEmitter(Direction.DOWN, Fluids.WATER)
                 .part(Direction.SOUTH, AEParts.INTERFACE);
         plot.cable("0 1 2")
                 .part(Direction.NORTH, AEParts.STORAGE_BUS, storageBus -> {

--- a/src/main/java/appeng/server/testworld/CableBuilder.java
+++ b/src/main/java/appeng/server/testworld/CableBuilder.java
@@ -3,8 +3,17 @@ package appeng.server.testworld;
 import java.util.function.Consumer;
 
 import net.minecraft.core.Direction;
+import net.minecraft.world.level.ItemLike;
+import net.minecraft.world.level.material.Fluid;
 
+import appeng.api.config.Settings;
+import appeng.api.config.YesNo;
 import appeng.api.parts.IPart;
+import appeng.api.stacks.AEFluidKey;
+import appeng.api.stacks.AEItemKey;
+import appeng.api.stacks.AEKey;
+import appeng.core.definitions.AEItems;
+import appeng.core.definitions.AEParts;
 import appeng.core.definitions.ItemDefinition;
 import appeng.items.parts.PartItem;
 
@@ -27,5 +36,24 @@ public class CableBuilder {
             Consumer<T> partCustomizer) {
         plotBuilder.part(bb, side, part, partCustomizer);
         return this;
+    }
+
+    /**
+     * Set up a level emitter configured to emit a given item for crafting.
+     */
+    public CableBuilder craftingEmitter(Direction side, AEKey what) {
+        return part(side, AEParts.LEVEL_EMITTER, emitter -> {
+            emitter.getUpgrades().addItems(AEItems.CRAFTING_CARD.stack());
+            emitter.getConfigManager().putSetting(Settings.CRAFT_VIA_REDSTONE, YesNo.YES);
+            emitter.getConfig().addFilter(what);
+        });
+    }
+
+    public CableBuilder craftingEmitter(Direction side, ItemLike what) {
+        return craftingEmitter(side, AEItemKey.of(what));
+    }
+
+    public CableBuilder craftingEmitter(Direction side, Fluid what) {
+        return craftingEmitter(side, AEFluidKey.of(what));
     }
 }

--- a/src/main/java/appeng/util/ConfigInventory.java
+++ b/src/main/java/appeng/util/ConfigInventory.java
@@ -137,12 +137,15 @@ public class ConfigInventory extends GenericStackInv {
     }
 
     public void addFilter(ItemLike item) {
-        Preconditions.checkState(getMode() == Mode.CONFIG_TYPES);
-        insert(AEItemKey.of(item), 1, Actionable.MODULATE, new BaseActionSource());
+        addFilter(AEItemKey.of(item));
     }
 
     public void addFilter(Fluid fluid) {
+        addFilter(AEFluidKey.of(fluid));
+    }
+
+    public void addFilter(AEKey what) {
         Preconditions.checkState(getMode() == Mode.CONFIG_TYPES);
-        insert(AEFluidKey.of(fluid), 1, Actionable.MODULATE, new BaseActionSource());
+        insert(what, 1, Actionable.MODULATE, new BaseActionSource());
     }
 }


### PR DESCRIPTION
Fixes a crash with crafting/stocking interfaces where the requested item is subsequently inserted on the same tick after the crafting card had already been removed.

Fixes #5919