### PR TITLE
Fix processing patterns with duplicate outputs

### DIFF
--- a/src/main/java/appeng/crafting/pattern/AEProcessingPattern.java
+++ b/src/main/java/appeng/crafting/pattern/AEProcessingPattern.java
@@ -50,10 +50,10 @@ public class AEProcessingPattern implements IAEPatternDetails {
 
         var primaryOutput = this.sparseOutputs[0];
         this.condensedOutputs = AEPatternHelper.condenseStacks(sparseOutputs);
-        // Ensure the primary output is the first in the list, even if it has a smaller stack size.
+        // Ensure the primary output is the first in the list, even if it has a larger stack size from being merged
         int primaryOutputIndex = -1;
         for (int i = 0; i < condensedOutputs.length; ++i) {
-            if (primaryOutput.equals(condensedOutputs[i])) {
+            if (primaryOutput.what().equals(condensedOutputs[i].what())) {
                 primaryOutputIndex = i;
             }
         }


### PR DESCRIPTION
Fixes #5917: Correctly decode processing patterns where the same item was specified as a primary and secondary output.

![grafik](https://user-images.githubusercontent.com/1261399/147565327-76e9b35e-af10-426b-9981-cf9e2c571863.png)
