### PR TITLE
Fix potential to get stuck on Worldgen when Vanilla flows Water/Lava

### DIFF
--- a/src/main/java/appeng/worldgen/meteorite/MeteoriteBlockPutter.java
+++ b/src/main/java/appeng/worldgen/meteorite/MeteoriteBlockPutter.java
@@ -20,6 +20,7 @@ package appeng.worldgen.meteorite;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 
@@ -31,7 +32,7 @@ public class MeteoriteBlockPutter {
             return false;
         }
 
-        level.setBlock(pos, blk, 0);
+        level.setBlock(pos, blk, Block.UPDATE_ALL);
         return true;
     }
 

--- a/src/main/java/appeng/worldgen/meteorite/MeteoritePlacer.java
+++ b/src/main/java/appeng/worldgen/meteorite/MeteoritePlacer.java
@@ -267,7 +267,7 @@ public final class MeteoritePlacer {
                     if (state.getMaterial().isReplaceable()) {
                         if (!level.isEmptyBlock(blockPosUp)) {
                             final BlockState stateUp = level.getBlockState(blockPosUp);
-                            level.setBlock(blockPos, stateUp, 3);
+                            level.setBlock(blockPos, stateUp, Block.UPDATE_ALL);
                         } else if (randomShit < 100 * this.crater) {
                             final double dx = i - x;
                             final double dy = j - y;


### PR DESCRIPTION
Fixes #5939: Trigger block/neighbor updates while still generating the world-gen chunk to prevent world-gen from stalling when it tries to flow water/make obsidian after the fact.