### PR TITLE
Backport of Spatial IO dimension fix for 1.16.5

### DIFF
--- a/src/main/java/appeng/hooks/FixupDimensionHook.java
+++ b/src/main/java/appeng/hooks/FixupDimensionHook.java
@@ -1,0 +1,76 @@
+package appeng.hooks;
+
+import com.mojang.serialization.Dynamic;
+
+import net.minecraft.nbt.CompoundNBT;
+import net.minecraftforge.common.util.Constants;
+
+import appeng.core.AELog;
+
+/**
+ * This fixes an issue with DFU that essentially trips over the spatial storage dimension if it happens to be the first
+ * dimension it sees in the iteration order of the dimension compound tag, and a version update (i.e. 1.18 -> 1.18.1)
+ * happens to be applied.
+ * <p/>
+ * It does this by removing the AE2 dimension from the level.dat NBT before it is processed by DFU, and re-adding it
+ * before the actual level data is deserialized. This will also fix cases where the data is missing from level.dat
+ * entirely.
+ */
+public final class FixupDimensionHook {
+    private FixupDimensionHook() {
+    }
+
+    public static <T> void removeDimension(Dynamic<T> nbt) {
+        if (!(nbt.getValue() instanceof CompoundNBT)) {
+            AELog.warn("Failed to fixup spatial dimension: Not loading from NBT");
+            return;
+        }
+
+        CompoundNBT compoundTag = (CompoundNBT) nbt.getValue();
+
+        if (!compoundTag.contains("WorldGenSettings", Constants.NBT.TAG_COMPOUND)) {
+            AELog.warn("Failed to fixup spatial dimension: Missing WorldGenSettings");
+            return;
+        }
+
+        CompoundNBT worldGenSettings = compoundTag.getCompound("WorldGenSettings");
+        if (!worldGenSettings.contains("dimensions", Constants.NBT.TAG_COMPOUND)) {
+            AELog.warn("Failed to fixup spatial dimension: Missing WorldGenSettings.dimensions");
+            return;
+        }
+
+        CompoundNBT dimensions = worldGenSettings.getCompound("dimensions");
+        if (dimensions.contains("appliedenergistics2:spatial_storage")) {
+            dimensions.remove("appliedenergistics2:spatial_storage");
+            AELog.debug("Removed AE2 spatial storage before DFU can 'fix' it");
+        } else {
+            AELog.warn("AE2 spatial storage dimension missing. It will be re-added.");
+        }
+    }
+
+    public static <T> void addDimension(Dynamic<T> nbt) {
+        // NOTE this method gets the WorldGenSettings passed directly, not the top-level tag
+        if (!(nbt.getValue() instanceof CompoundNBT)) {
+            AELog.warn("Failed to re-add spatial dimension: Not loading from NBT");
+            return;
+        }
+        CompoundNBT worldGenSettings = (CompoundNBT) nbt.getValue();
+
+        if (!worldGenSettings.contains("dimensions", Constants.NBT.TAG_COMPOUND)) {
+            AELog.warn("Failed to re-add spatial dimension: Missing dimensions key");
+            return;
+        }
+
+        CompoundNBT dimensions = worldGenSettings.getCompound("dimensions");
+        if (!dimensions.contains("appliedenergistics2:spatial_storage")) {
+            AELog.debug("Re-adding spatial storage NBT to world generation settings");
+
+            CompoundNBT spatialStorage = new CompoundNBT();
+            spatialStorage.putString("type", "appliedenergistics2:spatial_storage");
+            CompoundNBT generator = new CompoundNBT();
+            generator.putString("type", "appliedenergistics2:spatial_storage");
+            spatialStorage.put("generator", generator);
+            dimensions.put("appliedenergistics2:spatial_storage", spatialStorage);
+        }
+    }
+}

--- a/src/main/java/appeng/mixins/spatial/FixupDimensionsMixin.java
+++ b/src/main/java/appeng/mixins/spatial/FixupDimensionsMixin.java
@@ -1,0 +1,34 @@
+package appeng.mixins.spatial;
+
+import com.mojang.datafixers.DataFixer;
+import com.mojang.datafixers.util.Pair;
+import com.mojang.serialization.Dynamic;
+import com.mojang.serialization.Lifecycle;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.world.gen.settings.DimensionGeneratorSettings;
+import net.minecraft.world.storage.SaveFormat;
+
+import appeng.hooks.FixupDimensionHook;
+
+@Mixin(SaveFormat.class)
+public class FixupDimensionsMixin {
+    @Inject(method = "getSettingLifecyclePair", at = @At("HEAD"))
+    private static <T> void startDimensionFixup(Dynamic<T> nbt, DataFixer fixer, int version,
+            CallbackInfoReturnable<Pair<DimensionGeneratorSettings, Lifecycle>> cri) {
+        // Strips out the AE2 dimension before DFU runs because DFU is based on pattern matching, more or less
+        // and can choke HARD on the AE2 dimension, potentially removing the Vanilla dimensions.
+        FixupDimensionHook.removeDimension(nbt);
+    }
+
+    @ModifyArg(method = "getSettingLifecyclePair", at = @At(value = "INVOKE", target = "Lcom/mojang/serialization/Codec;parse(Lcom/mojang/serialization/Dynamic;)Lcom/mojang/serialization/DataResult;"), index = 0)
+    private static <T> Dynamic<T> injectBack(Dynamic<T> nbt) {
+        FixupDimensionHook.addDimension(nbt);
+        return nbt;
+    }
+}

--- a/src/main/resources/appliedenergistics2.mixins.json
+++ b/src/main/resources/appliedenergistics2.mixins.json
@@ -7,6 +7,7 @@
   "mixins": [
     "spatial.DimensionTypeMixin",
     "spatial.DimensionOptionMixin",
+    "spatial.FixupDimensionsMixin",
     "structure.DimensionStructuresSettingsMixin",
     "structure.ConfiguredStructureFeaturesAccessor",
     "feature.ConfiguredFeaturesAccessor",


### PR DESCRIPTION
Backport of #5925

For some reason the Forge fix doesn't work for us, so this does it manually:

1) Remove dimension before level.dat runs through DFU
2) Add it back before it's actually parsed (and this will auto-fix missing spatial dimensions)