### PR TITLE
Fixes some config slots of storage bus being empty when first opened (with capacity upgrades)

### DIFF
--- a/src/main/java/appeng/menu/implementations/CellWorkbenchMenu.java
+++ b/src/main/java/appeng/menu/implementations/CellWorkbenchMenu.java
@@ -44,10 +44,8 @@ import appeng.blockentity.misc.CellWorkbenchBlockEntity;
 import appeng.helpers.externalstorage.GenericStackInv;
 import appeng.menu.SlotSemantics;
 import appeng.menu.guisync.GuiSync;
-import appeng.menu.slot.FakeSlot;
 import appeng.menu.slot.OptionalRestrictedInputSlot;
 import appeng.menu.slot.RestrictedInputSlot;
-import appeng.util.ConfigMenuInventory;
 import appeng.util.EnumCycler;
 import appeng.util.inv.SupplierInternalInventory;
 
@@ -107,12 +105,11 @@ public class CellWorkbenchMenu extends UpgradeableMenu<CellWorkbenchBlockEntity>
         this.addSlot(new RestrictedInputSlot(RestrictedInputSlot.PlacableItemType.WORKBENCH_CELL, cell, 0),
                 SlotSemantics.STORAGE_CELL);
 
-        ConfigMenuInventory configInv = getConfigInventory().createMenuWrapper();
+        addConfigSlots(getConfigInventory(), 7, 9);
+    }
 
-        for (int i = 0; i < 7 * 9; i++) {
-            this.addSlot(new FakeSlot(configInv, i), SlotSemantics.CONFIG);
-        }
-
+    @Override
+    protected void setupUpgrades() {
         // We support up to 8 upgrade slots, see ICellWorkbenchItem, but we need to pre-create all slots here
         // while the active number of slots changes depending on the item inserted
         var upgradeInventory = new SupplierInternalInventory(this::getUpgrades);

--- a/src/main/java/appeng/menu/implementations/EnergyLevelEmitterMenu.java
+++ b/src/main/java/appeng/menu/implementations/EnergyLevelEmitterMenu.java
@@ -65,10 +65,6 @@ public class EnergyLevelEmitterMenu extends UpgradeableMenu<EnergyLevelEmitterPa
     }
 
     @Override
-    protected void setupConfig() {
-    }
-
-    @Override
     protected void loadSettingsFromHost(IConfigManager cm) {
         this.setRedStoneMode(cm.getSetting(Settings.REDSTONE_EMITTER));
     }

--- a/src/main/java/appeng/menu/implementations/FormationPlaneMenu.java
+++ b/src/main/java/appeng/menu/implementations/FormationPlaneMenu.java
@@ -28,10 +28,7 @@ import appeng.api.stacks.AEKey;
 import appeng.api.util.IConfigManager;
 import appeng.client.gui.implementations.FormationPlaneScreen;
 import appeng.core.definitions.AEItems;
-import appeng.menu.SlotSemantics;
 import appeng.menu.guisync.GuiSync;
-import appeng.menu.slot.FakeSlot;
-import appeng.menu.slot.OptionalFakeSlot;
 import appeng.parts.automation.FormationPlanePart;
 
 /**
@@ -54,19 +51,7 @@ public class FormationPlaneMenu extends UpgradeableMenu<FormationPlanePart> {
 
     @Override
     protected void setupConfig() {
-        var config = this.getHost().getConfig().createMenuWrapper();
-        for (int y = 0; y < 7; y++) {
-            for (int x = 0; x < 9; x++) {
-                int invIdx = y * 9 + x;
-                if (y < 2) {
-                    this.addSlot(new FakeSlot(config, invIdx), SlotSemantics.CONFIG);
-                } else {
-                    this.addSlot(new OptionalFakeSlot(config, this, invIdx, y - 2), SlotSemantics.CONFIG);
-                }
-            }
-        }
-
-        this.setupUpgrades();
+        addExpandableConfigSlots(getHost().getConfig(), 2, 9, 5);
     }
 
     @Override

--- a/src/main/java/appeng/menu/implementations/IOBusMenu.java
+++ b/src/main/java/appeng/menu/implementations/IOBusMenu.java
@@ -53,8 +53,6 @@ public class IOBusMenu extends UpgradeableMenu<IOBusPart> {
 
     @Override
     protected void setupConfig() {
-        this.setupUpgrades();
-
         var inv = this.getHost().getConfig().createMenuWrapper();
         var s = SlotSemantics.CONFIG;
         this.addSlot(new FakeSlot(inv, 0), s);

--- a/src/main/java/appeng/menu/implementations/IOPortMenu.java
+++ b/src/main/java/appeng/menu/implementations/IOPortMenu.java
@@ -65,8 +65,6 @@ public class IOPortMenu extends UpgradeableMenu<IOPortBlockEntity> {
             this.addSlot(new OutputSlot(cells, 6 + i,
                     RestrictedInputSlot.PlacableItemType.STORAGE_CELLS.icon), SlotSemantics.MACHINE_OUTPUT);
         }
-
-        this.setupUpgrades();
     }
 
     @Override

--- a/src/main/java/appeng/menu/implementations/InscriberMenu.java
+++ b/src/main/java/appeng/menu/implementations/InscriberMenu.java
@@ -82,11 +82,6 @@ public class InscriberMenu extends UpgradeableMenu<InscriberBlockEntity> impleme
     }
 
     @Override
-    protected void setupConfig() {
-        this.setupUpgrades();
-    }
-
-    @Override
     protected void standardDetectAndSendChanges() {
         if (isServer()) {
             this.maxProcessingTime = getHost().getMaxProcessingTime();

--- a/src/main/java/appeng/menu/implementations/InterfaceMenu.java
+++ b/src/main/java/appeng/menu/implementations/InterfaceMenu.java
@@ -66,11 +66,6 @@ public class InterfaceMenu extends UpgradeableMenu<InterfaceLogicHost> {
         this.setFuzzyMode(cm.getSetting(Settings.FUZZY_MODE));
     }
 
-    @Override
-    protected void setupConfig() {
-        this.setupUpgrades();
-    }
-
     /**
      * Opens a sub-menu to enter the amount for a config-slot
      *

--- a/src/main/java/appeng/menu/implementations/MolecularAssemblerMenu.java
+++ b/src/main/java/appeng/menu/implementations/MolecularAssemblerMenu.java
@@ -78,8 +78,6 @@ public class MolecularAssemblerMenu extends UpgradeableMenu<MolecularAssemblerBl
                 SlotSemantics.ENCODED_PATTERN);
 
         this.addSlot(new OutputSlot(mac, 9, null), SlotSemantics.MACHINE_OUTPUT);
-
-        setupUpgrades();
     }
 
     @Override

--- a/src/main/java/appeng/menu/implementations/StorageBusMenu.java
+++ b/src/main/java/appeng/menu/implementations/StorageBusMenu.java
@@ -40,10 +40,7 @@ import appeng.api.stacks.GenericStack;
 import appeng.api.util.IConfigManager;
 import appeng.client.gui.implementations.StorageBusScreen;
 import appeng.core.definitions.AEItems;
-import appeng.menu.SlotSemantics;
 import appeng.menu.guisync.GuiSync;
-import appeng.menu.slot.FakeSlot;
-import appeng.menu.slot.OptionalFakeSlot;
 import appeng.parts.storagebus.StorageBusPart;
 
 /**
@@ -84,19 +81,7 @@ public class StorageBusMenu extends UpgradeableMenu<StorageBusPart> {
 
     @Override
     protected void setupConfig() {
-        var config = getHost().getConfig().createMenuWrapper();
-        for (int y = 0; y < 7; y++) {
-            for (int x = 0; x < 9; x++) {
-                int invSlot = y * 9 + x;
-                if (y < 2) {
-                    this.addSlot(new FakeSlot(config, invSlot), SlotSemantics.CONFIG);
-                } else {
-                    this.addSlot(new OptionalFakeSlot(config, this, invSlot, y - 2), SlotSemantics.CONFIG);
-                }
-            }
-        }
-
-        this.setupUpgrades();
+        addExpandableConfigSlots(getHost().getConfig(), 2, 9, 5);
     }
 
     @Override

--- a/src/main/java/appeng/menu/implementations/StorageLevelEmitterMenu.java
+++ b/src/main/java/appeng/menu/implementations/StorageLevelEmitterMenu.java
@@ -81,8 +81,6 @@ public class StorageLevelEmitterMenu extends UpgradeableMenu<StorageLevelEmitter
 
     @Override
     protected void setupConfig() {
-        this.setupUpgrades();
-
         var inv = getHost().getConfig().createMenuWrapper();
         this.addSlot(new FakeSlot(inv, 0), SlotSemantics.CONFIG);
     }


### PR DESCRIPTION
Fixes #5961: Upgrade slots need to come before slots that depend on them to prevent these config slots from being empty the first time the UI is opened on the client.