### PR TITLE
Color Applicator Enhancements

### DIFF
--- a/src/main/java/appeng/core/sync/BasePacketHandler.java
+++ b/src/main/java/appeng/core/sync/BasePacketHandler.java
@@ -80,7 +80,9 @@ public class BasePacketHandler {
 
         CRAFTING_STATUS(CraftingStatusPacket.class, CraftingStatusPacket::new),
 
-        MOUSE_WHEEL(MouseWheelPacket.class, MouseWheelPacket::new);
+        MOUSE_WHEEL(MouseWheelPacket.class, MouseWheelPacket::new),
+
+        COLOR_APPLICATOR_SELECT_COLOR(ColorApplicatorSelectColorPacket.class, ColorApplicatorSelectColorPacket::new);
 
         private final Function<FriendlyByteBuf, BasePacket> factory;
 

--- a/src/main/java/appeng/core/sync/packets/ColorApplicatorSelectColorPacket.java
+++ b/src/main/java/appeng/core/sync/packets/ColorApplicatorSelectColorPacket.java
@@ -1,0 +1,73 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.core.sync.packets;
+
+import javax.annotation.Nullable;
+
+import io.netty.buffer.Unpooled;
+
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.item.ItemStack;
+
+import appeng.api.util.AEColor;
+import appeng.core.sync.BasePacket;
+import appeng.core.sync.network.INetworkInfo;
+import appeng.items.tools.powered.ColorApplicatorItem;
+
+/**
+ * Switches the color of any held color applicator to the desired color.
+ */
+public class ColorApplicatorSelectColorPacket extends BasePacket {
+    @Nullable
+    private AEColor color;
+
+    public ColorApplicatorSelectColorPacket(FriendlyByteBuf stream) {
+        if (stream.readBoolean()) {
+            this.color = stream.readEnum(AEColor.class);
+        } else {
+            this.color = null;
+        }
+    }
+
+    // api
+    public ColorApplicatorSelectColorPacket(@Nullable AEColor color) {
+        var data = new FriendlyByteBuf(Unpooled.buffer());
+        data.writeInt(this.getPacketID());
+        if (color != null) {
+            data.writeBoolean(true);
+            data.writeEnum(color);
+        } else {
+            data.writeBoolean(false);
+        }
+        this.configureWrite(data);
+    }
+
+    @Override
+    public void serverPacketData(INetworkInfo manager, ServerPlayer player) {
+        switchColor(player.getMainHandItem(), color);
+        switchColor(player.getOffhandItem(), color);
+    }
+
+    private static void switchColor(ItemStack stack, AEColor color) {
+        if (!stack.isEmpty() && stack.getItem() instanceof ColorApplicatorItem colorApplicator) {
+            colorApplicator.setActiveColor(stack, color);
+        }
+    }
+}

--- a/src/main/java/appeng/hooks/ColorApplicatorPickColorHook.java
+++ b/src/main/java/appeng/hooks/ColorApplicatorPickColorHook.java
@@ -1,0 +1,31 @@
+package appeng.hooks;
+
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.phys.BlockHitResult;
+
+import appeng.api.implementations.blockentities.IColorableBlockEntity;
+import appeng.core.definitions.AEItems;
+import appeng.core.sync.network.NetworkHandler;
+import appeng.core.sync.packets.ColorApplicatorSelectColorPacket;
+
+public final class ColorApplicatorPickColorHook {
+    private ColorApplicatorPickColorHook() {
+    }
+
+    public static boolean onPickColor(Player player, BlockHitResult hitResult) {
+        if (!AEItems.COLOR_APPLICATOR.isSameAs(player.getOffhandItem())
+                && !AEItems.COLOR_APPLICATOR.isSameAs(player.getMainHandItem())) {
+            return false;
+        }
+
+        // Figure out which color...
+        var be = player.level.getBlockEntity(hitResult.getBlockPos());
+        if (be instanceof IColorableBlockEntity colorableBlockEntity) {
+            NetworkHandler.instance()
+                    .sendToServer(new ColorApplicatorSelectColorPacket(colorableBlockEntity.getColor()));
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/appeng/mixins/PickColorMixin.java
+++ b/src/main/java/appeng/mixins/PickColorMixin.java
@@ -1,0 +1,35 @@
+package appeng.mixins;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.HitResult;
+
+import appeng.hooks.ColorApplicatorPickColorHook;
+
+/**
+ * This mixin hooks the pick block method on the client to allow a player to easily switch the color of a held color
+ * applicator to that of a block or part in the world. pickBlock is also called in survival mode.
+ */
+@Mixin(Minecraft.class)
+public class PickColorMixin {
+    @Shadow
+    LocalPlayer player;
+    @Shadow
+    HitResult hitResult;
+
+    @Inject(method = "pickBlock", at = @At("HEAD"), cancellable = true)
+    public void pickColor(CallbackInfo ci) {
+        if (this.player != null && this.hitResult != null && this.hitResult.getType() == HitResult.Type.BLOCK) {
+            if (ColorApplicatorPickColorHook.onPickColor(player, (BlockHitResult) this.hitResult)) {
+                ci.cancel();
+            }
+        }
+    }
+}

--- a/src/main/java/appeng/parts/networking/CablePart.java
+++ b/src/main/java/appeng/parts/networking/CablePart.java
@@ -24,6 +24,7 @@ import java.util.Set;
 
 import net.minecraft.core.Direction;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.player.Player;
 
 import appeng.api.config.SecurityPermissions;
@@ -42,6 +43,7 @@ import appeng.api.util.AECableType;
 import appeng.api.util.AEColor;
 import appeng.core.definitions.AEParts;
 import appeng.items.parts.ColoredPartItem;
+import appeng.items.tools.powered.ColorApplicatorItem;
 import appeng.parts.AEBasePart;
 
 public class CablePart extends AEBasePart implements ICablePart {
@@ -100,6 +102,22 @@ public class CablePart extends AEBasePart implements ICablePart {
             return -1;
         } else {
             return 8;
+        }
+    }
+
+    @Override
+    public void onPlacement(Player player) {
+        super.onPlacement(player);
+
+        // Apply the color of a held color applicator on placement
+        var stack = player.getItemInHand(InteractionHand.OFF_HAND);
+        if (!stack.isEmpty() && stack.getItem() instanceof ColorApplicatorItem item) {
+            var color = item.getActiveColor(stack);
+            if (color != null && color != getCableColor() && item.consumeColor(stack, color, true)) {
+                if (changeColor(color, player) && !player.getAbilities().instabuild) {
+                    item.consumeColor(stack, color, false);
+                }
+            }
         }
     }
 

--- a/src/main/resources/ae2.mixins.json
+++ b/src/main/resources/ae2.mixins.json
@@ -28,7 +28,8 @@
     "MouseWheelMixin",
     "ItemRendererMixin",
     "WrappedGenericStackTooltipModIdMixin",
-    "ResizableSlotHighlightMixin"
+    "ResizableSlotHighlightMixin",
+    "PickColorMixin"
   ],
   "server": [],
   "injectors": {


### PR DESCRIPTION
Implements #3896 for 1.18

- Clear the active color if the applicator runs out of that item (Fixes #3895)
- Allow switching the color applicator to the color of a cable using middle-click (Fixes #88)
- Use the selected color applicators color when it is held in off-hand while placing cables (Fixes #3854)