### PR TITLE
Optimize StorageService tick performance

### DIFF
--- a/src/main/java/appeng/me/helpers/InterestManager.java
+++ b/src/main/java/appeng/me/helpers/InterestManager.java
@@ -62,4 +62,8 @@ public class InterestManager<T> {
     public Collection<T> getAllStacksWatchers() {
         return this.allStacksWatchers;
     }
+
+    public boolean isEmpty() {
+        return allStacksWatchers.isEmpty() && container.isEmpty();
+    }
 }


### PR DESCRIPTION
Optimize storage service tick performance in the following ways:
- Lazily update cache if there is no registered listener. This will ensure that the cache is not rebuilt too often for chained storage subnetworks.
- Reduce use of `KeyCounter` since I don't think the nested maps are that performant.