### PR TITLE
"Split damage at 99%" fuzzy mode is confusing

### DIFF
--- a/src/main/java/appeng/core/localization/ButtonToolTips.java
+++ b/src/main/java/appeng/core/localization/ButtonToolTips.java
@@ -62,7 +62,7 @@ public enum ButtonToolTips implements LocalizationEnum {
     FZPercent_25("Split Damage at 25%"),
     FZPercent_50("Split Damage at 50%"),
     FZPercent_75("Split Damage at 75%"),
-    FZPercent_99("Split Damage at 99%"),
+    FZPercent_99("Split Damaged Items"),
     FilterMode("Search Filter Mode"),
     FilterModeClear("Clear on each opening."),
     FilterModeKeep("Restore previous search filter."),


### PR DESCRIPTION
Honestly, not many better ways to write this tooltip that ar not just the technical description of how it works but this should do it. 
Still would need to be translated in the respective langs files tho.