### PR TITLE
Fix #6106: FindMe causing wrong encoded pattern display

### DIFF
--- a/src/main/java/appeng/client/gui/AEBaseScreen.java
+++ b/src/main/java/appeng/client/gui/AEBaseScreen.java
@@ -740,14 +740,7 @@ public abstract class AEBaseScreen<T extends AEBaseMenu> extends AbstractContain
             fill(poseStack, s.x, s.y, 16 + s.x, 16 + s.y, 0x66ff6666);
         }
 
-        // Makes it so the first call to s.getStack will return getDisplayStack instead, the finally is there
-        // just for making absolutely sure the flag gets reset (it should be reset inside of getStack)
-        s.setRendering(true);
-        try {
-            super.renderSlot(poseStack, s);
-        } finally {
-            s.setRendering(false);
-        }
+        super.renderSlot(poseStack, s);
     }
 
     public void bindTexture(String file) {

--- a/src/main/java/appeng/menu/slot/AppEngSlot.java
+++ b/src/main/java/appeng/menu/slot/AppEngSlot.java
@@ -60,7 +60,6 @@ public class AppEngSlot extends Slot {
      * Caches if the item stack currently contained in this slot is "valid" or not for UI purposes.
      */
     private Boolean validState = null;
-    private boolean rendering = false;
 
     public AppEngSlot(InternalInventory inv, int invSlot) {
         super(EMPTY_INVENTORY, invSlot, 0, 0);
@@ -108,13 +107,6 @@ public class AppEngSlot extends Slot {
 
         if (this.slot >= this.inventory.size()) {
             return ItemStack.EMPTY;
-        }
-
-        // Some slots may want to display a different stack in the GUI, which we solve by
-        // returning getDisplayStack() during rendering, which a slot can override.
-        if (this.rendering) {
-            this.rendering = false;
-            return this.getDisplayStack();
         }
 
         return this.inventory.getStackInSlot(this.invSlot);
@@ -232,14 +224,6 @@ public class AppEngSlot extends Slot {
 
     public void setIcon(Icon icon) {
         this.icon = icon;
-    }
-
-    /**
-     * Indicate that this slot is currently being rendered, which is used to provide a slot with the ability to return a
-     * different stack for rendering purposes by overriding {@link #getDisplayStack()}.
-     */
-    public void setRendering(boolean rendering) {
-        this.rendering = rendering;
     }
 
     public boolean isDraggable() {

--- a/src/main/java/appeng/mixins/AbstractContainerScreenMixin.java
+++ b/src/main/java/appeng/mixins/AbstractContainerScreenMixin.java
@@ -1,0 +1,27 @@
+package appeng.mixins;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ItemStack;
+
+import appeng.menu.slot.AppEngSlot;
+
+/**
+ * Ensure we render {@link AppEngSlot#getDisplayStack()} instead of {@link AppEngSlot#getItem()}.
+ */
+@Mixin(AbstractContainerScreen.class)
+public class AbstractContainerScreenMixin {
+    @ModifyVariable(method = "renderSlot", index = 5, at = @At(value = "STORE", ordinal = 0))
+    protected ItemStack ae2_changeStackForDisplay(ItemStack stack, PoseStack poseStack, Slot slot) {
+        if (slot instanceof AppEngSlot aeSlot) {
+            return aeSlot.getDisplayStack();
+        }
+        return stack;
+    }
+}

--- a/src/main/resources/ae2.mixins.json
+++ b/src/main/resources/ae2.mixins.json
@@ -22,6 +22,7 @@
     "unlitquad.ModelBakeryMixin",
     "unlitquad.BlockModelMixin",
     "unlitquad.BlockPartFaceDeserializerMixin",
+    "AbstractContainerScreenMixin",
     "BlockBreakParticleMixin",
     "ModelsReloadMixin",
     "MouseWheelMixin",


### PR DESCRIPTION
Happened because FindMe inserts a second Slot#getItem call in renderSlot. Fixed by using a `@ModifyVariable` inject, should be quite compatible and safe.