### PR TITLE
Fix #6139: rare crash when level emitter is broken

### DIFF
--- a/src/main/java/appeng/api/networking/IStackWatcher.java
+++ b/src/main/java/appeng/api/networking/IStackWatcher.java
@@ -23,17 +23,13 @@ public interface IStackWatcher {
      * Add a specific {@link AEKey} to watch.
      *
      * Supports multiple values, duplicate ones will not be added.
-     *
-     * @return true, if successfully added.
      */
-    boolean add(AEKey stack);
+    void add(AEKey stack);
 
     /**
      * Remove a specific {@link AEKey} from the watcher.
-     *
-     * @return true, if successfully removed.
      */
-    boolean remove(AEKey stack);
+    void remove(AEKey stack);
 
     /**
      * Removes all watched stacks and resets the watcher to a clean state.

--- a/src/main/java/appeng/me/helpers/StackWatcher.java
+++ b/src/main/java/appeng/me/helpers/StackWatcher.java
@@ -15,6 +15,7 @@ public class StackWatcher<T> implements IStackWatcher {
     private final InterestManager<StackWatcher<T>> interestManager;
     private final T myHost;
     private final Set<AEKey> myInterests = new HashSet<>();
+    private boolean destroyed = false;
 
     public StackWatcher(InterestManager<StackWatcher<T>> interestManager, T host) {
         this.interestManager = interestManager;
@@ -27,21 +28,23 @@ public class StackWatcher<T> implements IStackWatcher {
 
     @Override
     public void setWatchAll(boolean watchAll) {
-        interestManager.setWatchAll(watchAll, this);
-    }
-
-    @Override
-    public boolean add(AEKey e) {
-        if (this.myInterests.contains(e)) {
-            return false;
+        if (!destroyed) {
+            interestManager.setWatchAll(watchAll, this);
         }
-
-        return this.myInterests.add(e) && interestManager.put(e, this);
     }
 
     @Override
-    public boolean remove(AEKey o) {
-        return this.myInterests.remove(o) && interestManager.remove(o, this);
+    public void add(AEKey e) {
+        if (!destroyed && this.myInterests.add(e)) {
+            interestManager.put(e, this);
+        }
+    }
+
+    @Override
+    public void remove(AEKey o) {
+        if (!destroyed && this.myInterests.remove(o)) {
+            interestManager.remove(o, this);
+        }
     }
 
     @Override
@@ -54,5 +57,15 @@ public class StackWatcher<T> implements IStackWatcher {
             interestManager.remove(i.next(), this);
             i.remove();
         }
+    }
+
+    /**
+     * Call this when the watcher is not going to be used anymore, to reset it and disable it forever. It's important
+     * that we disable the watcher, since some hosts (e.g. level emitter) might still hold a reference to it and try to
+     * modify it later, which could lead to invalid state and potentially crashes down the line.
+     */
+    public void destroy() {
+        reset();
+        destroyed = true;
     }
 }

--- a/src/main/java/appeng/me/service/CraftingService.java
+++ b/src/main/java/appeng/me/service/CraftingService.java
@@ -162,7 +162,7 @@ public class CraftingService implements ICraftingService, IGridServiceProvider {
 
         var craftingWatcher = this.craftingWatchers.remove(gridNode);
         if (craftingWatcher != null) {
-            craftingWatcher.reset();
+            craftingWatcher.destroy();
         }
 
         var requester = gridNode.getService(ICraftingRequester.class);

--- a/src/main/java/appeng/me/service/StorageService.java
+++ b/src/main/java/appeng/me/service/StorageService.java
@@ -168,7 +168,7 @@ public class StorageService implements IStorageService, IGridServiceProvider {
     public void removeNode(IGridNode node) {
         var watcher = this.watchers.remove(node);
         if (watcher != null) {
-            watcher.reset();
+            watcher.destroy();
         }
 
         var providerState = this.nodeProviders.remove(node);


### PR DESCRIPTION
Also contains an API breaking change, removing the useless `boolean` return values. To my knowledge, it shouldn't affect any add-on.