### PR TITLE
Add waterlogging to QNB and other blocks

### DIFF
--- a/src/main/java/appeng/block/misc/InscriberBlock.java
+++ b/src/main/java/appeng/block/misc/InscriberBlock.java
@@ -21,14 +21,24 @@ package appeng.block.misc;
 import javax.annotation.Nullable;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.SimpleWaterloggedBlock;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.StateDefinition;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+import net.minecraft.world.level.block.state.properties.BooleanProperty;
+import net.minecraft.world.level.material.FluidState;
+import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.phys.BlockHitResult;
 
 import appeng.block.AEBaseEntityBlock;
@@ -38,10 +48,13 @@ import appeng.menu.implementations.InscriberMenu;
 import appeng.menu.locator.MenuLocators;
 import appeng.util.InteractionUtil;
 
-public class InscriberBlock extends AEBaseEntityBlock<InscriberBlockEntity> {
+public class InscriberBlock extends AEBaseEntityBlock<InscriberBlockEntity> implements SimpleWaterloggedBlock {
+
+    private static final BooleanProperty WATERLOGGED = BlockStateProperties.WATERLOGGED;
 
     public InscriberBlock(BlockBehaviour.Properties props) {
         super(props);
+        this.registerDefaultState(this.defaultBlockState().setValue(WATERLOGGED, false));
     }
 
     @Override
@@ -67,6 +80,40 @@ public class InscriberBlock extends AEBaseEntityBlock<InscriberBlockEntity> {
         }
         return InteractionResult.PASS;
 
+    }
+
+    @Override
+    protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> builder) {
+        super.createBlockStateDefinition(builder);
+        builder.add(WATERLOGGED);
+    }
+
+    @Override
+    @Nullable
+    public BlockState getStateForPlacement(BlockPlaceContext context) {
+        BlockPos pos = context.getClickedPos();
+        FluidState fluidState = context.getLevel().getFluidState(pos);
+        BlockState blockState = this.defaultBlockState()
+                .setValue(WATERLOGGED, fluidState.getType() == Fluids.WATER);
+
+        return blockState;
+    }
+
+    @Override
+    public FluidState getFluidState(BlockState blockState) {
+        return blockState.getValue(WATERLOGGED).booleanValue()
+                ? Fluids.WATER.getSource(false)
+                : super.getFluidState(blockState);
+    }
+
+    @Override
+    public BlockState updateShape(BlockState blockState, Direction facing, BlockState facingState, LevelAccessor level,
+                                  BlockPos currentPos, BlockPos facingPos) {
+        if (blockState.getValue(WATERLOGGED).booleanValue()) {
+            level.scheduleTick(currentPos, Fluids.WATER, Fluids.WATER.getTickDelay(level));
+        }
+
+        return super.updateShape(blockState, facing, facingState, level, currentPos, facingPos);
     }
 
 }

--- a/src/main/java/appeng/block/misc/InscriberBlock.java
+++ b/src/main/java/appeng/block/misc/InscriberBlock.java
@@ -108,7 +108,7 @@ public class InscriberBlock extends AEBaseEntityBlock<InscriberBlockEntity> impl
 
     @Override
     public BlockState updateShape(BlockState blockState, Direction facing, BlockState facingState, LevelAccessor level,
-                                  BlockPos currentPos, BlockPos facingPos) {
+            BlockPos currentPos, BlockPos facingPos) {
         if (blockState.getValue(WATERLOGGED).booleanValue()) {
             level.scheduleTick(currentPos, Fluids.WATER, Fluids.WATER.getTickDelay(level));
         }

--- a/src/main/java/appeng/block/misc/SkyCompassBlock.java
+++ b/src/main/java/appeng/block/misc/SkyCompassBlock.java
@@ -18,6 +18,8 @@
 
 package appeng.block.misc;
 
+import javax.annotation.Nullable;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.item.context.BlockPlaceContext;
@@ -41,8 +43,6 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 
 import appeng.block.AEBaseEntityBlock;
 import appeng.blockentity.misc.SkyCompassBlockEntity;
-
-import javax.annotation.Nullable;
 
 public class SkyCompassBlock extends AEBaseEntityBlock<SkyCompassBlockEntity> implements SimpleWaterloggedBlock {
 
@@ -189,7 +189,7 @@ public class SkyCompassBlock extends AEBaseEntityBlock<SkyCompassBlockEntity> im
 
     @Override
     public BlockState updateShape(BlockState blockState, Direction facing, BlockState facingState, LevelAccessor level,
-                                  BlockPos currentPos, BlockPos facingPos) {
+            BlockPos currentPos, BlockPos facingPos) {
         if (blockState.getValue(WATERLOGGED).booleanValue()) {
             level.scheduleTick(currentPos, Fluids.WATER, Fluids.WATER.getTickDelay(level));
         }

--- a/src/main/java/appeng/block/misc/SkyCompassBlock.java
+++ b/src/main/java/appeng/block/misc/SkyCompassBlock.java
@@ -20,13 +20,20 @@ package appeng.block.misc;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.SimpleWaterloggedBlock;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.StateDefinition;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+import net.minecraft.world.level.block.state.properties.BooleanProperty;
+import net.minecraft.world.level.material.FluidState;
+import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
@@ -35,9 +42,15 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 import appeng.block.AEBaseEntityBlock;
 import appeng.blockentity.misc.SkyCompassBlockEntity;
 
-public class SkyCompassBlock extends AEBaseEntityBlock<SkyCompassBlockEntity> {
+import javax.annotation.Nullable;
+
+public class SkyCompassBlock extends AEBaseEntityBlock<SkyCompassBlockEntity> implements SimpleWaterloggedBlock {
+
+    private static final BooleanProperty WATERLOGGED = BlockStateProperties.WATERLOGGED;
+
     public SkyCompassBlock(BlockBehaviour.Properties props) {
         super(props);
+        this.registerDefaultState(this.defaultBlockState().setValue(WATERLOGGED, false));
     }
 
     @Override
@@ -61,7 +74,7 @@ public class SkyCompassBlock extends AEBaseEntityBlock<SkyCompassBlockEntity> {
             boolean isMoving) {
         final SkyCompassBlockEntity sc = this.getBlockEntity(level, pos);
         final Direction forward = sc.getForward();
-        if (!this.canPlaceAt(level, pos, forward.getOpposite())) {
+        if (!this.canPlaceAt(level, pos, forward.getOpposite()) || !this.getFluidState(state).isSource()) {
             this.dropTorch(level, pos);
         }
     }
@@ -149,4 +162,39 @@ public class SkyCompassBlock extends AEBaseEntityBlock<SkyCompassBlockEntity> {
             CollisionContext context) {
         return Shapes.empty();
     }
+
+    @Override
+    protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> builder) {
+        super.createBlockStateDefinition(builder);
+        builder.add(WATERLOGGED);
+    }
+
+    @Override
+    @Nullable
+    public BlockState getStateForPlacement(BlockPlaceContext context) {
+        BlockPos pos = context.getClickedPos();
+        FluidState fluidState = context.getLevel().getFluidState(pos);
+        BlockState blockState = this.defaultBlockState()
+                .setValue(WATERLOGGED, fluidState.getType() == Fluids.WATER);
+
+        return blockState;
+    }
+
+    @Override
+    public FluidState getFluidState(BlockState blockState) {
+        return blockState.getValue(WATERLOGGED).booleanValue()
+                ? Fluids.WATER.getSource(false)
+                : super.getFluidState(blockState);
+    }
+
+    @Override
+    public BlockState updateShape(BlockState blockState, Direction facing, BlockState facingState, LevelAccessor level,
+                                  BlockPos currentPos, BlockPos facingPos) {
+        if (blockState.getValue(WATERLOGGED).booleanValue()) {
+            level.scheduleTick(currentPos, Fluids.WATER, Fluids.WATER.getTickDelay(level));
+        }
+
+        return super.updateShape(blockState, facing, facingState, level, currentPos, facingPos);
+    }
+
 }

--- a/src/main/java/appeng/block/networking/WirelessBlock.java
+++ b/src/main/java/appeng/block/networking/WirelessBlock.java
@@ -20,6 +20,8 @@ package appeng.block.networking;
 
 import java.util.Locale;
 
+import javax.annotation.Nullable;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.util.StringRepresentable;
@@ -52,8 +54,6 @@ import appeng.menu.MenuOpener;
 import appeng.menu.implementations.WirelessMenu;
 import appeng.menu.locator.MenuLocators;
 import appeng.util.InteractionUtil;
-
-import javax.annotation.Nullable;
 
 public class WirelessBlock extends AEBaseEntityBlock<WirelessBlockEntity> implements SimpleWaterloggedBlock {
 
@@ -258,7 +258,7 @@ public class WirelessBlock extends AEBaseEntityBlock<WirelessBlockEntity> implem
 
     @Override
     public BlockState updateShape(BlockState blockState, Direction facing, BlockState facingState, LevelAccessor level,
-                                  BlockPos currentPos, BlockPos facingPos) {
+            BlockPos currentPos, BlockPos facingPos) {
         if (blockState.getValue(WATERLOGGED).booleanValue()) {
             level.scheduleTick(currentPos, Fluids.WATER, Fluids.WATER.getTickDelay(level));
         }

--- a/src/main/java/appeng/block/qnb/QuantumBaseBlock.java
+++ b/src/main/java/appeng/block/qnb/QuantumBaseBlock.java
@@ -18,6 +18,8 @@
 
 package appeng.block.qnb;
 
+import javax.annotation.Nullable;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.item.context.BlockPlaceContext;
@@ -41,9 +43,8 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 import appeng.block.AEBaseEntityBlock;
 import appeng.blockentity.qnb.QuantumBridgeBlockEntity;
 
-import javax.annotation.Nullable;
-
-public abstract class QuantumBaseBlock extends AEBaseEntityBlock<QuantumBridgeBlockEntity> implements SimpleWaterloggedBlock {
+public abstract class QuantumBaseBlock extends AEBaseEntityBlock<QuantumBridgeBlockEntity>
+        implements SimpleWaterloggedBlock {
 
     public static final BooleanProperty FORMED = BooleanProperty.create("formed");
     private static final BooleanProperty WATERLOGGED = BlockStateProperties.WATERLOGGED;
@@ -121,7 +122,7 @@ public abstract class QuantumBaseBlock extends AEBaseEntityBlock<QuantumBridgeBl
 
     @Override
     public BlockState updateShape(BlockState blockState, Direction facing, BlockState facingState, LevelAccessor level,
-                                  BlockPos currentPos, BlockPos facingPos) {
+            BlockPos currentPos, BlockPos facingPos) {
         if (blockState.getValue(WATERLOGGED).booleanValue()) {
             level.scheduleTick(currentPos, Fluids.WATER, Fluids.WATER.getTickDelay(level));
         }

--- a/src/main/java/appeng/block/qnb/QuantumBaseBlock.java
+++ b/src/main/java/appeng/block/qnb/QuantumBaseBlock.java
@@ -19,13 +19,20 @@
 package appeng.block.qnb;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.SimpleWaterloggedBlock;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition.Builder;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.block.state.properties.BooleanProperty;
+import net.minecraft.world.level.material.FluidState;
+import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
@@ -34,9 +41,12 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 import appeng.block.AEBaseEntityBlock;
 import appeng.blockentity.qnb.QuantumBridgeBlockEntity;
 
-public abstract class QuantumBaseBlock extends AEBaseEntityBlock<QuantumBridgeBlockEntity> {
+import javax.annotation.Nullable;
+
+public abstract class QuantumBaseBlock extends AEBaseEntityBlock<QuantumBridgeBlockEntity> implements SimpleWaterloggedBlock {
 
     public static final BooleanProperty FORMED = BooleanProperty.create("formed");
+    private static final BooleanProperty WATERLOGGED = BlockStateProperties.WATERLOGGED;
 
     private static final VoxelShape SHAPE;
 
@@ -47,7 +57,8 @@ public abstract class QuantumBaseBlock extends AEBaseEntityBlock<QuantumBridgeBl
 
     public QuantumBaseBlock(BlockBehaviour.Properties props) {
         super(props);
-        this.registerDefaultState(this.defaultBlockState().setValue(FORMED, false));
+        this.registerDefaultState(this.defaultBlockState().setValue(FORMED, false)
+                .setValue(WATERLOGGED, false));
     }
 
     @Override
@@ -59,6 +70,7 @@ public abstract class QuantumBaseBlock extends AEBaseEntityBlock<QuantumBridgeBl
     protected void createBlockStateDefinition(Builder<Block, BlockState> builder) {
         super.createBlockStateDefinition(builder);
         builder.add(FORMED);
+        builder.add(WATERLOGGED);
     }
 
     @Override
@@ -87,6 +99,34 @@ public abstract class QuantumBaseBlock extends AEBaseEntityBlock<QuantumBridgeBl
         }
 
         super.onRemove(state, level, pos, newState, isMoving);
+    }
+
+    @Override
+    @Nullable
+    public BlockState getStateForPlacement(BlockPlaceContext context) {
+        BlockPos pos = context.getClickedPos();
+        FluidState fluidState = context.getLevel().getFluidState(pos);
+        BlockState blockState = this.defaultBlockState()
+                .setValue(WATERLOGGED, fluidState.getType() == Fluids.WATER);
+
+        return blockState;
+    }
+
+    @Override
+    public FluidState getFluidState(BlockState blockState) {
+        return blockState.getValue(WATERLOGGED).booleanValue()
+                ? Fluids.WATER.getSource(false)
+                : super.getFluidState(blockState);
+    }
+
+    @Override
+    public BlockState updateShape(BlockState blockState, Direction facing, BlockState facingState, LevelAccessor level,
+                                  BlockPos currentPos, BlockPos facingPos) {
+        if (blockState.getValue(WATERLOGGED).booleanValue()) {
+            level.scheduleTick(currentPos, Fluids.WATER, Fluids.WATER.getTickDelay(level));
+        }
+
+        return super.updateShape(blockState, facing, facingState, level, currentPos, facingPos);
     }
 
 }


### PR DESCRIPTION
Tacky copy-paste job for something requested on the Discord some time earlier today. Waterlogging has been omitted from Charger and Tiny TNT blocks, and the Meteorite Compass will also drop itself as a torch would when in contact with flowing water, rather than a source block.