### PR TITLE
Fix #5994: Let automation access the blank pattern slot

### DIFF
--- a/src/main/java/appeng/init/InitApiLookup.java
+++ b/src/main/java/appeng/init/InitApiLookup.java
@@ -19,6 +19,7 @@ import appeng.helpers.externalstorage.GenericStackFluidStorage;
 import appeng.helpers.externalstorage.GenericStackItemStorage;
 import appeng.items.tools.powered.powersink.PoweredItemCapabilities;
 import appeng.parts.crafting.PatternProviderPart;
+import appeng.parts.encoding.PatternEncodingTerminalPart;
 import appeng.parts.misc.InterfacePart;
 import appeng.parts.networking.EnergyAcceptorPart;
 import appeng.parts.p2p.FEP2PTunnelPart;
@@ -133,6 +134,8 @@ public final class InitApiLookup {
         }, AEBlockEntities.DEBUG_ITEM_GEN);
         EnergyStorage.SIDED.registerSelf(AEBlockEntities.DEBUG_ENERGY_GEN);
         FluidStorage.SIDED.registerForBlockEntity(SkyStoneTankBlockEntity::getStorage, AEBlockEntities.SKY_STONE_TANK);
+        PartApiLookup.register(ItemStorage.SIDED, (part, direction) -> part.getLogic().getBlankPatternInv().toStorage(),
+                PatternEncodingTerminalPart.class);
     }
 
     private static void initPoweredItem() {

--- a/src/main/java/appeng/parts/encoding/PatternEncodingLogic.java
+++ b/src/main/java/appeng/parts/encoding/PatternEncodingLogic.java
@@ -25,6 +25,7 @@ import appeng.api.crafting.PatternDetailsHelper;
 import appeng.api.inventories.InternalInventory;
 import appeng.api.stacks.AEItemKey;
 import appeng.api.stacks.GenericStack;
+import appeng.core.definitions.AEItems;
 import appeng.crafting.pattern.AECraftingPattern;
 import appeng.crafting.pattern.AEProcessingPattern;
 import appeng.crafting.pattern.IAEPatternDetails;
@@ -32,6 +33,7 @@ import appeng.helpers.IPatternTerminalLogicHost;
 import appeng.util.ConfigInventory;
 import appeng.util.inv.AppEngInternalInventory;
 import appeng.util.inv.InternalInventoryHost;
+import appeng.util.inv.filter.AEItemDefinitionFilter;
 
 public class PatternEncodingLogic implements InternalInventoryHost {
 
@@ -55,6 +57,7 @@ public class PatternEncodingLogic implements InternalInventoryHost {
 
     public PatternEncodingLogic(IPatternTerminalLogicHost host) {
         this.host = host;
+        this.blankPatternInv.setFilter(new AEItemDefinitionFilter(AEItems.BLANK_PATTERN));
     }
 
     @Override


### PR DESCRIPTION
This is not perfect since there is no easy way to access the pattern encoding terminal if an automation device is placed next to it. That won't be an issue if you are playing with "phantomface" mods.

I was thinking of maybe adding some sort of "ME Mirror" part that would allow automation to access the opposite side of a cable. I think this could lead to interesting setups (for example the ME Mirror would allow access to the pattern encoding terminal from the opposite side of the cable, or it could be combined in interesting ways with p2p tunnels or pattern providers). To be determined later.