### PR TITLE
Fix usage of PartModels for addons using IAEAddonEntrypoint

### DIFF
--- a/src/main/java/appeng/api/IAEAddonEntrypoint.java
+++ b/src/main/java/appeng/api/IAEAddonEntrypoint.java
@@ -6,7 +6,7 @@ package appeng.api;
  * <p/>
  * Entrypoint IDs supported by AE2:
  * <ul>
- * <li><code>appliedenergistics2</code> will be called on both server and client.</li>
+ * <li><code>ae2</code> will be called on both server and client.</li>
  * <li><code>ae2:client</code> will be called on the client.</li>
  * <li><code>ae2:server</code> will be called on a dedicated server.</li>
  * </ul>

--- a/src/main/java/appeng/init/client/InitAdditionalModels.java
+++ b/src/main/java/appeng/init/client/InitAdditionalModels.java
@@ -36,8 +36,8 @@ public class InitAdditionalModels {
             consumer.accept(MolecularAssemblerRenderer.LIGHTS_MODEL);
         });
 
-        PartModelsInternal.freeze();
         ModelLoadingRegistry.INSTANCE.registerModelProvider((resourceManager, consumer) -> {
+            PartModelsInternal.freeze();
             PartModelsInternal.getModels().forEach(consumer);
         });
     }


### PR DESCRIPTION
Allows usage of PartModels from within IAEAddonEntrypoint by not freezing it before calling addons.

Fixes #6165 