### PR TITLE
Fix #5613 and #6137: network flashing when booting status changes, and level emitter cycle restart (other approach)

### DIFF
--- a/src/main/java/appeng/api/networking/IGridNodeListener.java
+++ b/src/main/java/appeng/api/networking/IGridNodeListener.java
@@ -63,6 +63,10 @@ public interface IGridNodeListener<T> {
     /**
      * Called when one of the node's state properties has changed. Any of those changes might have potentially changed
      * the {@link IGridNode#isActive() active-state} as well.
+     * <p>
+     * Note that no update will be sent when the grid starts booting in spite of the active state changing. This is to
+     * prevent parts turning off and back on for a split second. So make sure to always check the GridNode directly for
+     * activeness before perform an action that requires it! An update will always be sent once booting is complete.
      *
      * @param state Indicates the node property that might have changed.
      */
@@ -82,7 +86,7 @@ public interface IGridNodeListener<T> {
          */
         CHANNEL,
         /**
-         * The grid that the node's attached to has either started or finished booting up.
+         * The grid that the node's attached to has just finished booting up.
          */
         GRID_BOOT
     }

--- a/src/main/java/appeng/api/networking/IGridNodeListener.java
+++ b/src/main/java/appeng/api/networking/IGridNodeListener.java
@@ -63,10 +63,6 @@ public interface IGridNodeListener<T> {
     /**
      * Called when one of the node's state properties has changed. Any of those changes might have potentially changed
      * the {@link IGridNode#isActive() active-state} as well.
-     * <p>
-     * Note that no update will be sent when the grid starts booting in spite of the active state changing. This is to
-     * prevent parts turning off and back on for a split second. So make sure to always check the GridNode directly for
-     * activeness before perform an action that requires it! An update will always be sent once booting is complete.
      *
      * @param state Indicates the node property that might have changed.
      */
@@ -86,7 +82,7 @@ public interface IGridNodeListener<T> {
          */
         CHANNEL,
         /**
-         * The grid that the node's attached to has just finished booting up.
+         * The grid that the node's attached to has either started or finished booting up.
          */
         GRID_BOOT
     }

--- a/src/main/java/appeng/api/networking/IManagedGridNode.java
+++ b/src/main/java/appeng/api/networking/IManagedGridNode.java
@@ -170,7 +170,7 @@ public interface IManagedGridNode {
     boolean isPowered();
 
     /**
-     * @return True if the grid is connected to a network, and that network has fully booted.
+     * @return True if the node is connected to a grid, and that grid has fully booted.
      * @see IPathingService#isNetworkBooting()
      */
     boolean hasGridBooted();

--- a/src/main/java/appeng/api/networking/IManagedGridNode.java
+++ b/src/main/java/appeng/api/networking/IManagedGridNode.java
@@ -38,6 +38,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.ItemLike;
 import net.minecraft.world.level.Level;
 
+import appeng.api.networking.pathing.IPathingService;
 import appeng.api.stacks.AEItemKey;
 import appeng.api.util.AEColor;
 
@@ -167,6 +168,12 @@ public interface IManagedGridNode {
     boolean isActive();
 
     boolean isPowered();
+
+    /**
+     * @return True if the grid is connected to a network, and that network has fully booted.
+     * @see IPathingService#isNetworkBooting()
+     */
+    boolean hasGridBooted();
 
     /**
      * tell the node who was responsible for placing it, failure to do this may result in in-compatibility with the

--- a/src/main/java/appeng/api/networking/events/GridBootingStatusChange.java
+++ b/src/main/java/appeng/api/networking/events/GridBootingStatusChange.java
@@ -32,5 +32,16 @@ import appeng.api.networking.IGridNode;
  * Note: Most machines just need to check {@link IGridNode}.isActive()
  */
 public class GridBootingStatusChange extends GridEvent {
+    private final boolean booting;
 
+    public GridBootingStatusChange(boolean booting) {
+        this.booting = booting;
+    }
+
+    /**
+     * True if the grid is now booting, false if it just finished booting.
+     */
+    public boolean isBooting() {
+        return this.booting;
+    }
 }

--- a/src/main/java/appeng/api/networking/pathing/IPathingService.java
+++ b/src/main/java/appeng/api/networking/pathing/IPathingService.java
@@ -34,6 +34,12 @@ import appeng.api.networking.IGridService;
 public interface IPathingService extends IGridService {
 
     /**
+     * When the structure of a grid is changed in any way, the grid will reboot. While it is booting, the path
+     * from every grid node to the controller, and the number of channels will be re-calculated.
+     * <p/>
+     * The start and end of the boot process is signaled by the {@link appeng.api.networking.events.GridBootingStatusChange}
+     * event.
+     *
      * @return true if the network is in its booting stage
      */
     boolean isNetworkBooting();

--- a/src/main/java/appeng/api/networking/pathing/IPathingService.java
+++ b/src/main/java/appeng/api/networking/pathing/IPathingService.java
@@ -34,11 +34,11 @@ import appeng.api.networking.IGridService;
 public interface IPathingService extends IGridService {
 
     /**
-     * When the structure of a grid is changed in any way, the grid will reboot. While it is booting, the path
-     * from every grid node to the controller, and the number of channels will be re-calculated.
+     * When the structure of a grid is changed in any way, the grid will reboot. While it is booting, the path from
+     * every grid node to the controller, and the number of channels will be re-calculated.
      * <p/>
-     * The start and end of the boot process is signaled by the {@link appeng.api.networking.events.GridBootingStatusChange}
-     * event.
+     * The start and end of the boot process is signaled by the
+     * {@link appeng.api.networking.events.GridBootingStatusChange} event.
      *
      * @return true if the network is in its booting stage
      */

--- a/src/main/java/appeng/blockentity/crafting/CraftingBlockEntity.java
+++ b/src/main/java/appeng/blockentity/crafting/CraftingBlockEntity.java
@@ -211,7 +211,9 @@ public class CraftingBlockEntity extends AENetworkBlockEntity
 
     @Override
     public void onMainNodeStateChanged(IGridNodeListener.State reason) {
-        this.updateSubType(false);
+        if (getMainNode().hasGridBooted()) {
+            this.updateSubType(false);
+        }
     }
 
     public boolean isStatus() {

--- a/src/main/java/appeng/blockentity/crafting/CraftingBlockEntity.java
+++ b/src/main/java/appeng/blockentity/crafting/CraftingBlockEntity.java
@@ -211,7 +211,7 @@ public class CraftingBlockEntity extends AENetworkBlockEntity
 
     @Override
     public void onMainNodeStateChanged(IGridNodeListener.State reason) {
-        if (getMainNode().hasGridBooted()) {
+        if (reason != IGridNodeListener.State.GRID_BOOT) {
             this.updateSubType(false);
         }
     }

--- a/src/main/java/appeng/blockentity/crafting/MolecularAssemblerBlockEntity.java
+++ b/src/main/java/appeng/blockentity/crafting/MolecularAssemblerBlockEntity.java
@@ -538,7 +538,7 @@ public class MolecularAssemblerBlockEntity extends AENetworkInvBlockEntity
 
     @Override
     public void onMainNodeStateChanged(IGridNodeListener.State reason) {
-        if (getMainNode().hasGridBooted()) {
+        if (reason != IGridNodeListener.State.GRID_BOOT) {
             boolean newState = false;
 
             var grid = getMainNode().getGrid();

--- a/src/main/java/appeng/blockentity/crafting/MolecularAssemblerBlockEntity.java
+++ b/src/main/java/appeng/blockentity/crafting/MolecularAssemblerBlockEntity.java
@@ -538,18 +538,19 @@ public class MolecularAssemblerBlockEntity extends AENetworkInvBlockEntity
 
     @Override
     public void onMainNodeStateChanged(IGridNodeListener.State reason) {
-        boolean newState = false;
+        if (getMainNode().hasGridBooted()) {
+            boolean newState = false;
 
-        var grid = getMainNode().getGrid();
-        if (grid != null) {
-            newState = this.getMainNode().isActive()
-                    && grid.getEnergyService().extractAEPower(1, Actionable.SIMULATE,
-                            PowerMultiplier.CONFIG) > 0.0001;
-        }
+            var grid = getMainNode().getGrid();
+            if (grid != null) {
+                newState = this.getMainNode().isActive() && grid.getEnergyService().extractAEPower(1,
+                        Actionable.SIMULATE, PowerMultiplier.CONFIG) > 0.0001;
+            }
 
-        if (newState != this.isPowered) {
-            this.isPowered = newState;
-            this.markForUpdate();
+            if (newState != this.isPowered) {
+                this.isPowered = newState;
+                this.markForUpdate();
+            }
         }
     }
 

--- a/src/main/java/appeng/blockentity/misc/InterfaceBlockEntity.java
+++ b/src/main/java/appeng/blockentity/misc/InterfaceBlockEntity.java
@@ -71,7 +71,9 @@ public class InterfaceBlockEntity extends AENetworkBlockEntity
 
     @Override
     public void onMainNodeStateChanged(IGridNodeListener.State reason) {
-        this.logic.notifyNeighbors();
+        if (getMainNode().hasGridBooted()) {
+            this.logic.notifyNeighbors();
+        }
     }
 
     @Override

--- a/src/main/java/appeng/blockentity/misc/SecurityStationBlockEntity.java
+++ b/src/main/java/appeng/blockentity/misc/SecurityStationBlockEntity.java
@@ -173,7 +173,7 @@ public class SecurityStationBlockEntity extends AENetworkBlockEntity implements 
 
     @Override
     public void onMainNodeStateChanged(IGridNodeListener.State reason) {
-        if (getMainNode().hasGridBooted()) {
+        if (reason != IGridNodeListener.State.GRID_BOOT) {
             this.markForUpdate();
         }
     }

--- a/src/main/java/appeng/blockentity/misc/SecurityStationBlockEntity.java
+++ b/src/main/java/appeng/blockentity/misc/SecurityStationBlockEntity.java
@@ -173,7 +173,9 @@ public class SecurityStationBlockEntity extends AENetworkBlockEntity implements 
 
     @Override
     public void onMainNodeStateChanged(IGridNodeListener.State reason) {
-        this.markForUpdate();
+        if (getMainNode().hasGridBooted()) {
+            this.markForUpdate();
+        }
     }
 
     @Override

--- a/src/main/java/appeng/blockentity/networking/WirelessBlockEntity.java
+++ b/src/main/java/appeng/blockentity/networking/WirelessBlockEntity.java
@@ -65,7 +65,9 @@ public class WirelessBlockEntity extends AENetworkInvBlockEntity implements IWir
 
     @Override
     public void onMainNodeStateChanged(IGridNodeListener.State reason) {
-        this.markForUpdate();
+        if (reason != IGridNodeListener.State.GRID_BOOT) {
+            this.markForUpdate();
+        }
     }
 
     @Override

--- a/src/main/java/appeng/blockentity/spatial/SpatialAnchorBlockEntity.java
+++ b/src/main/java/appeng/blockentity/spatial/SpatialAnchorBlockEntity.java
@@ -225,7 +225,7 @@ public class SpatialAnchorBlockEntity extends AENetworkBlockEntity
     @Override
     public TickRateModulation tickingRequest(IGridNode node, int ticksSinceLastCall) {
         // Initialize once the network is ready and there are no entries marked as loaded.
-        if (!this.initialized && this.getMainNode().isActive() && this.getMainNode().isPowered()) {
+        if (!this.initialized && this.getMainNode().isActive()) {
             this.forceAll();
             this.initialized = true;
         } else {

--- a/src/main/java/appeng/blockentity/spatial/SpatialPylonBlockEntity.java
+++ b/src/main/java/appeng/blockentity/spatial/SpatialPylonBlockEntity.java
@@ -181,7 +181,9 @@ public class SpatialPylonBlockEntity extends AENetworkBlockEntity implements IAE
 
     @Override
     public void onMainNodeStateChanged(IGridNodeListener.State reason) {
-        this.recalculateDisplay();
+        if (reason != IGridNodeListener.State.GRID_BOOT) {
+            this.recalculateDisplay();
+        }
     }
 
     public int getDisplayBits() {

--- a/src/main/java/appeng/blockentity/storage/ChestBlockEntity.java
+++ b/src/main/java/appeng/blockentity/storage/ChestBlockEntity.java
@@ -367,11 +367,13 @@ public class ChestBlockEntity extends AENetworkPowerBlockEntity
 
     @Override
     public void onMainNodeStateChanged(IGridNodeListener.State reason) {
-        var currentActive = this.getMainNode().isActive();
-        if (this.wasActive != currentActive) {
-            this.wasActive = currentActive;
-            IStorageProvider.requestUpdate(getMainNode());
-            recalculateDisplay();
+        if (reason != IGridNodeListener.State.GRID_BOOT) {
+            var currentActive = this.getMainNode().isActive();
+            if (this.wasActive != currentActive) {
+                this.wasActive = currentActive;
+                IStorageProvider.requestUpdate(getMainNode());
+                recalculateDisplay();
+            }
         }
     }
 

--- a/src/main/java/appeng/blockentity/storage/DriveBlockEntity.java
+++ b/src/main/java/appeng/blockentity/storage/DriveBlockEntity.java
@@ -268,14 +268,14 @@ public class DriveBlockEntity extends AENetworkInvBlockEntity
 
     @Override
     public void onMainNodeStateChanged(IGridNodeListener.State reason) {
-
-        var currentActive = getMainNode().isActive();
-        if (this.wasActive != currentActive) {
-            this.wasActive = currentActive;
-            IStorageProvider.requestUpdate(getMainNode());
-            updateVisualStateIfNeeded();
+        if (reason != IGridNodeListener.State.GRID_BOOT) {
+            var currentActive = getMainNode().isActive();
+            if (this.wasActive != currentActive) {
+                this.wasActive = currentActive;
+                IStorageProvider.requestUpdate(getMainNode());
+                updateVisualStateIfNeeded();
+            }
         }
-
     }
 
     @Override

--- a/src/main/java/appeng/helpers/iface/PatternProviderLogic.java
+++ b/src/main/java/appeng/helpers/iface/PatternProviderLogic.java
@@ -360,9 +360,12 @@ public class PatternProviderLogic implements InternalInventoryHost, ICraftingPro
 
     public void onMainNodeStateChanged() {
         ICraftingProvider.requestUpdate(this.mainNode);
-        this.mainNode.ifPresent((grid, node) -> {
-            grid.getTickManager().alertDevice(node);
-        });
+
+        if (this.mainNode.hasGridBooted()) {
+            this.mainNode.ifPresent((grid, node) -> {
+                grid.getTickManager().alertDevice(node);
+            });
+        }
     }
 
     public void addDrops(List<ItemStack> drops) {

--- a/src/main/java/appeng/me/ManagedGridNode.java
+++ b/src/main/java/appeng/me/ManagedGridNode.java
@@ -219,6 +219,14 @@ public class ManagedGridNode implements IManagedGridNode {
     }
 
     @Override
+    public boolean hasGridBooted() {
+        if (this.node == null) {
+            return false;
+        }
+        return this.node.hasGridBooted();
+    }
+
+    @Override
     public void setOwningPlayerId(int ownerPlayerId) {
         if (this.initData != null) {
             getInitData().owner = ownerPlayerId;

--- a/src/main/java/appeng/me/pathfinding/AdHocChannelUpdater.java
+++ b/src/main/java/appeng/me/pathfinding/AdHocChannelUpdater.java
@@ -37,7 +37,6 @@ public class AdHocChannelUpdater implements IGridConnectionVisitor {
         final GridNode gn = (GridNode) n;
         gn.setControllerRoute(null);
         gn.incrementChannelCount(this.usedChannels);
-        gn.finalizeChannels();
         return true;
     }
 
@@ -46,6 +45,5 @@ public class AdHocChannelUpdater implements IGridConnectionVisitor {
         final GridConnection gc = (GridConnection) gcc;
         gc.setControllerRoute(null);
         gc.incrementChannelCount(this.usedChannels);
-        gc.finalizeChannels();
     }
 }

--- a/src/main/java/appeng/me/pathfinding/ChannelFinalizer.java
+++ b/src/main/java/appeng/me/pathfinding/ChannelFinalizer.java
@@ -24,7 +24,7 @@ import appeng.api.networking.IGridNode;
 import appeng.me.GridConnection;
 import appeng.me.GridNode;
 
-public class ControllerChannelUpdater implements IGridConnectionVisitor {
+public class ChannelFinalizer implements IGridConnectionVisitor {
 
     @Override
     public boolean visitNode(IGridNode n) {

--- a/src/main/java/appeng/me/service/P2PService.java
+++ b/src/main/java/appeng/me/service/P2PService.java
@@ -41,7 +41,9 @@ public class P2PService implements IGridService, IGridServiceProvider {
     static {
         GridHelper.addGridServiceEventHandler(GridBootingStatusChange.class, P2PService.class,
                 (service, evt) -> {
-                    service.wakeInputTunnels();
+                    if (!evt.isBooting()) {
+                        service.wakeInputTunnels();
+                    }
                 });
         GridHelper.addGridServiceEventHandler(GridPowerStatusChange.class, P2PService.class,
                 (service, evt) -> {

--- a/src/main/java/appeng/me/service/PathingService.java
+++ b/src/main/java/appeng/me/service/PathingService.java
@@ -99,9 +99,7 @@ public class PathingService implements IPathingService, IGridServiceProvider {
 
             if (!this.booting) {
                 this.booting = true;
-                // GridNode#isActive() will now return false, but we don't want all nodes to turn off visually now.
-                // That's why we do NOT notify nodes. We still send the grid event in case something needs it.
-                this.postBootingStatusChange(false);
+                this.postBootingStatusChange();
             }
 
             this.channelsInUse = 0;
@@ -156,7 +154,7 @@ public class PathingService implements IPathingService, IGridServiceProvider {
 
                 this.booting = false;
                 this.setChannelPowerUsage(this.channelsByBlocks / 128.0);
-                this.postBootingStatusChange(true);
+                this.postBootingStatusChange();
                 // Notify of channel changes after we finish booting, this ensures that any activeness check will
                 // properly return true.
                 this.grid.getPivot().beginVisit(new ChannelFinalizer());
@@ -166,11 +164,9 @@ public class PathingService implements IPathingService, IGridServiceProvider {
         }
     }
 
-    private void postBootingStatusChange(boolean notifyNodes) {
+    private void postBootingStatusChange() {
         this.grid.postEvent(new GridBootingStatusChange(this.booting));
-        if (notifyNodes) {
-            this.grid.notifyAllNodes(IGridNodeListener.State.GRID_BOOT);
-        }
+        this.grid.notifyAllNodes(IGridNodeListener.State.GRID_BOOT);
     }
 
     @Override

--- a/src/main/java/appeng/me/service/PathingService.java
+++ b/src/main/java/appeng/me/service/PathingService.java
@@ -154,10 +154,10 @@ public class PathingService implements IPathingService, IGridServiceProvider {
 
                 this.booting = false;
                 this.setChannelPowerUsage(this.channelsByBlocks / 128.0);
-                this.postBootingStatusChange();
-                // Notify of channel changes after we finish booting, this ensures that any activeness check will
+                // Notify of channel changes AFTER we set booting to false, this ensures that any activeness check will
                 // properly return true.
                 this.grid.getPivot().beginVisit(new ChannelFinalizer());
+                this.postBootingStatusChange();
             } else if (ticksUntilReady == -2000) {
                 AELog.warn("Booting has still not completed after 2000 ticks for %s", grid);
             }

--- a/src/main/java/appeng/me/service/PathingService.java
+++ b/src/main/java/appeng/me/service/PathingService.java
@@ -72,10 +72,10 @@ public class PathingService implements IPathingService, IGridServiceProvider {
     // Flag to indicate a reboot should occur next tick
     private boolean reboot = true;
     private boolean booting = false;
+    private int bootingTicks = 0;
     @Nullable
     private AdHocNetworkError adHocNetworkError;
     private ControllerState controllerState = ControllerState.NO_CONTROLLER;
-    private int ticksUntilReady = 0;
     private int lastChannels = 0;
     /**
      * This can be used for testing to set a specific channel mode on this grid that will not be overwritten by
@@ -99,6 +99,7 @@ public class PathingService implements IPathingService, IGridServiceProvider {
 
             if (!this.booting) {
                 this.booting = true;
+                this.bootingTicks = 0;
                 this.postBootingStatusChange();
             }
 
@@ -116,17 +117,13 @@ public class PathingService implements IPathingService, IGridServiceProvider {
                 this.channelsInUse = this.calculateAdHocChannels();
 
                 var nodes = this.grid.size();
-                this.ticksUntilReady = Math.max(5, nodes / 100);
                 this.channelsByBlocks = nodes * this.channelsInUse;
                 this.setChannelPowerUsage(this.channelsByBlocks / 128.0);
 
                 this.grid.getPivot().beginVisit(new AdHocChannelUpdater(this.channelsInUse));
             } else if (this.controllerState == ControllerState.CONTROLLER_CONFLICT) {
-                this.ticksUntilReady = 5;
                 this.grid.getPivot().beginVisit(new AdHocChannelUpdater(0));
             } else {
-                var nodes = this.grid.size();
-                this.ticksUntilReady = Math.max(5, nodes / 100);
                 this.ongoingCalculation = new PathingCalculation(grid);
             }
         }
@@ -145,10 +142,10 @@ public class PathingService implements IPathingService, IGridServiceProvider {
                 }
             }
 
-            this.ticksUntilReady--;
+            bootingTicks++;
 
             // Booting completes when both pathfinding completes, and the minimum boot time has elapsed
-            if (ongoingCalculation == null && ticksUntilReady <= 0) {
+            if (ongoingCalculation == null) {
                 // check for achievements
                 this.achievementPost();
 
@@ -158,8 +155,8 @@ public class PathingService implements IPathingService, IGridServiceProvider {
                 // properly return true.
                 this.grid.getPivot().beginVisit(new ChannelFinalizer());
                 this.postBootingStatusChange();
-            } else if (ticksUntilReady == -2000) {
-                AELog.warn("Booting has still not completed after 2000 ticks for %s", grid);
+            } else if (bootingTicks == 2000) {
+                AELog.warn("Booting has still not completed after %d ticks for %s", bootingTicks, grid);
             }
         }
     }

--- a/src/main/java/appeng/parts/BasicStatePart.java
+++ b/src/main/java/appeng/parts/BasicStatePart.java
@@ -54,8 +54,10 @@ public abstract class BasicStatePart extends AEBasePart implements IPowerChannel
 
     @Override
     protected void onMainNodeStateChanged(IGridNodeListener.State reason) {
-        if (calculateClientFlags() != getClientFlags()) {
-            getHost().markForUpdate();
+        if (getMainNode().hasGridBooted()) {
+            if (calculateClientFlags() != getClientFlags()) {
+                getHost().markForUpdate();
+            }
         }
     }
 

--- a/src/main/java/appeng/parts/BasicStatePart.java
+++ b/src/main/java/appeng/parts/BasicStatePart.java
@@ -54,7 +54,7 @@ public abstract class BasicStatePart extends AEBasePart implements IPowerChannel
 
     @Override
     protected void onMainNodeStateChanged(IGridNodeListener.State reason) {
-        if (getMainNode().hasGridBooted()) {
+        if (reason != IGridNodeListener.State.GRID_BOOT) {
             if (calculateClientFlags() != getClientFlags()) {
                 getHost().markForUpdate();
             }

--- a/src/main/java/appeng/parts/automation/AbstractLevelEmitterPart.java
+++ b/src/main/java/appeng/parts/automation/AbstractLevelEmitterPart.java
@@ -65,7 +65,9 @@ public abstract class AbstractLevelEmitterPart extends UpgradeablePart {
 
     @Override
     protected final void onMainNodeStateChanged(IGridNodeListener.State reason) {
-        updateState();
+        if (getMainNode().hasGridBooted()) {
+            updateState();
+        }
     }
 
     protected void updateState() {

--- a/src/main/java/appeng/parts/automation/AnnihilationPlanePart.java
+++ b/src/main/java/appeng/parts/automation/AnnihilationPlanePart.java
@@ -181,7 +181,10 @@ public class AnnihilationPlanePart extends BasicStatePart implements IGridTickab
     @Override
     protected void onMainNodeStateChanged(IGridNodeListener.State reason) {
         super.onMainNodeStateChanged(reason);
-        this.refresh();
+
+        if (getMainNode().hasGridBooted()) {
+            this.refresh();
+        }
     }
 
     @Override

--- a/src/main/java/appeng/parts/automation/FormationPlanePart.java
+++ b/src/main/java/appeng/parts/automation/FormationPlanePart.java
@@ -136,7 +136,9 @@ public class FormationPlanePart extends UpgradeablePart implements IStorageProvi
 
     @Override
     protected void onMainNodeStateChanged(IGridNodeListener.State reason) {
-        stateChanged();
+        if (reason != IGridNodeListener.State.GRID_BOOT) {
+            stateChanged();
+        }
     }
 
     @Override

--- a/src/main/java/appeng/parts/misc/InterfacePart.java
+++ b/src/main/java/appeng/parts/misc/InterfacePart.java
@@ -92,7 +92,9 @@ public class InterfacePart extends BasicStatePart implements InterfaceLogicHost 
     @Override
     protected void onMainNodeStateChanged(IGridNodeListener.State reason) {
         super.onMainNodeStateChanged(reason);
-        this.logic.notifyNeighbors();
+        if (getMainNode().hasGridBooted()) {
+            this.logic.notifyNeighbors();
+        }
     }
 
     @Override

--- a/src/main/java/appeng/parts/networking/SmartCablePart.java
+++ b/src/main/java/appeng/parts/networking/SmartCablePart.java
@@ -35,7 +35,9 @@ public class SmartCablePart extends CablePart implements IUsedChannelProvider {
      */
     @Override
     protected void onMainNodeStateChanged(IGridNodeListener.State reason) {
-        this.getHost().markForUpdate();
+        if (reason != IGridNodeListener.State.GRID_BOOT) {
+            this.getHost().markForUpdate();
+        }
     }
 
     @Override

--- a/src/main/java/appeng/parts/networking/SmartDenseCablePart.java
+++ b/src/main/java/appeng/parts/networking/SmartDenseCablePart.java
@@ -40,7 +40,9 @@ public class SmartDenseCablePart extends DenseCablePart implements IUsedChannelP
      */
     @Override
     protected void onMainNodeStateChanged(IGridNodeListener.State reason) {
-        this.getHost().markForUpdate();
+        if (reason != IGridNodeListener.State.GRID_BOOT) {
+            this.getHost().markForUpdate();
+        }
     }
 
 }

--- a/src/main/java/appeng/parts/p2p/LightP2PTunnelPart.java
+++ b/src/main/java/appeng/parts/p2p/LightP2PTunnelPart.java
@@ -62,7 +62,9 @@ public class LightP2PTunnelPart extends P2PTunnelPart<LightP2PTunnelPart> implem
     @Override
     protected void onMainNodeStateChanged(IGridNodeListener.State reason) {
         super.onMainNodeStateChanged(reason);
-        this.onTunnelNetworkChange();
+        if (getMainNode().hasGridBooted()) {
+            this.onTunnelNetworkChange();
+        }
     }
 
     @Override

--- a/src/main/java/appeng/parts/p2p/RedstoneP2PTunnelPart.java
+++ b/src/main/java/appeng/parts/p2p/RedstoneP2PTunnelPart.java
@@ -95,7 +95,9 @@ public class RedstoneP2PTunnelPart extends P2PTunnelPart<RedstoneP2PTunnelPart> 
     @Override
     protected void onMainNodeStateChanged(IGridNodeListener.State reason) {
         super.onMainNodeStateChanged(reason);
-        this.setNetworkReady();
+        if (getMainNode().hasGridBooted()) {
+            this.setNetworkReady();
+        }
     }
 
     @Override

--- a/src/main/java/appeng/parts/storagebus/StorageBusPart.java
+++ b/src/main/java/appeng/parts/storagebus/StorageBusPart.java
@@ -141,11 +141,13 @@ public class StorageBusPart extends UpgradeablePart
 
     @Override
     protected final void onMainNodeStateChanged(IGridNodeListener.State reason) {
-        var currentActive = this.getMainNode().isActive();
-        if (this.wasActive != currentActive) {
-            this.wasActive = currentActive;
-            this.getHost().markForUpdate();
-            remountStorage();
+        if (reason != IGridNodeListener.State.GRID_BOOT) {
+            var currentActive = this.getMainNode().isActive();
+            if (this.wasActive != currentActive) {
+                this.wasActive = currentActive;
+                this.getHost().markForUpdate();
+                remountStorage();
+            }
         }
     }
 

--- a/src/test/java/appeng/me/GridNodeTest.java
+++ b/src/test/java/appeng/me/GridNodeTest.java
@@ -14,15 +14,11 @@ import appeng.me.service.PathingService;
 
 class GridNodeTest extends AbstractGridNodeTest {
     /**
-     * Tests that:
-     * <ul>
-     * <li>{@link appeng.integration.modules.waila.GridNodeState#NETWORK_BOOTING} is only sent after booting is
-     * complete, and that the node is active after that event.</li>
-     * <li>No event is sent when booting starts.</li>
-     * </ul>
+     * Regression test for the {@link appeng.integration.modules.waila.GridNodeState#NETWORK_BOOTING} notification. It
+     * was previously sent before the state actually changed, causing various problems.
      */
     @Test
-    public void testRebootNotifications() {
+    public void rebootNotificationIsPostedAfterGridBeginsBooting() {
         var node = makePoweredNode();
         assertTrue(node.hasGridBooted());
         reset(listener);
@@ -33,14 +29,8 @@ class GridNodeTest extends AbstractGridNodeTest {
         }).when(listener).onStateChanged(owner, node, IGridNodeListener.State.GRID_BOOT);
         var pathingService = (PathingService) node.getGrid().getPathingService();
         pathingService.repath();
-        // First tick: should start rebooting, but not send any notification.
         runTick(node.getGrid());
-        assertThat(calls).isEmpty();
-        // After a few ticks: reboot should be complete, and node should be active in the event listener
-        for (int i = 0; i < 10; ++i) {
-            runTick(node.getGrid());
-        }
-        assertThat(calls).containsOnly(true);
+        assertThat(calls).containsOnly(false);
     }
 
 }

--- a/src/test/java/appeng/me/GridNodeTest.java
+++ b/src/test/java/appeng/me/GridNodeTest.java
@@ -14,11 +14,15 @@ import appeng.me.service.PathingService;
 
 class GridNodeTest extends AbstractGridNodeTest {
     /**
-     * Regression test for the {@link appeng.integration.modules.waila.GridNodeState#NETWORK_BOOTING} notification. It
-     * was previously sent before the state actually changed, causing various problems.
+     * Tests that:
+     * <ul>
+     * <li>{@link appeng.integration.modules.waila.GridNodeState#NETWORK_BOOTING} is only sent after booting is
+     * complete, and that the node is active after that event.</li>
+     * <li>No event is sent when booting starts.</li>
+     * </ul>
      */
     @Test
-    public void rebootNotificationIsPostedAfterGridBeginsBooting() {
+    public void testRebootNotifications() {
         var node = makePoweredNode();
         assertTrue(node.hasGridBooted());
         reset(listener);
@@ -29,8 +33,14 @@ class GridNodeTest extends AbstractGridNodeTest {
         }).when(listener).onStateChanged(owner, node, IGridNodeListener.State.GRID_BOOT);
         var pathingService = (PathingService) node.getGrid().getPathingService();
         pathingService.repath();
+        // First tick: should start rebooting, but not send any notification.
         runTick(node.getGrid());
-        assertThat(calls).containsOnly(false);
+        assertThat(calls).isEmpty();
+        // After a few ticks: reboot should be complete, and node should be active in the event listener
+        for (int i = 0; i < 10; ++i) {
+            runTick(node.getGrid());
+        }
+        assertThat(calls).containsOnly(true);
     }
 
 }

--- a/src/test/java/appeng/me/GridNodeTest.java
+++ b/src/test/java/appeng/me/GridNodeTest.java
@@ -30,7 +30,7 @@ class GridNodeTest extends AbstractGridNodeTest {
         var pathingService = (PathingService) node.getGrid().getPathingService();
         pathingService.repath();
         runTick(node.getGrid());
-        assertThat(calls).containsOnly(false);
+        assertThat(calls).containsExactly(false, true);
     }
 
 }


### PR DESCRIPTION
I changed when the channels are finalized (this is what sends the channel change events to grid node listeners) to be after the grid has finished booting so `isActive` checks properly succeed in there. There are two ways to filter out unwanted notifications while the grid is booting:
- Check `state != State.GRID_BOOTED`: this will only be called if either power or channel state changes. Checking `isActive` there will properly return the new active state. This is appropriate when activeness is only used for display purposes or decided whether some logic should be skipped.
- Check `getMainNode().hasGridBooted()`: this will be called if either the power or channel state changes, and also every time the grid finished booting. This is appropriate when the device was sleeping while booting and might need to be awakened. For example, for ME interfaces, this has to be used to avoid issues such as #5603.