### PR TITLE
fix `ICraftingRequester#insertCraftedItems` doc

### DIFF
--- a/src/main/java/appeng/api/networking/crafting/ICraftingRequester.java
+++ b/src/main/java/appeng/api/networking/crafting/ICraftingRequester.java
@@ -41,13 +41,12 @@ public interface ICraftingRequester extends IActionHost, IGridNodeService {
     ImmutableSet<ICraftingLink> getRequestedJobs();
 
     /**
-     * items are injected into the requester as they are completed, any items that cannot be taken, or are unwanted can
-     * be returned.
+     * items are injected into the requester as they are completed.
      *
      * @param items item
      * @param mode  action mode
      *
-     * @return unwanted item
+     * @return the number of items inserted.
      */
     long insertCraftedItems(ICraftingLink link, AEKey what, long amount, Actionable mode);
 


### PR DESCRIPTION
related to https://github.com/AppliedEnergistics/Applied-Energistics-2/pull/6176

I found this when handling the crafting results myself and then returning the unwanted amount as `0` which resulted in duping my items.