### PR TITLE
Fix #6198: Cache stack display names to improve terminal sorting performance

### DIFF
--- a/src/main/java/appeng/api/stacks/AEFluidKey.java
+++ b/src/main/java/appeng/api/stacks/AEFluidKey.java
@@ -3,6 +3,7 @@ package appeng.api.stacks;
 import java.util.List;
 import java.util.Objects;
 
+import net.minecraft.network.chat.TranslatableComponent;
 import org.jetbrains.annotations.Nullable;
 
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidConstants;
@@ -30,10 +31,11 @@ public final class AEFluidKey extends AEKey {
     private final CompoundTag tag;
     private final int hashCode;
 
-    private AEFluidKey(Fluid Fluid, @Nullable CompoundTag tag) {
-        this.fluid = Fluid;
+    private AEFluidKey(Fluid fluid, @Nullable CompoundTag tag) {
+        super(Platform.getFluidDisplayName(fluid));
+        this.fluid = fluid;
         this.tag = tag;
-        this.hashCode = Objects.hash(Fluid, tag);
+        this.hashCode = Objects.hash(fluid, tag);
     }
 
     public static AEFluidKey of(Fluid fluid, @Nullable CompoundTag tag) {
@@ -127,11 +129,6 @@ public final class AEFluidKey extends AEKey {
     @Override
     public String getModId() {
         return Registry.FLUID.getKey(fluid).getNamespace();
-    }
-
-    @Override
-    public Component getDisplayName() {
-        return Platform.getFluidDisplayName(this);
     }
 
     @Override

--- a/src/main/java/appeng/api/stacks/AEFluidKey.java
+++ b/src/main/java/appeng/api/stacks/AEFluidKey.java
@@ -3,7 +3,6 @@ package appeng.api.stacks;
 import java.util.List;
 import java.util.Objects;
 
-import net.minecraft.network.chat.TranslatableComponent;
 import org.jetbrains.annotations.Nullable;
 
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidConstants;
@@ -12,7 +11,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Registry;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.FriendlyByteBuf;
-import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;

--- a/src/main/java/appeng/api/stacks/AEItemKey.java
+++ b/src/main/java/appeng/api/stacks/AEItemKey.java
@@ -25,9 +25,11 @@ public final class AEItemKey extends AEKey {
     @Nullable
     private final CompoundTag tag;
     private final int hashCode;
+    private final Component displayName;
 
     private AEItemKey(Item item, @Nullable CompoundTag tag) {
         this.item = item;
+        this.displayName = toStack().getHoverName();
         this.tag = tag;
         this.hashCode = Objects.hash(item, tag);
     }
@@ -203,7 +205,7 @@ public final class AEItemKey extends AEKey {
 
     @Override
     public Component getDisplayName() {
-        return toStack().getHoverName();
+        return this.displayName;
     }
 
     @Override

--- a/src/main/java/appeng/api/stacks/AEItemKey.java
+++ b/src/main/java/appeng/api/stacks/AEItemKey.java
@@ -1,8 +1,10 @@
 package appeng.api.stacks;
 
-import appeng.api.storage.AEKeyFilter;
-import appeng.core.AELog;
-import appeng.util.Platform;
+import java.util.List;
+import java.util.Objects;
+
+import org.jetbrains.annotations.Nullable;
+
 import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Registry;
@@ -13,16 +15,17 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.ItemLike;
 import net.minecraft.world.level.Level;
-import org.jetbrains.annotations.Nullable;
 
-import java.util.List;
-import java.util.Objects;
+import appeng.api.storage.AEKeyFilter;
+import appeng.core.AELog;
+import appeng.util.Platform;
 
 public final class AEItemKey extends AEKey {
     private final Item item;
     @Nullable
     private final CompoundTag tag;
     private final int hashCode;
+
     private AEItemKey(Item item, @Nullable CompoundTag tag) {
         super(Platform.getItemDisplayName(item, tag));
         this.item = item;

--- a/src/main/java/appeng/api/stacks/AEItemKey.java
+++ b/src/main/java/appeng/api/stacks/AEItemKey.java
@@ -1,35 +1,31 @@
 package appeng.api.stacks;
 
-import java.util.List;
-import java.util.Objects;
-
-import org.jetbrains.annotations.Nullable;
-
+import appeng.api.storage.AEKeyFilter;
+import appeng.core.AELog;
+import appeng.util.Platform;
 import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Registry;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.FriendlyByteBuf;
-import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.ItemLike;
 import net.minecraft.world.level.Level;
+import org.jetbrains.annotations.Nullable;
 
-import appeng.api.storage.AEKeyFilter;
-import appeng.core.AELog;
+import java.util.List;
+import java.util.Objects;
 
 public final class AEItemKey extends AEKey {
     private final Item item;
     @Nullable
     private final CompoundTag tag;
     private final int hashCode;
-    private final Component displayName;
-
     private AEItemKey(Item item, @Nullable CompoundTag tag) {
+        super(Platform.getItemDisplayName(item, tag));
         this.item = item;
-        this.displayName = toStack().getHoverName();
         this.tag = tag;
         this.hashCode = Objects.hash(item, tag);
     }
@@ -201,11 +197,6 @@ public final class AEItemKey extends AEKey {
     @Override
     public ItemStack wrap(int amount) {
         return toStack(amount);
-    }
-
-    @Override
-    public Component getDisplayName() {
-        return this.displayName;
     }
 
     @Override

--- a/src/main/java/appeng/api/stacks/AEKey.java
+++ b/src/main/java/appeng/api/stacks/AEKey.java
@@ -41,8 +41,8 @@ public abstract class AEKey {
     private final Component displayName;
 
     /**
-     * @deprecated It has been deprecated because we should cache the display name in the initialization to speed
-     * up the sorting process.
+     * @deprecated It has been deprecated because we should cache the display name in the initialization to speed up the
+     *             sorting process.
      */
     @Deprecated
     public AEKey() {

--- a/src/main/java/appeng/api/stacks/AEKey.java
+++ b/src/main/java/appeng/api/stacks/AEKey.java
@@ -34,6 +34,27 @@ import appeng.items.misc.WrappedGenericStack;
  */
 public abstract class AEKey {
 
+    /**
+     * The display name, which is used to sort by name in client terminal
+     */
+    private final Component displayName;
+
+    /**
+     * @deprecated It has been deprecated because we should cache the display name in the initialization to speed
+     * up the sorting process.
+     */
+    @Deprecated
+    public AEKey() {
+        this.displayName = null;
+    }
+
+    /**
+     * @param displayName the display name, which is used to sort by name in client terminal
+     */
+    public AEKey(Component displayName) {
+        this.displayName = displayName;
+    }
+
     @Nullable
     public static AEKey fromTagGeneric(CompoundTag tag) {
         // Handle malformed tags where the channel is missing
@@ -242,7 +263,10 @@ public abstract class AEKey {
         return getType().supportsFuzzyRangeSearch();
     }
 
-    public abstract Component getDisplayName();
+    public Component getDisplayName() {
+        assert this.displayName != null;
+        return this.displayName;
+    }
 
     /**
      * Adds the drops if the container holding this key is broken, such as an interface holding stacks. Item stacks

--- a/src/main/java/appeng/api/stacks/AEKey.java
+++ b/src/main/java/appeng/api/stacks/AEKey.java
@@ -1,6 +1,7 @@
 package appeng.api.stacks;
 
 import java.util.List;
+import java.util.Objects;
 
 import javax.annotation.Nullable;
 
@@ -264,8 +265,7 @@ public abstract class AEKey {
     }
 
     public Component getDisplayName() {
-        assert this.displayName != null;
-        return this.displayName;
+        return Objects.requireNonNull(this.displayName);
     }
 
     /**

--- a/src/main/java/appeng/util/Platform.java
+++ b/src/main/java/appeng/util/Platform.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Iterables;
@@ -41,6 +41,7 @@ import net.minecraft.Util;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.network.protocol.Packet;
@@ -50,6 +51,7 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.CraftingContainer;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag.Default;
 import net.minecraft.world.item.crafting.Recipe;
@@ -324,8 +326,16 @@ public class Platform {
         return getDescriptionId(fluid.getFluid());
     }
 
-    public static Component getFluidDisplayName(AEFluidKey o) {
-        return new TranslatableComponent(getDescriptionId(o.toVariant()));
+    public static Component getFluidDisplayName(Fluid fluid) {
+        return new TranslatableComponent(getDescriptionId(fluid));
+    }
+
+    // tag copy is not necessary, as the tag is not modified.
+    // and this itemStack is not reachable
+    public static Component getItemDisplayName(Item item, @Nullable CompoundTag tag) {
+        var itemStack = new ItemStack(item);
+        itemStack.setTag(tag);
+        return itemStack.getHoverName();
     }
 
     public static boolean isChargeable(ItemStack i) {
@@ -482,7 +492,7 @@ public class Platform {
         }
 
         if (a_isSecure && !b_isSecure) {
-            // NOTE: a cannot be powered/secure if a has no grid, so b.getGrid() should succeed
+            // NOTE: a cannot be powered/secure if a has no grid, so a.getGrid() should succeed
             return checkPlayerPermissions(a.getGrid(), b.getOwningPlayerId());
         }
 

--- a/src/main/java/appeng/util/Platform.java
+++ b/src/main/java/appeng/util/Platform.java
@@ -26,10 +26,10 @@ import java.util.Objects;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
-import org.jetbrains.annotations.Nullable;
-
 import com.google.common.base.Strings;
 import com.google.common.collect.Iterables;
+
+import org.jetbrains.annotations.Nullable;
 
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
@@ -77,7 +77,6 @@ import appeng.api.networking.IManagedGridNode;
 import appeng.api.networking.energy.IEnergySource;
 import appeng.api.networking.security.IActionHost;
 import appeng.api.networking.security.IActionSource;
-import appeng.api.stacks.AEFluidKey;
 import appeng.api.stacks.AEItemKey;
 import appeng.api.stacks.AEKey;
 import appeng.api.stacks.KeyCounter;


### PR DESCRIPTION
I have created the displayName field in the AEItemKey as a cache. When sorting by name, the cache is used.

before:
![9998FBFE61039CB8AF247E1139FE7F94](https://user-images.githubusercontent.com/24197013/164290074-71de1306-81b5-42e9-a10a-a427a848246d.jpg)

after:
![4E154F2E6D4AC3854D329B650A554380](https://user-images.githubusercontent.com/24197013/164289626-c45d37a8-50c2-46f6-9491-6fda292db9f4.jpg)

see details in #6198 
