### PR TITLE
Fix #3890: Add indicator for craftable items when displaying quantities

### DIFF
--- a/src/main/java/appeng/client/gui/me/common/MEStorageScreen.java
+++ b/src/main/java/appeng/client/gui/me/common/MEStorageScreen.java
@@ -511,6 +511,9 @@ public class MEStorageScreen<C extends MEStorageMenu>
                                 : AmountFormat.PREVIEW_REGULAR;
                         var text = entry.getWhat().formatAmount(storedAmount, format);
                         StackSizeRenderer.renderSizeLabel(this.font, s.x, s.y, text, useLargeFonts);
+                        if (craftable) {
+                            StackSizeRenderer.renderSizeLabel(this.font, s.x - 11, s.y - 11, "+", false);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Low-cost solution to #3890. Uses a separate text label treated as a static icon so as not to interfere with the length of the item count, especially when using large fonts.

![image](https://user-images.githubusercontent.com/5098830/166108279-a5faa5aa-5e7a-4cc8-b09c-6017f824b37e.png)
