### PR TITLE
Fix #6210: Render Spatial Anchor overlay down to bedrock again

### DIFF
--- a/src/main/java/appeng/client/render/overlay/OverlayRenderer.java
+++ b/src/main/java/appeng/client/render/overlay/OverlayRenderer.java
@@ -64,7 +64,7 @@ public class OverlayRenderer {
         // Render around a whole chunk
         float x1 = 0f;
         float x2 = 16f;
-        float y1 = 0f;
+        float y1 = -64f;
         float y2 = 256f;
         float z1 = 0f;
         float z2 = 16f;


### PR DESCRIPTION
This could probably do with a better approach than simply hard-coding min/max Y-values if ever the cave system gets extended below Y = -64 again.