### PR TITLE
Simplify P2P tunnel attunement API

### DIFF
--- a/src/main/java/appeng/core/localization/InGameTooltip.java
+++ b/src/main/java/appeng/core/localization/InGameTooltip.java
@@ -35,6 +35,8 @@ public enum InGameTooltip implements LocalizationEnum {
     ErrorTooManyChannels("Error: Too Many Channels"),
     Locked("Locked"),
     NetworkBooting("Network Booting"),
+    P2PAttunementEnergy("Portable TechReborn Energy Storage (i.e. Batteries)"),
+    P2PAttunementFluid("Portable Fabric Fluid Storage (i.e. Tanks, Buckets)"),
     P2PInputManyOutputs("Linked (Input Side) - %d Outputs"),
     P2PInputOneOutput("Linked (Input Side)"),
     P2POutput("Linked (Output Side)"),

--- a/src/main/java/appeng/datagen/providers/tags/ItemTagsProvider.java
+++ b/src/main/java/appeng/datagen/providers/tags/ItemTagsProvider.java
@@ -29,6 +29,7 @@ import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.Items;
 
+import appeng.api.features.P2PTunnelAttunement;
 import appeng.api.ids.AETags;
 import appeng.api.util.AEColor;
 import appeng.core.AppEng;
@@ -131,6 +132,8 @@ public class ItemTagsProvider extends net.minecraft.data.tags.ItemTagsProvider i
                 AEItems.NETWORK_TOOL.asItem());
 
         addConventionTags();
+
+        addP2pAttunementTags();
     }
 
     private void addConventionTags() {
@@ -251,6 +254,34 @@ public class ItemTagsProvider extends net.minecraft.data.tags.ItemTagsProvider i
 
     private void mirrorBlockTag(ResourceLocation tagName) {
         copy(TagKey.create(Registry.BLOCK_REGISTRY, tagName), TagKey.create(Registry.ITEM_REGISTRY, tagName));
+    }
+
+    private void addP2pAttunementTags() {
+        tag(P2PTunnelAttunement.getAttunementTag(P2PTunnelAttunement.LIGHT_TUNNEL))
+                .add(Items.TORCH, Items.GLOWSTONE);
+
+        tag(P2PTunnelAttunement.getAttunementTag(P2PTunnelAttunement.ENERGY_TUNNEL))
+                .add(AEBlocks.DENSE_ENERGY_CELL.asItem(), AEBlocks.ENERGY_ACCEPTOR.asItem(),
+                        AEBlocks.ENERGY_CELL.asItem(), AEBlocks.CREATIVE_ENERGY_CELL.asItem());
+
+        tag(P2PTunnelAttunement.getAttunementTag(P2PTunnelAttunement.REDSTONE_TUNNEL))
+                .add(Items.REDSTONE, Items.REPEATER, Items.REDSTONE_LAMP, Items.COMPARATOR, Items.DAYLIGHT_DETECTOR,
+                        Items.REDSTONE_TORCH, Items.REDSTONE_BLOCK, Items.LEVER);
+
+        tag(P2PTunnelAttunement.getAttunementTag(P2PTunnelAttunement.ITEM_TUNNEL))
+                .add(AEParts.STORAGE_BUS.asItem(), AEParts.EXPORT_BUS.asItem(), AEParts.IMPORT_BUS.asItem(),
+                        Items.HOPPER, Items.CHEST, Items.TRAPPED_CHEST)
+                .addTag(ConventionTags.INTERFACE);
+
+        tag(P2PTunnelAttunement.getAttunementTag(P2PTunnelAttunement.FLUID_TUNNEL))
+                .add(Items.BUCKET, Items.MILK_BUCKET, Items.WATER_BUCKET, Items.LAVA_BUCKET);
+
+        tag(P2PTunnelAttunement.getAttunementTag(P2PTunnelAttunement.ME_TUNNEL))
+                .addTag(ConventionTags.COVERED_CABLE)
+                .addTag(ConventionTags.COVERED_DENSE_CABLE)
+                .addTag(ConventionTags.GLASS_CABLE)
+                .addTag(ConventionTags.SMART_CABLE)
+                .addTag(ConventionTags.SMART_DENSE_CABLE);
     }
 
     @Override

--- a/src/main/java/appeng/init/internal/InitP2PAttunements.java
+++ b/src/main/java/appeng/init/internal/InitP2PAttunements.java
@@ -19,16 +19,12 @@
 package appeng.init.internal;
 
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidStorage;
-import net.minecraft.world.item.Items;
-import net.minecraft.world.level.block.Blocks;
 
 import team.reborn.energy.api.EnergyStorage;
 
 import appeng.api.features.P2PTunnelAttunement;
-import appeng.api.util.AEColor;
-import appeng.core.definitions.AEBlocks;
 import appeng.core.definitions.AEParts;
-import appeng.datagen.providers.tags.ConventionTags;
+import appeng.core.localization.InGameTooltip;
 
 public final class InitP2PAttunements {
 
@@ -36,64 +32,16 @@ public final class InitP2PAttunements {
     }
 
     public static void init() {
-        /*
-         * Light tunnel
-         */
-        P2PTunnelAttunement.addItem(Blocks.TORCH, P2PTunnelAttunement.LIGHT_TUNNEL);
-        P2PTunnelAttunement.addItem(Blocks.GLOWSTONE, P2PTunnelAttunement.LIGHT_TUNNEL);
+        P2PTunnelAttunement.registerAttunementTag(AEParts.ME_P2P_TUNNEL);
+        P2PTunnelAttunement.registerAttunementTag(AEParts.FE_P2P_TUNNEL);
+        P2PTunnelAttunement.registerAttunementTag(AEParts.REDSTONE_P2P_TUNNEL);
+        P2PTunnelAttunement.registerAttunementTag(AEParts.FLUID_P2P_TUNNEL);
+        P2PTunnelAttunement.registerAttunementTag(AEParts.ITEM_P2P_TUNNEL);
+        P2PTunnelAttunement.registerAttunementTag(AEParts.LIGHT_P2P_TUNNEL);
 
-        /*
-         * Energy tunnel
-         */
-        P2PTunnelAttunement.addItem(AEBlocks.DENSE_ENERGY_CELL, P2PTunnelAttunement.ENERGY_TUNNEL);
-        P2PTunnelAttunement.addItem(AEBlocks.ENERGY_ACCEPTOR, P2PTunnelAttunement.ENERGY_TUNNEL);
-        P2PTunnelAttunement.addItem(AEBlocks.ENERGY_CELL, P2PTunnelAttunement.ENERGY_TUNNEL);
-        P2PTunnelAttunement.addItem(AEBlocks.CREATIVE_ENERGY_CELL, P2PTunnelAttunement.ENERGY_TUNNEL);
-        P2PTunnelAttunement.addItemByApi(EnergyStorage.ITEM, P2PTunnelAttunement.ENERGY_TUNNEL);
-        P2PTunnelAttunement.addItemByMod("thermaldynamics", P2PTunnelAttunement.ENERGY_TUNNEL);
-        P2PTunnelAttunement.addItemByMod("thermalexpansion", P2PTunnelAttunement.ENERGY_TUNNEL);
-        P2PTunnelAttunement.addItemByMod("thermalfoundation", P2PTunnelAttunement.ENERGY_TUNNEL);
-        P2PTunnelAttunement.addItemByMod("mekanism", P2PTunnelAttunement.ENERGY_TUNNEL);
-        P2PTunnelAttunement.addItemByMod("rftools", P2PTunnelAttunement.ENERGY_TUNNEL);
-
-        /*
-         * Redstone tunnel
-         */
-        P2PTunnelAttunement.addItem(Items.REDSTONE, P2PTunnelAttunement.REDSTONE_TUNNEL);
-        P2PTunnelAttunement.addItem(Items.REPEATER, P2PTunnelAttunement.REDSTONE_TUNNEL);
-        P2PTunnelAttunement.addItem(Items.REDSTONE_LAMP, P2PTunnelAttunement.REDSTONE_TUNNEL);
-        P2PTunnelAttunement.addItem(Items.COMPARATOR, P2PTunnelAttunement.REDSTONE_TUNNEL);
-        P2PTunnelAttunement.addItem(Items.DAYLIGHT_DETECTOR, P2PTunnelAttunement.REDSTONE_TUNNEL);
-        P2PTunnelAttunement.addItem(Items.REDSTONE_TORCH, P2PTunnelAttunement.REDSTONE_TUNNEL);
-        P2PTunnelAttunement.addItem(Items.REDSTONE_BLOCK, P2PTunnelAttunement.REDSTONE_TUNNEL);
-        P2PTunnelAttunement.addItem(Items.LEVER, P2PTunnelAttunement.REDSTONE_TUNNEL);
-
-        /*
-         * Item tunnel
-         */
-        P2PTunnelAttunement.addItemByTag(ConventionTags.INTERFACE, P2PTunnelAttunement.ITEM_TUNNEL);
-        P2PTunnelAttunement.addItem(AEParts.STORAGE_BUS, P2PTunnelAttunement.ITEM_TUNNEL);
-        P2PTunnelAttunement.addItem(AEParts.IMPORT_BUS, P2PTunnelAttunement.ITEM_TUNNEL);
-        P2PTunnelAttunement.addItem(AEParts.EXPORT_BUS, P2PTunnelAttunement.ITEM_TUNNEL);
-
-        P2PTunnelAttunement.addItem(Blocks.HOPPER, P2PTunnelAttunement.ITEM_TUNNEL);
-        P2PTunnelAttunement.addItem(Blocks.CHEST, P2PTunnelAttunement.ITEM_TUNNEL);
-        P2PTunnelAttunement.addItem(Blocks.TRAPPED_CHEST, P2PTunnelAttunement.ITEM_TUNNEL);
-
-        /*
-         * Fluid tunnel
-         */
-        P2PTunnelAttunement.addItem(Items.BUCKET, P2PTunnelAttunement.FLUID_TUNNEL);
-        P2PTunnelAttunement.addItem(Items.LAVA_BUCKET, P2PTunnelAttunement.FLUID_TUNNEL);
-        P2PTunnelAttunement.addItem(Items.MILK_BUCKET, P2PTunnelAttunement.FLUID_TUNNEL);
-        P2PTunnelAttunement.addItem(Items.WATER_BUCKET, P2PTunnelAttunement.FLUID_TUNNEL);
-        P2PTunnelAttunement.addItemByApi(FluidStorage.ITEM, P2PTunnelAttunement.FLUID_TUNNEL);
-
-        for (var c : AEColor.values()) {
-            P2PTunnelAttunement.addItem(AEParts.GLASS_CABLE.item(c), P2PTunnelAttunement.ME_TUNNEL);
-            P2PTunnelAttunement.addItem(AEParts.COVERED_CABLE.item(c), P2PTunnelAttunement.ME_TUNNEL);
-            P2PTunnelAttunement.addItem(AEParts.SMART_CABLE.item(c), P2PTunnelAttunement.ME_TUNNEL);
-            P2PTunnelAttunement.addItem(AEParts.SMART_DENSE_CABLE.item(c), P2PTunnelAttunement.ME_TUNNEL);
-        }
+        P2PTunnelAttunement.registerAttunementApi(P2PTunnelAttunement.ENERGY_TUNNEL, EnergyStorage.ITEM,
+                InGameTooltip.P2PAttunementEnergy.text());
+        P2PTunnelAttunement.registerAttunementApi(P2PTunnelAttunement.FLUID_TUNNEL, FluidStorage.ITEM,
+                InGameTooltip.P2PAttunementFluid.text());
     }
 }


### PR DESCRIPTION
Simplify the API so that:
1) modpack devs can configure p2p attunements, and
2) we can easily show just the standard tag and the API attunements in REI.