### PR TITLE
Make using internal P2P stuff easier

### DIFF
--- a/src/main/java/appeng/parts/p2p/CapabilityP2PTunnelPart.java
+++ b/src/main/java/appeng/parts/p2p/CapabilityP2PTunnelPart.java
@@ -86,7 +86,7 @@ public abstract class CapabilityP2PTunnelPart<P extends CapabilityP2PTunnelPart<
         /**
          * Get the capability, or a null handler if not available. Use within the scope of the enclosing AdjCapability.
          */
-        protected A get() {
+        public A get() {
             if (accessDepth == 0) {
                 throw new IllegalStateException("get was called after closing the wrapper");
             } else if (accessDepth == 1) {
@@ -129,7 +129,7 @@ public abstract class CapabilityP2PTunnelPart<P extends CapabilityP2PTunnelPart<
         }
 
         @Override
-        protected A get() {
+        public A get() {
             return emptyHandler;
         }
     }

--- a/src/main/java/appeng/parts/p2p/FEP2PTunnelPart.java
+++ b/src/main/java/appeng/parts/p2p/FEP2PTunnelPart.java
@@ -28,10 +28,11 @@ import team.reborn.energy.api.EnergyStorage;
 import appeng.api.config.PowerUnits;
 import appeng.api.parts.IPartItem;
 import appeng.api.parts.IPartModel;
+import appeng.core.AppEng;
 import appeng.items.parts.PartModels;
 
 public class FEP2PTunnelPart extends CapabilityP2PTunnelPart<FEP2PTunnelPart, EnergyStorage> {
-    private static final P2PModels MODELS = new P2PModels("part/p2p/p2p_tunnel_fe");
+    private static final P2PModels MODELS = new P2PModels(AppEng.makeId("part/p2p/p2p_tunnel_fe"));
 
     @PartModels
     public static List<IPartModel> getModels() {

--- a/src/main/java/appeng/parts/p2p/FluidP2PTunnelPart.java
+++ b/src/main/java/appeng/parts/p2p/FluidP2PTunnelPart.java
@@ -26,11 +26,12 @@ import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
 import appeng.api.parts.IPartItem;
 import appeng.api.parts.IPartModel;
 import appeng.api.stacks.AEKeyType;
+import appeng.core.AppEng;
 import appeng.items.parts.PartModels;
 
 public class FluidP2PTunnelPart extends StorageP2PTunnelPart<FluidP2PTunnelPart, FluidVariant> {
 
-    private static final P2PModels MODELS = new P2PModels("part/p2p/p2p_tunnel_fluids");
+    private static final P2PModels MODELS = new P2PModels(AppEng.makeId("part/p2p/p2p_tunnel_fluids"));
 
     @PartModels
     public static List<IPartModel> getModels() {

--- a/src/main/java/appeng/parts/p2p/ItemP2PTunnelPart.java
+++ b/src/main/java/appeng/parts/p2p/ItemP2PTunnelPart.java
@@ -26,11 +26,12 @@ import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
 import appeng.api.parts.IPartItem;
 import appeng.api.parts.IPartModel;
 import appeng.api.stacks.AEKeyType;
+import appeng.core.AppEng;
 import appeng.items.parts.PartModels;
 
 public class ItemP2PTunnelPart extends StorageP2PTunnelPart<ItemP2PTunnelPart, ItemVariant> {
 
-    private static final P2PModels MODELS = new P2PModels("part/p2p/p2p_tunnel_items");
+    private static final P2PModels MODELS = new P2PModels(AppEng.makeId("part/p2p/p2p_tunnel_items"));
 
     @PartModels
     public static List<IPartModel> getModels() {

--- a/src/main/java/appeng/parts/p2p/LightP2PTunnelPart.java
+++ b/src/main/java/appeng/parts/p2p/LightP2PTunnelPart.java
@@ -34,12 +34,13 @@ import appeng.api.networking.ticking.TickRateModulation;
 import appeng.api.networking.ticking.TickingRequest;
 import appeng.api.parts.IPartItem;
 import appeng.api.parts.IPartModel;
+import appeng.core.AppEng;
 import appeng.core.settings.TickRates;
 import appeng.items.parts.PartModels;
 
 public class LightP2PTunnelPart extends P2PTunnelPart<LightP2PTunnelPart> implements IGridTickable {
 
-    private static final P2PModels MODELS = new P2PModels("part/p2p/p2p_tunnel_light");
+    private static final P2PModels MODELS = new P2PModels(AppEng.makeId("part/p2p/p2p_tunnel_light"));
 
     @PartModels
     public static List<IPartModel> getModels() {

--- a/src/main/java/appeng/parts/p2p/MEP2PTunnelPart.java
+++ b/src/main/java/appeng/parts/p2p/MEP2PTunnelPart.java
@@ -39,6 +39,7 @@ import appeng.api.parts.IPartItem;
 import appeng.api.parts.IPartModel;
 import appeng.api.util.AECableType;
 import appeng.core.AELog;
+import appeng.core.AppEng;
 import appeng.core.settings.TickRates;
 import appeng.hooks.ticking.TickHandler;
 import appeng.items.parts.PartModels;
@@ -47,7 +48,7 @@ import appeng.me.service.helpers.TunnelConnection;
 
 public class MEP2PTunnelPart extends P2PTunnelPart<MEP2PTunnelPart> implements IGridTickable {
 
-    private static final P2PModels MODELS = new P2PModels("part/p2p/p2p_tunnel_me");
+    private static final P2PModels MODELS = new P2PModels(AppEng.makeId("part/p2p/p2p_tunnel_me"));
 
     @PartModels
     public static List<IPartModel> getModels() {

--- a/src/main/java/appeng/parts/p2p/P2PModels.java
+++ b/src/main/java/appeng/parts/p2p/P2PModels.java
@@ -30,24 +30,19 @@ import appeng.parts.PartModel;
 /**
  * Helper for maintaining the models used for a variant of the P2P bus.
  */
-class P2PModels {
+public class P2PModels {
 
-    public static final ResourceLocation MODEL_STATUS_OFF = new ResourceLocation(AppEng.MOD_ID,
-            "part/p2p/p2p_tunnel_status_off");
-    public static final ResourceLocation MODEL_STATUS_ON = new ResourceLocation(AppEng.MOD_ID,
-            "part/p2p/p2p_tunnel_status_on");
-    public static final ResourceLocation MODEL_STATUS_HAS_CHANNEL = new ResourceLocation(AppEng.MOD_ID,
-            "part/p2p/p2p_tunnel_status_has_channel");
-    public static final ResourceLocation MODEL_FREQUENCY = new ResourceLocation(AppEng.MOD_ID,
-            "part/p2p/p2p_tunnel_frequency");
+    public static final ResourceLocation MODEL_STATUS_OFF = AppEng.makeId("part/p2p/p2p_tunnel_status_off");
+    public static final ResourceLocation MODEL_STATUS_ON = AppEng.makeId("part/p2p/p2p_tunnel_status_on");
+    public static final ResourceLocation MODEL_STATUS_HAS_CHANNEL = AppEng
+            .makeId("part/p2p/p2p_tunnel_status_has_channel");
+    public static final ResourceLocation MODEL_FREQUENCY = AppEng.makeId("part/p2p/p2p_tunnel_frequency");
 
     private final IPartModel modelsOff;
     private final IPartModel modelsOn;
     private final IPartModel modelsHasChannel;
 
-    public P2PModels(String frontModelPath) {
-        ResourceLocation frontModel = new ResourceLocation(AppEng.MOD_ID, frontModelPath);
-
+    public P2PModels(ResourceLocation frontModel) {
         this.modelsOff = new PartModel(MODEL_STATUS_OFF, MODEL_FREQUENCY, frontModel);
         this.modelsOn = new PartModel(MODEL_STATUS_ON, MODEL_FREQUENCY, frontModel);
         this.modelsHasChannel = new PartModel(MODEL_STATUS_HAS_CHANNEL, MODEL_FREQUENCY, frontModel);

--- a/src/main/java/appeng/parts/p2p/RedstoneP2PTunnelPart.java
+++ b/src/main/java/appeng/parts/p2p/RedstoneP2PTunnelPart.java
@@ -32,12 +32,13 @@ import net.minecraft.world.level.block.state.BlockState;
 import appeng.api.networking.IGridNodeListener;
 import appeng.api.parts.IPartItem;
 import appeng.api.parts.IPartModel;
+import appeng.core.AppEng;
 import appeng.items.parts.PartModels;
 import appeng.util.Platform;
 
 public class RedstoneP2PTunnelPart extends P2PTunnelPart<RedstoneP2PTunnelPart> {
 
-    private static final P2PModels MODELS = new P2PModels("part/p2p/p2p_tunnel_redstone");
+    private static final P2PModels MODELS = new P2PModels(AppEng.makeId("part/p2p/p2p_tunnel_redstone"));
 
     @PartModels
     public static List<IPartModel> getModels() {


### PR DESCRIPTION
Would allow Applied Mekanistics, Applied Botanics and Modern Industrialization to remove their duplicate classes and remove reflection to `CapabilityGuard#get`