### PR TITLE
Fix #6283: use standard #forge:tools/wrench tag for wrenches

### DIFF
--- a/src/main/java/appeng/api/features/AEToolActions.java
+++ b/src/main/java/appeng/api/features/AEToolActions.java
@@ -23,11 +23,17 @@
 
 package appeng.api.features;
 
+import org.jetbrains.annotations.ApiStatus;
+
 import net.minecraftforge.common.ToolAction;
 
 /**
  * Tool actions defined by AE.
+ *
+ * @deprecated Check for the standard {@code #forge:tools/wrench} tag instead.
  */
+@ApiStatus.ScheduledForRemoval(inVersion = "1.19")
+@Deprecated(forRemoval = true)
 public final class AEToolActions {
     private AEToolActions() {
     }

--- a/src/main/java/appeng/datagen/providers/tags/ConventionTags.java
+++ b/src/main/java/appeng/datagen/providers/tags/ConventionTags.java
@@ -112,6 +112,11 @@ public final class ConventionTags {
     public static TagKey<Item> PAINT_BALLS = tag("ae2:paint_balls");
     public static TagKey<Item> MEMORY_CARDS = tag("ae2:memory_cards");
 
+    /**
+     * Used to identify items that act as wrenches.
+     */
+    public static final TagKey<Item> WRENCH = tag("forge:tools/wrench");
+
     public static final Map<DyeColor, TagKey<Item>> DYES = Arrays.stream(DyeColor.values())
             .collect(Collectors.toMap(
                     Function.identity(),

--- a/src/main/java/appeng/datagen/providers/tags/ItemTagsProvider.java
+++ b/src/main/java/appeng/datagen/providers/tags/ItemTagsProvider.java
@@ -146,6 +146,15 @@ public class ItemTagsProvider extends net.minecraft.data.tags.ItemTagsProvider i
                 .add(AEItems.CERTUS_QUARTZ_CRYSTAL.asItem())
                 .add(AEItems.CERTUS_QUARTZ_CRYSTAL_CHARGED.asItem());
 
+        // Fabric replacement for ToolActions for now
+        tag(ConventionTags.WRENCH).add(
+                AEItems.CERTUS_QUARTZ_WRENCH.asItem(),
+                AEItems.NETHER_QUARTZ_WRENCH.asItem(),
+                AEItems.NETWORK_TOOL.asItem());
+
+        // Manually add tags for mods that are unlikely to do it themselves since we don't want to force users to craft
+        tag(ConventionTags.WRENCH).addOptional(new ResourceLocation("immersiveengineering:hammer"));
+
         addP2pAttunementTags();
     }
 

--- a/src/main/java/appeng/items/tools/quartz/QuartzWrenchItem.java
+++ b/src/main/java/appeng/items/tools/quartz/QuartzWrenchItem.java
@@ -19,22 +19,11 @@
 package appeng.items.tools.quartz;
 
 import net.minecraft.world.item.Item;
-import net.minecraft.world.item.ItemStack;
-import net.minecraftforge.common.ToolAction;
 
-import appeng.api.features.AEToolActions;
 import appeng.items.AEBaseItem;
 
 public class QuartzWrenchItem extends AEBaseItem {
     public QuartzWrenchItem(Item.Properties props) {
         super(props);
-    }
-
-    @Override
-    public boolean canPerformAction(ItemStack stack, ToolAction toolAction) {
-        if (toolAction == AEToolActions.WRENCH_DISASSEMBLE || toolAction == AEToolActions.WRENCH_ROTATE) {
-            return true;
-        }
-        return super.canPerformAction(stack, toolAction);
     }
 }

--- a/src/main/java/appeng/util/InteractionUtil.java
+++ b/src/main/java/appeng/util/InteractionUtil.java
@@ -35,7 +35,8 @@ import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.common.ForgeMod;
 
-import appeng.api.features.AEToolActions;
+import appeng.datagen.providers.tags.ConventionTags;
+import appeng.items.tools.NetworkToolItem;
 
 /**
  * Utility functions revolving around using or placing items.
@@ -49,20 +50,27 @@ public final class InteractionUtil {
      * Checks if the given tool is a wrench capable of disassembling.
      */
     public static boolean canWrenchDisassemble(ItemStack tool) {
-        return tool.canPerformAction(AEToolActions.WRENCH_DISASSEMBLE);
+        // TODO FABRIC 117 Currently Fabric cannot dynamically distinguish tools / tool actions
+        return tool.is(ConventionTags.WRENCH);
     }
 
     /**
      * Checks if the given tool is a wrench capable of rotating.
      */
     public static boolean canWrenchRotate(ItemStack tool) {
-        return tool.canPerformAction(AEToolActions.WRENCH_ROTATE);
+        // TODO FABRIC 117 Currently Fabric cannot dynamically distinguish tools / tool actions
+        // Special case to stop the network tool from rotating things instead of opening the appropriate UI
+        if (tool.getItem() instanceof NetworkToolItem) {
+            return false;
+        }
+
+        return tool.is(ConventionTags.WRENCH);
     }
 
     /**
      * Checks if the given player is in the alternate use mode commonly expressed by "crouching" (holding shift).
      * Although there's also {@link Player#isCrouching()}, this actually is only the visual pose, while
-     * {@link Player#isSneaking()} signifies that the player is holding shift.
+     * {@link Player#isShiftKeyDown()} signifies that the player is holding shift.
      */
     public static boolean isInAlternateUseMode(Player player) {
         return player.isShiftKeyDown();


### PR DESCRIPTION
This aligns the wrenching system to agreed-upon conventions.

The tag is already used by Thermal, and we agreed to follow this convention with McJty and amadornes. I expect most other modders to follow our footsteps in at least defining their wrenches in the tag, and hopefully eventually checking for the tag directly for any tagged item to work on their blocks.