### PR TITLE
Fix accelerated Export Bus Dupe Issues when Network shows items twice

### DIFF
--- a/src/main/java/appeng/parts/automation/ExportBusPart.java
+++ b/src/main/java/appeng/parts/automation/ExportBusPart.java
@@ -154,11 +154,11 @@ public class ExportBusPart extends IOBusPart implements ICraftingRequester {
                 }
             } else {
                 // The max amount exported is scaled by the key-space's transfer factor (think millibuckets vs. items)
-                var transferFactory = what.getAmountPerOperation();
-                long amount = (long) context.getOperationsRemaining() * transferFactory;
+                var transferFactor = what.getAmountPerOperation();
+                long amount = (long) context.getOperationsRemaining() * transferFactor;
                 amount = getExportStrategy().transfer(context, what, amount, Actionable.MODULATE);
                 if (amount > 0) {
-                    context.reduceOperationsRemaining(Math.max(1, amount / transferFactory));
+                    context.reduceOperationsRemaining(Math.max(1, amount / transferFactor));
                 }
             }
 

--- a/src/main/java/appeng/server/testworld/PlotTestHelper.java
+++ b/src/main/java/appeng/server/testworld/PlotTestHelper.java
@@ -6,6 +6,7 @@ import net.minecraft.gametest.framework.GameTestAssertException;
 import net.minecraft.gametest.framework.GameTestHelper;
 import net.minecraft.gametest.framework.GameTestInfo;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.level.block.entity.BaseContainerBlockEntity;
 import net.minecraft.world.phys.Vec3;
 
 import appeng.api.config.Actionable;
@@ -14,6 +15,7 @@ import appeng.api.networking.IInWorldGridNodeHost;
 import appeng.api.parts.IPartHost;
 import appeng.api.stacks.AEItemKey;
 import appeng.api.stacks.AEKey;
+import appeng.api.stacks.KeyCounter;
 import appeng.api.storage.MEStorage;
 import appeng.me.helpers.BaseActionSource;
 import appeng.me.helpers.IGridConnectedBlockEntity;
@@ -119,6 +121,22 @@ public class PlotTestHelper extends GameTestHelper {
     public void check(boolean test, String errorMessage) throws GameTestAssertException {
         if (!test) {
             throw new GameTestAssertException(errorMessage);
+        }
+    }
+
+    public KeyCounter countContainerContentAt(BlockPos pos) {
+        var counter = new KeyCounter();
+        countContainerContentAt(pos, counter);
+        return counter;
+    }
+
+    public void countContainerContentAt(BlockPos pos, KeyCounter counter) {
+        var container = ((BaseContainerBlockEntity) getBlockEntity(pos));
+        for (int i = 0; i < container.getContainerSize(); i++) {
+            var item = container.getItem(i);
+            if (!item.isEmpty()) {
+                counter.add(AEItemKey.of(item), item.getCount());
+            }
         }
     }
 }


### PR DESCRIPTION
Export buses were too trusting of the simulated extraction amounts.
I.e. double chest with two storage buses over-report available items and successfully allow simulated extractions with too many items.

Fixes #6294