### PR TITLE
Fix Cable/Part Placement not being obstructed by entities

### DIFF
--- a/src/main/java/appeng/api/parts/IPartHost.java
+++ b/src/main/java/appeng/api/parts/IPartHost.java
@@ -32,6 +32,9 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
+import net.minecraft.world.phys.shapes.CollisionContext;
+import net.minecraft.world.phys.shapes.Shapes;
+import net.minecraft.world.phys.shapes.VoxelShape;
 
 import appeng.api.util.AEColor;
 import appeng.api.util.DimensionalBlockPos;
@@ -142,6 +145,36 @@ public interface IPartHost extends ICustomCableConnection {
     SelectedPart selectPartLocal(Vec3 pos);
 
     /**
+     * Gets the collision shape of the part host. Used to reject placing parts if the resulting collision shape would be
+     * obstructed in the level.
+     *
+     * @return The collision shape of this part host including all attached parts.
+     */
+    // TODO 1.19: Remove default implementation in 1.19
+    default VoxelShape getCollisionShape(CollisionContext context) {
+        return Shapes.empty();
+    }
+
+    /**
+     * Removes a specific part from this host and returns if the part was actually present and removed.
+     */
+    // TODO 1.19: Remove default implementation in 1.19, rename "removePart(Direction)" to "removePartFromSide", rename
+    // this to "removePart"
+    default boolean removePartInstance(IPart part) {
+        if (getPart(null) == part) {
+            removePart(null);
+            return true;
+        }
+        for (var side : Direction.values()) {
+            if (getPart(side) == part) {
+                removePart(side);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Same as {@link #selectPartLocal(Vec3)}, but with world instead of local coordinates. Provided for easier
      * interoperability with {@link BlockHitResult#getLocation()}.
      */
@@ -188,5 +221,4 @@ public interface IPartHost extends ICustomCableConnection {
      * @return true if block entity is in world
      */
     boolean isInWorld();
-
 }

--- a/src/main/java/appeng/blockentity/networking/CableBusBlockEntity.java
+++ b/src/main/java/appeng/blockentity/networking/CableBusBlockEntity.java
@@ -36,6 +36,8 @@ import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
+import net.minecraft.world.phys.shapes.CollisionContext;
+import net.minecraft.world.phys.shapes.VoxelShape;
 
 import appeng.api.networking.IGridNode;
 import appeng.api.parts.IFacadeContainer;
@@ -335,5 +337,10 @@ public class CableBusBlockEntity extends AEBaseBlockEntity implements AEMultiBlo
 
         return InteractionResult.sidedSuccess(level.isClientSide());
 
+    }
+
+    @Override
+    public VoxelShape getCollisionShape(CollisionContext context) {
+        return cb.getCollisionShape(context);
     }
 }

--- a/src/main/java/appeng/parts/PartPlacement.java
+++ b/src/main/java/appeng/parts/PartPlacement.java
@@ -85,6 +85,19 @@ public class PartPlacement {
             return null;
         }
 
+        // Check collisions with entities and revert placement
+        // Due to cables being able to react to parts being added to the host, we can't really
+        // simulate this without really placing the part
+        var collisionShape = host.getCollisionShape(null);
+        if (!collisionShape.isEmpty()
+                && !level.isUnobstructed(null, collisionShape.move(pos.getX(), pos.getY(), pos.getZ()))) {
+            host.removePartInstance(addedPart);
+            if (host.isEmpty()) {
+                host.cleanup();
+            }
+            return null;
+        }
+
         // Import settings from the item if possible
         if (configTag != null) {
             try {


### PR DESCRIPTION
Check if the newly placed cable bus / part is obstructed by something else in the level (i.e. the player or other entities).

Fixes #6355