### PR TITLE
Reimplement config option to disable Meteorites

### DIFF
--- a/src/main/java/appeng/core/AEConfig.java
+++ b/src/main/java/appeng/core/AEConfig.java
@@ -381,6 +381,10 @@ public final class AEConfig {
         return COMMON.generateQuartzOre.get();
     }
 
+    public boolean isGenerateMeteorites() {
+        return COMMON.generateMeteorites.get();
+    }
+
     public boolean isMatterCanonBlockDamageEnabled() {
         return COMMON.matterCannonBlockDamage.get();
     }
@@ -534,6 +538,7 @@ public final class AEConfig {
         public final IntegerOption quartzOresPerCluster;
         public final IntegerOption quartzOresClusterAmount;
         public final BooleanOption generateQuartzOre;
+        public final BooleanOption generateMeteorites;
         public final StringListOption quartzOresBiomeBlacklist;
 
         // Meteors
@@ -634,6 +639,7 @@ public final class AEConfig {
             this.spawnPressesInMeteorites = worldGen.addBoolean("spawnPressesInMeteorites", true);
 
             this.generateQuartzOre = worldGen.addBoolean("generateQuartzOre", true);
+            this.generateMeteorites = worldGen.addBoolean("generateMeteorites", true);
             this.quartzOresPerCluster = worldGen.addInt("quartzOresPerCluster", 7);
             this.quartzOresClusterAmount = worldGen.addInt("quartzOresClusterAmount", 20);
             this.quartzOresBiomeBlacklist = worldGen.addStringList("quartzOresBiomeBlacklist", new ArrayList<>(),

--- a/src/main/java/appeng/init/worldgen/InitStructures.java
+++ b/src/main/java/appeng/init/worldgen/InitStructures.java
@@ -31,6 +31,8 @@ import net.minecraft.world.level.levelgen.structure.StructureSet;
 import net.minecraft.world.level.levelgen.structure.placement.RandomSpreadStructurePlacement;
 import net.minecraft.world.level.levelgen.structure.placement.RandomSpreadType;
 
+import appeng.core.AEConfig;
+import appeng.core.AELog;
 import appeng.worldgen.meteorite.MeteoriteStructure;
 import appeng.worldgen.meteorite.MeteoriteStructurePiece;
 
@@ -50,11 +52,15 @@ public final class InitStructures {
                 MeteoriteStructure.INSTANCE.configured(NoneFeatureConfiguration.INSTANCE,
                         MeteoriteStructure.BIOME_TAG_KEY));
 
-        StructureSets.register(
-                MeteoriteStructure.STRUCTURE_SET_KEY,
-                new StructureSet(
-                        List.of(StructureSet.entry(MeteoriteStructure.CONFIGURED_INSTANCE)),
-                        new RandomSpreadStructurePlacement(32, 8, RandomSpreadType.LINEAR, 124895654)));
+        if (AEConfig.instance().isGenerateMeteorites()) {
+            StructureSets.register(
+                    MeteoriteStructure.STRUCTURE_SET_KEY,
+                    new StructureSet(
+                            List.of(StructureSet.entry(MeteoriteStructure.CONFIGURED_INSTANCE)),
+                            new RandomSpreadStructurePlacement(32, 8, RandomSpreadType.LINEAR, 124895654)));
+        } else {
+            AELog.info("AE2 meteorites are disabled in the config file.");
+        }
     }
 
     // This mirrors the Vanilla registration method for structures, but uses the


### PR DESCRIPTION
Reimplement config option to disable Meteorite generation. This is now much "safer" on 1.18.2 as it no longer hangs the /locate command. Should work transparently on Forge now that we use our own config system there.

Fixes #5971