### PR TITLE
Make EnergyCellBlockEntity#setInternalMaxPower public

### DIFF
--- a/src/main/java/appeng/blockentity/networking/EnergyCellBlockEntity.java
+++ b/src/main/java/appeng/blockentity/networking/EnergyCellBlockEntity.java
@@ -227,7 +227,7 @@ public class EnergyCellBlockEntity extends AENetworkBlockEntity implements IAEPo
         return this.internalMaxPower;
     }
 
-    void setInternalMaxPower(double internalMaxPower) {
+    public void setInternalMaxPower(double internalMaxPower) {
         this.internalMaxPower = internalMaxPower;
     }
 


### PR DESCRIPTION
Somewhat temporary solution to not being able to add extra energy cells in add-ons very easily. Energy cells in general could do with a slight rewrite for better extensibility, most likely in 1.19.