### PR TITLE
Transform recipe datapack support goes brrr

### DIFF
--- a/src/main/java/appeng/datagen/AE2DataGenerators.java
+++ b/src/main/java/appeng/datagen/AE2DataGenerators.java
@@ -38,6 +38,7 @@ import appeng.datagen.providers.recipes.InscriberRecipes;
 import appeng.datagen.providers.recipes.MatterCannonAmmoProvider;
 import appeng.datagen.providers.recipes.SmeltingRecipes;
 import appeng.datagen.providers.recipes.SmithingRecipes;
+import appeng.datagen.providers.recipes.TransformRecipes;
 import appeng.datagen.providers.tags.BiomeTagsProvider;
 import appeng.datagen.providers.tags.BlockTagsProvider;
 import appeng.datagen.providers.tags.FluidTagsProvider;
@@ -78,6 +79,7 @@ public class AE2DataGenerators {
         generator.addProvider(true, new SmeltingRecipes(generator));
         generator.addProvider(true, new CraftingRecipes(generator));
         generator.addProvider(true, new SmithingRecipes(generator));
+        generator.addProvider(true, new TransformRecipes(generator));
 
         // Must run last
         generator.addProvider(true, localization);

--- a/src/main/java/appeng/datagen/providers/recipes/TransformRecipes.java
+++ b/src/main/java/appeng/datagen/providers/recipes/TransformRecipes.java
@@ -1,0 +1,113 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2021, TeamAppliedEnergistics, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.datagen.providers.recipes;
+
+import appeng.core.AppEng;
+import appeng.core.definitions.AEBlocks;
+import appeng.core.definitions.AEItems;
+import appeng.recipes.handlers.TransformRecipeSerializer;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import net.minecraft.data.DataGenerator;
+import net.minecraft.data.recipes.FinishedRecipe;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.item.crafting.RecipeSerializer;
+
+import javax.annotation.Nullable;
+import java.util.Set;
+import java.util.function.Consumer;
+
+public class TransformRecipes extends AE2RecipeProvider {
+    public TransformRecipes(DataGenerator generator) {
+        super(generator);
+    }
+
+    @Override
+    protected void buildAE2CraftingRecipes(Consumer<FinishedRecipe> consumer) {
+
+        // Fluix crystals
+        transform(Set.of(Items.REDSTONE, Items.QUARTZ), AEItems.FLUIX_CRYSTAL.asItem(), 2).save(consumer, "fluix_crystals");
+
+        // Recycle dust back into crystals
+        transform(Set.of(AEItems.CERTUS_QUARTZ_DUST.asItem()), AEItems.CERTUS_QUARTZ_CRYSTAL.asItem(), 2).save(consumer, "certus_quartz_crystal");
+        transform(Set.of(AEItems.FLUIX_DUST.asItem()), AEItems.FLUIX_CRYSTAL.asItem(), 1).save(consumer, "fluix_crystal");
+        // Restore budding quartz
+        transform(Set.of(AEBlocks.QUARTZ_BLOCK.asItem()),
+        AEBlocks.DAMAGED_BUDDING_QUARTZ.asItem(), 1).save(consumer, "damaged_budding_quartz");
+        transform(Set.of(AEBlocks.DAMAGED_BUDDING_QUARTZ.asItem()),
+        AEBlocks.CHIPPED_BUDDING_QUARTZ.asItem(), 1).save(consumer, "chipped_budding_quartz");
+        transform(Set.of(AEBlocks.CHIPPED_BUDDING_QUARTZ.asItem()),
+        AEBlocks.FLAWED_BUDDING_QUARTZ.asItem(), 1).save(consumer, "flawed_budding_quartz");
+    }
+
+    private TransformRecipeBuilder transform(Set<Item> additionalItems, Item output, int count) {
+        return new TransformRecipeBuilder(additionalItems, output, count);
+    }
+
+    public record TransformRecipeBuilder(Set<Item> additionalItems, Item output, int count) {
+
+        public void save(Consumer<FinishedRecipe> consumer, String name) {
+            consumer.accept(new Result(name));
+        }
+
+        class Result implements FinishedRecipe {
+            private final String name;
+
+            public Result(String name) {
+                this.name = name;
+            }
+
+            @Override
+            public void serializeRecipeData(JsonObject json) {
+                json.add("result", toJson(new ItemStack(output, count)));
+
+                var ingredients = new JsonArray();
+                additionalItems.forEach(item -> ingredients.add(Ingredient.of(item).toJson()));
+                json.add("ingredients", ingredients);
+            }
+
+            @Override
+            public ResourceLocation getId() {
+                return AppEng.makeId("transform/" + name);
+            }
+
+            @Override
+            public RecipeSerializer<?> getType() {
+                return TransformRecipeSerializer.INSTANCE;
+            }
+
+            @Nullable
+            @Override
+            public JsonObject serializeAdvancement() {
+                return null;
+            }
+
+            @Nullable
+            @Override
+            public ResourceLocation getAdvancementId() {
+                return null;
+            }
+        }
+    }
+
+}

--- a/src/main/java/appeng/datagen/providers/recipes/TransformRecipes.java
+++ b/src/main/java/appeng/datagen/providers/recipes/TransformRecipes.java
@@ -45,26 +45,27 @@ public class TransformRecipes extends AE2RecipeProvider {
     @Override
     protected void buildAE2CraftingRecipes(Consumer<FinishedRecipe> consumer) {
 
+
         // Fluix crystals
-        transform(Set.of(Items.REDSTONE, Items.QUARTZ), AEItems.FLUIX_CRYSTAL.asItem(), 2).save(consumer, "fluix_crystals");
+        transform(Ingredient.of(Items.REDSTONE, Items.QUARTZ), AEItems.FLUIX_CRYSTAL.asItem(), 2).save(consumer, "fluix_crystals");
 
         // Recycle dust back into crystals
-        transform(Set.of(AEItems.CERTUS_QUARTZ_DUST.asItem()), AEItems.CERTUS_QUARTZ_CRYSTAL.asItem(), 2).save(consumer, "certus_quartz_crystal");
-        transform(Set.of(AEItems.FLUIX_DUST.asItem()), AEItems.FLUIX_CRYSTAL.asItem(), 1).save(consumer, "fluix_crystal");
+        transform(Ingredient.of(AEItems.CERTUS_QUARTZ_DUST.asItem()), AEItems.CERTUS_QUARTZ_CRYSTAL.asItem(), 2).save(consumer, "certus_quartz_crystals");
+        transform(Ingredient.of(AEItems.FLUIX_DUST.asItem()), AEItems.FLUIX_CRYSTAL.asItem(), 1).save(consumer, "fluix_crystal");
         // Restore budding quartz
-        transform(Set.of(AEBlocks.QUARTZ_BLOCK.asItem()),
+        transform(Ingredient.of(AEBlocks.QUARTZ_BLOCK.asItem()),
         AEBlocks.DAMAGED_BUDDING_QUARTZ.asItem(), 1).save(consumer, "damaged_budding_quartz");
-        transform(Set.of(AEBlocks.DAMAGED_BUDDING_QUARTZ.asItem()),
+        transform(Ingredient.of(AEBlocks.DAMAGED_BUDDING_QUARTZ.asItem()),
         AEBlocks.CHIPPED_BUDDING_QUARTZ.asItem(), 1).save(consumer, "chipped_budding_quartz");
-        transform(Set.of(AEBlocks.CHIPPED_BUDDING_QUARTZ.asItem()),
+        transform(Ingredient.of(AEBlocks.CHIPPED_BUDDING_QUARTZ.asItem()),
         AEBlocks.FLAWED_BUDDING_QUARTZ.asItem(), 1).save(consumer, "flawed_budding_quartz");
     }
 
-    private TransformRecipeBuilder transform(Set<Item> additionalItems, Item output, int count) {
-        return new TransformRecipeBuilder(additionalItems, output, count);
+    private TransformRecipeBuilder transform(Ingredient inputs, Item output, int count) {
+        return new TransformRecipeBuilder(inputs, output, count);
     }
 
-    public record TransformRecipeBuilder(Set<Item> additionalItems, Item output, int count) {
+    public record TransformRecipeBuilder(Ingredient ingredients, Item output, int count) {
 
         public void save(Consumer<FinishedRecipe> consumer, String name) {
             consumer.accept(new Result(name));
@@ -80,10 +81,7 @@ public class TransformRecipes extends AE2RecipeProvider {
             @Override
             public void serializeRecipeData(JsonObject json) {
                 json.add("result", toJson(new ItemStack(output, count)));
-
-                var ingredients = new JsonArray();
-                additionalItems.forEach(item -> ingredients.add(Ingredient.of(item).toJson()));
-                json.add("ingredients", ingredients);
+                json.add("ingredients", ingredients.toJson());
             }
 
             @Override

--- a/src/main/java/appeng/datagen/providers/recipes/TransformRecipes.java
+++ b/src/main/java/appeng/datagen/providers/recipes/TransformRecipes.java
@@ -22,7 +22,6 @@ import appeng.core.AppEng;
 import appeng.core.definitions.AEBlocks;
 import appeng.core.definitions.AEItems;
 import appeng.recipes.handlers.TransformRecipeSerializer;
-import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import net.minecraft.data.DataGenerator;
 import net.minecraft.data.recipes.FinishedRecipe;
@@ -34,6 +33,7 @@ import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.Set;
 import java.util.function.Consumer;
 
@@ -45,24 +45,26 @@ public class TransformRecipes extends AE2RecipeProvider {
     @Override
     protected void buildAE2CraftingRecipes(Consumer<FinishedRecipe> consumer) {
 
-
         // Fluix crystals
-        transform(Ingredient.of(Items.REDSTONE, Items.QUARTZ), AEItems.FLUIX_CRYSTAL.asItem(), 2).save(consumer, "fluix_crystals");
+        transform(Set.of(Items.REDSTONE, Items.QUARTZ), AEItems.FLUIX_CRYSTAL.asItem(), 2).save(consumer, "fluix_crystals");
 
         // Recycle dust back into crystals
-        transform(Ingredient.of(AEItems.CERTUS_QUARTZ_DUST.asItem()), AEItems.CERTUS_QUARTZ_CRYSTAL.asItem(), 2).save(consumer, "certus_quartz_crystals");
-        transform(Ingredient.of(AEItems.FLUIX_DUST.asItem()), AEItems.FLUIX_CRYSTAL.asItem(), 1).save(consumer, "fluix_crystal");
+        transform(Set.of(AEItems.CERTUS_QUARTZ_DUST.asItem()), AEItems.CERTUS_QUARTZ_CRYSTAL.asItem(), 2).save(consumer, "certus_quartz_crystals");
+        transform(Set.of(AEItems.FLUIX_DUST.asItem()), AEItems.FLUIX_CRYSTAL.asItem(), 1).save(consumer, "fluix_crystal");
         // Restore budding quartz
-        transform(Ingredient.of(AEBlocks.QUARTZ_BLOCK.asItem()),
+        transform(Set.of(AEBlocks.QUARTZ_BLOCK.asItem()),
         AEBlocks.DAMAGED_BUDDING_QUARTZ.asItem(), 1).save(consumer, "damaged_budding_quartz");
-        transform(Ingredient.of(AEBlocks.DAMAGED_BUDDING_QUARTZ.asItem()),
+        transform(Set.of(AEBlocks.DAMAGED_BUDDING_QUARTZ.asItem()),
         AEBlocks.CHIPPED_BUDDING_QUARTZ.asItem(), 1).save(consumer, "chipped_budding_quartz");
-        transform(Ingredient.of(AEBlocks.CHIPPED_BUDDING_QUARTZ.asItem()),
+        transform(Set.of(AEBlocks.CHIPPED_BUDDING_QUARTZ.asItem()),
         AEBlocks.FLAWED_BUDDING_QUARTZ.asItem(), 1).save(consumer, "flawed_budding_quartz");
     }
 
-    private TransformRecipeBuilder transform(Ingredient inputs, Item output, int count) {
-        return new TransformRecipeBuilder(inputs, output, count);
+    private TransformRecipeBuilder transform(Set<Item> inputs, Item output, int count) {
+        ArrayList<Item> inputz = new ArrayList<>(inputs);
+        inputz.add(0, AEItems.CERTUS_QUARTZ_CRYSTAL_CHARGED.asItem());
+
+        return new TransformRecipeBuilder(Ingredient.of(inputz.toArray(Item[]::new)), output, count);
     }
 
     public record TransformRecipeBuilder(Ingredient ingredients, Item output, int count) {

--- a/src/main/java/appeng/datagen/providers/recipes/TransformRecipes.java
+++ b/src/main/java/appeng/datagen/providers/recipes/TransformRecipes.java
@@ -18,12 +18,16 @@
 
 package appeng.datagen.providers.recipes;
 
-import appeng.core.AppEng;
-import appeng.core.definitions.AEBlocks;
-import appeng.core.definitions.AEItems;
-import appeng.recipes.handlers.TransformRecipeSerializer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import javax.annotation.Nullable;
+
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+
 import net.minecraft.data.DataGenerator;
 import net.minecraft.data.recipes.FinishedRecipe;
 import net.minecraft.resources.ResourceLocation;
@@ -33,11 +37,10 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 
-import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-import java.util.function.Consumer;
+import appeng.core.AppEng;
+import appeng.core.definitions.AEBlocks;
+import appeng.core.definitions.AEItems;
+import appeng.recipes.handlers.TransformRecipeSerializer;
 
 public class TransformRecipes extends AE2RecipeProvider {
     public TransformRecipes(DataGenerator generator) {
@@ -48,18 +51,21 @@ public class TransformRecipes extends AE2RecipeProvider {
     protected void buildAE2CraftingRecipes(Consumer<FinishedRecipe> consumer) {
 
         // Fluix crystals
-        transform(Set.of(Items.REDSTONE, Items.QUARTZ), AEItems.FLUIX_CRYSTAL.asItem(), 2).save(consumer, "fluix_crystals");
+        transform(Set.of(Items.REDSTONE, Items.QUARTZ), AEItems.FLUIX_CRYSTAL.asItem(), 2).save(consumer,
+                "fluix_crystals");
 
         // Recycle dust back into crystals
-        transform(Set.of(AEItems.CERTUS_QUARTZ_DUST.asItem()), AEItems.CERTUS_QUARTZ_CRYSTAL.asItem(), 2).save(consumer, "certus_quartz_crystals");
-        transform(Set.of(AEItems.FLUIX_DUST.asItem()), AEItems.FLUIX_CRYSTAL.asItem(), 1).save(consumer, "fluix_crystal");
+        transform(Set.of(AEItems.CERTUS_QUARTZ_DUST.asItem()), AEItems.CERTUS_QUARTZ_CRYSTAL.asItem(), 2).save(consumer,
+                "certus_quartz_crystals");
+        transform(Set.of(AEItems.FLUIX_DUST.asItem()), AEItems.FLUIX_CRYSTAL.asItem(), 1).save(consumer,
+                "fluix_crystal");
         // Restore budding quartz
         transform(Set.of(AEBlocks.QUARTZ_BLOCK.asItem()),
-        AEBlocks.DAMAGED_BUDDING_QUARTZ.asItem(), 1).save(consumer, "damaged_budding_quartz");
+                AEBlocks.DAMAGED_BUDDING_QUARTZ.asItem(), 1).save(consumer, "damaged_budding_quartz");
         transform(Set.of(AEBlocks.DAMAGED_BUDDING_QUARTZ.asItem()),
-        AEBlocks.CHIPPED_BUDDING_QUARTZ.asItem(), 1).save(consumer, "chipped_budding_quartz");
+                AEBlocks.CHIPPED_BUDDING_QUARTZ.asItem(), 1).save(consumer, "chipped_budding_quartz");
         transform(Set.of(AEBlocks.CHIPPED_BUDDING_QUARTZ.asItem()),
-        AEBlocks.FLAWED_BUDDING_QUARTZ.asItem(), 1).save(consumer, "flawed_budding_quartz");
+                AEBlocks.FLAWED_BUDDING_QUARTZ.asItem(), 1).save(consumer, "flawed_budding_quartz");
     }
 
     private TransformRecipeBuilder transform(Set<Item> inputs, Item output, int count) {

--- a/src/main/java/appeng/datagen/providers/recipes/TransformRecipes.java
+++ b/src/main/java/appeng/datagen/providers/recipes/TransformRecipes.java
@@ -22,6 +22,7 @@ import appeng.core.AppEng;
 import appeng.core.definitions.AEBlocks;
 import appeng.core.definitions.AEItems;
 import appeng.recipes.handlers.TransformRecipeSerializer;
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import net.minecraft.data.DataGenerator;
 import net.minecraft.data.recipes.FinishedRecipe;
@@ -34,6 +35,7 @@ import net.minecraft.world.item.crafting.RecipeSerializer;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
 
@@ -61,13 +63,15 @@ public class TransformRecipes extends AE2RecipeProvider {
     }
 
     private TransformRecipeBuilder transform(Set<Item> inputs, Item output, int count) {
-        ArrayList<Item> inputz = new ArrayList<>(inputs);
-        inputz.add(0, AEItems.CERTUS_QUARTZ_CRYSTAL_CHARGED.asItem());
+        List<Ingredient> ingredients = new ArrayList<>(3);
 
-        return new TransformRecipeBuilder(Ingredient.of(inputz.toArray(Item[]::new)), output, count);
+        ingredients.add(Ingredient.of(AEItems.CERTUS_QUARTZ_CRYSTAL_CHARGED.asItem()));
+        inputs.forEach(item -> ingredients.add(Ingredient.of(item)));
+
+        return new TransformRecipeBuilder(ingredients, output, count);
     }
 
-    public record TransformRecipeBuilder(Ingredient ingredients, Item output, int count) {
+    public record TransformRecipeBuilder(List<Ingredient> ingredients, Item output, int count) {
 
         public void save(Consumer<FinishedRecipe> consumer, String name) {
             consumer.accept(new Result(name));
@@ -83,7 +87,10 @@ public class TransformRecipes extends AE2RecipeProvider {
             @Override
             public void serializeRecipeData(JsonObject json) {
                 json.add("result", toJson(new ItemStack(output, count)));
-                json.add("ingredients", ingredients.toJson());
+
+                JsonArray inputs = new JsonArray();
+                ingredients.forEach(ingredient -> inputs.add(ingredient.toJson()));
+                json.add("ingredients", inputs);
             }
 
             @Override

--- a/src/main/java/appeng/entity/AEBaseItemEntity.java
+++ b/src/main/java/appeng/entity/AEBaseItemEntity.java
@@ -46,6 +46,10 @@ public abstract class AEBaseItemEntity extends ItemEntity implements ICustomEnti
         this.setItem(stack);
     }
 
+    protected List<Entity> getCheckedEntitiesWithinAABB(AABB region) {
+        return this.level.getEntities(null, region);
+    }
+
     protected List<Entity> getCheckedEntitiesWithinAABBExcludingEntity(AABB region) {
         return this.level.getEntities(this, region);
     }

--- a/src/main/java/appeng/entity/ChargedQuartzEntity.java
+++ b/src/main/java/appeng/entity/ChargedQuartzEntity.java
@@ -21,7 +21,6 @@ package appeng.entity;
 import java.util.List;
 import java.util.Set;
 
-import appeng.recipes.handlers.TransformRecipe;
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.Mth;
 import net.minecraft.util.RandomSource;
@@ -41,6 +40,7 @@ import appeng.core.AEConfig;
 import appeng.core.AppEng;
 import appeng.core.definitions.AEEntities;
 import appeng.core.definitions.AEItems;
+import appeng.recipes.handlers.TransformRecipe;
 
 public final class ChargedQuartzEntity extends AEBaseItemEntity {
 

--- a/src/main/java/appeng/entity/ChargedQuartzEntity.java
+++ b/src/main/java/appeng/entity/ChargedQuartzEntity.java
@@ -21,15 +21,14 @@ package appeng.entity;
 import java.util.List;
 import java.util.Set;
 
+import appeng.recipes.handlers.TransformRecipe;
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.Mth;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.item.ItemEntity;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Material;
@@ -40,27 +39,10 @@ import it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet;
 import appeng.client.EffectType;
 import appeng.core.AEConfig;
 import appeng.core.AppEng;
-import appeng.core.definitions.AEBlocks;
 import appeng.core.definitions.AEEntities;
 import appeng.core.definitions.AEItems;
 
 public final class ChargedQuartzEntity extends AEBaseItemEntity {
-    public record TransformRecipe(Set<Item> additionalItems, Item output, int count) {
-    }
-
-    // TODO: datapack support
-    public static List<TransformRecipe> RECIPES = List.of(
-            // Fluix crystals
-            new TransformRecipe(Set.of(Items.REDSTONE, Items.QUARTZ), AEItems.FLUIX_CRYSTAL.asItem(), 2),
-            // Recycle dust back into crystals
-            new TransformRecipe(Set.of(AEItems.CERTUS_QUARTZ_DUST.asItem()), AEItems.CERTUS_QUARTZ_CRYSTAL.asItem(), 2),
-            new TransformRecipe(Set.of(AEItems.FLUIX_DUST.asItem()), AEItems.FLUIX_CRYSTAL.asItem(), 1),
-            // Restore budding quartz
-            new TransformRecipe(Set.of(AEBlocks.QUARTZ_BLOCK.asItem()), AEBlocks.DAMAGED_BUDDING_QUARTZ.asItem(), 1),
-            new TransformRecipe(Set.of(AEBlocks.DAMAGED_BUDDING_QUARTZ.asItem()),
-                    AEBlocks.CHIPPED_BUDDING_QUARTZ.asItem(), 1),
-            new TransformRecipe(Set.of(AEBlocks.CHIPPED_BUDDING_QUARTZ.asItem()),
-                    AEBlocks.FLAWED_BUDDING_QUARTZ.asItem(), 1));
 
     private static final RandomSource RANDOM = RandomSource.create();
 
@@ -120,7 +102,7 @@ public final class ChargedQuartzEntity extends AEBaseItemEntity {
                 this.getX() + 1, this.getY() + 1, this.getZ() + 1);
         final List<Entity> l = this.getCheckedEntitiesWithinAABBExcludingEntity(region);
 
-        for (var recipe : RECIPES) {
+        for (var recipe : level.getRecipeManager().byType(TransformRecipe.TYPE).values()) {
             Set<ItemEntity> selectedEntities = new ReferenceOpenHashSet<>();
 
             entityLoop: for (Entity e : l) {

--- a/src/main/java/appeng/entity/ChargedQuartzEntity.java
+++ b/src/main/java/appeng/entity/ChargedQuartzEntity.java
@@ -109,7 +109,7 @@ public final class ChargedQuartzEntity extends AEBaseItemEntity {
                 if (e instanceof ItemEntity itemEntity && !e.isRemoved()) {
                     final ItemStack other = itemEntity.getItem();
                     if (!other.isEmpty()) {
-                        if (!recipe.additionalItems.contains(other.getItem())) {
+                        if (!recipe.ingredients.test(other)) {
                             continue; // Skip not required item
                         }
 
@@ -124,7 +124,7 @@ public final class ChargedQuartzEntity extends AEBaseItemEntity {
                 }
             }
 
-            if (selectedEntities.size() == recipe.additionalItems.size()) {
+            if (selectedEntities.size() == recipe.ingredients.getItems().length) {
                 this.getItem().grow(-1);
 
                 if (this.getItem().getCount() <= 0) {

--- a/src/main/java/appeng/entity/ChargedQuartzEntity.java
+++ b/src/main/java/appeng/entity/ChargedQuartzEntity.java
@@ -100,7 +100,7 @@ public final class ChargedQuartzEntity extends AEBaseItemEntity {
 
         final AABB region = new AABB(this.getX() - 1, this.getY() - 1, this.getZ() - 1,
                 this.getX() + 1, this.getY() + 1, this.getZ() + 1);
-        final List<Entity> l = this.getCheckedEntitiesWithinAABBExcludingEntity(region);
+        final List<Entity> l = this.getCheckedEntitiesWithinAABB(region);
 
         for (var recipe : level.getRecipeManager().byType(TransformRecipe.TYPE).values()) {
             Set<ItemEntity> selectedEntities = new ReferenceOpenHashSet<>();

--- a/src/main/java/appeng/entity/ChargedQuartzEntity.java
+++ b/src/main/java/appeng/entity/ChargedQuartzEntity.java
@@ -109,7 +109,7 @@ public final class ChargedQuartzEntity extends AEBaseItemEntity {
                 if (e instanceof ItemEntity itemEntity && !e.isRemoved()) {
                     final ItemStack other = itemEntity.getItem();
                     if (!other.isEmpty()) {
-                        if (recipe.ingredients.stream().anyMatch(ingredient -> ingredient.test(other))) {
+                        if (recipe.ingredients.stream().noneMatch(ingredient -> ingredient.test(other))) {
                             continue; // Skip not required item
                         }
 

--- a/src/main/java/appeng/entity/ChargedQuartzEntity.java
+++ b/src/main/java/appeng/entity/ChargedQuartzEntity.java
@@ -109,7 +109,7 @@ public final class ChargedQuartzEntity extends AEBaseItemEntity {
                 if (e instanceof ItemEntity itemEntity && !e.isRemoved()) {
                     final ItemStack other = itemEntity.getItem();
                     if (!other.isEmpty()) {
-                        if (!recipe.ingredients.test(other)) {
+                        if (recipe.ingredients.stream().anyMatch(ingredient -> ingredient.test(other))) {
                             continue; // Skip not required item
                         }
 
@@ -124,7 +124,7 @@ public final class ChargedQuartzEntity extends AEBaseItemEntity {
                 }
             }
 
-            if (selectedEntities.size() == recipe.ingredients.getItems().length) {
+            if (selectedEntities.size() == recipe.ingredients.size()) {
                 this.getItem().grow(-1);
 
                 if (this.getItem().getCount() <= 0) {

--- a/src/main/java/appeng/init/InitRecipeSerializers.java
+++ b/src/main/java/appeng/init/InitRecipeSerializers.java
@@ -30,6 +30,8 @@ import appeng.recipes.entropy.EntropyRecipeSerializer;
 import appeng.recipes.game.FacadeRecipe;
 import appeng.recipes.handlers.InscriberRecipe;
 import appeng.recipes.handlers.InscriberRecipeSerializer;
+import appeng.recipes.handlers.TransformRecipe;
+import appeng.recipes.handlers.TransformRecipeSerializer;
 import appeng.recipes.mattercannon.MatterCannonAmmo;
 import appeng.recipes.mattercannon.MatterCannonAmmoSerializer;
 
@@ -44,6 +46,7 @@ public final class InitRecipeSerializers {
         register(registry, AppEng.makeId("facade"), FacadeRecipe.getSerializer(facadeItem));
         register(registry, EntropyRecipe.TYPE_ID, EntropyRecipeSerializer.INSTANCE);
         register(registry, MatterCannonAmmo.TYPE_ID, MatterCannonAmmoSerializer.INSTANCE);
+        register(registry, TransformRecipe.TYPE_ID, TransformRecipeSerializer.INSTANCE);
     }
 
     private static void register(Registry<RecipeSerializer<?>> registry, ResourceLocation id,

--- a/src/main/java/appeng/integration/modules/jei/ReiPlugin.java
+++ b/src/main/java/appeng/integration/modules/jei/ReiPlugin.java
@@ -73,6 +73,7 @@ import appeng.integration.modules.jei.transfer.UseCraftingRecipeTransfer;
 import appeng.menu.me.items.CraftingTermMenu;
 import appeng.menu.me.items.PatternEncodingTermMenu;
 import appeng.recipes.handlers.InscriberRecipe;
+import appeng.recipes.handlers.TransformRecipe;
 
 public class ReiPlugin implements REIClientPlugin {
 
@@ -117,7 +118,7 @@ public class ReiPlugin implements REIClientPlugin {
 
         // Add displays for charged quartz transformation
         if (AEConfig.instance().isInWorldChargedQuartzTransformEnabled()) {
-            for (var recipe : ChargedQuartzEntity.RECIPES) {
+            for (var recipe : registry.getRecipeManager().byType(TransformRecipe.TYPE).values()) {
                 var ingredients = new ArrayList<Ingredient>();
                 ingredients.add(Ingredient.of(AEItems.CERTUS_QUARTZ_CRYSTAL_CHARGED));
                 for (var additional : recipe.additionalItems()) {

--- a/src/main/java/appeng/integration/modules/jei/ReiPlugin.java
+++ b/src/main/java/appeng/integration/modules/jei/ReiPlugin.java
@@ -121,9 +121,7 @@ public class ReiPlugin implements REIClientPlugin {
             for (var recipe : registry.getRecipeManager().byType(TransformRecipe.TYPE).values()) {
                 var ingredients = new ArrayList<Ingredient>();
                 ingredients.add(Ingredient.of(AEItems.CERTUS_QUARTZ_CRYSTAL_CHARGED));
-                for (var additional : recipe.additionalItems()) {
-                    ingredients.add(Ingredient.of(additional));
-                }
+                ingredients.add(recipe.ingredients);
 
                 registry.add(new ThrowingInWaterDisplay(ingredients, new ItemStack(recipe.output(), recipe.count())));
             }

--- a/src/main/java/appeng/integration/modules/jei/ReiPlugin.java
+++ b/src/main/java/appeng/integration/modules/jei/ReiPlugin.java
@@ -64,7 +64,6 @@ import appeng.core.definitions.AEParts;
 import appeng.core.definitions.ItemDefinition;
 import appeng.core.localization.GuiText;
 import appeng.core.localization.ItemModText;
-import appeng.entity.ChargedQuartzEntity;
 import appeng.integration.abstraction.REIFacade;
 import appeng.integration.modules.jei.throwinginwater.ThrowingInWaterCategory;
 import appeng.integration.modules.jei.throwinginwater.ThrowingInWaterDisplay;
@@ -119,7 +118,8 @@ public class ReiPlugin implements REIClientPlugin {
         // Add displays for charged quartz transformation
         if (AEConfig.instance().isInWorldChargedQuartzTransformEnabled()) {
             for (var recipe : registry.getRecipeManager().byType(TransformRecipe.TYPE).values()) {
-                registry.add(new ThrowingInWaterDisplay(recipe.ingredients, new ItemStack(recipe.output(), recipe.count())));
+                registry.add(
+                        new ThrowingInWaterDisplay(recipe.ingredients, new ItemStack(recipe.output(), recipe.count())));
             }
         }
     }

--- a/src/main/java/appeng/integration/modules/jei/ReiPlugin.java
+++ b/src/main/java/appeng/integration/modules/jei/ReiPlugin.java
@@ -119,12 +119,7 @@ public class ReiPlugin implements REIClientPlugin {
         // Add displays for charged quartz transformation
         if (AEConfig.instance().isInWorldChargedQuartzTransformEnabled()) {
             for (var recipe : registry.getRecipeManager().byType(TransformRecipe.TYPE).values()) {
-                var ingredients = new ArrayList<Ingredient>();
-                for (ItemStack itemStack : recipe.ingredients.getItems()) {
-                    ingredients.add(Ingredient.of(itemStack));
-                }
-
-                registry.add(new ThrowingInWaterDisplay(ingredients, new ItemStack(recipe.output(), recipe.count())));
+                registry.add(new ThrowingInWaterDisplay(recipe.ingredients, new ItemStack(recipe.output(), recipe.count())));
             }
         }
     }

--- a/src/main/java/appeng/integration/modules/jei/ReiPlugin.java
+++ b/src/main/java/appeng/integration/modules/jei/ReiPlugin.java
@@ -120,8 +120,9 @@ public class ReiPlugin implements REIClientPlugin {
         if (AEConfig.instance().isInWorldChargedQuartzTransformEnabled()) {
             for (var recipe : registry.getRecipeManager().byType(TransformRecipe.TYPE).values()) {
                 var ingredients = new ArrayList<Ingredient>();
-                ingredients.add(Ingredient.of(AEItems.CERTUS_QUARTZ_CRYSTAL_CHARGED));
-                ingredients.add(recipe.ingredients);
+                for (ItemStack itemStack : recipe.ingredients.getItems()) {
+                    ingredients.add(Ingredient.of(itemStack));
+                }
 
                 registry.add(new ThrowingInWaterDisplay(ingredients, new ItemStack(recipe.output(), recipe.count())));
             }

--- a/src/main/java/appeng/recipes/handlers/TransformRecipe.java
+++ b/src/main/java/appeng/recipes/handlers/TransformRecipe.java
@@ -11,16 +11,18 @@ import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.Level;
 
+import java.util.List;
+
 public final class TransformRecipe implements Recipe<Container>{
     public static final ResourceLocation TYPE_ID = AppEng.makeId("transform");
     public static final RecipeType<TransformRecipe> TYPE = RecipeType.register(TYPE_ID.toString());
 
     private final ResourceLocation id;
-    public final Ingredient ingredients;
+    public final List<Ingredient> ingredients;
     public final Item output;
     public final int count;
 
-    public TransformRecipe(ResourceLocation id, Ingredient ingredients, Item output, int count){
+    public TransformRecipe(ResourceLocation id, List<Ingredient> ingredients, Item output, int count){
         this.id = id;
         this.ingredients = ingredients;
         this.output = output;

--- a/src/main/java/appeng/recipes/handlers/TransformRecipe.java
+++ b/src/main/java/appeng/recipes/handlers/TransformRecipe.java
@@ -1,0 +1,108 @@
+package appeng.recipes.handlers;
+
+import appeng.core.AppEng;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.Container;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Recipe;
+import net.minecraft.world.item.crafting.RecipeSerializer;
+import net.minecraft.world.item.crafting.RecipeType;
+import net.minecraft.world.level.Level;
+
+import java.util.Objects;
+import java.util.Set;
+
+public final class TransformRecipe implements Recipe<Container>{
+    public static final ResourceLocation TYPE_ID = AppEng.makeId("transform");
+    public static final RecipeType<TransformRecipe> TYPE = RecipeType.register(TYPE_ID.toString());
+
+    private final ResourceLocation id;
+    public final Set<Item> additionalItems;
+    public final Item output;
+    public final int count;
+
+    public TransformRecipe(ResourceLocation id, Set<Item> additionalItems, Item output, int count){
+        this.id = id;
+        this.additionalItems = additionalItems;
+        this.output = output;
+        this.count = count;
+    }
+
+    @Override
+    public boolean matches(Container container, Level level){
+        return false;
+    }
+
+    @Override
+    public ItemStack assemble(Container container){
+        return null;
+    }
+
+    @Override
+    public boolean canCraftInDimensions(int width, int height){
+        return false;
+    }
+
+    @Override
+    public ItemStack getResultItem(){
+        return new ItemStack(output, count);
+    }
+
+    @Override
+    public ResourceLocation getId(){
+        return id;
+    }
+
+    @Override
+    public RecipeSerializer<?> getSerializer(){
+        return TransformRecipeSerializer.INSTANCE;
+    }
+
+    @Override
+    public RecipeType<?> getType(){
+        return TYPE;
+    }
+
+    public ResourceLocation id(){
+        return id;
+    }
+
+    public Set<Item> additionalItems(){
+        return additionalItems;
+    }
+
+    public Item output(){
+        return output;
+    }
+
+    public int count(){
+        return count;
+    }
+
+    @Override
+    public boolean equals(Object obj){
+        if(obj == this) return true;
+        if(obj == null || obj.getClass() != this.getClass()) return false;
+        var that = (TransformRecipe)obj;
+        return Objects.equals(this.id, that.id) &&
+        Objects.equals(this.additionalItems, that.additionalItems) &&
+        Objects.equals(this.output, that.output) &&
+        this.count == that.count;
+    }
+
+    @Override
+    public int hashCode(){
+        return Objects.hash(id, additionalItems, output, count);
+    }
+
+    @Override
+    public String toString(){
+        return "TransformRecipe[" +
+        "id=" + id + ", " +
+        "additionalItems=" + additionalItems + ", " +
+        "output=" + output + ", " +
+        "count=" + count + ']';
+    }
+
+}

--- a/src/main/java/appeng/recipes/handlers/TransformRecipe.java
+++ b/src/main/java/appeng/recipes/handlers/TransformRecipe.java
@@ -5,26 +5,24 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.Container;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.Level;
-
-import java.util.Objects;
-import java.util.Set;
 
 public final class TransformRecipe implements Recipe<Container>{
     public static final ResourceLocation TYPE_ID = AppEng.makeId("transform");
     public static final RecipeType<TransformRecipe> TYPE = RecipeType.register(TYPE_ID.toString());
 
     private final ResourceLocation id;
-    public final Set<Item> additionalItems;
+    public final Ingredient ingredients;
     public final Item output;
     public final int count;
 
-    public TransformRecipe(ResourceLocation id, Set<Item> additionalItems, Item output, int count){
+    public TransformRecipe(ResourceLocation id, Ingredient ingredients, Item output, int count){
         this.id = id;
-        this.additionalItems = additionalItems;
+        this.ingredients = ingredients;
         this.output = output;
         this.count = count;
     }
@@ -68,10 +66,6 @@ public final class TransformRecipe implements Recipe<Container>{
         return id;
     }
 
-    public Set<Item> additionalItems(){
-        return additionalItems;
-    }
-
     public Item output(){
         return output;
     }
@@ -79,30 +73,4 @@ public final class TransformRecipe implements Recipe<Container>{
     public int count(){
         return count;
     }
-
-    @Override
-    public boolean equals(Object obj){
-        if(obj == this) return true;
-        if(obj == null || obj.getClass() != this.getClass()) return false;
-        var that = (TransformRecipe)obj;
-        return Objects.equals(this.id, that.id) &&
-        Objects.equals(this.additionalItems, that.additionalItems) &&
-        Objects.equals(this.output, that.output) &&
-        this.count == that.count;
-    }
-
-    @Override
-    public int hashCode(){
-        return Objects.hash(id, additionalItems, output, count);
-    }
-
-    @Override
-    public String toString(){
-        return "TransformRecipe[" +
-        "id=" + id + ", " +
-        "additionalItems=" + additionalItems + ", " +
-        "output=" + output + ", " +
-        "count=" + count + ']';
-    }
-
 }

--- a/src/main/java/appeng/recipes/handlers/TransformRecipe.java
+++ b/src/main/java/appeng/recipes/handlers/TransformRecipe.java
@@ -1,6 +1,7 @@
 package appeng.recipes.handlers;
 
-import appeng.core.AppEng;
+import java.util.List;
+
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.Container;
 import net.minecraft.world.item.Item;
@@ -11,9 +12,9 @@ import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.Level;
 
-import java.util.List;
+import appeng.core.AppEng;
 
-public final class TransformRecipe implements Recipe<Container>{
+public final class TransformRecipe implements Recipe<Container> {
     public static final ResourceLocation TYPE_ID = AppEng.makeId("transform");
     public static final RecipeType<TransformRecipe> TYPE = RecipeType.register(TYPE_ID.toString());
 
@@ -22,7 +23,7 @@ public final class TransformRecipe implements Recipe<Container>{
     public final Item output;
     public final int count;
 
-    public TransformRecipe(ResourceLocation id, List<Ingredient> ingredients, Item output, int count){
+    public TransformRecipe(ResourceLocation id, List<Ingredient> ingredients, Item output, int count) {
         this.id = id;
         this.ingredients = ingredients;
         this.output = output;
@@ -30,49 +31,49 @@ public final class TransformRecipe implements Recipe<Container>{
     }
 
     @Override
-    public boolean matches(Container container, Level level){
+    public boolean matches(Container container, Level level) {
         return false;
     }
 
     @Override
-    public ItemStack assemble(Container container){
+    public ItemStack assemble(Container container) {
         return null;
     }
 
     @Override
-    public boolean canCraftInDimensions(int width, int height){
+    public boolean canCraftInDimensions(int width, int height) {
         return false;
     }
 
     @Override
-    public ItemStack getResultItem(){
+    public ItemStack getResultItem() {
         return new ItemStack(output, count);
     }
 
     @Override
-    public ResourceLocation getId(){
+    public ResourceLocation getId() {
         return id;
     }
 
     @Override
-    public RecipeSerializer<?> getSerializer(){
+    public RecipeSerializer<?> getSerializer() {
         return TransformRecipeSerializer.INSTANCE;
     }
 
     @Override
-    public RecipeType<?> getType(){
+    public RecipeType<?> getType() {
         return TYPE;
     }
 
-    public ResourceLocation id(){
+    public ResourceLocation id() {
         return id;
     }
 
-    public Item output(){
+    public Item output() {
         return output;
     }
 
-    public int count(){
+    public int count() {
         return count;
     }
 }

--- a/src/main/java/appeng/recipes/handlers/TransformRecipeSerializer.java
+++ b/src/main/java/appeng/recipes/handlers/TransformRecipeSerializer.java
@@ -1,0 +1,79 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2021, TeamAppliedEnergistics, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.recipes.handlers;
+
+import com.google.gson.JsonObject;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.item.crafting.RecipeSerializer;
+import net.minecraft.world.item.crafting.ShapedRecipe;
+
+import javax.annotation.Nullable;
+import java.util.Set;
+import java.util.HashSet;
+
+public class TransformRecipeSerializer implements RecipeSerializer<TransformRecipe> {
+
+    public static final TransformRecipeSerializer INSTANCE = new TransformRecipeSerializer();
+
+    private TransformRecipeSerializer() {
+    }
+
+    @Override
+    public TransformRecipe fromJson(ResourceLocation recipeId, JsonObject json) {
+
+        Ingredient ingredients = Ingredient.fromJson(GsonHelper.getAsJsonArray(json, "ingredients"));
+        ItemStack result = ShapedRecipe.itemStackFromJson(GsonHelper.getAsJsonObject(json, "result"));
+
+        Set<Item> additionalItems = new HashSet<>();
+        for (ItemStack itemStack : ingredients.getItems()) {
+            additionalItems.add(itemStack.getItem());
+        }
+
+        return new TransformRecipe(recipeId, additionalItems, result.getItem(), result.getCount());
+    }
+
+    @Nullable
+    @Override
+    public TransformRecipe fromNetwork(ResourceLocation recipeId, FriendlyByteBuf buffer) {
+        ItemStack output = buffer.readItem();
+
+        Set<Item> inputs = new HashSet<>();
+        for(int i = 0; i < buffer.readInt(); i++){
+            inputs.add(buffer.readItem().getItem());
+        }
+
+        return new TransformRecipe(recipeId, inputs, output.getItem(), output.getCount());
+    }
+
+    @Override
+    public void toNetwork(FriendlyByteBuf buffer, TransformRecipe recipe) {
+        buffer.writeItem(new ItemStack(recipe.output, recipe.count));
+
+        buffer.writeInt(recipe.additionalItems.size());
+        recipe.additionalItems.forEach(additionalItem -> {
+            buffer.writeItem(new ItemStack(additionalItem));
+        });
+    }
+
+}

--- a/src/main/java/appeng/recipes/handlers/TransformRecipeSerializer.java
+++ b/src/main/java/appeng/recipes/handlers/TransformRecipeSerializer.java
@@ -18,7 +18,13 @@
 
 package appeng.recipes.handlers;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.Nullable;
+
 import com.google.gson.JsonObject;
+
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.GsonHelper;
@@ -26,10 +32,6 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.ShapedRecipe;
-
-import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.List;
 
 public class TransformRecipeSerializer implements RecipeSerializer<TransformRecipe> {
 
@@ -41,7 +43,8 @@ public class TransformRecipeSerializer implements RecipeSerializer<TransformReci
     @Override
     public TransformRecipe fromJson(ResourceLocation recipeId, JsonObject json) {
         List<Ingredient> ingredients = new ArrayList<>();
-        GsonHelper.getAsJsonArray(json, "ingredients").forEach(ingredient -> ingredients.add(Ingredient.fromJson(ingredient)));
+        GsonHelper.getAsJsonArray(json, "ingredients")
+                .forEach(ingredient -> ingredients.add(Ingredient.fromJson(ingredient)));
 
         ItemStack result = ShapedRecipe.itemStackFromJson(GsonHelper.getAsJsonObject(json, "result"));
 
@@ -54,7 +57,7 @@ public class TransformRecipeSerializer implements RecipeSerializer<TransformReci
         ItemStack output = buffer.readItem();
 
         List<Ingredient> ingredients = new ArrayList<>();
-        for(int i = 0; i < buffer.readByte(); i++){
+        for (int i = 0; i < buffer.readByte(); i++) {
             ingredients.add(Ingredient.fromNetwork(buffer));
         }
 


### PR DESCRIPTION
Challenged by @Technici4n on the enigmatica discord to implement datapack support for water transformation recipes with no prior knowledge of the ae2 codebase or ever having implemented generators for in java defined recipes before, so ideally you'll leave the reviewing to him since he knows the full context. ^-^ (in case a fellow member/contributor reads this first :O) 

Where do i even begin pitching this pr, i've basically scavenged the codebase and copy pasted stuff that looked like i might need, as well as somewhat follow pre-established structures in order to make it not stand out like a sore thumb too much.

Obviously there are (lots of) improvements to be made, e.g. me not being in-the-know about serializing an ingredient array of items to the network, so i took a page out of the book of `Mindustry` and just write the length first and then send the items one by one, and on the receiving end just get the length and unserialize that amount of items, it seems to work. :tm:

Functions that still return null, dunno what is important when, all i know is that this appears to work for single player.

Without a doubt this will require some finetuning by Technici4n, but at least the bulk of the work has been done for him.