### PR TITLE
use more generic container for crafting pattern output

### DIFF
--- a/src/main/java/appeng/crafting/CraftingEvent.java
+++ b/src/main/java/appeng/crafting/CraftingEvent.java
@@ -21,7 +21,6 @@ package appeng.crafting;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.Container;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.inventory.CraftingContainer;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 
@@ -39,7 +38,7 @@ public class CraftingEvent {
 
     public static void fireAutoCraftingEvent(Level level,
             AECraftingPattern pattern,
-            CraftingContainer container) {
+            Container container) {
         var craftedItem = pattern.getOutput(container, level);
         fireAutoCraftingEvent(level, pattern, craftedItem, container);
     }
@@ -48,7 +47,7 @@ public class CraftingEvent {
             // NOTE: We want to be able to include the recipe in the event later
             @SuppressWarnings("unused") AECraftingPattern pattern,
             ItemStack craftedItem,
-            CraftingContainer container) {
+            Container container) {
         var serverLevel = (ServerLevel) level;
         var fakePlayer = Platform.getPlayer(serverLevel);
         // TODO FABRIC 117 Expose an event for this in the API

--- a/src/main/java/appeng/crafting/pattern/AECraftingPattern.java
+++ b/src/main/java/appeng/crafting/pattern/AECraftingPattern.java
@@ -25,6 +25,7 @@ import java.util.Objects;
 import javax.annotation.Nullable;
 
 import net.minecraft.core.NonNullList;
+import net.minecraft.world.Container;
 import net.minecraft.world.inventory.CraftingContainer;
 import net.minecraft.world.item.BucketItem;
 import net.minecraft.world.item.Item;
@@ -279,7 +280,7 @@ public class AECraftingPattern implements IAEPatternDetails {
 
     /**
      * Retrieve a previous result of testing whether <code>what</code> is a valid ingredient for <code>slot</code>.
-     * 
+     *
      * @return null if the result is unknown, otherwise indicates whether the key is valid or not.
      */
     @Nullable
@@ -319,14 +320,14 @@ public class AECraftingPattern implements IAEPatternDetails {
         return sparseToCompressed[sparse];
     }
 
-    public ItemStack getOutput(CraftingContainer craftingContainer, Level level) {
+    public ItemStack getOutput(Container container, Level level) {
         if (canSubstitute && recipe.isSpecial()) {
             // For special recipes, we need to test the recipe with assemble, unfortunately, since the output might
             // depend on the inputs in a way that can't be detected by changing one input at the time.
             specialRecipeTestFrame.clearContent();
 
-            for (int x = 0; x < craftingContainer.getContainerSize(); ++x) {
-                ItemStack item = craftingContainer.getItem(x);
+            for (int x = 0; x < container.getContainerSize(); ++x) {
+                ItemStack item = container.getItem(x);
                 var stack = GenericStack.unwrapItemStack(item);
                 if (stack != null) {
                     // If we receive a pure fluid stack, we convert it to the appropriate container item
@@ -343,8 +344,8 @@ public class AECraftingPattern implements IAEPatternDetails {
             return recipe.assemble(specialRecipeTestFrame);
         }
 
-        for (int x = 0; x < craftingContainer.getContainerSize(); x++) {
-            ItemStack item = craftingContainer.getItem(x);
+        for (int x = 0; x < container.getContainerSize(); x++) {
+            ItemStack item = container.getItem(x);
             var stack = GenericStack.unwrapItemStack(item);
             if (stack != null) {
                 // If we receive a pure fluid stack, we'll convert it to the appropriate container item


### PR DESCRIPTION
This allows using more generic inventories for retrieving a pattern output.

On Forge, this has the benefit to use a `IItemHandler` inventory with the help of the `RecipeWrapper` which is already in place for assembling recipe outputs.