### PR TITLE
refill the condenser output interface when it got emptied

### DIFF
--- a/src/main/java/appeng/blockentity/misc/CondenserBlockEntity.java
+++ b/src/main/java/appeng/blockentity/misc/CondenserBlockEntity.java
@@ -109,7 +109,10 @@ public class CondenserBlockEntity extends AEBaseInvBlockEntity implements IConfi
     public void addPower(double rawPower) {
         this.setStoredPower(this.getStoredPower() + rawPower);
         this.setStoredPower(Math.max(0.0, Math.min(this.getStorage(), this.getStoredPower())));
+        fillOutput();
+    }
 
+    private void fillOutput() {
         var requiredPower = this.getRequiredPower();
         var output = this.getOutput();
         while (requiredPower <= this.getStoredPower() && !output.isEmpty() && requiredPower > 0) {
@@ -159,6 +162,8 @@ public class CondenserBlockEntity extends AEBaseInvBlockEntity implements IConfi
 
     @Override
     public void onChangeInventory(InternalInventory inv, int slot) {
+        if (inv == outputSlot)
+            fillOutput();
     }
 
     @Override


### PR DESCRIPTION
it used to stay empty until the energy was increased, even if it still had plenty energy left