### PR TITLE
Fix #6400: Formed Quantum Ring hitboxes don't match the model

### DIFF
--- a/src/main/java/appeng/block/qnb/QuantumRingBlock.java
+++ b/src/main/java/appeng/block/qnb/QuantumRingBlock.java
@@ -19,6 +19,7 @@
 package appeng.block.qnb;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Material;
@@ -33,7 +34,10 @@ public class QuantumRingBlock extends QuantumBaseBlock {
 
     private static final VoxelShape SHAPE = createShape(2.0 / 16.0);
     private static final VoxelShape SHAPE_CORNER = createShape(2.0 / 16.0);
-    private static final VoxelShape SHAPE_FORMED = createShape(0.0 / 16.0);
+    private static final VoxelShape SHAPE_CENTER = createCenterShape(2.0 / 16.0);
+
+    private static final double DEFAULT_MODEL_MIN = 2.0 / 16.0;
+    private static final double DEFAULT_MODEL_MAX = 14.0 / 16.0;
 
     public QuantumRingBlock() {
         super(defaultProps(Material.METAL));
@@ -45,7 +49,7 @@ public class QuantumRingBlock extends QuantumBaseBlock {
         if (bridge != null && bridge.isCorner()) {
             return SHAPE_CORNER;
         } else if (bridge != null && bridge.isFormed()) {
-            return SHAPE_FORMED;
+            return SHAPE_CENTER;
         }
         return SHAPE;
     }
@@ -53,5 +57,23 @@ public class QuantumRingBlock extends QuantumBaseBlock {
     private static VoxelShape createShape(double onePixel) {
         return Shapes.create(
                 new AABB(onePixel, onePixel, onePixel, 1.0 - onePixel, 1.0 - onePixel, 1.0 - onePixel));
+    }
+
+    private static VoxelShape createCenterShape(double offset) {
+        VoxelShape centerShape = SHAPE;
+        for (Direction facing : Direction.values()) {
+            double xOffset = Math.abs(facing.getStepX() * offset);
+            double yOffset = Math.abs(facing.getStepY() * offset);
+            double zOffset = Math.abs(facing.getStepZ() * offset);
+
+            VoxelShape extrusion = Shapes.create(
+                    new AABB(DEFAULT_MODEL_MIN - xOffset, DEFAULT_MODEL_MIN - yOffset,
+                            DEFAULT_MODEL_MIN - zOffset, DEFAULT_MODEL_MAX + xOffset,
+                            DEFAULT_MODEL_MAX + yOffset, DEFAULT_MODEL_MAX + zOffset));
+
+            centerShape = Shapes.or(centerShape, extrusion);
+        }
+
+        return centerShape;
     }
 }

--- a/src/main/java/appeng/block/qnb/QuantumRingBlock.java
+++ b/src/main/java/appeng/block/qnb/QuantumRingBlock.java
@@ -32,8 +32,8 @@ import appeng.blockentity.qnb.QuantumBridgeBlockEntity;
 public class QuantumRingBlock extends QuantumBaseBlock {
 
     private static final VoxelShape SHAPE = createShape(2.0 / 16.0);
-    private static final VoxelShape SHAPE_CORNER = createShape(4.0 / 16.0);
-    private static final VoxelShape SHAPE_FORMED = createShape(1.0 / 16.0);
+    private static final VoxelShape SHAPE_CORNER = createShape(2.0 / 16.0);
+    private static final VoxelShape SHAPE_FORMED = createShape(0.0 / 16.0);
 
     public QuantumRingBlock() {
         super(defaultProps(Material.METAL));


### PR DESCRIPTION
I started by building from the master branch and creating an instance of minecraft 1.19 to test out the issue.  The hitboxes were fine on an unformed Quantum Ring block, but once it was formed into the correct shape for the ring, both the corner and edge piece hitboxes were too small. Standing on top of the shape, feet sunk into both blocks at differing heights.

After modifying the values for the shape of the formed and corner blocks, I rebuilt the jar and tested it in that same minecraft world. This fixed both blocks, now the player can stand on them and the feet properly rest on the top of each block.