### PR TITLE
change amount setting logic

### DIFF
--- a/src/main/java/appeng/client/gui/widgets/NumberEntryWidget.java
+++ b/src/main/java/appeng/client/gui/widgets/NumberEntryWidget.java
@@ -270,7 +270,14 @@ public class NumberEntryWidget extends GuiComponent implements ICompositeWidget 
 
     private void addQty(long delta) {
         var currentValue = getValueInternal().orElse(BigDecimal.ZERO);
-        setValueInternal(currentValue.add(BigDecimal.valueOf(delta)));
+        var newValue = currentValue.add(BigDecimal.valueOf(delta));
+        var minimum = BigDecimal.valueOf(this.minValue);
+        if (newValue.compareTo(minimum) < 0) {
+            newValue = minimum;
+        } else if (currentValue.compareTo(BigDecimal.ONE) == 0 && delta > 0 && delta % 10 == 0) {
+            newValue = newValue.subtract(BigDecimal.ONE);
+        }
+        setValueInternal(newValue);
     }
 
     /**


### PR DESCRIPTION
fixes #6455

This PR changes the behavior of the `NumberEntryWidget`.

**Button Press:**
When the current value is 1 and one of the positive amount buttons is pressed, it will use the value of the button without adding the initial value of 1 to it. You will get 100 instead of 101 when you press the 100 button.
I check for `% 10` so only necessary buttons are taken into account and to keep the scrolling behavior.

**Minimum Changes:**
When a screen defines a minimum for the widget, there is now a check if the new value falls below the minimum and will set the new value to the minimum instead. This avoid having negative values or a 0 value in a crafting request sub screen which would block the next button and makes no sense.

I made sure the scrolling behavior, manual adjustment of the value and all the buttons still work.
[Here](https://imgur.com/a/c8UjpEK) is a video of the new behavior.