### PR TITLE
Use a different injection point for model reloads

### DIFF
--- a/src/main/java/appeng/mixins/ModelsReloadMixin.java
+++ b/src/main/java/appeng/mixins/ModelsReloadMixin.java
@@ -1,24 +1,22 @@
 package appeng.mixins;
 
-import java.util.Map;
-
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.client.resources.model.ModelBakery;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.client.resources.model.ModelManager;
+import net.minecraft.server.packs.resources.ResourceManager;
+import net.minecraft.util.profiling.ProfilerFiller;
 
 import appeng.hooks.ModelsReloadCallback;
 
-@Mixin(ModelBakery.class)
+@Mixin(ModelManager.class)
 public class ModelsReloadMixin {
-
-    @Inject(method = "getBakedTopLevelModels", at = @At("RETURN"))
-    public void onGetBakedModelMap(CallbackInfoReturnable<Map<ResourceLocation, BakedModel>> ci) {
-        ModelsReloadCallback.EVENT.invoker().onModelsReloaded(ci.getReturnValue());
+    @Inject(method = "apply(Lnet/minecraft/client/resources/model/ModelBakery;Lnet/minecraft/server/packs/resources/ResourceManager;Lnet/minecraft/util/profiling/ProfilerFiller;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/block/BlockModelShaper;rebuildCache()V"))
+    public void onGetBakedModelMap(ModelBakery modelBakery, ResourceManager resourceManager,
+            ProfilerFiller profilerFiller, CallbackInfo callbackInfo) {
+        ModelsReloadCallback.EVENT.invoker().onModelsReloaded(modelBakery.getBakedTopLevelModels());
     }
-
 }

--- a/src/main/java/appeng/mixins/spatial/MinecraftServerMixin.java
+++ b/src/main/java/appeng/mixins/spatial/MinecraftServerMixin.java
@@ -5,13 +5,13 @@ import java.util.concurrent.Executor;
 
 import com.google.common.collect.ImmutableList;
 
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerWorldEvents;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerWorldEvents;
 import net.minecraft.core.Registry;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.resources.ResourceKey;


### PR DESCRIPTION
Use a different injection point to avoid repeated calls to the model bakeries top-level map causing AE2 to repeatedly apply its model customizations.

Fixes #6464