### PR TITLE
Fix storage monitor and crafting monitor rotation issues

### DIFF
--- a/src/main/java/appeng/client/render/BlockEntityRenderHelper.java
+++ b/src/main/java/appeng/client/render/BlockEntityRenderHelper.java
@@ -29,11 +29,32 @@ import net.minecraft.core.Direction;
 import appeng.api.client.AEStackRendering;
 import appeng.api.stacks.AEKey;
 import appeng.api.stacks.AmountFormat;
+import appeng.util.Platform;
 
 /**
  * Helper methods for rendering block entities.
  */
 public class BlockEntityRenderHelper {
+    /**
+     * Find the spin based on two-direction orientation, for use with {@link #rotateToFace}.
+     */
+    public static byte findSpin(Direction facing, Direction up) {
+        // Find spin by iterating rotation...
+        Direction currentUp = switch (facing) {
+            case UP -> Direction.NORTH;
+            case DOWN -> Direction.SOUTH;
+            default -> Direction.UP;
+        };
+
+        for (byte spin = 0; spin < 4; ++spin) {
+            if (currentUp == up) {
+                return spin;
+            }
+
+            currentUp = Platform.rotateAround(currentUp, facing);
+        }
+        return 0;
+    }
 
     /**
      * Rotate the current coordinate system so it is on the face of the given block side. This can be used to render on
@@ -41,34 +62,16 @@ public class BlockEntityRenderHelper {
      */
     public static void rotateToFace(PoseStack mStack, Direction face, byte spin) {
         switch (face) {
-            case UP:
-                mStack.mulPose(Vector3f.XP.rotationDegrees(270));
-                mStack.mulPose(Vector3f.ZP.rotationDegrees(-spin * 90.0F));
-                break;
-
-            case DOWN:
-                mStack.mulPose(Vector3f.XP.rotationDegrees(90.0F));
-                mStack.mulPose(Vector3f.ZP.rotationDegrees(spin * -90.0F));
-                break;
-
-            case EAST:
-                mStack.mulPose(Vector3f.YP.rotationDegrees(90.0F));
-                break;
-
-            case WEST:
-                mStack.mulPose(Vector3f.YP.rotationDegrees(-90.0F));
-                break;
-
-            case NORTH:
-                mStack.mulPose(Vector3f.YP.rotationDegrees(180.0F));
-                break;
-
-            case SOUTH:
-                break;
-
-            default:
-                break;
+            case UP -> mStack.mulPose(Vector3f.XP.rotationDegrees(270));
+            case DOWN -> mStack.mulPose(Vector3f.XP.rotationDegrees(90.0F));
+            case EAST -> mStack.mulPose(Vector3f.YP.rotationDegrees(90.0F));
+            case WEST -> mStack.mulPose(Vector3f.YP.rotationDegrees(-90.0F));
+            case NORTH -> mStack.mulPose(Vector3f.YP.rotationDegrees(180.0F));
+            case SOUTH -> {
+            }
         }
+
+        mStack.last().pose().multiply(Vector3f.ZP.rotationDegrees(-spin * 90.0F));
     }
 
     /**

--- a/src/main/java/appeng/client/render/crafting/CraftingMonitorRenderer.java
+++ b/src/main/java/appeng/client/render/crafting/CraftingMonitorRenderer.java
@@ -51,8 +51,9 @@ public class CraftingMonitorRenderer implements BlockEntityRenderer<CraftingMoni
             poseStack.pushPose();
             poseStack.translate(0.5, 0.5, 0.5); // Move to the center of the block
 
-            BlockEntityRenderHelper.rotateToFace(poseStack, facing, (byte) 0);
-            poseStack.translate(0, 0.08, 0.5);
+            byte spin = BlockEntityRenderHelper.findSpin(facing, te.getUp());
+            BlockEntityRenderHelper.rotateToFace(poseStack, facing, spin);
+            poseStack.translate(0, 0.02, 0.5);
 
             BlockEntityRenderHelper.renderItem2dWithAmount(
                     poseStack,

--- a/src/main/java/appeng/client/render/crafting/MonitorBakedModel.java
+++ b/src/main/java/appeng/client/render/crafting/MonitorBakedModel.java
@@ -90,6 +90,7 @@ public class MonitorBakedModel extends CraftingCubeBakedModel {
         builder.addCube(x1, y1, z1, x2, y2, z2);
 
         // Reset back to default
+        builder.setColor(-1);
         builder.setEmissiveMaterial(false);
     }
 

--- a/src/main/java/appeng/util/Platform.java
+++ b/src/main/java/appeng/util/Platform.java
@@ -341,97 +341,11 @@ public class Platform {
     }
 
     public static Direction rotateAround(Direction forward, Direction axis) {
-        switch (forward) {
-            case DOWN:
-                switch (axis) {
-                    case DOWN:
-                        return forward;
-                    case UP:
-                        return forward;
-                    case NORTH:
-                        return Direction.EAST;
-                    case SOUTH:
-                        return Direction.WEST;
-                    case EAST:
-                        return Direction.NORTH;
-                    case WEST:
-                        return Direction.SOUTH;
-                    default:
-                        break;
-                }
-                break;
-            case UP:
-                switch (axis) {
-                    case NORTH:
-                        return Direction.WEST;
-                    case SOUTH:
-                        return Direction.EAST;
-                    case EAST:
-                        return Direction.SOUTH;
-                    case WEST:
-                        return Direction.NORTH;
-                    default:
-                        break;
-                }
-                break;
-            case NORTH:
-                switch (axis) {
-                    case UP:
-                        return Direction.WEST;
-                    case DOWN:
-                        return Direction.EAST;
-                    case EAST:
-                        return Direction.UP;
-                    case WEST:
-                        return Direction.DOWN;
-                    default:
-                        break;
-                }
-                break;
-            case SOUTH:
-                switch (axis) {
-                    case UP:
-                        return Direction.EAST;
-                    case DOWN:
-                        return Direction.WEST;
-                    case EAST:
-                        return Direction.DOWN;
-                    case WEST:
-                        return Direction.UP;
-                    default:
-                        break;
-                }
-                break;
-            case EAST:
-                switch (axis) {
-                    case UP:
-                        return Direction.NORTH;
-                    case DOWN:
-                        return Direction.SOUTH;
-                    case NORTH:
-                        return Direction.UP;
-                    case SOUTH:
-                        return Direction.DOWN;
-                    default:
-                        break;
-                }
-            case WEST:
-                switch (axis) {
-                    case UP:
-                        return Direction.SOUTH;
-                    case DOWN:
-                        return Direction.NORTH;
-                    case NORTH:
-                        return Direction.DOWN;
-                    case SOUTH:
-                        return Direction.UP;
-                    default:
-                        break;
-                }
-            default:
-                break;
+        if (forward.getAxis() == axis.getAxis()) {
+            return forward;
         }
-        return forward;
+        var newForward = forward.getNormal().cross(axis.getNormal());
+        return Objects.requireNonNull(Direction.fromNormal(new BlockPos(newForward)));
     }
 
     public static boolean securityCheck(GridNode a, GridNode b) {


### PR DESCRIPTION
- Fix #5934: Rotating a storage monitor does not rotate the item inside.
- Fix #6374: Rotate the displayed item when a crafting monitor is rotated.
- Make rotation of AE2 blocks a bit more consistent (always clockwise).
- Fix coloring issue with crafting monitor model.