### PR TITLE
Fix #6534: Better configuration of facade display in JEI

### DIFF
--- a/src/main/java/appeng/core/AEConfig.java
+++ b/src/main/java/appeng/core/AEConfig.java
@@ -127,6 +127,7 @@ public final class AEConfig {
     private boolean useColoredCraftingStatus;
     private boolean disableColoredCableRecipesInJEI;
     private boolean isEnableFacadesInJEI;
+    private boolean isEnableFacadeRecipesInJEI;
     private int craftingCalculationTimePerTick;
     private boolean craftingSimulatedExtraction;
 
@@ -160,6 +161,7 @@ public final class AEConfig {
     private void syncClientConfig() {
         this.disableColoredCableRecipesInJEI = CLIENT.disableColoredCableRecipesInJEI.get();
         this.isEnableFacadesInJEI = CLIENT.enableFacadesInJEI.get();
+        this.isEnableFacadeRecipesInJEI = CLIENT.enableFacadeRecipesInJEI.get();
         this.enableEffects = CLIENT.enableEffects.get();
         this.useLargeFonts = CLIENT.useLargeFonts.get();
         this.useColoredCraftingStatus = CLIENT.useColoredCraftingStatus.get();
@@ -287,6 +289,10 @@ public final class AEConfig {
 
     public boolean isEnableFacadesInJEI() {
         return this.isEnableFacadesInJEI;
+    }
+
+    public boolean isEnableFacadeRecipesInJEI() {
+        return this.isEnableFacadeRecipesInJEI;
     }
 
     public int getCraftingCalculationTimePerTick() {
@@ -418,6 +424,7 @@ public final class AEConfig {
         public final BooleanOption useColoredCraftingStatus;
         public final BooleanOption disableColoredCableRecipesInJEI;
         public final BooleanOption enableFacadesInJEI;
+        public final BooleanOption enableFacadeRecipesInJEI;
         public final EnumOption<PowerUnits> selectedPowerUnit;
         public final BooleanOption debugGuiOverlays;
         public final BooleanOption showPlacementPreview;
@@ -430,7 +437,10 @@ public final class AEConfig {
         public ClientConfig(ConfigSection root) {
             ConfigSection client = root.subsection("client");
             this.disableColoredCableRecipesInJEI = client.addBoolean("disableColoredCableRecipesInJEI", true);
-            this.enableFacadesInJEI = client.addBoolean("enableFacadesInJEI", false);
+            this.enableFacadesInJEI = client.addBoolean("enableFacadesInJEI", true,
+                    "Show facades in JEI ingredient list");
+            this.enableFacadeRecipesInJEI = client.addBoolean("enableFacadeRecipesInJEI", true,
+                    "Show facade recipes in JEI for supported blocks");
             this.enableEffects = client.addBoolean("enableEffects", true);
             this.useLargeFonts = client.addBoolean("useTerminalUseLargeFont", false);
             this.useColoredCraftingStatus = client.addBoolean("useColoredCraftingStatus", true);

--- a/src/main/java/appeng/integration/modules/jei/JEIPlugin.java
+++ b/src/main/java/appeng/integration/modules/jei/JEIPlugin.java
@@ -42,6 +42,7 @@ import appeng.client.gui.AEBaseScreen;
 import appeng.client.gui.implementations.InscriberScreen;
 import appeng.core.AEConfig;
 import appeng.core.AppEng;
+import appeng.core.FacadeCreativeTab;
 import appeng.core.definitions.AEBlocks;
 import appeng.core.definitions.AEItems;
 import appeng.core.definitions.AEParts;
@@ -208,7 +209,7 @@ public class JEIPlugin implements IModPlugin {
 
     @Override
     public void registerAdvanced(IAdvancedRegistration registration) {
-        if (AEConfig.instance().isEnableFacadesInJEI()) {
+        if (AEConfig.instance().isEnableFacadeRecipesInJEI()) {
             FacadeItem itemFacade = AEItems.FACADE.asItem();
             ItemStack cableAnchor = AEParts.CABLE_ANCHOR.stack();
             registration.addRecipeManagerPlugin(new FacadeRegistryPlugin(itemFacade, cableAnchor));
@@ -256,6 +257,11 @@ public class JEIPlugin implements IModPlugin {
     public void onRuntimeAvailable(IJeiRuntime jeiRuntime) {
         JEIFacade.setInstance(new JeiRuntimeAdapter(jeiRuntime));
         this.hideDebugTools(jeiRuntime);
+
+        if (!AEConfig.instance().isEnableFacadesInJEI()) {
+            jeiRuntime.getIngredientManager().removeIngredientsAtRuntime(VanillaTypes.ITEM_STACK,
+                    FacadeCreativeTab.getSubTypes());
+        }
     }
 
     private void hideDebugTools(IJeiRuntime jeiRuntime) {


### PR DESCRIPTION
Without this PR, facades are always enabled in JEI, and setting the `enableFacadesInJEI` option to `false` only disables the dynamic recipe generation for looked-up items.

With this PR, there are separate config options for the facades in the ingredient list, and the dynamic facade recipe display generation.