### PR TITLE
Allow color to be removed from cables and memory cards with snowballs

### DIFF
--- a/src/main/java/appeng/datagen/providers/recipes/CraftingRecipes.java
+++ b/src/main/java/appeng/datagen/providers/recipes/CraftingRecipes.java
@@ -900,7 +900,7 @@ public class CraftingRecipes extends AE2RecipeProvider {
 
         ShapelessRecipeBuilder.shapeless(AEItems.MEMORY_CARDS.item(AEColor.TRANSPARENT))
                 .requires(ConventionTags.MEMORY_CARDS)
-                .requires(Items.WATER_BUCKET)
+                .requires(ConventionTags.CAN_REMOVE_COLOR)
                 .unlockedBy("has_memory_card", has(ConventionTags.MEMORY_CARDS))
                 .save(consumer, AppEng.makeId("network/cables/network_memory_card_clean"));
 
@@ -1371,7 +1371,7 @@ public class CraftingRecipes extends AE2RecipeProvider {
         // Remove color from any colored cable
         ShapelessRecipeBuilder.shapeless(AEParts.COVERED_CABLE.item(AEColor.TRANSPARENT))
                 .requires(ConventionTags.COVERED_CABLE)
-                .requires(Items.WATER_BUCKET)
+                .requires(ConventionTags.CAN_REMOVE_COLOR)
                 .unlockedBy("has_covered_cable", has(ConventionTags.COVERED_CABLE))
                 .save(consumer, AppEng.makeId("network/cables/covered_fluix_clean"));
         // Craft the actual colored cable initially
@@ -1402,7 +1402,7 @@ public class CraftingRecipes extends AE2RecipeProvider {
                 .save(consumer, AppEng.makeId("network/cables/dense_covered_fluix"));
         ShapelessRecipeBuilder.shapeless(AEParts.COVERED_DENSE_CABLE.item(AEColor.TRANSPARENT))
                 .requires(ConventionTags.COVERED_DENSE_CABLE)
-                .requires(Items.WATER_BUCKET)
+                .requires(ConventionTags.CAN_REMOVE_COLOR)
                 .unlockedBy("has_covered_dense_cable", has(ConventionTags.COVERED_DENSE_CABLE))
                 .save(consumer, AppEng.makeId("network/cables/dense_covered_fluix_clean"));
 
@@ -1434,7 +1434,7 @@ public class CraftingRecipes extends AE2RecipeProvider {
                 .save(consumer, AppEng.makeId("network/cables/dense_smart_from_smart"));
         ShapelessRecipeBuilder.shapeless(AEParts.SMART_DENSE_CABLE.item(AEColor.TRANSPARENT))
                 .requires(ConventionTags.SMART_DENSE_CABLE)
-                .requires(Items.WATER_BUCKET)
+                .requires(ConventionTags.CAN_REMOVE_COLOR)
                 .unlockedBy("has_smart_dense_cable", has(ConventionTags.SMART_DENSE_CABLE))
                 .save(consumer, AppEng.makeId("network/cables/dense_smart_fluix_clean"));
 
@@ -1459,7 +1459,7 @@ public class CraftingRecipes extends AE2RecipeProvider {
                 .save(consumer, AppEng.makeId("network/cables/glass_fluix"));
         ShapelessRecipeBuilder.shapeless(AEParts.GLASS_CABLE.item(AEColor.TRANSPARENT))
                 .requires(ConventionTags.GLASS_CABLE)
-                .requires(Items.WATER_BUCKET)
+                .requires(ConventionTags.CAN_REMOVE_COLOR)
                 .unlockedBy("has_glass_cable", has(ConventionTags.GLASS_CABLE))
                 .save(consumer, AppEng.makeId("network/cables/glass_fluix_clean"));
 
@@ -1485,7 +1485,7 @@ public class CraftingRecipes extends AE2RecipeProvider {
                 .save(consumer, AppEng.makeId("network/cables/smart_fluix"));
         ShapelessRecipeBuilder.shapeless(AEParts.SMART_CABLE.item(AEColor.TRANSPARENT))
                 .requires(ConventionTags.SMART_CABLE)
-                .requires(Items.WATER_BUCKET)
+                .requires(ConventionTags.CAN_REMOVE_COLOR)
                 .unlockedBy("has_smart_cable", has(ConventionTags.SMART_CABLE))
                 .save(consumer, AppEng.makeId("network/cables/smart_fluix_clean"));
     }

--- a/src/main/java/appeng/datagen/providers/tags/ConventionTags.java
+++ b/src/main/java/appeng/datagen/providers/tags/ConventionTags.java
@@ -87,7 +87,6 @@ public final class ConventionTags {
 
     public static TagKey<Item> ENDER_PEARL = tag("c:ender_pearls");
     public static TagKey<Item> ENDER_PEARL_DUST = tag("c:ender_pearl_dusts");
-    public static TagKey<Item> WHEAT_CROP = tag("c:wheat_crops");
 
     public static TagKey<Item> WOOD_STICK = tag("c:wooden_rods");
     public static TagKey<Item> CHEST = tag("c:wooden_chests");
@@ -114,6 +113,10 @@ public final class ConventionTags {
     public static TagKey<Item> PAINT_BALLS = tag("ae2:paint_balls");
     public static TagKey<Item> MEMORY_CARDS = tag("ae2:memory_cards");
     public static TagKey<Item> INSCRIBER_PRESSES = tag("ae2:inscriber_presses");
+    /**
+     * Items that can be used in recipes to remove color from colored items.
+     */
+    public static TagKey<Item> CAN_REMOVE_COLOR = tag("ae2:can_remove_color");
 
     // Budding stuff
     public static final TagKey<Item> BUDDING_BLOCKS = tag("c:budding_blocks");

--- a/src/main/java/appeng/datagen/providers/tags/ItemTagsProvider.java
+++ b/src/main/java/appeng/datagen/providers/tags/ItemTagsProvider.java
@@ -283,8 +283,7 @@ public class ItemTagsProvider extends net.minecraft.data.tags.ItemTagsProvider i
         tag(ConventionTags.dye(DyeColor.RED)).add(Items.RED_DYE);
         tag(ConventionTags.dye(DyeColor.BLACK)).add(Items.BLACK_DYE);
 
-        tag(ConventionTags.WHEAT_CROP).add(Items.WHEAT);
-
+        tag(ConventionTags.CAN_REMOVE_COLOR).add(Items.WATER_BUCKET, Items.SNOWBALL);
     }
 
     // Copy the entries AE2 added to certain block tags over to item tags of the same name


### PR DESCRIPTION
In addition to water buckets. Since snowballs can be stacked, this should make removal from many cables easier.