### PR TITLE
Add platform immovable block tag to spatial blacklist

### DIFF
--- a/src/main/java/appeng/datagen/providers/tags/BlockTagsProvider.java
+++ b/src/main/java/appeng/datagen/providers/tags/BlockTagsProvider.java
@@ -44,7 +44,9 @@ public class BlockTagsProvider extends net.minecraft.data.tags.BlockTagsProvider
     @Override
     protected void addTags() {
         // Black- and whitelist tags
-        tag(AETags.SPATIAL_BLACKLIST).add(Blocks.BEDROCK);
+        tag(AETags.SPATIAL_BLACKLIST)
+                .add(Blocks.BEDROCK)
+                .addTag(ConventionTags.IMMOVABLE_BLOCKS);
         tag(AETags.ANNIHILATION_PLANE_BLOCK_BLACKLIST);
         tag(AETags.FACADE_BLOCK_WHITELIST)
                 .add(Blocks.GLASS,

--- a/src/main/java/appeng/datagen/providers/tags/BlockTagsProvider.java
+++ b/src/main/java/appeng/datagen/providers/tags/BlockTagsProvider.java
@@ -46,7 +46,7 @@ public class BlockTagsProvider extends net.minecraft.data.tags.BlockTagsProvider
         // Black- and whitelist tags
         tag(AETags.SPATIAL_BLACKLIST)
                 .add(Blocks.BEDROCK)
-                .addTag(ConventionTags.IMMOVABLE_BLOCKS);
+                .addOptionalTag(ConventionTags.IMMOVABLE_BLOCKS.location());
         tag(AETags.ANNIHILATION_PLANE_BLOCK_BLACKLIST);
         tag(AETags.FACADE_BLOCK_WHITELIST)
                 .add(Blocks.GLASS,

--- a/src/main/java/appeng/datagen/providers/tags/ConventionTags.java
+++ b/src/main/java/appeng/datagen/providers/tags/ConventionTags.java
@@ -24,6 +24,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import net.fabricmc.fabric.api.tag.convention.v1.ConventionalBiomeTags;
+import net.fabricmc.fabric.api.tag.convention.v1.ConventionalBlockTags;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
@@ -125,6 +126,11 @@ public final class ConventionTags {
     public static final TagKey<Block> BUDDING_BLOCKS_BLOCKS = blockTag("c:budding_blocks");
     public static final TagKey<Block> BUDS_BLOCKS = blockTag("c:buds");
     public static final TagKey<Block> CLUSTERS_BLOCKS = blockTag("c:clusters");
+
+    /**
+     * Platform tags for blocks that should not be moved, i.e. some pipes, chunk loaders, etc...
+     */
+    public static final TagKey<Block> IMMOVABLE_BLOCKS = ConventionalBlockTags.MOVEMENT_RESTRICTED;
 
     /**
      * For Worldgen Biomes


### PR DESCRIPTION
On forge it should be `#forge:relocation_not_supported`.