### PR TITLE
Fix "craft missing items" sometimes using an outdated network inventory for the crafting plan

### DIFF
--- a/src/main/java/appeng/api/networking/storage/IStorageService.java
+++ b/src/main/java/appeng/api/networking/storage/IStorageService.java
@@ -81,4 +81,12 @@ public interface IStorageService extends IGridService {
      * @throws IllegalArgumentException If the given provider has not been {@link #addGlobalStorageProvider registered}.
      */
     void refreshGlobalStorageProvider(IStorageProvider provider);
+
+    /**
+     * Invalidates the {@link #getCachedInventory() cached inventory}, causing it to be re-calculated the next time it
+     * is accessed.
+     * <p>
+     * <strong>THIS IS A PERFORMANCE INTENSIVE OPERATION AND SHOULD BE USED WITH CARE.</strong>
+     */
+    void invalidateCache();
 }

--- a/src/main/java/appeng/me/service/StorageService.java
+++ b/src/main/java/appeng/me/service/StorageService.java
@@ -228,6 +228,11 @@ public class StorageService implements IStorageService, IGridServiceProvider {
         throw new IllegalArgumentException("The given node is not part of this grid or has no storage provider.");
     }
 
+    @Override
+    public void invalidateCache() {
+        cachedStacksNeedUpdate = true;
+    }
+
     /**
      * A {@link IStorageProvider}-specific mount table facade which allows the provider to easily mount/remount its
      * storage.

--- a/src/test/java/appeng/crafting/simulation/helpers/SimulationEnv.java
+++ b/src/test/java/appeng/crafting/simulation/helpers/SimulationEnv.java
@@ -218,6 +218,10 @@ public class SimulationEnv {
             }
 
             @Override
+            public void invalidateCache() {
+            }
+
+            @Override
             public void refreshNodeStorageProvider(IGridNode node) {
                 throw new UnsupportedOperationException();
             }


### PR DESCRIPTION
Invalidate the storage cache when using "craft missing items" from JEI/REI
If items were moved to/from the grid. The crafting plan will use outdated info otherwise.