### PR TITLE
Fix ME chest not filtering external item input against partitioned cells

### DIFF
--- a/src/main/java/appeng/blockentity/storage/ChestBlockEntity.java
+++ b/src/main/java/appeng/blockentity/storage/ChestBlockEntity.java
@@ -671,9 +671,18 @@ public class ChestBlockEntity extends AENetworkPowerBlockEntity
 
         @Override
         public boolean allowInsert(InternalInventory inv, int slot, ItemStack stack) {
-            if (ChestBlockEntity.this.isPowered()) {
-                ChestBlockEntity.this.updateHandler();
-                return ChestBlockEntity.this.cellHandler != null;
+            if (isPowered()) {
+                updateHandler();
+                if (cellHandler == null) {
+                    return false;
+                }
+
+                var what = AEItemKey.of(stack);
+                if (what == null) {
+                    return false;
+                }
+
+                return cellHandler.insert(what, stack.getCount(), Actionable.SIMULATE, mySrc) > 0;
             }
             return false;
         }

--- a/src/main/java/appeng/server/testworld/PlotBuilder.java
+++ b/src/main/java/appeng/server/testworld/PlotBuilder.java
@@ -1,6 +1,7 @@
 package appeng.server.testworld;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -199,6 +200,10 @@ public interface PlotBuilder {
 
     default void hopper(BlockPos pos, Direction direction, ItemStack... stacks) {
         hopper(posToBb(pos), direction, stacks);
+    }
+
+    default void hopper(BlockPos pos, Direction direction, ItemLike... items) {
+        hopper(pos, direction, Arrays.stream(items).map(ItemStack::new).toArray(ItemStack[]::new));
     }
 
     default void hopper(String bb, Direction direction, ItemStack... stacks) {

--- a/src/main/java/appeng/server/testworld/PlotTestHelper.java
+++ b/src/main/java/appeng/server/testworld/PlotTestHelper.java
@@ -111,6 +111,13 @@ public class PlotTestHelper extends GameTestHelper {
         }
     }
 
+    public void assertContainsNot(MEStorage storage, AEKey key) {
+        var count = storage.getAvailableStacks().get(key);
+        if (count > 0) {
+            throw new GameTestAssertException("Network storage does contains " + key + ".");
+        }
+    }
+
     public void clearStorage(IGrid grid) {
         clearStorage(grid.getStorageService().getInventory());
     }

--- a/src/main/java/appeng/server/testworld/TestPlots.java
+++ b/src/main/java/appeng/server/testworld/TestPlots.java
@@ -85,6 +85,7 @@ public final class TestPlots {
             .put(AppEng.makeId("import_on_pulse_transactioncrash"), TestPlots::importOnPulseTransactionCrash)
             .put(AppEng.makeId("mattercannon_range"), TestPlots::matterCannonRange)
             .put(AppEng.makeId("insert_fluid_into_mechest"), TestPlots::testInsertFluidIntoMEChest)
+            .put(AppEng.makeId("insert_item_into_mechest"), TestPlots::testInsertItemsIntoMEChest)
             .put(AppEng.makeId("maxchannels_adhoctest"), TestPlots::maxChannelsAdHocTest)
             .put(AppEng.makeId("blockingmode_subnetwork_chesttest"), TestPlots::blockingModeSubnetworkChestTest)
             .put(AppEng.makeId("canceling_jobs_from_interfacecrash"), TestPlots::cancelingJobsFromInterfaceCrash)
@@ -511,6 +512,28 @@ public final class TestPlots {
         plot.test(helper -> helper.succeedWhen(() -> {
             var meChest = (appeng.blockentity.storage.ChestBlockEntity) helper.getBlockEntity(origin);
             helper.assertContains(meChest.getInventory(), AEFluidKey.of(Fluids.WATER));
+        }));
+    }
+
+    /**
+     * Regression test for https://github.com/AppliedEnergistics/Applied-Energistics-2/issues/6582
+     */
+    public static void testInsertItemsIntoMEChest(PlotBuilder plot) {
+        var origin = BlockPos.ZERO;
+        plot.creativeEnergyCell(origin.below());
+        plot.blockEntity(origin, AEBlocks.CHEST, chest -> {
+            var cell = AEItems.ITEM_CELL_1K.stack();
+            AEItems.ITEM_CELL_1K.asItem().getConfigInventory(cell).addFilter(Items.REDSTONE);
+            chest.setCell(cell);
+        });
+        // Hopper to test insertion of stuff. It should try to insert stick first.
+        plot.hopper(origin.above(), Direction.DOWN, Items.STICK, Items.REDSTONE);
+
+        plot.test(helper -> helper.succeedWhen(() -> {
+            var meChest = (appeng.blockentity.storage.ChestBlockEntity) helper.getBlockEntity(origin);
+            helper.assertContains(meChest.getInventory(), AEItemKey.of(Items.REDSTONE));
+            // The stick should still be in the hopper
+            helper.assertContainerContains(origin.above(), Items.STICK);
         }));
     }
 


### PR DESCRIPTION
Fixes that the ME chest does not filter external item input against the cells configured filter, and a non-insertable item would get stuck in the internal buffer slot.

Fixes #6582 