### PR TITLE
Fix #6524: Optimize KeyCounter

### DIFF
--- a/src/main/java/appeng/api/stacks/AEKey2LongMap.java
+++ b/src/main/java/appeng/api/stacks/AEKey2LongMap.java
@@ -1,0 +1,31 @@
+package appeng.api.stacks;
+
+import java.util.Comparator;
+
+import it.unimi.dsi.fastutil.objects.Object2LongAVLTreeMap;
+import it.unimi.dsi.fastutil.objects.Object2LongMap;
+import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
+
+/**
+ * Custom extension to expose the increment function in a polymorphic way. We don't want to use
+ * {@link Object2LongMap#mergeLong} because the fastutil maps don't override the naive implementation.
+ */
+interface AEKey2LongMap extends Object2LongMap<AEKey> {
+    /**
+     * Adds an increment to value currently associated with a key.
+     *
+     * @return the old value, or the {@linkplain #defaultReturnValue() default return value} if no value was present for
+     *         the given key.
+     */
+    @SuppressWarnings("UnusedReturnValue")
+    long addTo(AEKey k, long incr);
+
+    final class OpenHashMap extends Object2LongOpenHashMap<AEKey> implements AEKey2LongMap {
+    }
+
+    final class AVLTreeMap extends Object2LongAVLTreeMap<AEKey> implements AEKey2LongMap {
+        public AVLTreeMap(Comparator<? super AEKey> c) {
+            super(c);
+        }
+    }
+}

--- a/src/main/java/appeng/api/stacks/FuzzySearch.java
+++ b/src/main/java/appeng/api/stacks/FuzzySearch.java
@@ -8,8 +8,8 @@ import com.google.common.base.Preconditions;
 
 import net.minecraft.world.item.ItemStack;
 
-import it.unimi.dsi.fastutil.objects.Object2LongAVLTreeMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectAVLTreeMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectSortedMap;
 
 import appeng.api.config.FuzzyMode;
 
@@ -23,17 +23,15 @@ final class FuzzySearch {
     /**
      * Creates a map that is searchable via {@link #findFuzzy}.
      */
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    public static <K extends AEKey, V> Object2ObjectAVLTreeMap<K, V> createMap() {
-        return new Object2ObjectAVLTreeMap(COMPARATOR);
+    public static <K extends AEKey, V> Object2ObjectSortedMap<K, V> createMap() {
+        return new Object2ObjectAVLTreeMap<>(COMPARATOR);
     }
 
     /**
      * Creates a map that is searchable via {@link #findFuzzy}.
      */
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    public static <K extends AEKey> Object2LongAVLTreeMap<K> createMap2Long() {
-        return new Object2LongAVLTreeMap(COMPARATOR);
+    public static AEKey2LongMap.AVLTreeMap createMap2Long() {
+        return new AEKey2LongMap.AVLTreeMap(COMPARATOR);
     }
 
     /**

--- a/src/test/java/appeng/api/stacks/KeyCounterTest.java
+++ b/src/test/java/appeng/api/stacks/KeyCounterTest.java
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
 import com.google.common.collect.ImmutableSet;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -127,6 +128,7 @@ public class KeyCounterTest {
     }
 
     @Test
+    @Disabled // Disabled because the fastutil maps don't attempt to detect CMEs (by design).
     void testConcurrentModificationByAddingItemType() {
         var sword = diamondSword(100);
         itemList.add(sword, 1);


### PR DESCRIPTION
- Use `computeIfAbsent` when looking for a VariantCounter, and switch to the fastutil Reference2ObjectMap to have a non-naive implementation.
- Use `addTo` provided by certain Object2LongMap implementations instead of the naively implemented mergeLong.