### PR TITLE
Do not allow items from locked player inventory slots to be used for recipe transfers

### DIFF
--- a/src/main/java/appeng/core/sync/packets/FillCraftingGridFromRecipePacket.java
+++ b/src/main/java/appeng/core/sync/packets/FillCraftingGridFromRecipePacket.java
@@ -210,7 +210,7 @@ public class FillCraftingGridFromRecipePacket extends BasePacket {
 
             // If still nothing, try taking it from the player inventory
             if (currentItem.isEmpty()) {
-                currentItem = takeIngredientFromPlayer(player, ingredient);
+                currentItem = takeIngredientFromPlayer(cct, player, ingredient);
             }
 
             craftMatrix.setItemDirect(x, currentItem);
@@ -240,9 +240,14 @@ public class FillCraftingGridFromRecipePacket extends BasePacket {
         }
     }
 
-    private ItemStack takeIngredientFromPlayer(ServerPlayer player, Ingredient ingredient) {
+    private ItemStack takeIngredientFromPlayer(IMenuCraftingPacket cct, ServerPlayer player, Ingredient ingredient) {
         var playerInv = player.getInventory();
         for (int i = 0; i < playerInv.items.size(); i++) {
+            // Do not take ingredients out of locked slots
+            if (cct.isPlayerInventorySlotLocked(i)) {
+                continue;
+            }
+
             var item = playerInv.getItem(i);
             if (ingredient.test(item)) {
                 var result = item.split(1);

--- a/src/main/java/appeng/helpers/IMenuCraftingPacket.java
+++ b/src/main/java/appeng/helpers/IMenuCraftingPacket.java
@@ -60,6 +60,12 @@ public interface IMenuCraftingPacket {
     default void startAutoCrafting(List<AutoCraftEntry> toCraft) {
     }
 
+    /**
+     * @return True if the given player inventory slot is locked by the current menu and should not be used for
+     *         crafting. (i.e. the wireless terminal itself in case of a wireless crafting terminal).
+     */
+    boolean isPlayerInventorySlotLocked(int invSlot);
+
     record AutoCraftEntry(AEItemKey what, List<Integer> slots) {
     }
 }

--- a/src/main/java/appeng/menu/AEBaseMenu.java
+++ b/src/main/java/appeng/menu/AEBaseMenu.java
@@ -188,6 +188,10 @@ public abstract class AEBaseMenu extends AbstractContainerMenu {
         this.lockedPlayerInventorySlots.add(invSlot);
     }
 
+    public final boolean isPlayerInventorySlotLocked(int invSlot) {
+        return this.lockedPlayerInventorySlots.contains(invSlot);
+    }
+
     public Object getTarget() {
         if (this.blockEntity != null) {
             return this.blockEntity;

--- a/src/main/java/appeng/menu/me/items/CraftingTermMenu.java
+++ b/src/main/java/appeng/menu/me/items/CraftingTermMenu.java
@@ -213,6 +213,11 @@ public class CraftingTermMenu extends MEStorageMenu implements IMenuCraftingPack
             boolean found = false;
             // Player inventory is cheaper to check
             for (int i = 0; i < playerItems.size(); i++) {
+                // Do not consider locked slots
+                if (isPlayerInventorySlotLocked(i)) {
+                    continue;
+                }
+
                 var stack = playerItems.get(i);
                 if (stack.getCount() - reservedPlayerItems[i] > 0 && ingredient.test(stack)) {
                     reservedPlayerItems[i]++;


### PR DESCRIPTION
Fixes #6594