### PR TITLE
P2P QoL Improvements

### DIFF
--- a/src/main/java/appeng/core/localization/ButtonToolTips.java
+++ b/src/main/java/appeng/core/localization/ButtonToolTips.java
@@ -99,7 +99,6 @@ public enum ButtonToolTips implements LocalizationEnum {
     OverlayMode("Overlay Mode"),
     OverlayModeNo("Loaded area is hidden."),
     OverlayModeYes("Shows the loaded area within the world."),
-    P2PFrequency("Frequency: %s"),
     PartitionStorage("Partition Storage"),
     PartitionStorageHint("Configures Partition based on currently stored items."),
     PowerUnits("Power Units"),

--- a/src/main/java/appeng/core/localization/InGameTooltip.java
+++ b/src/main/java/appeng/core/localization/InGameTooltip.java
@@ -34,6 +34,8 @@ public enum InGameTooltip implements LocalizationEnum {
     ErrorControllerConflict("Error: Controller Conflict"),
     ErrorNestedP2PTunnel("Error: Nested P2P Tunnel"),
     ErrorTooManyChannels("Error: Too Many Channels"),
+    P2PFrequency("Frequency: %s"),
+    P2PMECarriedChannels("Carried Channels: %d"),
     Locked("Locked"),
     NetworkBooting("Network Booting"),
     P2PInputManyOutputs("Linked (Input Side) - %d Outputs"),


### PR DESCRIPTION
Show the number of channels carried through a ME P2P tunnel in the WTHIT/Jade/TOP tooltips.

Allow naming P2P tunnels and show the name of the input tunnel in the in-game tooltips of all linked tunnels.