### PR TITLE
Improvements for sub-screens (crafting status/crafting confirm) opened from terminals

### DIFF
--- a/src/main/java/appeng/blockentity/misc/SecurityStationBlockEntity.java
+++ b/src/main/java/appeng/blockentity/misc/SecurityStationBlockEntity.java
@@ -287,7 +287,7 @@ public class SecurityStationBlockEntity extends AENetworkBlockEntity implements 
 
     @Override
     public void returnToMainMenu(Player player, ISubMenu subMenu) {
-        openMenu(player);
+        MenuOpener.returnTo(SecurityStationMenu.TYPE, player, MenuLocators.forBlockEntity(this));
     }
 
     @Override

--- a/src/main/java/appeng/blockentity/storage/ChestBlockEntity.java
+++ b/src/main/java/appeng/blockentity/storage/ChestBlockEntity.java
@@ -709,6 +709,6 @@ public class ChestBlockEntity extends AENetworkPowerBlockEntity
 
     @Override
     public void returnToMainMenu(Player player, ISubMenu subMenu) {
-        openCellInventoryMenu(player);
+        MenuOpener.returnTo(ChestMenu.TYPE, player, MenuLocators.forBlockEntity(this));
     }
 }

--- a/src/main/java/appeng/blockentity/storage/DriveBlockEntity.java
+++ b/src/main/java/appeng/blockentity/storage/DriveBlockEntity.java
@@ -408,7 +408,7 @@ public class DriveBlockEntity extends AENetworkInvBlockEntity
 
     @Override
     public void returnToMainMenu(Player player, ISubMenu subMenu) {
-        openMenu(player);
+        MenuOpener.returnTo(DriveMenu.TYPE, player, MenuLocators.forBlockEntity(this));
     }
 
     @Override

--- a/src/main/java/appeng/client/gui/me/common/MEStorageScreen.java
+++ b/src/main/java/appeng/client/gui/me/common/MEStorageScreen.java
@@ -96,7 +96,7 @@ public class MEStorageScreen<C extends MEStorageMenu>
 
     private static final int MIN_ROWS = 3;
 
-    private static String memoryText = "";
+    private static String rememberedSearch = "";
     private final TerminalStyle style;
     protected final Repo repo;
     private final List<ItemStack> currentViewCells = new ArrayList<>();
@@ -112,7 +112,6 @@ public class MEStorageScreen<C extends MEStorageMenu>
     private int currentMouseX = 0;
     private int currentMouseY = 0;
     private final Scrollbar scrollbar;
-    private boolean firstInit = true;
 
     public MEStorageScreen(C menu, Inventory playerInventory,
             Component title, ScreenStyle style) {
@@ -189,6 +188,19 @@ public class MEStorageScreen<C extends MEStorageMenu>
                 menu.getHost()));
         if (menu.getToolbox().isPresent()) {
             this.widgets.add("toolbox", new ToolboxPanel(style, menu.getToolbox().getName()));
+        }
+
+        // Restore previous search term
+        if ((menu.isReturnedFromSubScreen() || config.isRememberLastSearch()) && rememberedSearch != null
+                && !rememberedSearch.isEmpty()) {
+            this.searchField.setValue(rememberedSearch);
+            this.searchField.selectAll();
+            setSearchText(rememberedSearch);
+        }
+
+        // Clear external search on open if configured, but not upon returning from a sub-screen
+        if (!menu.isReturnedFromSubScreen() && config.isUseExternalSearch() && config.isClearExternalSearchOnOpen()) {
+            ExternalSearch.clearExternalSearchText();
         }
     }
 
@@ -321,19 +333,6 @@ public class MEStorageScreen<C extends MEStorageMenu>
 
         if (shouldAutoFocus()) {
             setInitialFocus(this.searchField);
-        }
-
-        if (config.isRememberLastSearch() && memoryText != null && !memoryText.isEmpty()) {
-            this.searchField.setValue(memoryText);
-            this.searchField.selectAll();
-            setSearchText(memoryText);
-        }
-
-        if (firstInit) { // Avoid clearing again on resize, layout change, etc...
-            if (config.isUseExternalSearch() && config.isClearExternalSearchOnOpen()) {
-                ExternalSearch.clearExternalSearchText();
-            }
-            firstInit = false;
         }
 
         this.updateScrollbar();
@@ -479,7 +478,7 @@ public class MEStorageScreen<C extends MEStorageMenu>
     public void removed() {
         super.removed();
         getMinecraft().keyboardHandler.setSendRepeatsToGui(false);
-        memoryText = this.searchField.getValue();
+        storeState();
     }
 
     @Override
@@ -757,7 +756,12 @@ public class MEStorageScreen<C extends MEStorageMenu>
     }
 
     private void reinitalize() {
+        storeState();
         new ArrayList<>(this.children()).forEach(this::removeWidget);
         this.init();
+    }
+
+    private void storeState() {
+        rememberedSearch = this.searchField.getValue();
     }
 }

--- a/src/main/java/appeng/client/gui/widgets/Scrollbar.java
+++ b/src/main/java/appeng/client/gui/widgets/Scrollbar.java
@@ -174,6 +174,11 @@ public class Scrollbar implements IScrollSource, ICompositeWidget {
         return this.currentScroll;
     }
 
+    public void setCurrentScroll(int currentScroll) {
+        this.currentScroll = currentScroll;
+        applyRange();
+    }
+
     @Override
     public boolean onMouseDown(Point mousePos, int button) {
         if (button != InputConstants.MOUSE_BUTTON_LEFT) {

--- a/src/main/java/appeng/helpers/InterfaceLogicHost.java
+++ b/src/main/java/appeng/helpers/InterfaceLogicHost.java
@@ -75,6 +75,6 @@ public interface InterfaceLogicHost extends IConfigurableObject, IUpgradeableObj
 
     @Override
     default void returnToMainMenu(Player player, ISubMenu subMenu) {
-        openMenu(player, subMenu.getLocator());
+        MenuOpener.returnTo(InterfaceMenu.TYPE, player, subMenu.getLocator());
     }
 }

--- a/src/main/java/appeng/helpers/iface/PatternProviderLogicHost.java
+++ b/src/main/java/appeng/helpers/iface/PatternProviderLogicHost.java
@@ -68,6 +68,6 @@ public interface PatternProviderLogicHost extends IConfigurableObject, IPriority
 
     @Override
     default void returnToMainMenu(Player player, ISubMenu subMenu) {
-        openMenu(player, subMenu.getLocator());
+        MenuOpener.returnTo(PatternProviderMenu.TYPE, player, subMenu.getLocator());
     }
 }

--- a/src/main/java/appeng/items/tools/powered/PortableCellItem.java
+++ b/src/main/java/appeng/items/tools/powered/PortableCellItem.java
@@ -122,9 +122,14 @@ public class PortableCellItem extends AEBasePoweredItem
      * @return True if the menu was opened.
      */
     public boolean openFromInventory(Player player, int inventorySlot) {
+        return openFromInventory(player, inventorySlot, false);
+    }
+
+    protected boolean openFromInventory(Player player, int inventorySlot, boolean returningFromSubmenu) {
         var is = player.getInventory().getItem(inventorySlot);
         if (is.getItem() == this) {
-            return MenuOpener.open(getMenuType(), player, MenuLocators.forInventorySlot(inventorySlot));
+            return MenuOpener.open(getMenuType(), player, MenuLocators.forInventorySlot(inventorySlot),
+                    returningFromSubmenu);
         } else {
             return false;
         }
@@ -276,7 +281,7 @@ public class PortableCellItem extends AEBasePoweredItem
     @Override
     public PortableCellMenuHost getMenuHost(Player player, int inventorySlot, ItemStack stack, BlockPos pos) {
         return new PortableCellMenuHost(player, inventorySlot, this, stack,
-                (p, sm) -> openFromInventory(p, inventorySlot));
+                (p, sm) -> openFromInventory(p, inventorySlot, true));
     }
 
     @Override

--- a/src/main/java/appeng/items/tools/powered/WirelessCraftingTerminalItem.java
+++ b/src/main/java/appeng/items/tools/powered/WirelessCraftingTerminalItem.java
@@ -27,6 +27,6 @@ public class WirelessCraftingTerminalItem extends WirelessTerminalItem {
     @Override
     public ItemMenuHost getMenuHost(Player player, int inventorySlot, ItemStack stack, @Nullable BlockPos pos) {
         return new WirelessCraftingTerminalMenuHost(player, inventorySlot, stack,
-                (p, sm) -> openFromInventory(p, inventorySlot));
+                (p, sm) -> openFromInventory(p, inventorySlot, true));
     }
 }

--- a/src/main/java/appeng/items/tools/powered/WirelessTerminalItem.java
+++ b/src/main/java/appeng/items/tools/powered/WirelessTerminalItem.java
@@ -82,14 +82,26 @@ public class WirelessTerminalItem extends AEBasePoweredItem implements IMenuItem
 
     /**
      * Open a wireless terminal from a slot in the player inventory, i.e. activated via hotkey.
-     * 
+     *
      * @return True if the menu was opened.
      */
     public boolean openFromInventory(Player player, int inventorySlot) {
+        return openFromInventory(player, inventorySlot, false);
+    }
+
+    /**
+     * Open a wireless terminal from a slot in the player inventory, i.e. activated via hotkey.
+     *
+     * @param returningFromSubmenu Pass true if returning from a submenu that was opened from this terminal. Will
+     *                             restore previous search, scrollbar, etc.
+     * @return True if the menu was opened.
+     */
+    protected boolean openFromInventory(Player player, int inventorySlot, boolean returningFromSubmenu) {
         var is = player.getInventory().getItem(inventorySlot);
 
         if (checkPreconditions(is, player)) {
-            return MenuOpener.open(getMenuType(), player, MenuLocators.forInventorySlot(inventorySlot));
+            return MenuOpener.open(getMenuType(), player, MenuLocators.forInventorySlot(inventorySlot),
+                    returningFromSubmenu);
         }
         return false;
     }
@@ -155,7 +167,7 @@ public class WirelessTerminalItem extends AEBasePoweredItem implements IMenuItem
     @Override
     public ItemMenuHost getMenuHost(Player player, int inventorySlot, ItemStack stack, @Nullable BlockPos pos) {
         return new WirelessTerminalMenuHost(player, inventorySlot, stack,
-                (p, subMenu) -> openFromInventory(p, inventorySlot));
+                (p, subMenu) -> openFromInventory(p, inventorySlot, true));
     }
 
     /**

--- a/src/main/java/appeng/menu/AEBaseMenu.java
+++ b/src/main/java/appeng/menu/AEBaseMenu.java
@@ -96,6 +96,11 @@ public abstract class AEBaseMenu extends AbstractContainerMenu {
     private int ticksSinceCheck = 900;
     // Slots that are only present on the client-side
     private final Set<Slot> clientSideSlot = new HashSet<>();
+    /**
+     * Indicates that the menu was created after returning from a {@link ISubMenu}. Previous screen state stored on the
+     * client should be restored.
+     */
+    private boolean returnedFromSubScreen;
 
     public AEBaseMenu(MenuType<?> menuType, int id, Inventory playerInventory,
             Object host) {
@@ -989,5 +994,13 @@ public abstract class AEBaseMenu extends AbstractContainerMenu {
             slot.setNotDraggable();
             this.addSlot(slot, SlotSemantics.UPGRADE);
         }
+    }
+
+    public boolean isReturnedFromSubScreen() {
+        return returnedFromSubScreen;
+    }
+
+    public void setReturnedFromSubScreen(boolean returnedFromSubScreen) {
+        this.returnedFromSubScreen = returnedFromSubScreen;
     }
 }

--- a/src/main/java/appeng/menu/MenuOpener.java
+++ b/src/main/java/appeng/menu/MenuOpener.java
@@ -44,7 +44,15 @@ public final class MenuOpener {
         registry.put(type, opener);
     }
 
+    public static boolean returnTo(MenuType<?> type, Player player, MenuLocator locator) {
+        return open(type, player, locator, true);
+    }
+
     public static boolean open(MenuType<?> type, Player player, MenuLocator locator) {
+        return open(type, player, locator, false);
+    }
+
+    public static boolean open(MenuType<?> type, Player player, MenuLocator locator, boolean fromSubMenu) {
         Preconditions.checkArgument(!player.getLevel().isClientSide(), "Menus must be opened on the server.");
         Opener opener = registry.get(type);
         if (opener == null) {
@@ -52,13 +60,13 @@ public final class MenuOpener {
             return false;
         }
 
-        return opener.open(player, locator);
+        return opener.open(player, locator, fromSubMenu);
     }
 
     @FunctionalInterface
     public interface Opener {
 
-        boolean open(Player player, MenuLocator locator);
+        boolean open(Player player, MenuLocator locator, boolean fromSubMenu);
 
     }
 

--- a/src/main/java/appeng/parts/automation/FormationPlanePart.java
+++ b/src/main/java/appeng/parts/automation/FormationPlanePart.java
@@ -223,7 +223,7 @@ public class FormationPlanePart extends UpgradeablePart implements IStorageProvi
 
     @Override
     public void returnToMainMenu(Player player, ISubMenu subMenu) {
-        openConfigMenu(player);
+        MenuOpener.returnTo(getMenuType(), player, MenuLocators.forPart(this));
     }
 
     @Override

--- a/src/main/java/appeng/parts/reporting/AbstractTerminalPart.java
+++ b/src/main/java/appeng/parts/reporting/AbstractTerminalPart.java
@@ -115,7 +115,7 @@ public abstract class AbstractTerminalPart extends AbstractDisplayPart
 
     @Override
     public void returnToMainMenu(Player player, ISubMenu subMenu) {
-        MenuOpener.open(getMenuType(player), player, subMenu.getLocator());
+        MenuOpener.open(getMenuType(player), player, subMenu.getLocator(), true);
     }
 
     @Override

--- a/src/main/java/appeng/parts/storagebus/StorageBusPart.java
+++ b/src/main/java/appeng/parts/storagebus/StorageBusPart.java
@@ -205,7 +205,7 @@ public class StorageBusPart extends UpgradeablePart
 
     @Override
     public void returnToMainMenu(Player player, ISubMenu subMenu) {
-        openConfigMenu(player);
+        MenuOpener.returnTo(getMenuType(), player, MenuLocators.forPart(this));
     }
 
     @Override


### PR DESCRIPTION
Make screens aware of whether they were opened by returning from a submenu. Use this to remember search  when returning from crafting status / autocrafting, and also to not clear JEI search in such cases (if the option to clear on open is enabled). Also fixes the cursor from being recentered when switching to/from sub-menus on Fabric.

Fixes #6612 
Fixes #6630 