### PR TITLE
Remove charged certus obtaining info panel

### DIFF
--- a/src/main/java/appeng/core/localization/GuiText.java
+++ b/src/main/java/appeng/core/localization/GuiText.java
@@ -42,8 +42,6 @@ public enum GuiText implements LocalizationEnum {
     CertusQuartzObtain(
             "Certus Quartz is grown by the various Budding Certus Quartz blocks, which can be found in meteors, or crafted from regular Certus Quartz blocks."),
     ChannelEnergyDrain("Channel Passive Drain: %s"),
-    ChargedQuartz(
-            "Charged Certus Quartz is crafted by inserting an uncharged Certus Quartz Crystal into the Charger, and powering it."),
     Chest("ME Chest"),
     Clean("Clean"),
     CompatibleUpgrade("%s (%s)"),

--- a/src/main/java/appeng/integration/modules/jei/JEIPlugin.java
+++ b/src/main/java/appeng/integration/modules/jei/JEIPlugin.java
@@ -196,8 +196,6 @@ public class JEIPlugin implements IModPlugin {
     }
 
     private void registerDescriptions(IRecipeRegistration registry) {
-        this.addDescription(registry, AEItems.CERTUS_QUARTZ_CRYSTAL_CHARGED, GuiText.ChargedQuartz.text());
-
         this.addDescription(registry, AEItems.LOGIC_PROCESSOR_PRESS,
                 GuiText.inWorldCraftingPresses.text());
         this.addDescription(registry, AEItems.CALCULATION_PROCESSOR_PRESS,

--- a/src/main/java/appeng/integration/modules/rei/ReiPlugin.java
+++ b/src/main/java/appeng/integration/modules/rei/ReiPlugin.java
@@ -258,7 +258,6 @@ public class ReiPlugin implements REIClientPlugin {
         }
 
         addDescription(registry, AEItems.CERTUS_QUARTZ_CRYSTAL, GuiText.CertusQuartzObtain.getTranslationKey());
-        addDescription(registry, AEItems.CERTUS_QUARTZ_CRYSTAL_CHARGED, GuiText.ChargedQuartz.getTranslationKey());
 
         if (AEConfig.instance().isSpawnPressesInMeteoritesEnabled()) {
             addDescription(registry, AEItems.LOGIC_PROCESSOR_PRESS, GuiText.inWorldCraftingPresses.getTranslationKey());


### PR DESCRIPTION
Since the new charger category was implemented, I don't think an info panel inside the recipe viewers is required anymore.

![](https://i.imgur.com/ge25Ufe.png)