### PR TITLE
Remove the mod name from tooltips for search purposes

### DIFF
--- a/src/main/java/appeng/client/gui/me/search/RepoSearch.java
+++ b/src/main/java/appeng/client/gui/me/search/RepoSearch.java
@@ -1,18 +1,21 @@
 package appeng.client.gui.me.search;
 
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.WeakHashMap;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
-import net.minecraft.network.chat.Component;
+import net.minecraft.ChatFormatting;
 
 import it.unimi.dsi.fastutil.longs.Long2BooleanMap;
 import it.unimi.dsi.fastutil.longs.Long2BooleanOpenHashMap;
 
 import appeng.api.client.AEStackRendering;
 import appeng.api.stacks.AEKey;
+import appeng.core.AEConfig;
 import appeng.menu.me.common.GridInventoryEntry;
+import appeng.util.Platform;
 
 public class RepoSearch {
 
@@ -48,9 +51,41 @@ public class RepoSearch {
      */
     public String getTooltipText(AEKey what) {
         return tooltipCache.computeIfAbsent(what, key -> {
-            return AEStackRendering.getTooltip(key).stream()
-                    .map(Component::getString)
-                    .collect(Collectors.joining("\n"));
+            var lines = AEStackRendering.getTooltip(key);
+
+            var tooltipText = new StringBuilder();
+            for (int i = 0; i < lines.size(); i++) {
+                var line = lines.get(i);
+
+                // Process last line and skip mod name if our heuristic detects it
+                if (i > 0 && i >= lines.size() - 1 && !AEConfig.instance().isSearchModNameInTooltips()) {
+                    var text = line.getString();
+                    boolean hadFormatting = false;
+                    if (text.indexOf(ChatFormatting.PREFIX_CODE) != -1) {
+                        text = ChatFormatting.stripFormatting(text);
+                        hadFormatting = true;
+                    } else {
+                        hadFormatting = !line.getStyle().isEmpty();
+                    }
+
+                    if (!hadFormatting || !Objects.equals(text, Platform.getModName(what.getModId()))) {
+                        tooltipText.append('\n').append(text);
+                    }
+                } else {
+                    if (i > 0) {
+                        tooltipText.append('\n');
+                    }
+                    line.visit(text -> {
+                        if (text.indexOf(ChatFormatting.PREFIX_CODE) != -1) {
+                            text = ChatFormatting.stripFormatting(text);
+                        }
+                        tooltipText.append(text);
+                        return Optional.empty();
+                    });
+                }
+            }
+
+            return tooltipText.toString();
         });
     }
 }

--- a/src/main/java/appeng/core/AEConfig.java
+++ b/src/main/java/appeng/core/AEConfig.java
@@ -231,6 +231,14 @@ public final class AEConfig {
         CLIENT.searchTooltips.set(enable);
     }
 
+    public boolean isSearchModNameInTooltips() {
+        return CLIENT.searchModNameInTooltips.get();
+    }
+
+    public void setSearchModNameInTooltips(boolean enable) {
+        CLIENT.searchModNameInTooltips.set(enable);
+    }
+
     public boolean isUseExternalSearch() {
         return CLIENT.useExternalSearch.get();
     }
@@ -508,6 +516,7 @@ public final class AEConfig {
 
         // Search Settings
         public final BooleanOption searchTooltips;
+        public final BooleanOption searchModNameInTooltips;
         public final BooleanOption useExternalSearch;
         public final BooleanOption clearExternalSearchOnOpen;
         public final BooleanOption syncWithExternalSearch;
@@ -546,6 +555,8 @@ public final class AEConfig {
             var search = root.subsection("search");
             this.searchTooltips = search.addBoolean("searchTooltips", true,
                     "Should tooltips be searched. Performance impact");
+            this.searchModNameInTooltips = search.addBoolean("searchModNameInTooltips", false,
+                    "Should the mod name be included when searching in tooltips.");
             this.useExternalSearch = search.addBoolean("useExternalSearch", false,
                     "Replaces AEs own search with the search of REI or JEI");
             this.clearExternalSearchOnOpen = search.addBoolean("clearExternalSearchOnOpen", true,


### PR DESCRIPTION
So searching for "craft" doesn't return all items from Minecraft.

Fixes #6632

![grafik](https://user-images.githubusercontent.com/1261399/193364837-657d9778-3ab5-4ddf-9983-f8b846defe0d.png)
![grafik](https://user-images.githubusercontent.com/1261399/193364843-99dc52ed-d897-41eb-afe5-cc831ed811c4.png)
