### PR TITLE
Add terminal option to clear crafting/encoding grid on close

### DIFF
--- a/src/main/java/appeng/client/gui/me/common/TerminalSettingsScreen.java
+++ b/src/main/java/appeng/client/gui/me/common/TerminalSettingsScreen.java
@@ -16,6 +16,7 @@ public class TerminalSettingsScreen<C extends MEStorageMenu> extends AESubScreen
 
     private final AECheckbox pinAutoCraftedItemsCheckbox;
     private final AECheckbox notifyForFinishedCraftingJobsCheckbox;
+    private final AECheckbox clearGridOnCloseCheckbox;
 
     private final AECheckbox useInternalSearchRadio;
     private final AECheckbox useExternalSearchRadio;
@@ -49,6 +50,8 @@ public class TerminalSettingsScreen<C extends MEStorageMenu> extends AESubScreen
                 GuiText.TerminalSettingsPinAutoCraftedItems.text(), this::save);
         notifyForFinishedCraftingJobsCheckbox = widgets.addCheckbox("notifyForFinishedCraftingJobsCheckbox",
                 GuiText.TerminalSettingsNotifyForFinishedJobs.text(), this::save);
+        clearGridOnCloseCheckbox = widgets.addCheckbox("clearGridOnCloseCheckbox",
+                GuiText.TerminalSettingsClearGridOnClose.text(), this::save);
 
         useInternalSearchRadio = widgets.addCheckbox("useInternalSearchRadio",
                 GuiText.SearchSettingsUseInternalSearch.text(), this::switchToAeSearch);
@@ -89,15 +92,14 @@ public class TerminalSettingsScreen<C extends MEStorageMenu> extends AESubScreen
         var icon = menu.getHost().getMainMenuIcon();
         var label = icon.getHoverName();
         ItemRenderer itemRenderer = Minecraft.getInstance().getItemRenderer();
-        TabButton button = new TabButton(icon, label, itemRenderer, btn -> {
-            returnToParent();
-        });
+        TabButton button = new TabButton(icon, label, itemRenderer, btn -> returnToParent());
         widgets.add("back", button);
     }
 
     private void updateState() {
         pinAutoCraftedItemsCheckbox.setSelected(config.isPinAutoCraftedItems());
         notifyForFinishedCraftingJobsCheckbox.setSelected(config.isNotifyForFinishedCraftingJobs());
+        clearGridOnCloseCheckbox.setSelected(config.isClearGridOnClose());
 
         useInternalSearchRadio.setSelected(!config.isUseExternalSearch());
         useExternalSearchRadio.setSelected(config.isUseExternalSearch());
@@ -123,6 +125,7 @@ public class TerminalSettingsScreen<C extends MEStorageMenu> extends AESubScreen
         config.setSearchTooltips(searchTooltipsCheckbox.isSelected());
         config.setPinAutoCraftedItems(pinAutoCraftedItemsCheckbox.isSelected());
         config.setNotifyForFinishedCraftingJobs(notifyForFinishedCraftingJobsCheckbox.isSelected());
+        config.setClearGridOnClose(clearGridOnCloseCheckbox.isSelected());
 
         updateState();
     }

--- a/src/main/java/appeng/client/gui/me/items/CraftingTermScreen.java
+++ b/src/main/java/appeng/client/gui/me/items/CraftingTermScreen.java
@@ -25,6 +25,7 @@ import appeng.api.config.ActionItems;
 import appeng.client.gui.me.common.MEStorageScreen;
 import appeng.client.gui.style.ScreenStyle;
 import appeng.client.gui.widgets.ActionButton;
+import appeng.core.AEConfig;
 import appeng.menu.me.items.CraftingTermMenu;
 
 /**
@@ -47,4 +48,11 @@ public class CraftingTermScreen<C extends CraftingTermMenu> extends MEStorageScr
         widgets.add("clearToPlayerInv", clearToPlayerInvBtn);
     }
 
+    @Override
+    public void onClose() {
+        if (AEConfig.instance().isClearGridOnClose()) {
+            this.getMenu().clearCraftingGrid();
+        }
+        super.onClose();
+    }
 }

--- a/src/main/java/appeng/client/gui/me/items/PatternEncodingTermScreen.java
+++ b/src/main/java/appeng/client/gui/me/items/PatternEncodingTermScreen.java
@@ -43,6 +43,7 @@ import appeng.client.gui.widgets.IconButton;
 import appeng.client.gui.widgets.Scrollbar;
 import appeng.client.gui.widgets.TabButton;
 import appeng.client.gui.widgets.ToggleButton;
+import appeng.core.AEConfig;
 import appeng.core.localization.ButtonToolTips;
 import appeng.core.localization.GuiText;
 import appeng.core.localization.Tooltips;
@@ -244,11 +245,9 @@ public class PatternEncodingTermScreen<C extends PatternEncodingTermMenu> extend
                     var screen = new SetProcessingPatternAmountScreen<>(
                             this,
                             currentStack,
-                            newStack -> {
-                                NetworkHandler.instance().sendToServer(new InventoryActionPacket(
-                                        InventoryAction.SET_FILTER, slot.index,
-                                        GenericStack.wrapInItemStack(newStack)));
-                            });
+                            newStack -> NetworkHandler.instance().sendToServer(new InventoryActionPacket(
+                                    InventoryAction.SET_FILTER, slot.index,
+                                    GenericStack.wrapInItemStack(newStack))));
                     switchToScreen(screen);
                     return true;
                 }
@@ -304,5 +303,13 @@ public class PatternEncodingTermScreen<C extends PatternEncodingTermMenu> extend
             }
         }
         return super.mouseScrolled(x, y, wheelDelta);
+    }
+
+    @Override
+    public void onClose() {
+        if (AEConfig.instance().isClearGridOnClose()) {
+            this.getMenu().clear();
+        }
+        super.onClose();
     }
 }

--- a/src/main/java/appeng/core/AEConfig.java
+++ b/src/main/java/appeng/core/AEConfig.java
@@ -495,6 +495,14 @@ public final class AEConfig {
         CLIENT.notifyForFinishedCraftingJobs.set(enabled);
     }
 
+    public boolean isClearGridOnClose() {
+        return CLIENT.clearGridOnClose.get();
+    }
+
+    public void setClearGridOnClose(boolean enabled) {
+        CLIENT.clearGridOnClose.set(enabled);
+    }
+
     // Setters keep visibility as low as possible.
 
     private static class ClientConfig {
@@ -513,6 +521,8 @@ public final class AEConfig {
 
         // Terminal Settings
         public final EnumOption<TerminalStyle> terminalStyle;
+        public final BooleanOption pinAutoCraftedItems;
+        public final BooleanOption clearGridOnClose;
 
         // Search Settings
         public final BooleanOption searchTooltips;
@@ -524,7 +534,6 @@ public final class AEConfig {
         public final BooleanOption autoFocusSearch;
 
         // Tooltip settings
-        public final BooleanOption pinAutoCraftedItems;
         public final BooleanOption tooltipShowCellUpgrades;
         public final BooleanOption tooltipShowCellContent;
         public final IntegerOption tooltipMaxCellContentShown;
@@ -550,6 +559,8 @@ public final class AEConfig {
             this.terminalStyle = terminals.addEnum("terminalStyle", TerminalStyle.TALL);
             this.pinAutoCraftedItems = terminals.addBoolean("pinAutoCraftedItems", true,
                     "Pin items that the player auto-crafts to the top of the terminal");
+            this.clearGridOnClose = client.addBoolean("clearGridOnClose", false,
+                    "Automatically clear the crafting/encoding grid when closing the terminal");
 
             // Search Settings
             var search = root.subsection("search");

--- a/src/main/java/appeng/core/localization/GuiText.java
+++ b/src/main/java/appeng/core/localization/GuiText.java
@@ -228,6 +228,7 @@ public enum GuiText implements LocalizationEnum {
     TerminalSettingsTitle("Terminal Settings"),
     TerminalSettingsPinAutoCraftedItems("Pin auto-crafted items to first row"),
     TerminalSettingsNotifyForFinishedJobs("Notify about finished crafting jobs (requires wireless terminal)"),
+    TerminalSettingsClearGridOnClose("Automatically clear terminal grid on close (if applicable)"),
     TerminalViewCellsTooltip("View Cells"),
     ToastCraftingJobFinishedTitle("Auto-Crafting Complete"),
     ToastCraftingJobFinishedText("%d %s"),

--- a/src/main/resources/assets/ae2/screens/terminals/terminal_settings.json
+++ b/src/main/resources/assets/ae2/screens/terminals/terminal_settings.json
@@ -3,7 +3,7 @@
   "includes": ["../common/common.json"],
   "generatedBackground": {
     "width": 200,
-    "height": 200
+    "height": 216
   },
   "text": {
     "dialog_title": {
@@ -18,7 +18,7 @@
     "search_settings_title": {
       "position": {
         "left": 8,
-        "top": 83
+        "top": 110
       },
       "text": {
         "translate": "gui.ae2.SearchSettingsTitle"
@@ -40,39 +40,44 @@
       "top": 50,
       "width": 180
     },
+    "clearGridOnCloseCheckbox": {
+      "left": 10,
+      "top": 82,
+      "width": 180
+    },
     "useInternalSearchRadio": {
       "left": 10,
-      "top": 97,
+      "top": 124,
       "width": 75
     },
     "useExternalSearchRadio": {
       "left": 95,
-      "top": 97,
+      "top": 124,
       "width": 75
     },
     "searchTooltipsCheckbox": {
       "left": 10,
-      "top": 117,
+      "top": 144,
       "width": 150
     },
     "rememberCheckbox": {
       "left": 10,
-      "top": 133,
+      "top": 160,
       "width": 150
     },
     "autoFocusCheckbox": {
       "left": 10,
-      "top": 151,
+      "top": 176,
       "width": 150
     },
     "syncWithExternalCheckbox": {
       "left": 10,
-      "top": 169,
+      "top": 192,
       "width": 150
     },
     "clearExternalCheckbox": {
       "left": 10,
-      "top": 133,
+      "top": 160,
       "width": 150
     }
   }


### PR DESCRIPTION
Closes #5236, albeit using the new global terminal settings screen rather than a per-terminal setting.