### PR TITLE
Energy cell add-on extensibility, part two

### DIFF
--- a/src/main/java/appeng/block/EnergyCellBlockItem.java
+++ b/src/main/java/appeng/block/EnergyCellBlockItem.java
@@ -33,12 +33,12 @@ import net.minecraft.world.level.block.Block;
 import appeng.api.config.AccessRestriction;
 import appeng.api.config.Actionable;
 import appeng.api.implementations.items.IAEItemPowerStorage;
-import appeng.core.definitions.AEBlocks;
+import appeng.block.networking.EnergyCellBlock;
 import appeng.core.localization.Tooltips;
 
-public class AEBaseBlockItemChargeable extends AEBaseBlockItem implements IAEItemPowerStorage {
+public class EnergyCellBlockItem extends AEBaseBlockItem implements IAEItemPowerStorage {
 
-    public AEBaseBlockItemChargeable(Block block, Item.Properties props) {
+    public EnergyCellBlockItem(Block block, Item.Properties props) {
         super(block, props);
     }
 
@@ -108,19 +108,11 @@ public class AEBaseBlockItemChargeable extends AEBaseBlockItem implements IAEIte
 
     @Override
     public double getChargeRate(ItemStack stack) {
-        if (getBlock() == AEBlocks.ENERGY_CELL.block()) {
-            return 800d;
-        } else {
-            return 1600d;
-        }
+        return ((EnergyCellBlock) getBlock()).getChargeRate();
     }
 
     private double getMaxEnergyCapacity() {
-        if (getBlock() == AEBlocks.ENERGY_CELL.block()) {
-            return 200000;
-        } else {
-            return 8 * 200000;
-        }
+        return ((EnergyCellBlock) getBlock()).getMaxPower();
     }
 
     private double getInternal(ItemStack is) {

--- a/src/main/java/appeng/block/networking/EnergyCellBlock.java
+++ b/src/main/java/appeng/block/networking/EnergyCellBlock.java
@@ -43,11 +43,13 @@ public class EnergyCellBlock extends AEBaseEntityBlock<EnergyCellBlockEntity> {
     public static final IntegerProperty ENERGY_STORAGE = IntegerProperty.create("fullness", 0, MAX_FULLNESS);
 
     private final double maxPower;
+    private final double chargeRate;
     private final int priority;
 
-    public EnergyCellBlock(double maxPower, int priority) {
+    public EnergyCellBlock(double maxPower, double chargeRate, int priority) {
         super(defaultProps(AEMaterials.GLASS));
         this.maxPower = maxPower;
+        this.chargeRate = chargeRate;
         this.priority = priority;
     }
 
@@ -66,6 +68,10 @@ public class EnergyCellBlock extends AEBaseEntityBlock<EnergyCellBlockEntity> {
 
     public double getMaxPower() {
         return this.maxPower;
+    }
+
+    public double getChargeRate() {
+        return this.chargeRate;
     }
 
     public int getPriority() {

--- a/src/main/java/appeng/core/definitions/AEBlocks.java
+++ b/src/main/java/appeng/core/definitions/AEBlocks.java
@@ -46,7 +46,7 @@ import net.minecraft.world.level.material.MaterialColor;
 import appeng.api.ids.AEBlockIds;
 import appeng.block.AEBaseBlock;
 import appeng.block.AEBaseBlockItem;
-import appeng.block.AEBaseBlockItemChargeable;
+import appeng.block.EnergyCellBlockItem;
 import appeng.block.crafting.CraftingBlockItem;
 import appeng.block.crafting.CraftingMonitorBlock;
 import appeng.block.crafting.CraftingUnitBlock;
@@ -176,8 +176,8 @@ public final class AEBlocks {
     public static final BlockDefinition<EnergyAcceptorBlock> ENERGY_ACCEPTOR = block("Energy Acceptor", AEBlockIds.ENERGY_ACCEPTOR, EnergyAcceptorBlock::new);
     public static final BlockDefinition<VibrationChamberBlock> VIBRATION_CHAMBER = block("Vibration Chamber", AEBlockIds.VIBRATION_CHAMBER, VibrationChamberBlock::new);
     public static final BlockDefinition<QuartzGrowthAcceleratorBlock> QUARTZ_GROWTH_ACCELERATOR = block("Crystal Growth Accelerator", AEBlockIds.QUARTZ_GROWTH_ACCELERATOR, QuartzGrowthAcceleratorBlock::new);
-    public static final BlockDefinition<EnergyCellBlock> ENERGY_CELL = block("Energy Cell", AEBlockIds.ENERGY_CELL, () -> new EnergyCellBlock(200000.0, 200), AEBaseBlockItemChargeable::new);
-    public static final BlockDefinition<EnergyCellBlock> DENSE_ENERGY_CELL = block("Dense Energy Cell", AEBlockIds.DENSE_ENERGY_CELL, () -> new EnergyCellBlock(1600000.0, 1600), AEBaseBlockItemChargeable::new);
+    public static final BlockDefinition<EnergyCellBlock> ENERGY_CELL = block("Energy Cell", AEBlockIds.ENERGY_CELL, () -> new EnergyCellBlock(200000, 800, 200), EnergyCellBlockItem::new);
+    public static final BlockDefinition<EnergyCellBlock> DENSE_ENERGY_CELL = block("Dense Energy Cell", AEBlockIds.DENSE_ENERGY_CELL, () -> new EnergyCellBlock(1600000, 1600, 1600), EnergyCellBlockItem::new);
     public static final BlockDefinition<CreativeEnergyCellBlock> CREATIVE_ENERGY_CELL = block("Creative Energy Cell", AEBlockIds.CREATIVE_ENERGY_CELL, CreativeEnergyCellBlock::new);
 
     public static final BlockDefinition<CraftingUnitBlock> CRAFTING_UNIT = block("Crafting Unit", AEBlockIds.CRAFTING_UNIT, () -> new CraftingUnitBlock(defaultProps(Material.METAL), CraftingUnitType.UNIT));

--- a/src/main/java/appeng/init/client/InitItemModelsProperties.java
+++ b/src/main/java/appeng/init/client/InitItemModelsProperties.java
@@ -25,7 +25,7 @@ import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceLocation;
 
 import appeng.api.util.AEColor;
-import appeng.block.AEBaseBlockItemChargeable;
+import appeng.block.EnergyCellBlockItem;
 import appeng.core.AppEng;
 import appeng.core.definitions.AEItems;
 import appeng.items.tools.powered.ColorApplicatorItem;
@@ -55,17 +55,17 @@ public final class InitItemModelsProperties {
                     return col != null ? 1 : 0;
                 });
 
-        // Register the client-only item model property for chargeable items
+        // Register the client-only item model property for energy cells
         Registry.ITEM.forEach(item -> {
-            if (!(item instanceof AEBaseBlockItemChargeable chargeable)) {
+            if (!(item instanceof EnergyCellBlockItem energyCell)) {
                 return;
             }
 
-            ItemProperties.register(chargeable,
+            ItemProperties.register(energyCell,
                     ENERGY_FILL_LEVEL_ID,
                     (is, level, entity, seed) -> {
-                        double curPower = chargeable.getAECurrentPower(is);
-                        double maxPower = chargeable.getAEMaxPower(is);
+                        double curPower = energyCell.getAECurrentPower(is);
+                        double maxPower = energyCell.getAEMaxPower(is);
 
                         return (float) (curPower / maxPower);
                     });

--- a/src/main/java/appeng/items/tools/powered/PortableCellItem.java
+++ b/src/main/java/appeng/items/tools/powered/PortableCellItem.java
@@ -61,7 +61,7 @@ import appeng.api.storage.cells.IBasicCellItem;
 import appeng.api.upgrades.IUpgradeInventory;
 import appeng.api.upgrades.IUpgradeableItem;
 import appeng.api.upgrades.UpgradeInventories;
-import appeng.block.AEBaseBlockItemChargeable;
+import appeng.block.EnergyCellBlockItem;
 import appeng.core.AEConfig;
 import appeng.core.AELog;
 import appeng.core.AppEng;
@@ -190,8 +190,8 @@ public class PortableCellItem extends AEBasePoweredItem
                 var ingredientStack = ingredient.getItems()[0].copy();
 
                 // Dump remaining energy into whatever can accept it
-                if (remainingEnergy > 0 && ingredientStack.getItem() instanceof AEBaseBlockItemChargeable chargeable) {
-                    remainingEnergy = chargeable.injectAEPower(ingredientStack, remainingEnergy, Actionable.MODULATE);
+                if (remainingEnergy > 0 && ingredientStack.getItem() instanceof EnergyCellBlockItem energyCell) {
+                    remainingEnergy = energyCell.injectAEPower(ingredientStack, remainingEnergy, Actionable.MODULATE);
                 }
 
                 playerInventory.placeItemBackInInventory(ingredientStack);


### PR DESCRIPTION
First PR neglected to include the block item used by the energy cell for easier add-on instantiation.