### PR TITLE
return from REI ghost ingredient application

### DIFF
--- a/src/main/java/appeng/integration/modules/rei/GhostIngredientHandler.java
+++ b/src/main/java/appeng/integration/modules/rei/GhostIngredientHandler.java
@@ -144,6 +144,7 @@ class GhostIngredientHandler implements DraggableStackVisitor<AEBaseScreen> {
                 ItemStack itemStack = entryStack.castValue();
                 NetworkHandler.instance().sendToServer(new InventoryActionPacket(InventoryAction.SET_FILTER,
                         slot.index, itemStack));
+                return true;
             } else if (entryStack.getType() == VanillaEntryTypes.FLUID) {
                 FluidStack fluidStack = entryStack.castValue();
 
@@ -152,6 +153,7 @@ class GhostIngredientHandler implements DraggableStackVisitor<AEBaseScreen> {
                         new GenericStack(AEFluidKey.of(fluidStack.getFluid()), fluidStack.getAmount()));
                 NetworkHandler.instance().sendToServer(new InventoryActionPacket(InventoryAction.SET_FILTER,
                         slot.index, wrappedFluid));
+                return true;
             }
             return false;
         }


### PR DESCRIPTION
The current drag and drop behavior inside the `GhostIngredientHandler` loops through all possible targets and even if the current target is applicable, it doesn't return `DraggedAcceptorResult.ACCEPTED` because the `apply` method never returns true.
This PR should fix that.