### PR TITLE
Abstract/refactor portable storage cells

### DIFF
--- a/src/main/java/appeng/api/storage/cells/IBasicCellItem.java
+++ b/src/main/java/appeng/api/storage/cells/IBasicCellItem.java
@@ -35,7 +35,6 @@ import net.minecraft.world.item.ItemStack;
 import appeng.api.stacks.AEKey;
 import appeng.api.stacks.AEKeyType;
 import appeng.me.cells.BasicCellHandler;
-import appeng.util.ConfigInventory;
 
 /**
  * Implement this on any item to register a "basic cell", which is a cell that works similarly to AE2's own item and
@@ -113,8 +112,6 @@ public interface IBasicCellItem extends ICellWorkbenchItem {
      * @return drain in ae/t this storage cell will use.
      */
     double getIdleDrain();
-
-    ConfigInventory getConfigInventory(ItemStack is);
 
     /**
      * Convenient helper to append useful tooltip information.

--- a/src/main/java/appeng/api/storage/cells/ICellWorkbenchItem.java
+++ b/src/main/java/appeng/api/storage/cells/ICellWorkbenchItem.java
@@ -31,21 +31,26 @@ import appeng.util.ConfigInventory;
 
 public interface ICellWorkbenchItem extends IUpgradeableItem {
     /**
-     * if this return false, the item will not be treated as a cell, and cannot be inserted into the work bench.
+     * Determines whether or not the item should be treated as a cell and allow for configuration via a cell workbench.
+     * By default, any such item with either a filtering or upgrade inventory is thus assumed to be editable.
      *
      * @param is item
      * @return true if the item should be editable in the cell workbench.
      */
-    boolean isEditable(ItemStack is);
+    default boolean isEditable(ItemStack is) {
+        return getConfigInventory(is).size() > 0 || getUpgrades(is).size() > 0;
+    }
 
     /**
      * Used to extract, or mirror the contents of the work bench onto the cell.
      * <p>
-     * - This should have exactly 63 slots, any more, or less might cause issues.
+     * This should not exceed 63 slots. Any more than that might cause issues.
      * <p>
      * onInventoryChange will be called when saving is needed.
      */
-    ConfigInventory getConfigInventory(ItemStack is);
+    default ConfigInventory getConfigInventory(ItemStack is) {
+        return ConfigInventory.EMPTY_TYPES;
+    }
 
     /**
      * @return the current fuzzy status.

--- a/src/main/java/appeng/core/definitions/AEItems.java
+++ b/src/main/java/appeng/core/definitions/AEItems.java
@@ -57,6 +57,7 @@ import appeng.items.parts.FacadeItem;
 import appeng.items.storage.BasicStorageCell;
 import appeng.items.storage.CreativeCellItem;
 import appeng.items.storage.SpatialStorageCellItem;
+import appeng.items.storage.StorageTier;
 import appeng.items.storage.ViewCellItem;
 import appeng.items.tools.BiometricCardItem;
 import appeng.items.tools.MemoryCardItem;
@@ -71,7 +72,6 @@ import appeng.items.tools.powered.ColorApplicatorItem;
 import appeng.items.tools.powered.EntropyManipulatorItem;
 import appeng.items.tools.powered.MatterCannonItem;
 import appeng.items.tools.powered.PortableCellItem;
-import appeng.items.tools.powered.PortableCellItem.StorageTier;
 import appeng.items.tools.powered.WirelessCraftingTerminalItem;
 import appeng.items.tools.powered.WirelessTerminalItem;
 import appeng.items.tools.quartz.QuartzAxeItem;
@@ -151,17 +151,17 @@ public final class AEItems {
         return item(name, id, p -> new PortableCellItem(AEKeyType.fluids(), MEStorageMenu.PORTABLE_FLUID_CELL_TYPE, tier, p.stacksTo(1)));
     }
 
-    public static final ItemDefinition<PortableCellItem> PORTABLE_ITEM_CELL1K = makePortableItemCell(AEItemIds.PORTABLE_ITEM_CELL1K, PortableCellItem.SIZE_1K);
-    public static final ItemDefinition<PortableCellItem> PORTABLE_ITEM_CELL4K = makePortableItemCell(AEItemIds.PORTABLE_ITEM_CELL4K, PortableCellItem.SIZE_4K);
-    public static final ItemDefinition<PortableCellItem> PORTABLE_ITEM_CELL16K = makePortableItemCell(AEItemIds.PORTABLE_ITEM_CELL16K, PortableCellItem.SIZE_16K);
-    public static final ItemDefinition<PortableCellItem> PORTABLE_ITEM_CELL64K = makePortableItemCell(AEItemIds.PORTABLE_ITEM_CELL64K, PortableCellItem.SIZE_64K);
-    public static final ItemDefinition<PortableCellItem> PORTABLE_ITEM_CELL256K = makePortableItemCell(AEItemIds.PORTABLE_ITEM_CELL256K, PortableCellItem.SIZE_256K);
+    public static final ItemDefinition<PortableCellItem> PORTABLE_ITEM_CELL1K = makePortableItemCell(AEItemIds.PORTABLE_ITEM_CELL1K, StorageTier.SIZE_1K);
+    public static final ItemDefinition<PortableCellItem> PORTABLE_ITEM_CELL4K = makePortableItemCell(AEItemIds.PORTABLE_ITEM_CELL4K, StorageTier.SIZE_4K);
+    public static final ItemDefinition<PortableCellItem> PORTABLE_ITEM_CELL16K = makePortableItemCell(AEItemIds.PORTABLE_ITEM_CELL16K, StorageTier.SIZE_16K);
+    public static final ItemDefinition<PortableCellItem> PORTABLE_ITEM_CELL64K = makePortableItemCell(AEItemIds.PORTABLE_ITEM_CELL64K, StorageTier.SIZE_64K);
+    public static final ItemDefinition<PortableCellItem> PORTABLE_ITEM_CELL256K = makePortableItemCell(AEItemIds.PORTABLE_ITEM_CELL256K, StorageTier.SIZE_256K);
 
-    public static final ItemDefinition<PortableCellItem> PORTABLE_FLUID_CELL1K = makePortableFluidCell(AEItemIds.PORTABLE_FLUID_CELL1K, PortableCellItem.SIZE_1K);
-    public static final ItemDefinition<PortableCellItem> PORTABLE_FLUID_CELL4K = makePortableFluidCell(AEItemIds.PORTABLE_FLUID_CELL4K, PortableCellItem.SIZE_4K);
-    public static final ItemDefinition<PortableCellItem> PORTABLE_FLUID_CELL16K = makePortableFluidCell(AEItemIds.PORTABLE_FLUID_CELL16K, PortableCellItem.SIZE_16K);
-    public static final ItemDefinition<PortableCellItem> PORTABLE_FLUID_CELL64K = makePortableFluidCell(AEItemIds.PORTABLE_FLUID_CELL64K, PortableCellItem.SIZE_64K);
-    public static final ItemDefinition<PortableCellItem> PORTABLE_FLUID_CELL256K = makePortableFluidCell(AEItemIds.PORTABLE_FLUID_CELL256K, PortableCellItem.SIZE_256K);
+    public static final ItemDefinition<PortableCellItem> PORTABLE_FLUID_CELL1K = makePortableFluidCell(AEItemIds.PORTABLE_FLUID_CELL1K, StorageTier.SIZE_1K);
+    public static final ItemDefinition<PortableCellItem> PORTABLE_FLUID_CELL4K = makePortableFluidCell(AEItemIds.PORTABLE_FLUID_CELL4K, StorageTier.SIZE_4K);
+    public static final ItemDefinition<PortableCellItem> PORTABLE_FLUID_CELL16K = makePortableFluidCell(AEItemIds.PORTABLE_FLUID_CELL16K, StorageTier.SIZE_16K);
+    public static final ItemDefinition<PortableCellItem> PORTABLE_FLUID_CELL64K = makePortableFluidCell(AEItemIds.PORTABLE_FLUID_CELL64K, StorageTier.SIZE_64K);
+    public static final ItemDefinition<PortableCellItem> PORTABLE_FLUID_CELL256K = makePortableFluidCell(AEItemIds.PORTABLE_FLUID_CELL256K, StorageTier.SIZE_256K);
 
     ///
     /// NETWORK RELATED TOOLS

--- a/src/main/java/appeng/hotkeys/HotkeyActions.java
+++ b/src/main/java/appeng/hotkeys/HotkeyActions.java
@@ -12,7 +12,7 @@ import appeng.api.features.HotkeyAction;
 import appeng.core.AppEng;
 import appeng.core.definitions.AEItems;
 import appeng.core.definitions.ItemDefinition;
-import appeng.items.tools.powered.PortableCellItem;
+import appeng.items.tools.powered.AbstractPortableCell;
 
 /**
  * registers {@link HotkeyAction}
@@ -50,7 +50,7 @@ public class HotkeyActions {
     /**
      * a convenience helper for registering hotkeys for portable cells
      */
-    public static void registerPortableCell(ItemDefinition<PortableCellItem> cell, String id) {
+    public static void registerPortableCell(ItemDefinition<? extends AbstractPortableCell> cell, String id) {
         register(new InventoryHotkeyAction(cell.asItem(), cell.asItem()::openFromInventory), id);
     }
 

--- a/src/main/java/appeng/items/contents/PortableCellMenuHost.java
+++ b/src/main/java/appeng/items/contents/PortableCellMenuHost.java
@@ -40,19 +40,19 @@ import appeng.api.implementations.menuobjects.ItemMenuHost;
 import appeng.api.storage.MEStorage;
 import appeng.api.storage.StorageCells;
 import appeng.api.util.IConfigManager;
-import appeng.items.tools.powered.PortableCellItem;
+import appeng.items.tools.powered.AbstractPortableCell;
 import appeng.menu.ISubMenu;
 import appeng.util.ConfigManager;
 
 /**
- * Hosts the terminal interface for a {@link appeng.items.tools.powered.PortableCellItem}.
+ * Hosts the terminal interface for a {@link appeng.items.tools.powered.AbstractPortableCell}.
  */
 public class PortableCellMenuHost extends ItemMenuHost implements IPortableTerminal {
     private final BiConsumer<Player, ISubMenu> returnMainMenu;
     private final MEStorage cellStorage;
-    private final PortableCellItem item;
+    private final AbstractPortableCell item;
 
-    public PortableCellMenuHost(Player player, @Nullable Integer slot, PortableCellItem item, ItemStack itemStack,
+    public PortableCellMenuHost(Player player, @Nullable Integer slot, AbstractPortableCell item, ItemStack itemStack,
             BiConsumer<Player, ISubMenu> returnMainMenu) {
         super(player, slot, itemStack);
         Preconditions.checkArgument(itemStack.getItem() == item, "Stack doesn't match item");

--- a/src/main/java/appeng/items/storage/BasicStorageCell.java
+++ b/src/main/java/appeng/items/storage/BasicStorageCell.java
@@ -120,11 +120,6 @@ public class BasicStorageCell extends AEBaseItem implements IBasicCellItem, AETo
     }
 
     @Override
-    public boolean isEditable(ItemStack is) {
-        return true;
-    }
-
-    @Override
     public IUpgradeInventory getUpgrades(ItemStack is) {
         return UpgradeInventories.forItem(is, keyType == AEKeyType.items() ? 4 : 3);
     }

--- a/src/main/java/appeng/items/storage/CreativeCellItem.java
+++ b/src/main/java/appeng/items/storage/CreativeCellItem.java
@@ -46,11 +46,6 @@ public class CreativeCellItem extends AEBaseItem implements ICellWorkbenchItem {
     }
 
     @Override
-    public boolean isEditable(ItemStack is) {
-        return true;
-    }
-
-    @Override
     public ConfigInventory getConfigInventory(ItemStack is) {
         return CellConfig.create(is);
     }

--- a/src/main/java/appeng/items/storage/StorageTier.java
+++ b/src/main/java/appeng/items/storage/StorageTier.java
@@ -1,0 +1,21 @@
+package appeng.items.storage;
+
+import java.util.function.Supplier;
+
+import net.minecraft.core.Registry;
+import net.minecraft.world.item.Item;
+
+import appeng.api.ids.AEItemIds;
+
+public record StorageTier(int index, String namePrefix, int bytes, double idleDrain, Supplier<Item> componentSupplier) {
+    public static final StorageTier SIZE_1K = new StorageTier(1, "1k", 1024, 0.5,
+            () -> Registry.ITEM.get(AEItemIds.CELL_COMPONENT_1K));
+    public static final StorageTier SIZE_4K = new StorageTier(2, "4k", 4096, 1.0,
+            () -> Registry.ITEM.get(AEItemIds.CELL_COMPONENT_4K));
+    public static final StorageTier SIZE_16K = new StorageTier(3, "16k", 16384, 1.5,
+            () -> Registry.ITEM.get(AEItemIds.CELL_COMPONENT_16K));
+    public static final StorageTier SIZE_64K = new StorageTier(4, "64k", 65536, 2.0,
+            () -> Registry.ITEM.get(AEItemIds.CELL_COMPONENT_64K));
+    public static final StorageTier SIZE_256K = new StorageTier(5, "256k", 262144, 2.5,
+            () -> Registry.ITEM.get(AEItemIds.CELL_COMPONENT_256K));
+}

--- a/src/main/java/appeng/items/storage/ViewCellItem.java
+++ b/src/main/java/appeng/items/storage/ViewCellItem.java
@@ -94,11 +94,6 @@ public class ViewCellItem extends AEBaseItem implements ICellWorkbenchItem {
     }
 
     @Override
-    public boolean isEditable(ItemStack is) {
-        return true;
-    }
-
-    @Override
     public IUpgradeInventory getUpgrades(ItemStack is) {
         return UpgradeInventories.forItem(is, 2);
     }

--- a/src/main/java/appeng/items/tools/powered/AbstractPortableCell.java
+++ b/src/main/java/appeng/items/tools/powered/AbstractPortableCell.java
@@ -1,0 +1,222 @@
+package appeng.items.tools.powered;
+
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.InteractionResultHolder;
+import net.minecraft.world.entity.SlotAccess;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.ClickAction;
+import net.minecraft.world.inventory.MenuType;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.context.UseOnContext;
+import net.minecraft.world.item.crafting.CraftingRecipe;
+import net.minecraft.world.level.Level;
+
+import appeng.api.config.Actionable;
+import appeng.api.implementations.menuobjects.IMenuItem;
+import appeng.api.stacks.AEKey;
+import appeng.api.stacks.AEKeyType;
+import appeng.api.storage.StorageCells;
+import appeng.api.storage.StorageHelper;
+import appeng.api.storage.cells.CellState;
+import appeng.api.storage.cells.ICellWorkbenchItem;
+import appeng.api.upgrades.IUpgradeInventory;
+import appeng.api.upgrades.UpgradeInventories;
+import appeng.api.upgrades.Upgrades;
+import appeng.block.networking.EnergyCellBlockItem;
+import appeng.core.AEConfig;
+import appeng.core.AELog;
+import appeng.core.localization.PlayerMessages;
+import appeng.hooks.AEToolItem;
+import appeng.items.contents.PortableCellMenuHost;
+import appeng.items.tools.powered.powersink.AEBasePoweredItem;
+import appeng.me.helpers.PlayerSource;
+import appeng.menu.MenuOpener;
+import appeng.menu.locator.MenuLocators;
+import appeng.util.InteractionUtil;
+
+public abstract class AbstractPortableCell extends AEBasePoweredItem
+        implements ICellWorkbenchItem, IMenuItem, AEToolItem {
+
+    private final MenuType<?> menuType;
+
+    public AbstractPortableCell(MenuType<?> menuType, Properties props) {
+        super(AEConfig.instance().getPortableCellBattery(), props);
+        this.menuType = menuType;
+    }
+
+    /**
+     * Gets the recipe ID for crafting this particular cell.
+     */
+    public abstract ResourceLocation getRecipeId();
+
+    @Override
+    public abstract double getChargeRate(ItemStack stack);
+
+    /**
+     * Open a Portable Cell from a slot in the player inventory, i.e. activated via hotkey.
+     *
+     * @return True if the menu was opened.
+     */
+    public boolean openFromInventory(Player player, int inventorySlot) {
+        return openFromInventory(player, inventorySlot, false);
+    }
+
+    protected boolean openFromInventory(Player player, int inventorySlot, boolean returningFromSubmenu) {
+        var is = player.getInventory().getItem(inventorySlot);
+        if (is.getItem() == this) {
+            return MenuOpener.open(this.menuType, player, MenuLocators.forInventorySlot(inventorySlot),
+                    returningFromSubmenu);
+        } else {
+            return false;
+        }
+    }
+
+    @Nullable
+    @Override
+    public PortableCellMenuHost getMenuHost(Player player, int inventorySlot, ItemStack stack, @Nullable BlockPos pos) {
+        return new PortableCellMenuHost(player, inventorySlot, this, stack,
+                (p, sm) -> openFromInventory(p, inventorySlot, true));
+    }
+
+    @Override
+    public boolean allowNbtUpdateAnimation(Player player, InteractionHand hand, ItemStack oldStack,
+            ItemStack newStack) {
+        return false;
+    }
+
+    @Override
+    public InteractionResult onItemUseFirst(ItemStack stack, UseOnContext context) {
+        return context.isSecondaryUseActive()
+                && this.disassembleDrive(stack, context.getLevel(), context.getPlayer())
+                        ? InteractionResult.sidedSuccess(context.getLevel().isClientSide())
+                        : InteractionResult.PASS;
+    }
+
+    @Override
+    public InteractionResultHolder<ItemStack> use(Level level, Player player, InteractionHand hand) {
+        if (!InteractionUtil.isInAlternateUseMode(player)
+                || !disassembleDrive(player.getItemInHand(hand), level, player)) {
+            if (!level.isClientSide()) {
+                MenuOpener.open(this.menuType, player, MenuLocators.forHand(player, hand));
+            }
+        }
+        return new InteractionResultHolder<>(InteractionResult.sidedSuccess(level.isClientSide()),
+                player.getItemInHand(hand));
+    }
+
+    private boolean disassembleDrive(ItemStack stack, Level level, Player player) {
+        if (!AEConfig.instance().isPortableCellDisassemblyEnabled()) {
+            return false;
+        }
+
+        // We refund the crafting recipe ingredients (the first one each)
+        var recipe = level.getRecipeManager().byKey(getRecipeId()).orElse(null);
+        if (!(recipe instanceof CraftingRecipe craftingRecipe)) {
+            AELog.debug("Cannot disassemble portable cell because it's crafting recipe doesn't exist: %s",
+                    getRecipeId());
+            return false;
+        }
+
+        if (level.isClientSide()) {
+            return true;
+        }
+
+        var playerInventory = player.getInventory();
+        if (playerInventory.getSelected() != stack) {
+            return false;
+        }
+
+        var inv = StorageCells.getCellInventory(stack, null);
+        if (inv == null) {
+            return false;
+        }
+
+        if (inv.getAvailableStacks().isEmpty()) {
+            playerInventory.setItem(playerInventory.selected, ItemStack.EMPTY);
+
+            var remainingEnergy = getAECurrentPower(stack);
+            for (var ingredient : craftingRecipe.getIngredients()) {
+                var ingredientStack = ingredient.getItems()[0].copy();
+
+                // Dump remaining energy into whatever can accept it
+                if (remainingEnergy > 0 && ingredientStack.getItem() instanceof EnergyCellBlockItem energyCell) {
+                    remainingEnergy = energyCell.injectAEPower(ingredientStack, remainingEnergy, Actionable.MODULATE);
+                }
+
+                playerInventory.placeItemBackInInventory(ingredientStack);
+            }
+
+            // Drop upgrades
+            for (var upgrade : getUpgrades(stack)) {
+                playerInventory.placeItemBackInInventory(upgrade);
+            }
+        } else {
+            player.sendSystemMessage(PlayerMessages.OnlyEmptyCellsCanBeDisassembled.text());
+        }
+
+        return true;
+    }
+
+    @Override
+    public IUpgradeInventory getUpgrades(ItemStack is) {
+        return UpgradeInventories.forItem(is, 2, this::onUpgradesChanged);
+    }
+
+    public void onUpgradesChanged(ItemStack stack, IUpgradeInventory upgrades) {
+        // The energy card is crafted with a dense energy cell, while the base portable just uses a normal energy cell.
+        // Since the dense cells capacity is 8x the normal capacity, the result should be 9x normal.
+        setAEMaxPowerMultiplier(stack, 1 + Upgrades.getEnergyCardMultiplier(upgrades) * 8);
+    }
+
+    /**
+     * Tries inserting into a portable cell without having to open it.
+     *
+     * @return Amount inserted.
+     */
+    public long insert(Player player, ItemStack stack, AEKey what, AEKeyType allowed, long amount, Actionable mode) {
+        if (allowed.tryCast(what) == null) {
+            return 0;
+        }
+
+        var host = getMenuHost(player, -1, stack, null);
+        if (host == null) {
+            return 0;
+        }
+
+        var inv = host.getInventory();
+        if (inv != null) {
+            return StorageHelper.poweredInsert(host, inv, what, amount, new PlayerSource(player), mode);
+        }
+        return 0;
+    };
+
+    @Override
+    public abstract boolean overrideStackedOnOther(ItemStack stack, Slot slot, ClickAction action, Player player);
+
+    @Override
+    public abstract boolean overrideOtherStackedOnMe(ItemStack stack, ItemStack other, Slot slot, ClickAction action,
+            Player player, SlotAccess access);
+
+    public static int getColor(ItemStack stack, int tintIndex) {
+        if (tintIndex == 1 && stack.getItem() instanceof AbstractPortableCell portableCell) {
+            // If the cell is out of power, always display empty
+            if (portableCell.getAECurrentPower(stack) <= 0) {
+                return CellState.ABSENT.getStateColor();
+            }
+
+            // Determine LED color
+            var cellInv = StorageCells.getCellInventory(stack, null);
+            var cellStatus = cellInv != null ? cellInv.getStatus() : CellState.EMPTY;
+            return cellStatus.getStateColor();
+        } else {
+            // White
+            return 0xFFFFFF;
+        }
+    }
+}

--- a/src/main/java/appeng/items/tools/powered/ColorApplicatorItem.java
+++ b/src/main/java/appeng/items/tools/powered/ColorApplicatorItem.java
@@ -507,11 +507,6 @@ public class ColorApplicatorItem extends AEBasePoweredItem
     }
 
     @Override
-    public boolean isEditable(ItemStack is) {
-        return true;
-    }
-
-    @Override
     public IUpgradeInventory getUpgrades(ItemStack is) {
         return UpgradeInventories.forItem(is, 2, this::onUpgradesChanged);
     }
@@ -583,24 +578,22 @@ public class ColorApplicatorItem extends AEBasePoweredItem
         return applicator;
     }
 
-    public boolean setActiveColor(ItemStack applicator, @Nullable AEColor color) {
+    public void setActiveColor(ItemStack applicator, @Nullable AEColor color) {
         if (color == null) {
             setColor(applicator, ItemStack.EMPTY);
-            return true;
+            return;
         }
 
         var inv = StorageCells.getCellInventory(applicator, null);
         if (inv == null) {
-            return false;
+            return;
         }
 
         for (var entry : inv.getAvailableStacks()) {
             if (entry.getKey() instanceof AEItemKey itemKey && getColorFromItem(itemKey.getItem()) == color) {
                 setColor(applicator, itemKey.toStack());
-                return true;
+                return;
             }
         }
-
-        return false;
     }
 }

--- a/src/main/java/appeng/items/tools/powered/MatterCannonItem.java
+++ b/src/main/java/appeng/items/tools/powered/MatterCannonItem.java
@@ -383,11 +383,6 @@ public class MatterCannonItem extends AEBasePoweredItem implements IBasicCellIte
     }
 
     @Override
-    public boolean isEditable(ItemStack is) {
-        return true;
-    }
-
-    @Override
     public IUpgradeInventory getUpgrades(ItemStack is) {
         return UpgradeInventories.forItem(is, 4, this::onUpgradesChanged);
     }

--- a/src/main/java/appeng/items/tools/powered/PortableCellItem.java
+++ b/src/main/java/appeng/items/tools/powered/PortableCellItem.java
@@ -21,94 +21,48 @@ package appeng.items.tools.powered;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Supplier;
 
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidStorage;
-import net.minecraft.core.BlockPos;
-import net.minecraft.core.Registry;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.InteractionHand;
-import net.minecraft.world.InteractionResult;
-import net.minecraft.world.InteractionResultHolder;
 import net.minecraft.world.entity.SlotAccess;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.ClickAction;
 import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.inventory.tooltip.TooltipComponent;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
-import net.minecraft.world.item.context.UseOnContext;
-import net.minecraft.world.item.crafting.CraftingRecipe;
 import net.minecraft.world.level.Level;
 
 import appeng.api.behaviors.GenericContainerHelper;
 import appeng.api.config.Actionable;
 import appeng.api.config.FuzzyMode;
-import appeng.api.ids.AEItemIds;
-import appeng.api.implementations.menuobjects.IMenuItem;
 import appeng.api.stacks.AEFluidKey;
 import appeng.api.stacks.AEItemKey;
 import appeng.api.stacks.AEKey;
 import appeng.api.stacks.AEKeyType;
 import appeng.api.stacks.GenericStack;
-import appeng.api.storage.StorageCells;
-import appeng.api.storage.StorageHelper;
-import appeng.api.storage.cells.CellState;
 import appeng.api.storage.cells.IBasicCellItem;
 import appeng.api.upgrades.IUpgradeInventory;
-import appeng.api.upgrades.IUpgradeableItem;
 import appeng.api.upgrades.UpgradeInventories;
 import appeng.api.upgrades.Upgrades;
-import appeng.block.networking.EnergyCellBlockItem;
-import appeng.core.AEConfig;
-import appeng.core.AELog;
 import appeng.core.AppEng;
-import appeng.core.localization.PlayerMessages;
-import appeng.hooks.AEToolItem;
 import appeng.items.contents.CellConfig;
-import appeng.items.contents.PortableCellMenuHost;
-import appeng.items.tools.powered.powersink.AEBasePoweredItem;
-import appeng.me.helpers.PlayerSource;
-import appeng.menu.MenuOpener;
-import appeng.menu.locator.MenuLocators;
+import appeng.items.storage.StorageTier;
 import appeng.util.ConfigInventory;
 import appeng.util.IVariantConversion;
-import appeng.util.InteractionUtil;
 import appeng.util.fluid.FluidSoundHelper;
 
-public class PortableCellItem extends AEBasePoweredItem
-        implements IBasicCellItem, IMenuItem, IUpgradeableItem, AEToolItem {
-
-    public static final StorageTier SIZE_1K = new StorageTier("1k", 512, 54, 8,
-            () -> Registry.ITEM.get(AEItemIds.CELL_COMPONENT_1K));
-    public static final StorageTier SIZE_4K = new StorageTier("4k", 2048, 45, 32,
-            () -> Registry.ITEM.get(AEItemIds.CELL_COMPONENT_4K));
-    public static final StorageTier SIZE_16K = new StorageTier("16k", 8192, 36, 128,
-            () -> Registry.ITEM.get(AEItemIds.CELL_COMPONENT_16K));
-    public static final StorageTier SIZE_64K = new StorageTier("64k", 32768, 27, 512,
-            () -> Registry.ITEM.get(AEItemIds.CELL_COMPONENT_64K));
-    public static final StorageTier SIZE_256K = new StorageTier("256k", 131072, 18, 2048,
-            () -> Registry.ITEM.get(AEItemIds.CELL_COMPONENT_256K));
-
-    /**
-     * Gets the recipe ID for crafting this particular cell.
-     */
-    public ResourceLocation getRecipeId() {
-        return AppEng.makeId("tools/" + Objects.requireNonNull(getRegistryName()).getPath());
-    }
+public class PortableCellItem extends AbstractPortableCell implements IBasicCellItem {
 
     private final StorageTier tier;
     private final AEKeyType keyType;
-    private final MenuType<?> menuType;
 
     public PortableCellItem(AEKeyType keyType, MenuType<?> menuType, StorageTier tier, Properties props) {
-        super(AEConfig.instance().getPortableCellBattery(), props);
-        this.menuType = menuType;
+        super(menuType, props);
         this.tier = tier;
         this.keyType = keyType;
     }
@@ -118,96 +72,9 @@ public class PortableCellItem extends AEBasePoweredItem
         return 80d + 80d * Upgrades.getEnergyCardMultiplier(getUpgrades(stack));
     }
 
-    /**
-     * Open a Portable Cell from a slot in the player inventory, i.e. activated via hotkey.
-     *
-     * @return True if the menu was opened.
-     */
-    public boolean openFromInventory(Player player, int inventorySlot) {
-        return openFromInventory(player, inventorySlot, false);
-    }
-
-    protected boolean openFromInventory(Player player, int inventorySlot, boolean returningFromSubmenu) {
-        var is = player.getInventory().getItem(inventorySlot);
-        if (is.getItem() == this) {
-            return MenuOpener.open(getMenuType(), player, MenuLocators.forInventorySlot(inventorySlot),
-                    returningFromSubmenu);
-        } else {
-            return false;
-        }
-    }
-
     @Override
-    public InteractionResult onItemUseFirst(ItemStack stack, UseOnContext context) {
-        return context.isSecondaryUseActive()
-                && this.disassembleDrive(stack, context.getLevel(), context.getPlayer())
-                        ? InteractionResult.sidedSuccess(context.getLevel().isClientSide())
-                        : InteractionResult.PASS;
-    }
-
-    @Override
-    public InteractionResultHolder<ItemStack> use(Level level, Player player, InteractionHand hand) {
-        if (!InteractionUtil.isInAlternateUseMode(player)
-                || !disassembleDrive(player.getItemInHand(hand), level, player)) {
-            if (!level.isClientSide()) {
-                MenuOpener.open(getMenuType(), player, MenuLocators.forHand(player, hand));
-            }
-        }
-        return new InteractionResultHolder<>(InteractionResult.sidedSuccess(level.isClientSide()),
-                player.getItemInHand(hand));
-    }
-
-    private boolean disassembleDrive(ItemStack stack, Level level, Player player) {
-        if (!AEConfig.instance().isPortableCellDisassemblyEnabled()) {
-            return false;
-        }
-
-        // We refund the crafting recipe ingredients (the first one each)
-        var recipe = level.getRecipeManager().byKey(getRecipeId()).orElse(null);
-        if (!(recipe instanceof CraftingRecipe craftingRecipe)) {
-            AELog.debug("Cannot disassemble portable cell because it's crafting recipe doesn't exist: %s",
-                    getRecipeId());
-            return false;
-        }
-
-        if (level.isClientSide()) {
-            return true;
-        }
-
-        var playerInventory = player.getInventory();
-        if (playerInventory.getSelected() != stack) {
-            return false;
-        }
-
-        var inv = StorageCells.getCellInventory(stack, null);
-        if (inv == null) {
-            return false;
-        }
-
-        if (inv.getAvailableStacks().isEmpty()) {
-            playerInventory.setItem(playerInventory.selected, ItemStack.EMPTY);
-
-            var remainingEnergy = getAECurrentPower(stack);
-            for (var ingredient : craftingRecipe.getIngredients()) {
-                var ingredientStack = ingredient.getItems()[0].copy();
-
-                // Dump remaining energy into whatever can accept it
-                if (remainingEnergy > 0 && ingredientStack.getItem() instanceof EnergyCellBlockItem energyCell) {
-                    remainingEnergy = energyCell.injectAEPower(ingredientStack, remainingEnergy, Actionable.MODULATE);
-                }
-
-                playerInventory.placeItemBackInInventory(ingredientStack);
-            }
-
-            // Drop upgrades
-            for (var upgrade : getUpgrades(stack)) {
-                playerInventory.placeItemBackInInventory(upgrade);
-            }
-        } else {
-            player.sendSystemMessage(PlayerMessages.OnlyEmptyCellsCanBeDisassembled.text());
-        }
-
-        return true;
+    public ResourceLocation getRecipeId() {
+        return AppEng.makeId("tools/" + Objects.requireNonNull(getRegistryName()).getPath());
     }
 
     @Override
@@ -225,17 +92,17 @@ public class PortableCellItem extends AEBasePoweredItem
 
     @Override
     public int getBytes(ItemStack cellItem) {
-        return this.tier.bytes();
+        return this.tier.bytes() / 2;
     }
 
     @Override
     public int getBytesPerType(ItemStack cellItem) {
-        return this.tier.bytesPerType();
+        return this.tier.bytes() / 128;
     }
 
     @Override
     public int getTotalTypes(ItemStack cellItem) {
-        return this.tier.types();
+        return 63 - this.tier.index() * 9;
     }
 
     @Override
@@ -244,19 +111,8 @@ public class PortableCellItem extends AEBasePoweredItem
     }
 
     @Override
-    public boolean isEditable(ItemStack is) {
-        return true;
-    }
-
-    @Override
     public IUpgradeInventory getUpgrades(ItemStack is) {
-        return UpgradeInventories.forItem(is, 2, this::onUpgradesChanged);
-    }
-
-    private void onUpgradesChanged(ItemStack stack, IUpgradeInventory upgrades) {
-        // The energy card is crafted with a dense energy cell, while the portable cell just uses a normal energy cell
-        // Since the dense cells capacity is 8x the normal capacity, the result should be 9x normal.
-        setAEMaxPowerMultiplier(stack, 1 + Upgrades.getEnergyCardMultiplier(upgrades) * 8);
+        return UpgradeInventories.forItem(is, this.keyType == AEKeyType.items() ? 4 : 3, super::onUpgradesChanged);
     }
 
     @Override
@@ -280,56 +136,8 @@ public class PortableCellItem extends AEBasePoweredItem
     }
 
     @Override
-    public PortableCellMenuHost getMenuHost(Player player, int inventorySlot, ItemStack stack, BlockPos pos) {
-        return new PortableCellMenuHost(player, inventorySlot, this, stack,
-                (p, sm) -> openFromInventory(p, inventorySlot, true));
-    }
-
-    @Override
-    public boolean allowNbtUpdateAnimation(Player player, InteractionHand hand, ItemStack oldStack,
-            ItemStack newStack) {
-        return false;
-    }
-
-    /**
-     * Tries inserting into a portable cell without having to open it.
-     *
-     * @return Amount inserted.
-     */
-    public long insert(Player player, ItemStack itemStack, AEKey what, long amount, Actionable mode) {
-        if (keyType.tryCast(what) == null) {
-            return 0;
-        }
-
-        var host = getMenuHost(player, -1, itemStack, null);
-        if (host == null) {
-            return 0;
-        }
-
-        var inv = host.getInventory();
-        if (inv != null) {
-            return StorageHelper.poweredInsert(
-                    host,
-                    inv,
-                    what,
-                    amount,
-                    new PlayerSource(player),
-                    mode);
-        }
-        return 0;
-    }
-
-    public record StorageTier(String namePrefix, int bytes, int types, int bytesPerType,
-            Supplier<Item> componentSupplier) {
-    }
-
-    @Override
     public AEKeyType getKeyType() {
         return keyType;
-    }
-
-    public MenuType<?> getMenuType() {
-        return menuType;
     }
 
     @Override
@@ -345,20 +153,20 @@ public class PortableCellItem extends AEBasePoweredItem
 
         if (keyType == AEKeyType.items()) {
             AEKey key = AEItemKey.of(other);
-            int inserted = (int) insert(player, stack, key, other.getCount(), Actionable.MODULATE);
+            int inserted = (int) insert(player, stack, key, keyType, other.getCount(), Actionable.MODULATE);
             other.shrink(inserted);
 
         } else if (keyType == AEKeyType.fluids()) {
             GenericStack fluidStack = GenericContainerHelper.getContainedStack(other, FluidStorage.ITEM,
                     IVariantConversion.FLUID);
             if (fluidStack != null) {
-                if (insert(player, stack, fluidStack.what(), fluidStack.amount(), Actionable.SIMULATE) == fluidStack
-                        .amount()) {
+                if (insert(player, stack, fluidStack.what(), keyType, fluidStack.amount(),
+                        Actionable.SIMULATE) == fluidStack.amount()) {
                     var extracted = GenericContainerHelper.extractFromPlayerInventory(player,
                             (AEFluidKey) fluidStack.what(), fluidStack.amount(), other, FluidStorage.ITEM,
                             IVariantConversion.FLUID);
                     if (extracted > 0) {
-                        insert(player, stack, fluidStack.what(), extracted, Actionable.MODULATE);
+                        insert(player, stack, fluidStack.what(), keyType, extracted, Actionable.MODULATE);
                         FluidSoundHelper.playEmptySound(player, (AEFluidKey) fluidStack.what());
                     }
                 }
@@ -384,19 +192,19 @@ public class PortableCellItem extends AEBasePoweredItem
 
         if (keyType == AEKeyType.items()) {
             AEKey key = AEItemKey.of(other);
-            int inserted = (int) insert(player, stack, key, other.getCount(), Actionable.MODULATE);
+            int inserted = (int) insert(player, stack, key, keyType, other.getCount(), Actionable.MODULATE);
             other.shrink(inserted);
 
         } else if (keyType == AEKeyType.fluids()) {
             GenericStack fluidStack = GenericContainerHelper.getContainedStack(other, FluidStorage.ITEM,
                     IVariantConversion.FLUID);
             if (fluidStack != null) {
-                if (insert(player, stack, fluidStack.what(), fluidStack.amount(), Actionable.SIMULATE) == fluidStack
-                        .amount()) {
+                if (insert(player, stack, fluidStack.what(), keyType, fluidStack.amount(),
+                        Actionable.SIMULATE) == fluidStack.amount()) {
                     var extracted = GenericContainerHelper.extractFromCarried(player, (AEFluidKey) fluidStack.what(),
                             fluidStack.amount(), other, FluidStorage.ITEM, IVariantConversion.FLUID);
                     if (extracted > 0) {
-                        insert(player, stack, fluidStack.what(), extracted, Actionable.MODULATE);
+                        insert(player, stack, fluidStack.what(), keyType, extracted, Actionable.MODULATE);
                         FluidSoundHelper.playEmptySound(player, (AEFluidKey) fluidStack.what());
                     }
                 }
@@ -407,22 +215,5 @@ public class PortableCellItem extends AEBasePoweredItem
 
     public StorageTier getTier() {
         return tier;
-    }
-
-    public static int getColor(ItemStack stack, int tintIndex) {
-        if (tintIndex == 1 && stack.getItem() instanceof PortableCellItem portableCellItem) {
-            // If the cell is out of power, always display empty
-            if (portableCellItem.getAECurrentPower(stack) <= 0) {
-                return CellState.ABSENT.getStateColor();
-            }
-
-            // Determine LED color
-            var cellInv = StorageCells.getCellInventory(stack, null);
-            var cellStatus = cellInv != null ? cellInv.getStatus() : CellState.EMPTY;
-            return cellStatus.getStateColor();
-        } else {
-            // White
-            return 0xFFFFFF;
-        }
     }
 }

--- a/src/main/java/appeng/util/ConfigInventory.java
+++ b/src/main/java/appeng/util/ConfigInventory.java
@@ -32,6 +32,11 @@ import appeng.me.helpers.BaseActionSource;
 public class ConfigInventory extends GenericStackInv {
     private final boolean allowOverstacking;
 
+    /**
+     * An empty config-type inventory.
+     */
+    public static final ConfigInventory EMPTY_TYPES = ConfigInventory.configTypes(null, 0, null);
+
     protected ConfigInventory(@Nullable AEKeyFilter filter, Mode mode, int size, @Nullable Runnable listener,
             boolean allowOverstacking) {
         super(listener, mode, size);


### PR DESCRIPTION
Ideally accomplishes the following three:
- Allows for easier extensibility and support in add-ons for portable cells that use a custom cell inventory (i.e. not implementing `IBasicCellItem` in cases such as `AEKey`s with only one possible type)
- Allows simply instantiating the existing `StorageTier` record previously only used for portable cells in add-ons looking to add custom tiers
- Allows add-ons to define custom cell states with their own respective LED colours*

*TODO: Change `CellState` from an `enum` to a `record` just like storage tiers.