### PR TITLE
Fix sky stone block recipe yields

### DIFF
--- a/src/main/java/appeng/datagen/providers/recipes/DecorationBlockRecipes.java
+++ b/src/main/java/appeng/datagen/providers/recipes/DecorationBlockRecipes.java
@@ -138,7 +138,7 @@ public class DecorationBlockRecipes extends AE2RecipeProvider {
     }
 
     private void skyStoneBlock(Consumer<FinishedRecipe> consumer, BlockDefinition<?> input, BlockDefinition<?> output) {
-        ShapedRecipeBuilder.shaped(output)
+        ShapedRecipeBuilder.shaped(output, 4)
                 .pattern("aa")
                 .pattern("aa")
                 .define('a', input)


### PR DESCRIPTION
Was supposed to be a 1:1 conversion, but up until now effectively took 4 sky stone blocks to craft a single one of the next brick variant.