### PR TITLE
fix #6858

### DIFF
--- a/src/main/java/appeng/recipes/transform/TransformLogic.java
+++ b/src/main/java/appeng/recipes/transform/TransformLogic.java
@@ -62,9 +62,6 @@ public final class TransformLogic {
                     continue;
             }
 
-            missingIngredients.remove(0);
-            selectedEntities.add(entity);
-
             for (var itemEntity : itemEntities) {
                 final ItemStack other = itemEntity.getItem();
                 if (!other.isEmpty()) {


### PR DESCRIPTION
Previously the first item to be damaged in the explosion was always being counted as the first ingredient, and could be counted again as another ingredient - an artifact of these checks only being run for the first ingredient on fluid transformations.

This logic was never actually needed for fluid transformation either, and could have had the effect of allowing the first ingredient to be counted twice if it also matched another ingredient.