### PR TITLE
[Forge] make processing pattern push items uncondensed and in order to the target inventory

### DIFF
--- a/src/main/java/appeng/crafting/pattern/AEProcessingPattern.java
+++ b/src/main/java/appeng/crafting/pattern/AEProcessingPattern.java
@@ -18,6 +18,7 @@
 
 package appeng.crafting.pattern;
 
+import java.util.ArrayList;
 import java.util.Objects;
 
 import javax.annotation.Nullable;
@@ -25,7 +26,6 @@ import javax.annotation.Nullable;
 import net.minecraft.world.level.Level;
 
 import appeng.api.crafting.IPatternDetails;
-import appeng.api.crafting.IPatternDetails.IInput;
 import appeng.api.stacks.AEItemKey;
 import appeng.api.stacks.AEKey;
 import appeng.api.stacks.GenericStack;
@@ -45,10 +45,14 @@ public class AEProcessingPattern implements IPatternDetails {
 
         this.sparseInputs = ProcessingPatternEncoding.getProcessingInputs(tag);
         this.sparseOutputs = ProcessingPatternEncoding.getProcessingOutputs(tag);
-        var condensedInputs = AEPatternHelper.condenseStacks(sparseInputs);
-        this.inputs = new Input[condensedInputs.length];
+        var nonEmptySparseInputs = new ArrayList<GenericStack>();
+        for (var sparseInput : sparseInputs) {
+            if (sparseInput != null)
+                nonEmptySparseInputs.add(sparseInput);
+        }
+        this.inputs = new Input[nonEmptySparseInputs.size()];
         for (int i = 0; i < inputs.length; ++i) {
-            inputs[i] = new Input(condensedInputs[i]);
+            inputs[i] = new Input(nonEmptySparseInputs.get(i));
         }
 
         // Ordering is preserved by condenseStacks

--- a/src/main/java/appeng/crafting/pattern/EncodedPatternItem.java
+++ b/src/main/java/appeng/crafting/pattern/EncodedPatternItem.java
@@ -18,6 +18,7 @@
 
 package appeng.crafting.pattern;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.WeakHashMap;
@@ -173,16 +174,20 @@ public abstract class EncodedPatternItem extends AEBaseItem {
             first = false;
         }
 
-        first = true;
+        var sparseInputStacks = new ArrayList<GenericStack>();
         for (var anIn : in) {
-            if (anIn == null) {
-                continue;
+            for (var inputStack : anIn.getPossibleInputs()) {
+                if (inputStack == null || inputStack.what().equals(AEItemKey.of(ItemStack.EMPTY.getItem())))
+                    continue;
+                sparseInputStacks.add(
+                        new GenericStack(inputStack.what(), inputStack.amount() * anIn.getMultiplier()));
             }
+        }
+        var condensedInputStacks = AEPatternHelper.condenseStacks(sparseInputStacks.toArray(GenericStack[]::new));
 
-            var primaryInputTemplate = anIn.getPossibleInputs()[0];
-            var primaryInput = new GenericStack(primaryInputTemplate.what(),
-                    primaryInputTemplate.amount() * anIn.getMultiplier());
-            lines.add((first ? with : and).copy().append(getStackComponent(primaryInput)));
+        first = true;
+        for (var inputStack : condensedInputStacks) {
+            lines.add((first ? with : and).copy().append(getStackComponent(inputStack)));
             first = false;
         }
 

--- a/src/main/java/appeng/me/storage/ExternalStorageFacade.java
+++ b/src/main/java/appeng/me/storage/ExternalStorageFacade.java
@@ -129,10 +129,17 @@ public abstract class ExternalStorageFacade implements MEStorage {
             int slotCount = handler.getSlots();
             boolean simulate = mode == Actionable.SIMULATE;
 
-            // This uses a brute force approach and tries to jam it in every slot the inventory exposes.
-            for (int i = 0; i < slotCount && !remaining.isEmpty(); i++) {
-                remaining = handler.insertItem(i, remaining, simulate);
-            }
+            int emptySlotsOnlyTries = 1;
+            do {
+                // This uses a brute force approach and tries to jam it in every slot the inventory exposes (first try
+                // to push to empty slots only).
+                for (int i = 0; i < slotCount && !remaining.isEmpty(); i++) {
+                    if (emptySlotsOnlyTries > 0 && !handler.getStackInSlot(i).isEmpty())
+                        continue;
+
+                    remaining = handler.insertItem(i, remaining, simulate);
+                }
+            } while (emptySlotsOnlyTries-- > 0 && !remaining.isEmpty());
 
             // At this point, we still have some items left...
             if (remaining == orgInput) {


### PR DESCRIPTION
Make Pattern Provider try to push items in order to the target inventory without condensing the ItemStacks first, only then, if there are remaining items from the recipe, it tries to jam items into valid slots.