### PR TITLE
fix useTerminalUseLargeFont location error

### DIFF
--- a/src/main/java/appeng/client/gui/me/common/StackSizeRenderer.java
+++ b/src/main/java/appeng/client/gui/me/common/StackSizeRenderer.java
@@ -48,8 +48,7 @@ public class StackSizeRenderer {
         Transformation tm = new Transformation(new Vector3f(0, 0, 300), // Taken from
                 // ItemRenderer.renderItemOverlayIntoGUI
                 null, new Vector3f(scaleFactor, scaleFactor, scaleFactor), null);
-
-        renderSizeLabel(tm.getMatrix(), fontRenderer, xPos, yPos, text, false);
+        renderSizeLabel(tm.getMatrix(), fontRenderer, xPos, yPos, text, largeFonts);
     }
 
     public static void renderSizeLabel(Matrix4f matrix, Font fontRenderer, float xPos, float yPos, String text,


### PR DESCRIPTION
The last parameter of `appeng.client.gui.me.common.StackSizeRenderer.renderSizeLabel` is written to `false`.
It fixed #6875 

> The number scaled to 0.85 times is still very blurred.
> Why not use the original magnification (1x).