### PR TITLE
Fix IO port redstone button, fixes #6989

### DIFF
--- a/src/main/java/appeng/client/gui/implementations/IOPortScreen.java
+++ b/src/main/java/appeng/client/gui/implementations/IOPortScreen.java
@@ -60,6 +60,7 @@ public class IOPortScreen extends UpgradeableScreen<IOPortMenu> {
         super.updateBeforeRender();
 
         this.redstoneMode.set(this.menu.getRedStoneMode());
+        this.redstoneMode.setVisibility(menu.hasUpgrade(AEItems.REDSTONE_CARD));
         this.operationMode.set(this.menu.getOperationMode());
         this.fullMode.set(this.menu.getFullMode());
     }


### PR DESCRIPTION
fixes the redstone mode button in the IO port not respecting wether a redstone card was inserted
fixes #6989 