### PR TITLE
Hide level emitter redstone button when a crafting card is inserted

### DIFF
--- a/src/main/java/appeng/client/gui/implementations/StorageLevelEmitterScreen.java
+++ b/src/main/java/appeng/client/gui/implementations/StorageLevelEmitterScreen.java
@@ -74,6 +74,7 @@ public class StorageLevelEmitterScreen extends UpgradeableScreen<StorageLevelEmi
 
         this.redstoneMode.active = notCraftingMode;
         this.redstoneMode.set(menu.getRedStoneMode());
+        this.redstoneMode.setVisibility(notCraftingMode);
 
         this.craftingMode.set(this.menu.getCraftingMode());
         this.craftingMode.setVisibility(!notCraftingMode);


### PR DESCRIPTION
The button doesn't do anything if there's a crafting card anyway
![ezgif com-gif-maker](https://user-images.githubusercontent.com/41390862/230212524-62ecf719-0601-48e1-82be-909d7b5f4dd0.gif)
