### PR TITLE
Update Platform.getFluidDisplayName to align with FluidKeyRenderHandler

### DIFF
--- a/src/main/java/appeng/util/Platform.java
+++ b/src/main/java/appeng/util/Platform.java
@@ -31,6 +31,7 @@ import org.jetbrains.annotations.Nullable;
 
 import net.fabricmc.api.EnvType;
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
+import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariantAttributes;
 import net.fabricmc.fabric.api.transfer.v1.transaction.Transaction;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.ChatFormatting;
@@ -322,8 +323,7 @@ public class Platform {
     }
 
     public static Component getFluidDisplayName(Fluid fluid, @Nullable CompoundTag tag) {
-        // no usage of the tag, but we keep it for compatibility
-        return Component.translatable(getDescriptionId(fluid));
+        return FluidVariantAttributes.getName(FluidVariant.of(fluid, tag));
     }
 
     // tag copy is not necessary, as the tag is not modified.


### PR DESCRIPTION
fixes fluids without an in-world block being reported as Air in pattern tooltips
also fixes the display name for fluids that use the fluid tag to determine their display name