### PR TITLE
Fix issues relating to Annihilation Plane checking if it can store a block and then breaking it in two separate ticks (by doing it all in one tick)

### DIFF
--- a/src/main/java/appeng/api/behaviors/PickupStrategy.java
+++ b/src/main/java/appeng/api/behaviors/PickupStrategy.java
@@ -40,9 +40,7 @@ public interface PickupStrategy {
      */
     boolean pickUpEntity(IEnergySource energySource, PickupSink sink, Entity entity);
 
-    Result tryStartPickup(IEnergySource energySource, PickupSink sink);
-
-    void completePickup(IEnergySource energySource, PickupSink sink);
+    Result tryPickup(IEnergySource energySource, PickupSink sink);
 
     enum Result {
         /**

--- a/src/main/java/appeng/parts/automation/AnnihilationPlanePart.java
+++ b/src/main/java/appeng/parts/automation/AnnihilationPlanePart.java
@@ -72,8 +72,6 @@ public class AnnihilationPlanePart extends BasicStatePart implements IGridTickab
     @Nullable
     protected List<PickupStrategy> pickupStrategies;
 
-    private PickupStrategy pendingPickupStrategy;
-
     /**
      * Enchantments found on the plane when it was placed will be used to enchant the fake tool used for picking up
      * blocks.
@@ -287,21 +285,15 @@ public class AnnihilationPlanePart extends BasicStatePart implements IGridTickab
             return TickRateModulation.IDLE;
         }
 
-        if (pendingPickupStrategy != null) {
-            pendingPickupStrategy.completePickup(grid.getEnergyService(), this::insertIntoGrid);
-            pendingPickupStrategy = null;
-        }
-
         // Reset to allow more entity pickups
         for (var pickupStrategy : getPickupStrategies()) {
             pickupStrategy.reset();
         }
 
         for (PickupStrategy pickupStrategy : getPickupStrategies()) {
-            var pickupResult = pickupStrategy.tryStartPickup(grid.getEnergyService(), this::insertIntoGrid);
+            var pickupResult = pickupStrategy.tryPickup(grid.getEnergyService(), this::insertIntoGrid);
 
             if (pickupResult == PickupStrategy.Result.PICKED_UP) {
-                pendingPickupStrategy = pickupStrategy;
                 return TickRateModulation.URGENT;
             } else if (pickupResult == PickupStrategy.Result.CANT_STORE) {
                 // If there's a compatible block, but we can't store it, wait longer

--- a/src/main/java/appeng/parts/automation/FluidPickupStrategy.java
+++ b/src/main/java/appeng/parts/automation/FluidPickupStrategy.java
@@ -53,7 +53,7 @@ public class FluidPickupStrategy implements PickupStrategy {
     }
 
     @Override
-    public Result tryStartPickup(IEnergySource energySource, PickupSink sink) {
+    public Result tryPickup(IEnergySource energySource, PickupSink sink) {
         var blockstate = level.getBlockState(pos);
         if (blockstate.getBlock() instanceof BucketPickup bucketPickup) {
             var fluidState = blockstate.getFluidState();
@@ -91,10 +91,6 @@ public class FluidPickupStrategy implements PickupStrategy {
 
         // nothing to do here :)
         return Result.CANT_PICKUP;
-    }
-
-    @Override
-    public void completePickup(IEnergySource energySource, PickupSink sink) {
     }
 
     private boolean storeFluid(PickupSink sink, AEFluidKey what, long amount, boolean modulate) {

--- a/src/main/java/appeng/parts/automation/ItemPickupStrategy.java
+++ b/src/main/java/appeng/parts/automation/ItemPickupStrategy.java
@@ -91,7 +91,7 @@ public class ItemPickupStrategy implements PickupStrategy {
     }
 
     @Override
-    public Result tryStartPickup(IEnergySource energySource, PickupSink sink) {
+    public Result tryPickup(IEnergySource energySource, PickupSink sink) {
         if (this.isAccepting) {
             var blockState = level.getBlockState(pos);
             if (this.canHandleBlock(level, pos, blockState)) {
@@ -104,6 +104,7 @@ public class ItemPickupStrategy implements PickupStrategy {
                 var canStore = this.canStoreItemStacks(sink, items);
 
                 if (hasPower && canStore) {
+                    this.completePickup(energySource, sink, items, requiredPower, blockState);
                     return Result.PICKED_UP;
                 } else {
                     return Result.CANT_STORE;
@@ -114,17 +115,8 @@ public class ItemPickupStrategy implements PickupStrategy {
         return Result.CANT_PICKUP;
     }
 
-    @Override
-    public void completePickup(IEnergySource energySource, PickupSink sink) {
-
-        var blockState = level.getBlockState(pos);
-        if (!this.canHandleBlock(level, pos, blockState)) {
-            return;
-        }
-
-        var items = this.obtainBlockDrops(level, pos);
-        var requiredPower = this.calculateEnergyUsage(level, pos, items);
-
+    private void completePickup(IEnergySource energySource, PickupSink sink, List<ItemStack> items, float requiredPower,
+            BlockState blockState) {
         if (!this.breakBlockAndStoreExtraItems(sink, level, pos)) {
             // We failed to actually replace the block with air, or it already was the case
             return;


### PR DESCRIPTION
The problem was most obvious when you had a setup with X annihilation planes and 1 formation plane as the only storage; if multiple planes tried to pickup a block in the same tick, one will store it and the rest will drop the item on the ground, as they all succeeded on the simulated insert, but only one will be able to actually insert on the next tick. But the issue could be seen any time the networks ability to store the break result changes between the first and second break process tick (or if two loot table rolls gave different results, and only the first could actually be stored).