### PR TITLE
Fix #6849: Don't require power to connect QNBs (but they still drain power)

### DIFF
--- a/src/main/java/appeng/me/cluster/implementations/QuantumCluster.java
+++ b/src/main/java/appeng/me/cluster/implementations/QuantumCluster.java
@@ -188,7 +188,7 @@ public class QuantumCluster implements IAECluster, IActionHost {
             return false;
         }
 
-        return this.center.isPowered() && this.hasQES();
+        return this.hasQES();
     }
 
     private IGridNode getNode() {


### PR DESCRIPTION
It's QUANTUM, Baby!