### PR TITLE
Fix #6821: Client/server desync in network tool upgrade slots

### DIFF
--- a/src/main/java/appeng/items/contents/NetworkToolMenuHost.java
+++ b/src/main/java/appeng/items/contents/NetworkToolMenuHost.java
@@ -42,6 +42,7 @@ public class NetworkToolMenuHost extends ItemMenuHost implements InternalInvento
         super(player, slot, is);
         this.host = host;
         this.inv = new AppEngInternalInventory(this, 9);
+        this.inv.setEnableClientEvents(true); // Also write to NBT on the client to prevent desyncs
         this.inv.setFilter(new NetworkToolInventoryFilter());
         if (is.hasTag()) // prevent crash when opening network status screen.
         {


### PR DESCRIPTION
This causes perceived dupe bugs in creative mode because the desynced stack on the client is authoritative.