### PR TITLE
Harmonize Import/Export Bus Filter Slot Count with Storage Bus

### DIFF
--- a/src/main/java/appeng/menu/implementations/IOBusMenu.java
+++ b/src/main/java/appeng/menu/implementations/IOBusMenu.java
@@ -23,9 +23,6 @@ import net.minecraft.world.inventory.MenuType;
 
 import appeng.api.config.SecurityPermissions;
 import appeng.client.gui.implementations.IOBusScreen;
-import appeng.menu.SlotSemantics;
-import appeng.menu.slot.FakeSlot;
-import appeng.menu.slot.OptionalFakeSlot;
 import appeng.parts.automation.ExportBusPart;
 import appeng.parts.automation.IOBusPart;
 import appeng.parts.automation.ImportBusPart;
@@ -53,21 +50,7 @@ public class IOBusMenu extends UpgradeableMenu<IOBusPart> {
 
     @Override
     protected void setupConfig() {
-        var inv = this.getHost().getConfig().createMenuWrapper();
-        var s = SlotSemantics.CONFIG;
-        this.addSlot(new FakeSlot(inv, 0), s);
-
-        // Slots that become available with 1 capacity card
-        this.addSlot(new OptionalFakeSlot(inv, this, 1, 1), s);
-        this.addSlot(new OptionalFakeSlot(inv, this, 2, 1), s);
-        this.addSlot(new OptionalFakeSlot(inv, this, 3, 1), s);
-        this.addSlot(new OptionalFakeSlot(inv, this, 4, 1), s);
-
-        // Slots that become available with 2 capacity cards
-        this.addSlot(new OptionalFakeSlot(inv, this, 5, 2), s);
-        this.addSlot(new OptionalFakeSlot(inv, this, 6, 2), s);
-        this.addSlot(new OptionalFakeSlot(inv, this, 7, 2), s);
-        this.addSlot(new OptionalFakeSlot(inv, this, 8, 2), s);
+        addExpandableConfigSlots(getHost().getConfig(), 3, 3, 0);
     }
 
 }

--- a/src/main/java/appeng/parts/automation/IOBusPart.java
+++ b/src/main/java/appeng/parts/automation/IOBusPart.java
@@ -171,7 +171,7 @@ public abstract class IOBusPart extends UpgradeablePart implements IGridTickable
     }
 
     protected int availableSlots() {
-        return Math.min(1 + getInstalledUpgrades(AEItems.CAPACITY_CARD) * 4, this.getConfig().size());
+        return Math.min(9, this.getConfig().size());
     }
 
     protected int getOperationsPerTick() {


### PR DESCRIPTION
## Add sounds to Facade placement/removal based on underlying block

### [Link to Issue](https://github.com/AppliedEnergistics/Applied-Energistics-2/issues/6835)

### Summary

Increase default number of filter slots from 1 to 9. This will be done by replacing the OptionalFakeSlot types with FakeSlot types in src/main/java/appeng/menu/implementations/IOBusMenu.java.

Old
![image](https://user-images.githubusercontent.com/70811875/233222577-2be3ffcd-e1f2-4a80-9c82-65c191cff2a5.png)

Current
![image](https://user-images.githubusercontent.com/70811875/233222948-55ec943f-0461-4680-9550-0e5c3f01254a.png)
As seen in the image above, the UI needs to display the full 3x3 grid for the filter

![image](https://user-images.githubusercontent.com/70811875/233223066-a8274c5c-5234-4eb3-b31a-3a4e32b925a6.png)
It also needs to not accept capacity cards


### TODO

- [x] ~increase slot capacity from 1 to 9~
- [ ] ~remove capacity cards from eligible upgrades~
- [ ] ~update UI to reflect 9 slots instead of 1~
- [ ] Change base UI class to the same as the storage bus

---
