### PR TITLE
Sort crafting status/plan entries in GUIs

### DIFF
--- a/src/main/java/appeng/client/gui/me/crafting/CraftingCPUScreen.java
+++ b/src/main/java/appeng/client/gui/me/crafting/CraftingCPUScreen.java
@@ -176,6 +176,7 @@ public class CraftingCPUScreen<T extends CraftingCPUMenu> extends AEBaseScreen<T
         }
 
         List<CraftingStatusEntry> sortedEntries = new ArrayList<>(entries.values());
+        Collections.sort(sortedEntries);
         this.status = new CraftingStatus(
                 true,
                 status.getElapsedTime(),

--- a/src/main/java/appeng/menu/me/crafting/CraftingPlanSummary.java
+++ b/src/main/java/appeng/menu/me/crafting/CraftingPlanSummary.java
@@ -18,6 +18,8 @@
 
 package appeng.menu.me.crafting;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
@@ -126,7 +128,7 @@ public class CraftingPlanSummary {
             }
         }
 
-        var entries = ImmutableList.<CraftingPlanSummaryEntry>builder();
+        var entries = new ArrayList<CraftingPlanSummaryEntry>();
 
         var storage = grid.getStorageService().getInventory();
         var crafting = grid.getCraftingService();
@@ -151,7 +153,9 @@ public class CraftingPlanSummary {
 
         }
 
-        return new CraftingPlanSummary(job.bytes(), job.simulation(), entries.build());
+        Collections.sort(entries);
+
+        return new CraftingPlanSummary(job.bytes(), job.simulation(), List.copyOf(entries));
 
     }
 

--- a/src/main/java/appeng/menu/me/crafting/CraftingPlanSummaryEntry.java
+++ b/src/main/java/appeng/menu/me/crafting/CraftingPlanSummaryEntry.java
@@ -18,6 +18,8 @@
 
 package appeng.menu.me.crafting;
 
+import java.util.Comparator;
+
 import net.minecraft.network.FriendlyByteBuf;
 
 import appeng.api.stacks.AEKey;
@@ -26,7 +28,13 @@ import appeng.api.stacks.AEKey;
  * Describes an entry in the crafting plan which describes how many items of one type are missing, already stored in the
  * network, or have to be crafted.
  */
-public class CraftingPlanSummaryEntry {
+public class CraftingPlanSummaryEntry implements Comparable<CraftingPlanSummaryEntry> {
+    private static final Comparator<CraftingPlanSummaryEntry> COMPARATOR = Comparator
+            .comparing(CraftingPlanSummaryEntry::getMissingAmount)
+            .thenComparing(CraftingPlanSummaryEntry::getCraftAmount)
+            .thenComparing(CraftingPlanSummaryEntry::getStoredAmount)
+            .reversed();
+
     private final AEKey what;
     private final long missingAmount;
     private final long storedAmount;
@@ -53,6 +61,11 @@ public class CraftingPlanSummaryEntry {
 
     public long getCraftAmount() {
         return craftAmount;
+    }
+
+    @Override
+    public int compareTo(final CraftingPlanSummaryEntry o) {
+        return COMPARATOR.compare(this, o);
     }
 
     public void write(FriendlyByteBuf buffer) {

--- a/src/main/java/appeng/menu/me/crafting/CraftingStatusEntry.java
+++ b/src/main/java/appeng/menu/me/crafting/CraftingStatusEntry.java
@@ -32,8 +32,7 @@ import appeng.api.stacks.AEKey;
  */
 public class CraftingStatusEntry implements Comparable<CraftingStatusEntry> {
     private static final Comparator<CraftingStatusEntry> COMPARATOR = Comparator
-            .comparing(CraftingStatusEntry::getActiveAmount)
-            .thenComparing(CraftingStatusEntry::getPendingAmount)
+            .comparing((CraftingStatusEntry e) -> e.getActiveAmount() + e.getPendingAmount())
             .thenComparing(CraftingStatusEntry::getStoredAmount)
             .reversed();
 

--- a/src/main/java/appeng/menu/me/crafting/CraftingStatusEntry.java
+++ b/src/main/java/appeng/menu/me/crafting/CraftingStatusEntry.java
@@ -18,6 +18,8 @@
 
 package appeng.menu.me.crafting;
 
+import java.util.Comparator;
+
 import javax.annotation.Nullable;
 
 import net.minecraft.network.FriendlyByteBuf;
@@ -28,7 +30,13 @@ import appeng.api.stacks.AEKey;
  * Describes an entry in a crafting job, which describes how many items of one type are yet to be crafted, or currently
  * scheduled to be crafted.
  */
-public class CraftingStatusEntry {
+public class CraftingStatusEntry implements Comparable<CraftingStatusEntry> {
+    private static final Comparator<CraftingStatusEntry> COMPARATOR = Comparator
+            .comparing(CraftingStatusEntry::getActiveAmount)
+            .thenComparing(CraftingStatusEntry::getPendingAmount)
+            .thenComparing(CraftingStatusEntry::getStoredAmount)
+            .reversed();
+
     private final long serial;
     @Nullable
     private final AEKey what;
@@ -89,4 +97,8 @@ public class CraftingStatusEntry {
         return storedAmount == 0 && activeAmount == 0 && pendingAmount == 0;
     }
 
+    @Override
+    public int compareTo(final CraftingStatusEntry o) {
+        return COMPARATOR.compare(this, o);
+    }
 }


### PR DESCRIPTION
- Sorts status entries by `active + pending`, then stored.

  - We add active and stored to avoid things jumping around when processing starts and stops, while still keeping the things the system is working on "most actively" in the largest amounts at the top.

- Plan entries are sorted by missing, to craft, and then stored.