### PR TITLE
change 'useTerminalUseLargeFont' to 'terminalFontSize'

### DIFF
--- a/src/main/java/appeng/client/gui/me/common/MEStorageScreen.java
+++ b/src/main/java/appeng/client/gui/me/common/MEStorageScreen.java
@@ -583,18 +583,18 @@ public class MEStorageScreen<C extends MEStorageMenu>
                     // regardless of stack size
                     long storedAmount = entry.getStoredAmount();
                     boolean craftable = entry.isCraftable();
-                    var useLargeFonts = config.isUseLargeFonts();
+                    var terminalFont = config.getTerminalFont();
                     if (craftable && (isViewOnlyCraftable() || storedAmount <= 0)) {
-                        var craftLabelText = useLargeFonts ? GuiText.LargeFontCraft.getLocal()
+                        var craftLabelText = terminalFont.isUseLargeFonts() ? GuiText.LargeFontCraft.getLocal()
                                 : GuiText.SmallFontCraft.getLocal();
                         StackSizeRenderer.renderSizeLabel(this.font, s.x, s.y, craftLabelText);
                     } else {
-                        AmountFormat format = useLargeFonts ? AmountFormat.PREVIEW_LARGE_FONT
+                        AmountFormat format = terminalFont.isUseLargeFonts() ? AmountFormat.PREVIEW_LARGE_FONT
                                 : AmountFormat.PREVIEW_REGULAR;
                         var text = entry.getWhat().formatAmount(storedAmount, format);
-                        StackSizeRenderer.renderSizeLabel(this.font, s.x, s.y, text, useLargeFonts);
+                        StackSizeRenderer.renderSizeLabel(this.font, s.x, s.y, text, terminalFont.getFontSize());
                         if (craftable) {
-                            StackSizeRenderer.renderSizeLabel(this.font, s.x - 11, s.y - 11, "+", false);
+                            StackSizeRenderer.renderSizeLabel(this.font, s.x - 11, s.y - 11, "+", terminalFont.getFontSize());
                         }
                     }
                 }

--- a/src/main/java/appeng/client/gui/me/common/StackSizeRenderer.java
+++ b/src/main/java/appeng/client/gui/me/common/StackSizeRenderer.java
@@ -39,42 +39,36 @@ import appeng.core.AEConfig;
  */
 public class StackSizeRenderer {
     public static void renderSizeLabel(Font fontRenderer, float xPos, float yPos, String text) {
-        renderSizeLabel(fontRenderer, xPos, yPos, text, AEConfig.instance().isUseLargeFonts());
+        renderSizeLabel(fontRenderer, xPos, yPos, text, AEConfig.instance().getTerminalFont().getFontSize());
     }
 
-    public static void renderSizeLabel(Font fontRenderer, float xPos, float yPos, String text, boolean largeFonts) {
-        final float scaleFactor = largeFonts ? 0.85f : 0.5f;
-
+    public static void renderSizeLabel(Font fontRenderer, float xPos, float yPos, String text, float fontSize) {
         Transformation tm = new Transformation(new Vector3f(0, 0, 300), // Taken from
                 // ItemRenderer.renderItemOverlayIntoGUI
-                null, new Vector3f(scaleFactor, scaleFactor, scaleFactor), null);
-        renderSizeLabel(tm.getMatrix(), fontRenderer, xPos, yPos, text, largeFonts);
+                null, new Vector3f(fontSize, fontSize, fontSize), null);
+        renderSizeLabel(tm.getMatrix(), fontRenderer, xPos, yPos, text, fontSize);
     }
 
-    public static void renderSizeLabel(Matrix4f matrix, Font fontRenderer, float xPos, float yPos, String text,
-            boolean largeFonts) {
-        final float scaleFactor = largeFonts ? 0.85f : 0.5f;
-        final float inverseScaleFactor = 1.0f / scaleFactor;
-        final int offset = largeFonts ? 0 : -1;
+    public static void renderSizeLabel(Matrix4f matrix, Font fontRenderer, float xPos, float yPos, String text, float fontSize) {
+        System.out.println(fontSize);
+        final float inverseScaleFactor = 1.0f / fontSize;
+        final float offset = fontSize * 2 - 2;
 
         RenderSystem.disableBlend();
-        final int X = (int) ((xPos + offset + 16.0f - fontRenderer.width(text) * scaleFactor)
+        final int X = (int) ((xPos + offset + 16.0f - fontRenderer.width(text) * fontSize)
                 * inverseScaleFactor);
-        final int Y = (int) ((yPos + offset + 16.0f - 7.0f * scaleFactor) * inverseScaleFactor);
+        final int Y = (int) ((yPos + offset + 16.0f - 7.0f * fontSize) * inverseScaleFactor);
         BufferSource buffer = MultiBufferSource.immediate(Tesselator.getInstance().getBuilder());
         fontRenderer.drawInBatch(text, X, Y, 0xffffff, true, matrix, buffer, false, 0, 15728880);
         buffer.endBatch();
         RenderSystem.enableBlend();
     }
 
-    public static void renderSizeLabel(PoseStack stack, Font fontRenderer, float xPos, float yPos, String text,
-            boolean largeFonts) {
-        final float scaleFactor = largeFonts ? 0.85f : 0.5f;
-
+    public static void renderSizeLabel(PoseStack stack, Font fontRenderer, float xPos, float yPos, String text, float fontSize) {
         stack.pushPose();
-        stack.scale(scaleFactor, scaleFactor, scaleFactor);
+        stack.scale(fontSize, fontSize, fontSize);
 
-        renderSizeLabel(stack.last().pose(), fontRenderer, xPos, yPos, text, largeFonts);
+        renderSizeLabel(stack.last().pose(), fontRenderer, xPos, yPos, text, fontSize);
 
         stack.popPose();
     }

--- a/src/main/java/appeng/client/gui/me/items/PatternEncodingTermScreen.java
+++ b/src/main/java/appeng/client/gui/me/items/PatternEncodingTermScreen.java
@@ -23,6 +23,7 @@ import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 
+import appeng.util.TerminalFont;
 import com.mojang.blaze3d.vertex.PoseStack;
 
 import net.minecraft.ChatFormatting;
@@ -155,7 +156,7 @@ public class PatternEncodingTermScreen<C extends PatternEncodingTermMenu> extend
         super.renderSlot(poseStack, s);
 
         if (shouldShowCraftableIndicatorForSlot(s)) {
-            StackSizeRenderer.renderSizeLabel(this.font, s.x - 11, s.y - 11, "+", false);
+            StackSizeRenderer.renderSizeLabel(this.font, s.x - 11, s.y - 11, "+", TerminalFont.DEFAULT_SIZE);
         }
     }
 

--- a/src/main/java/appeng/client/render/StorageCellClientTooltipComponent.java
+++ b/src/main/java/appeng/client/render/StorageCellClientTooltipComponent.java
@@ -1,5 +1,6 @@
 package appeng.client.render;
 
+import appeng.util.TerminalFont;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Matrix4f;
 
@@ -103,7 +104,7 @@ public class StorageCellClientTooltipComponent implements ClientTooltipComponent
             xoff = 0;
             for (var stack : content) {
                 var amtText = stack.what().formatAmount(stack.amount(), AmountFormat.PREVIEW_REGULAR);
-                StackSizeRenderer.renderSizeLabel(poseStack, font, x + xoff, y, amtText, false);
+                StackSizeRenderer.renderSizeLabel(poseStack, font, x + xoff, y, amtText, TerminalFont.DEFAULT_SIZE);
                 xoff += 17;
             }
             poseStack.popPose();

--- a/src/main/java/appeng/core/AEConfig.java
+++ b/src/main/java/appeng/core/AEConfig.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
+import appeng.util.TerminalFont;
 import com.google.common.base.Strings;
 
 import net.minecraft.core.Registry;
@@ -130,7 +131,7 @@ public final class AEConfig {
     // Misc
     private int formationPlaneEntityLimit;
     private boolean enableEffects;
-    private boolean useLargeFonts;
+    private TerminalFont terminalFont;
     private boolean useColoredCraftingStatus;
     private boolean disableColoredCableRecipesInJEI;
     private boolean isEnableFacadesInJEI;
@@ -170,7 +171,7 @@ public final class AEConfig {
         this.isEnableFacadesInJEI = CLIENT.enableFacadesInJEI.get();
         this.isEnableFacadeRecipesInJEI = CLIENT.enableFacadeRecipesInJEI.get();
         this.enableEffects = CLIENT.enableEffects.get();
-        this.useLargeFonts = CLIENT.useLargeFonts.get();
+        this.terminalFont = new TerminalFont(CLIENT.terminalFontSize.get());
         this.useColoredCraftingStatus = CLIENT.useColoredCraftingStatus.get();
     }
 
@@ -330,8 +331,8 @@ public final class AEConfig {
         return this.enableEffects;
     }
 
-    public boolean isUseLargeFonts() {
-        return this.useLargeFonts;
+    public TerminalFont getTerminalFont() {
+        return this.terminalFont;
     }
 
     public boolean isUseColoredCraftingStatus() {
@@ -553,7 +554,7 @@ public final class AEConfig {
 
         // Misc
         public final BooleanOption enableEffects;
-        public final BooleanOption useLargeFonts;
+        public final DoubleOption terminalFontSize;
         public final BooleanOption useColoredCraftingStatus;
         public final BooleanOption disableColoredCableRecipesInJEI;
         public final BooleanOption enableFacadesInJEI;
@@ -590,7 +591,7 @@ public final class AEConfig {
             this.enableFacadeRecipesInJEI = client.addBoolean("enableFacadeRecipesInJEI", true,
                     "Show facade recipes in JEI for supported blocks");
             this.enableEffects = client.addBoolean("enableEffects", true);
-            this.useLargeFonts = client.addBoolean("useTerminalUseLargeFont", false);
+            this.terminalFontSize = client.addDouble("terminalFontSize", 0.5, "Font size on each slot in AE UIs");
             this.useColoredCraftingStatus = client.addBoolean("useColoredCraftingStatus", true);
             this.selectedPowerUnit = client.addEnum("PowerUnit", PowerUnits.AE, "Power unit shown in AE UIs");
             this.debugGuiOverlays = client.addBoolean("showDebugGuiOverlays", false, "Show debugging GUI overlays");

--- a/src/main/java/appeng/core/localization/Tooltips.java
+++ b/src/main/java/appeng/core/localization/Tooltips.java
@@ -139,7 +139,7 @@ public final class Tooltips {
     public static boolean shouldShowAmountTooltip(AEKey what, long amount) {
         // TODO: Now that we can show fractional numbers, this approach of detecting whether the formatted amount has
         // been abbreviated or rounded no longer works
-        var bigNumber = AEConfig.instance().isUseLargeFonts() ? 999L : 9999L;
+        var bigNumber = AEConfig.instance().getTerminalFont().isUseLargeFonts() ? 999L : 9999L;
         return amount > bigNumber * what.getAmountPerUnit()
                 // Unit symbols are never shown in slots and must be shown in the tooltip instead
                 || what.getUnitSymbol() != null

--- a/src/main/java/appeng/hooks/ItemRendererHooks.java
+++ b/src/main/java/appeng/hooks/ItemRendererHooks.java
@@ -17,6 +17,7 @@
  */
 package appeng.hooks;
 
+import appeng.util.TerminalFont;
 import com.mojang.blaze3d.vertex.PoseStack;
 
 import net.minecraft.client.Minecraft;
@@ -80,7 +81,7 @@ public final class ItemRendererHooks {
             if (unwrapped.amount() > 0) {
                 String amtText = unwrapped.what().formatAmount(unwrapped.amount(), AmountFormat.PREVIEW_REGULAR);
                 Font font = minecraft.font;
-                StackSizeRenderer.renderSizeLabel(font, x, y, amtText, false);
+                StackSizeRenderer.renderSizeLabel(font, x, y, amtText, TerminalFont.DEFAULT_SIZE);
             }
 
             return true;

--- a/src/main/java/appeng/util/TerminalFont.java
+++ b/src/main/java/appeng/util/TerminalFont.java
@@ -1,5 +1,8 @@
 package appeng.util;
 
+/**
+ * {@link appeng.core.AEConfig.terminalFont AEConfig.terminalFont }
+ */
 public class TerminalFont {
     public static final float DEFAULT_SIZE = 0.5f;
     private final float fontSize;

--- a/src/main/java/appeng/util/TerminalFont.java
+++ b/src/main/java/appeng/util/TerminalFont.java
@@ -1,0 +1,20 @@
+package appeng.util;
+
+public class TerminalFont {
+    public static final float DEFAULT_SIZE = 0.5f;
+    private final float fontSize;
+    private final boolean isLargeFont;
+
+    public TerminalFont(double fontSize) {
+        this.fontSize = (float) fontSize;
+        this.isLargeFont = this.fontSize >= 0.85f;
+    }
+
+    public float getFontSize() {
+        return fontSize;
+    }
+
+    public boolean isUseLargeFonts() {
+        return isLargeFont;
+    }
+}


### PR DESCRIPTION
When `useTerminalUseLargeFont` is set to `true`, the scaling factor of 0.85 is still blurry when the `GUI scale` is 1 or 2.
I changed `useTerminalUseLargeFont` to `terminalFontSize`. it accept a double(converted to float in the code) value
If possible, I can port it to other branches