### PR TITLE
Fix #6725: Too many items in the system, prevents items from showing up

### DIFF
--- a/src/main/java/appeng/core/sync/packets/MEInventoryUpdatePacket.java
+++ b/src/main/java/appeng/core/sync/packets/MEInventoryUpdatePacket.java
@@ -48,7 +48,7 @@ public class MEInventoryUpdatePacket extends BasePacket {
     /**
      * Maximum size of a single packet before it will be flushed forcibly.
      */
-    private static final int UNCOMPRESSED_PACKET_BYTE_LIMIT = 512 * 1024 * 1024;
+    private static final int UNCOMPRESSED_PACKET_BYTE_LIMIT = 512 * 1024;
 
     /**
      * Initial buffer size for an update packet.


### PR DESCRIPTION
We already had the proper packet splitting logic, however it was splitting at 512 MiB instead of splitting at 512 KiB... :smile: