### PR TITLE
Fix Missing Particle Texture in block/cube

### DIFF
--- a/src/main/java/appeng/datagen/providers/models/BlockModelProvider.java
+++ b/src/main/java/appeng/datagen/providers/models/BlockModelProvider.java
@@ -228,6 +228,7 @@ public class BlockModelProvider extends AE2BlockStateProvider {
                 makeId("block/vibration_chamber_front"),
                 makeId("block/vibration_chamber_back"),
                 makeId("block/vibration_chamber"),
+                makeId("block/vibration_chamber"),
                 makeId("block/vibration_chamber"));
         var onModel = models().cube(
                 modelPath(AEBlocks.VIBRATION_CHAMBER) + "_on",
@@ -235,6 +236,7 @@ public class BlockModelProvider extends AE2BlockStateProvider {
                 makeId("block/vibration_chamber_top_on"),
                 makeId("block/vibration_chamber_front_on"),
                 makeId("block/vibration_chamber_back_on"),
+                makeId("block/vibration_chamber_on"),
                 makeId("block/vibration_chamber_on"),
                 makeId("block/vibration_chamber_on"));
 

--- a/src/portaforgy/java/net/minecraftforge/client/model/generators/ModelProvider.java
+++ b/src/portaforgy/java/net/minecraftforge/client/model/generators/ModelProvider.java
@@ -105,14 +105,15 @@ public abstract class ModelProvider<T extends ModelBuilder<T>> implements DataPr
         return getBuilder(name).parent(getExistingFile(parent));
     }
 
-    public T cube(String name, ResourceLocation down, ResourceLocation up, ResourceLocation north, ResourceLocation south, ResourceLocation east, ResourceLocation west) {
+    public T cube(String name, ResourceLocation down, ResourceLocation up, ResourceLocation north, ResourceLocation south, ResourceLocation east, ResourceLocation west, ResourceLocation particle) {
         return withExistingParent(name, "cube")
                 .texture("down", down)
                 .texture("up", up)
                 .texture("north", north)
                 .texture("south", south)
                 .texture("east", east)
-                .texture("west", west);
+                .texture("west", west)
+                .texture("particle", particle);
     }
 
     private T singleTexture(String name, String parent, ResourceLocation texture) {


### PR DESCRIPTION
minecraft's parent block/cube model doesn't have a defined break particle, so we have to define one ourselves in ModelProvider.java for the generic block model datagen to work correctly.