### PR TITLE
Allow switching between access points when a wireless terminal menu is open

### DIFF
--- a/src/main/java/appeng/helpers/WirelessTerminalMenuHost.java
+++ b/src/main/java/appeng/helpers/WirelessTerminalMenuHost.java
@@ -133,7 +133,8 @@ public class WirelessTerminalMenuHost extends ItemMenuHost implements IPortableT
             // else: Did not have an AP yet, or no longer in range of current AP. Try to find one we are in range of.
 
             for (var wap : this.targetGrid.getMachines(WirelessBlockEntity.class)) {
-                // `this.myWap` either already returned false for `this.testWap(this.myWap)`, or is null. no need to check it again
+                // `this.myWap` either already returned false for `this.testWap(this.myWap)`, or is null. no need to
+                // check it again
                 if (wap != this.myWap && this.testWap(wap)) {
                     this.myWap = wap;
                     // break now, if multiple APs are in range we just take the first one we find

--- a/src/main/java/appeng/helpers/WirelessTerminalMenuHost.java
+++ b/src/main/java/appeng/helpers/WirelessTerminalMenuHost.java
@@ -119,12 +119,21 @@ public class WirelessTerminalMenuHost extends ItemMenuHost implements IPortableT
 
         if (this.targetGrid != null) {
             if (this.myWap != null) {
-                return this.myWap.getGrid() == this.targetGrid && this.testWap(this.myWap);
+                if (this.myWap.getGrid() != this.targetGrid) {
+                    return false;
+                }
+                if (this.testWap(this.myWap)) {
+                    return true;
+                }
             }
 
             for (var wap : this.targetGrid.getMachines(WirelessBlockEntity.class)) {
+                if (wap == this.myWap) {
+                    continue;
+                }
                 if (this.testWap(wap)) {
                     this.myWap = wap;
+                    break;
                 }
             }
 

--- a/src/main/java/appeng/helpers/WirelessTerminalMenuHost.java
+++ b/src/main/java/appeng/helpers/WirelessTerminalMenuHost.java
@@ -119,20 +119,24 @@ public class WirelessTerminalMenuHost extends ItemMenuHost implements IPortableT
 
         if (this.targetGrid != null) {
             if (this.myWap != null) {
+                // If the grid changed, give up
                 if (this.myWap.getGrid() != this.targetGrid) {
                     return false;
                 }
+
                 if (this.testWap(this.myWap)) {
+                    // Still in range of current AP
                     return true;
                 }
             }
 
+            // else: Did not have an AP yet, or no longer in range of current AP. Try to find one we are in range of.
+
             for (var wap : this.targetGrid.getMachines(WirelessBlockEntity.class)) {
-                if (wap == this.myWap) {
-                    continue;
-                }
-                if (this.testWap(wap)) {
+                // `this.myWap` either already returned false for `this.testWap(this.myWap)`, or is null. no need to check it again
+                if (wap != this.myWap && this.testWap(wap)) {
                     this.myWap = wap;
+                    // break now, if multiple APs are in range we just take the first one we find
                     break;
                 }
             }


### PR DESCRIPTION
This allows the menu to stay open if you are moving between the range of 2+ APs while the menu is open, for example if you are in a mine cart, or are flying from one area to another with some momentum as you open the menu.