### PR TITLE
Prevent mobs from pathfinding through cables

### DIFF
--- a/src/main/java/appeng/block/networking/CableBusBlock.java
+++ b/src/main/java/appeng/block/networking/CableBusBlock.java
@@ -59,6 +59,7 @@ import net.minecraft.world.level.block.state.properties.BooleanProperty;
 import net.minecraft.world.level.block.state.properties.IntegerProperty;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.level.material.Fluids;
+import net.minecraft.world.level.pathfinder.PathComputationType;
 import net.minecraft.world.level.storage.loot.LootContext;
 import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
 import net.minecraft.world.phys.BlockHitResult;
@@ -105,6 +106,11 @@ public class CableBusBlock extends AEBaseEntityBlock<CableBusBlockEntity> implem
     @Override
     public boolean propagatesSkylightDown(BlockState state, BlockGetter reader, BlockPos pos) {
         return true;
+    }
+
+    @Override
+    public boolean isPathfindable(BlockState state, BlockGetter reader, BlockPos pos, PathComputationType type) {
+        return false;
     }
 
     @Override


### PR DESCRIPTION
Addresses issue [#7042](https://github.com/AppliedEnergistics/Applied-Energistics-2/issues/7042).

### Summary ###
Imported ```pathfinder.PathComputationType``` library and overrode ```isPathfindable``` to ```false```. 

Modifed only ```src/main/java/appeng/block/networking/CableBusBlock.java```. 

### **Testing** ###
Already described in the issue but is reiterated here:

- ### Without the fix ###

Hostile mobs, such as zombies, will see through the cables and attempt to walk through the cables, only being stopped by the physical cables.
Allays will see a dropped item through the cables and attempt to fly through the cables, only occasionally being stopped by the physical cables due to the thinner cables not being as wide as a normal block.

- ### With the fix ###

Hostile mobs, such as zombies, will still see through the cables but will navigate around the cables to reach either the player or a villager.
Allays don't seem to see dropped items through the cables. However, once guided around the cables, allays will pick up the dropped item and navigate around the cables to deliver them to the player.

The cables still function as normal as my fix didn't change how the cables worked. 