### PR TITLE
Add close hotkey for wireless terminals/portable cells

### DIFF
--- a/src/main/java/appeng/client/Hotkeys.java
+++ b/src/main/java/appeng/client/Hotkeys.java
@@ -27,4 +27,8 @@ public class Hotkeys {
     public static void checkHotkeys() {
         HOTKEYS.forEach((name, hotkey) -> hotkey.check());
     }
+
+    public static Hotkey getHotkeyMapping(String key) {
+        return HOTKEYS.get(key);
+    }
 }


### PR DESCRIPTION
Mostly functional but needs some work, just wanted to get some eyes on it. I am new to the Minecraft modding scene as well.

I still have the following concerns about my code:

1. I could not find a good way to retrieve the existing hotkey bindings so that I could check them. I am certain I am missing something obvious.
2. I could not determine how to distinguish a portable fluid cell from a portable item cell. Again, probably missing something very obvious. As such, using the hotkey to close the portable fluid cell is not implemented at the moment.

If it is inappropriate to use the pull request feature to discuss implementation let me know how best to accommodate your workflow.

Fixes #7020 