### PR TITLE
Fix #7231: Export bus not exporting items in slots past the first

### DIFF
--- a/src/main/java/appeng/client/gui/implementations/IOBusScreen.java
+++ b/src/main/java/appeng/client/gui/implementations/IOBusScreen.java
@@ -78,7 +78,6 @@ public class IOBusScreen extends UpgradeableScreen<IOBusMenu> {
         }
         if (this.schedulingMode != null) {
             this.schedulingMode.set(menu.getSchedulingMode());
-            this.schedulingMode.setVisibility(menu.hasUpgrade(AEItems.CAPACITY_CARD));
         }
     }
 

--- a/src/main/java/appeng/parts/automation/IOBusPart.java
+++ b/src/main/java/appeng/parts/automation/IOBusPart.java
@@ -177,7 +177,7 @@ public abstract class IOBusPart extends UpgradeablePart implements IGridTickable
     }
 
     protected int availableSlots() {
-        return Math.min(1 + getInstalledUpgrades(AEItems.CAPACITY_CARD) * 4, this.getConfig().size());
+        return Math.min(18 + getInstalledUpgrades(AEItems.CAPACITY_CARD) * 9, this.getConfig().size());
     }
 
     protected int getOperationsPerTick() {


### PR DESCRIPTION
Also fixes export mode toggle only being visible with a capacity card.