### PR TITLE
Fix the initial Orientation of Skystone Chests

### DIFF
--- a/src/main/java/appeng/api/orientation/FacingStrategy.java
+++ b/src/main/java/appeng/api/orientation/FacingStrategy.java
@@ -16,12 +16,16 @@ import net.minecraft.world.level.block.state.properties.Property;
 class FacingStrategy implements IOrientationStrategy {
     private final DirectionProperty property;
     private final List<Property<?>> properties;
-    private final boolean attached;
+    private final boolean allowsPlayerRotation;
 
-    public FacingStrategy(DirectionProperty property, boolean attached) {
+    public FacingStrategy(DirectionProperty property) {
+        this(property, true);
+    }
+
+    public FacingStrategy(DirectionProperty property, boolean allowsPlayerRotation) {
         this.property = property;
         this.properties = Collections.singletonList(property);
-        this.attached = attached;
+        this.allowsPlayerRotation = allowsPlayerRotation;
     }
 
     @Override
@@ -40,6 +44,11 @@ class FacingStrategy implements IOrientationStrategy {
     @Override
     public BlockState getStateForPlacement(BlockState state, BlockPlaceContext context) {
         return setFacing(state, context.getClickedFace());
+    }
+
+    @Override
+    public boolean allowsPlayerRotation() {
+        return allowsPlayerRotation;
     }
 
     @Override

--- a/src/main/java/appeng/api/orientation/HorizontalFacingStrategy.java
+++ b/src/main/java/appeng/api/orientation/HorizontalFacingStrategy.java
@@ -1,0 +1,20 @@
+package appeng.api.orientation;
+
+import net.minecraft.world.item.context.BlockPlaceContext;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+
+/**
+ * Implements a strategy that allows blocks to be oriented using a single directional property. It doesn't allow up and
+ * down, and uses the player facing instead in those cases.
+ */
+class HorizontalFacingStrategy extends FacingStrategy {
+    public HorizontalFacingStrategy() {
+        super(BlockStateProperties.HORIZONTAL_FACING);
+    }
+
+    @Override
+    public BlockState getStateForPlacement(BlockState state, BlockPlaceContext context) {
+        return setFacing(state, context.getHorizontalDirection().getOpposite());
+    }
+}

--- a/src/main/java/appeng/api/orientation/IOrientationStrategy.java
+++ b/src/main/java/appeng/api/orientation/IOrientationStrategy.java
@@ -75,6 +75,13 @@ public interface IOrientationStrategy {
     }
 
     /**
+     * Indicates that this orientation can be changed by the player (i.e. by wrench).
+     */
+    default boolean allowsPlayerRotation() {
+        return true;
+    }
+
+    /**
      * @return The block state properties used for storing orientation by this strategy.
      */
     Collection<Property<?>> getProperties();

--- a/src/main/java/appeng/api/orientation/OrientationStrategies.java
+++ b/src/main/java/appeng/api/orientation/OrientationStrategies.java
@@ -7,10 +7,10 @@ import net.minecraft.world.level.block.state.properties.BlockStateProperties;
  */
 public final class OrientationStrategies {
     private static final IOrientationStrategy none = new NoOrientationStrategy();
-    private static final IOrientationStrategy horizontalFacing = new FacingStrategy(
-            BlockStateProperties.HORIZONTAL_FACING, false);
-    private static final IOrientationStrategy facing = new FacingStrategy(BlockStateProperties.FACING, false);
-    private static final IOrientationStrategy facingAttached = new FacingStrategy(BlockStateProperties.FACING, true);
+    private static final IOrientationStrategy horizontalFacing = new HorizontalFacingStrategy();
+    private static final IOrientationStrategy facing = new FacingStrategy(BlockStateProperties.FACING);
+    private static final IOrientationStrategy facingNoPlayerRotation = new FacingStrategy(BlockStateProperties.FACING,
+            false);
     private static final IOrientationStrategy full = new FacingWithSpinStrategy();
 
     /**
@@ -25,23 +25,17 @@ public final class OrientationStrategies {
     }
 
     /**
-     * Block can be oriented in 6 directions, but not swivel around that axis. Semantically the block is attached to the
-     * face of another block, but the facing points away from the side it is attached to. This influences how the
-     * default placement is deduced.
+     * Block can be oriented in 6 directions, but not swivel around that axis.
      */
-    public static IOrientationStrategy facingAttached(boolean allowRotation) {
-        return facingAttached;
-    }
-
-    public static IOrientationStrategy facingAttached() {
-        return facingAttached(true);
+    public static IOrientationStrategy facing() {
+        return facing;
     }
 
     /**
      * Block can be oriented in 6 directions, but not swivel around that axis.
      */
-    public static IOrientationStrategy facing() {
-        return facing;
+    public static IOrientationStrategy facingNoPlayerRotation() {
+        return facingNoPlayerRotation;
     }
 
     /**

--- a/src/main/java/appeng/block/networking/WirelessAccessPointBlock.java
+++ b/src/main/java/appeng/block/networking/WirelessAccessPointBlock.java
@@ -190,7 +190,7 @@ public class WirelessAccessPointBlock extends AEBaseEntityBlock<WirelessAccessPo
 
     @Override
     public IOrientationStrategy getOrientationStrategy() {
-        return OrientationStrategies.facingAttached();
+        return OrientationStrategies.facing();
     }
 
     @Override

--- a/src/main/java/appeng/block/paint/PaintSplotchesBlock.java
+++ b/src/main/java/appeng/block/paint/PaintSplotchesBlock.java
@@ -68,7 +68,7 @@ public class PaintSplotchesBlock extends AEBaseEntityBlock<PaintSplotchesBlockEn
 
     @Override
     public IOrientationStrategy getOrientationStrategy() {
-        return OrientationStrategies.facingAttached(false);
+        return OrientationStrategies.facingNoPlayerRotation();
     }
 
     @Override

--- a/src/main/java/appeng/hooks/WrenchHook.java
+++ b/src/main/java/appeng/hooks/WrenchHook.java
@@ -53,20 +53,21 @@ public final class WrenchHook {
             var pos = hitResult.getBlockPos();
             var state = level.getBlockState(pos);
             var strategy = IOrientationStrategy.get(state);
+            if (strategy.allowsPlayerRotation()) {
+                var clickedFace = hitResult.getDirection();
+                var orientation = BlockOrientation.get(strategy, state);
+                orientation = orientation.rotateClockwiseAround(clickedFace);
+                var newState = strategy.setOrientation(state, orientation.getSide(RelativeSide.FRONT),
+                        orientation.getSpin());
 
-            var clickedFace = hitResult.getDirection();
-            var orientation = BlockOrientation.get(strategy, state);
-            orientation = orientation.rotateClockwiseAround(clickedFace);
-            var newState = strategy.setOrientation(state, orientation.getSide(RelativeSide.FRONT),
-                    orientation.getSpin());
+                if (newState != state && newState.canSurvive(level, pos)) {
+                    if (!Platform.hasPermissions(new DimensionalBlockPos(level, hitResult.getBlockPos()), player)) {
+                        return InteractionResult.FAIL;
+                    }
 
-            if (newState != state && newState.canSurvive(level, pos)) {
-                if (!Platform.hasPermissions(new DimensionalBlockPos(level, hitResult.getBlockPos()), player)) {
-                    return InteractionResult.FAIL;
+                    level.setBlockAndUpdate(pos, newState);
+                    return InteractionResult.sidedSuccess(level.isClientSide);
                 }
-
-                level.setBlockAndUpdate(pos, newState);
-                return InteractionResult.sidedSuccess(level.isClientSide);
             }
         }
 


### PR DESCRIPTION
Fixes #7261
Fix horizontal orientation strategy (chest placement) and disallow re-orientation of paint splotches. Attached facing is no longer used since the models were changed to accomodate the standard facing orientation.