### PR TITLE
Client config option to enable resorting of terminal

### DIFF
--- a/src/main/java/appeng/client/gui/me/common/MEStorageScreen.java
+++ b/src/main/java/appeng/client/gui/me/common/MEStorageScreen.java
@@ -343,7 +343,10 @@ public class MEStorageScreen<C extends MEStorageMenu>
     protected void updateBeforeRender() {
         super.updateBeforeRender();
 
-        repo.setPaused(hasShiftDown());
+        if (!config.isResortingWhileShiftIsHeldEnabled()) {
+            repo.setPaused(hasShiftDown());
+        }
+
         updateSearch();
 
         // Override the dialog title found in the screen JSON with the user-supplied name

--- a/src/main/java/appeng/core/AEConfig.java
+++ b/src/main/java/appeng/core/AEConfig.java
@@ -505,6 +505,10 @@ public final class AEConfig {
         CLIENT.clearGridOnClose.set(enabled);
     }
 
+    public boolean isResortingWhileShiftIsHeldEnabled() {
+        return CLIENT.resortingWhileShiftIsHeld.get();
+    }
+
     public double getVibrationChamberEnergyPerFuelTick() {
         return COMMON.vibrationChamberEnergyPerFuelTick.get();
     }
@@ -541,6 +545,7 @@ public final class AEConfig {
         public final EnumOption<TerminalStyle> terminalStyle;
         public final BooleanOption pinAutoCraftedItems;
         public final BooleanOption clearGridOnClose;
+        public final BooleanOption resortingWhileShiftIsHeld;
         public final IntegerOption terminalMargin;
 
         // Search Settings
@@ -580,6 +585,8 @@ public final class AEConfig {
                     "Pin items that the player auto-crafts to the top of the terminal");
             this.clearGridOnClose = client.addBoolean("clearGridOnClose", false,
                     "Automatically clear the crafting/encoding grid when closing the terminal");
+            this.resortingWhileShiftIsHeld = terminals.addBoolean("resortingWhileShiftIsHeld", false,
+                    "Setting this to TRUE will disable the feature where you hold SHIFT inside the terminal to freeze items in the grid");
             this.terminalMargin = client.addInt("terminalMargin", 25,
                     "The vertical margin to apply when sizing terminals. Used to make room for centered item mod search bars");
 


### PR DESCRIPTION
Added config option to Re-Sort the MEStorageScreen while holding SHIFT. 
This is to address large networks with high item throughput. 
Where pressing SHIFT might cause the player to experience a lot of lag. 
Therefore this option to enable it. (disabled by default)