### PR TITLE
Add loading state check to early startup mixin

### DIFF
--- a/src/main/java/appeng/mixins/EarlyStartupMixin.java
+++ b/src/main/java/appeng/mixins/EarlyStartupMixin.java
@@ -24,6 +24,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.minecraft.server.Bootstrap;
+import net.minecraftforge.fml.ModLoader;
 
 import appeng.core.AppEngBootstrap;
 
@@ -38,6 +39,10 @@ public abstract class EarlyStartupMixin {
     // and we don't want this to be invoked from the nested call since MC isn't fully initialized by then.
     @Inject(at = @At(value = "INVOKE", target = "net/minecraftforge/registries/GameData. vanillaSnapshot()V", shift = At.Shift.AFTER, by = 1), method = "bootStrap")
     private static void initRegistries(CallbackInfo ci) {
+        if (!ModLoader.isLoadingStateValid()) {
+            return;
+        }
+
         AppEngBootstrap.runEarlyStartup();
     }
 


### PR DESCRIPTION
Fixes #7295 and allows the game to simply start up to the missing dependencies screen again.