### PR TITLE
Add API method to get cell inventories from IChestOrDrive

### DIFF
--- a/src/main/java/appeng/api/implementations/blockentities/IChestOrDrive.java
+++ b/src/main/java/appeng/api/implementations/blockentities/IChestOrDrive.java
@@ -29,6 +29,7 @@ import net.minecraft.world.item.Item;
 
 import appeng.api.networking.security.IActionHost;
 import appeng.api.storage.cells.CellState;
+import appeng.api.storage.cells.StorageCell;
 
 public interface IChestOrDrive extends IActionHost {
 
@@ -62,4 +63,9 @@ public interface IChestOrDrive extends IActionHost {
     @Nullable
     Item getCellItem(int slot);
 
+    /**
+     * Returns the inventory of the storage cell in the given slot or null.
+     */
+    @Nullable
+    StorageCell getCellInventory(int slot);
 }

--- a/src/main/java/appeng/blockentity/storage/ChestBlockEntity.java
+++ b/src/main/java/appeng/blockentity/storage/ChestBlockEntity.java
@@ -246,6 +246,16 @@ public class ChestBlockEntity extends AENetworkPowerBlockEntity
         return cell.isEmpty() ? null : cell.getItem();
     }
 
+    @Nullable
+    @Override
+    public StorageCell getCellInventory(int slot) {
+        if (slot != 0 || this.cellHandler == null) {
+            return null;
+        }
+
+        return this.cellHandler.cellInventory;
+    }
+
     @Override
     public boolean isPowered() {
         if (isClientSide()) {

--- a/src/main/java/appeng/blockentity/storage/DriveBlockEntity.java
+++ b/src/main/java/appeng/blockentity/storage/DriveBlockEntity.java
@@ -49,6 +49,7 @@ import appeng.api.storage.IStorageMounts;
 import appeng.api.storage.IStorageProvider;
 import appeng.api.storage.StorageCells;
 import appeng.api.storage.cells.CellState;
+import appeng.api.storage.cells.StorageCell;
 import appeng.api.util.AECableType;
 import appeng.blockentity.grid.AENetworkInvBlockEntity;
 import appeng.blockentity.inventory.AppEngCellInventory;
@@ -224,6 +225,17 @@ public class DriveBlockEntity extends AENetworkInvBlockEntity
         }
 
         return handler.getStatus();
+    }
+
+    @Nullable
+    @Override
+    public StorageCell getCellInventory(int slot) {
+        var handler = this.invBySlot[slot];
+        if (handler == null) {
+            return null;
+        }
+
+        return handler.getCell();
     }
 
     @Override

--- a/src/main/java/appeng/me/storage/DriveWatcher.java
+++ b/src/main/java/appeng/me/storage/DriveWatcher.java
@@ -36,7 +36,11 @@ public class DriveWatcher extends MEInventoryHandler {
     }
 
     public CellState getStatus() {
-        return ((StorageCell) getDelegate()).getStatus();
+        return getCell().getStatus();
+    }
+
+    public StorageCell getCell() {
+        return (StorageCell) getDelegate();
     }
 
     @Override


### PR DESCRIPTION
Allows for individual cell contents to be queried directly from chests and drives by add-ons.