### PR TITLE
Fix #7312: Export bus with crafting card causes crash using slots beyond the first 9

### DIFF
--- a/src/main/java/appeng/parts/automation/ExportBusPart.java
+++ b/src/main/java/appeng/parts/automation/ExportBusPart.java
@@ -75,7 +75,7 @@ public class ExportBusPart extends IOBusPart implements ICraftingRequester {
     public static final IPartModel MODELS_HAS_CHANNEL = new PartModel(MODEL_BASE,
             new ResourceLocation(AppEng.MOD_ID, "part/export_bus_has_channel"));
 
-    private final MultiCraftingTracker craftingTracker = new MultiCraftingTracker(this, 9);
+    private final MultiCraftingTracker craftingTracker = new MultiCraftingTracker(this, 63);
     private int nextSlot = 0;
     @Nullable
     private StackExportStrategy exportStrategy;


### PR DESCRIPTION
Fixes #7312.