### PR TITLE
Fix quantum link chamber not dropping singularity

### DIFF
--- a/src/main/java/appeng/blockentity/qnb/QuantumBridgeBlockEntity.java
+++ b/src/main/java/appeng/blockentity/qnb/QuantumBridgeBlockEntity.java
@@ -285,6 +285,7 @@ public class QuantumBridgeBlockEntity extends AENetworkInvBlockEntity
             // because that would undo the removal.
             this.remove = true;
             this.cluster.destroy();
+            this.remove = false;
         }
     }
 


### PR DESCRIPTION
Pretty ugly fix because of how the quantum ring is invalidated. It's needs to be set to removed in order to work.

The `remove = true` causes the `AEBaseEntityBlock#onRemove` to exit early because the `BlockEntity` is already considered removed, thus the `getBlockEntity` method returns null.

An alternative approach would be to handle the inventory drops within the `QuantumLinkBaseBlock` but that's a bit ugly as well. Setting the `BlockEntity` to `remove = false` again will call the handler for the inventory drops as expected after the ring is already invalidated.

fixes #7310