### PR TITLE
Gave Matter Cannon unique view/held model positions

### DIFF
--- a/src/main/resources/assets/ae2/models/item/matter_cannon.json
+++ b/src/main/resources/assets/ae2/models/item/matter_cannon.json
@@ -1,14 +1,28 @@
 {
-  "parent": "item/handheld",
-  "textures": {
-    "layer0": "ae2:item/matter_cannon"
-  },
-  "display": {
-    "thirdperson_righthand": {
-      "rotation": [0, -90, 0]
-    },
-    "thirdperson_lefthand": {
-      "rotation": [0, 90, 0]
-    }
-  }
+	"parent": "item/generated",
+	"textures": {
+		"layer0": "ae2:item/matter_cannon"
+	},
+	"display": {
+		"thirdperson_righthand": {
+			"rotation": [0, -90, 0],
+			"translation": [0, 0.75, -3.5],
+			"scale": [0.8, 0.8, 0.8]
+		},
+		"thirdperson_lefthand": {
+			"rotation": [0, 90, 0],
+			"translation": [0, 0.75, -3.5],
+			"scale": [0.8, 0.8, 0.8]
+		},
+		"firstperson_righthand": {
+			"rotation": [-131.9, -89.03, -130.91],
+			"translation": [-2.75, 2.5, 1.13],
+			"scale": [0.68, 0.68, 0.68]
+		},
+		"firstperson_lefthand": {
+			"rotation": [-45, 89, 46],
+			"translation": [-2.75, 2.5, 1.13],
+			"scale": [0.68, 0.68, 0.68]
+		}
+	}
 }


### PR DESCRIPTION
Prior to this the Matter Cannon used the parent `item/handheld`, which made it look very strange and missized when held in first and third person.

It could probably stand to have a unique 3rd person pose like a loaded crossbow has, but that's a separate thing.

Before:
![`item/handheld` first person](https://github.com/AppliedEnergistics/Applied-Energistics-2/assets/22027276/1e8887f5-c7af-4a37-83d2-7cd96fba24a3)
![`item/handheld` third person](https://github.com/AppliedEnergistics/Applied-Energistics-2/assets/22027276/ac9eed7d-5357-4665-a62e-6055cd8e2c16)

After:
![New first person](https://github.com/AppliedEnergistics/Applied-Energistics-2/assets/22027276/e3d41eeb-8a90-4875-9176-fd248f2f64eb)
![New third person front](https://github.com/AppliedEnergistics/Applied-Energistics-2/assets/22027276/43ce7e65-0e48-45c5-a3ea-e3c7c4c03d9a)
![New third person back](https://github.com/AppliedEnergistics/Applied-Energistics-2/assets/22027276/69e75c84-d5c8-4b27-9a9f-33cf5aea0d59)

