### PR TITLE
Add StorageCell::isEmpty method to prevent recursive storage of non-empty cells other than IBasicCellItem

### DIFF
--- a/src/main/java/appeng/api/storage/cells/StorageCell.java
+++ b/src/main/java/appeng/api/storage/cells/StorageCell.java
@@ -40,6 +40,12 @@ public interface StorageCell extends MEStorage {
     double getIdleDrain();
 
     /**
+     * Return whether the cell does not currently contain anything. Use this to determine when your cell should be
+     * storable in or able to store other kinds of cells without recurring.
+     */
+    boolean isEmpty();
+
+    /**
      * Tells the cell to persist to NBT.
      */
     void persist();

--- a/src/main/java/appeng/me/cells/CreativeCellInventory.java
+++ b/src/main/java/appeng/me/cells/CreativeCellInventory.java
@@ -77,6 +77,11 @@ class CreativeCellInventory implements StorageCell {
     }
 
     @Override
+    public boolean isEmpty() {
+        return configured.isEmpty();
+    }
+
+    @Override
     public Component getDescription() {
         return stack.getHoverName();
     }


### PR DESCRIPTION
Provides an API method that dictates whether a cell is empty or not in order for a non-empty cell with a custom `StorageCell` implementation to not be stored in other cells.

There is, however, the caveat that cells that do implement `StorageCell` on their own, if accepting `AEItemKey`s, will need to also implement their own checks for other non-empty cells within their insertion logic each time.