### PR TITLE
Add in-game guide recipe (beyond initial method to obtain)

### DIFF
--- a/src/main/java/appeng/datagen/providers/recipes/ChargerRecipes.java
+++ b/src/main/java/appeng/datagen/providers/recipes/ChargerRecipes.java
@@ -23,6 +23,9 @@ public class ChargerRecipes extends AE2RecipeProvider {
         ChargerRecipeBuilder.charge(consumer,
                 AppEng.makeId("charger/meteorite_compass"),
                 Items.COMPASS, AEItems.METEORITE_COMPASS);
+        ChargerRecipeBuilder.charge(consumer,
+                AppEng.makeId("charger/guide"),
+                Items.BOOK, AEItems.TABLET);
     }
 
     @Override


### PR DESCRIPTION
Intuitively, it makes sense for this to be a book in a charger rather than the initial suggestion of a certus quartz slab. Closes #7322.