### PR TITLE
Always clamp current power when changing max power

### DIFF
--- a/src/main/java/appeng/items/tools/powered/powersink/AEBasePoweredItem.java
+++ b/src/main/java/appeng/items/tools/powered/powersink/AEBasePoweredItem.java
@@ -166,18 +166,14 @@ public abstract class AEBasePoweredItem extends AEBaseItem implements IAEItemPow
      */
     protected final void setAEMaxPowerMultiplier(ItemStack stack, int multiplier) {
         multiplier = Mth.clamp(multiplier, 1, 100);
-        if (multiplier == 1) {
-            resetAEMaxPower(stack);
-        } else {
-            setAEMaxPower(stack, multiplier * powerCapacity.getAsDouble());
-        }
+        setAEMaxPower(stack, multiplier * powerCapacity.getAsDouble());
     }
 
     /**
      * Clears any custom maximum power from the given stack.
      */
     protected final void resetAEMaxPower(ItemStack stack) {
-        stack.removeTagKey(MAX_POWER_NBT_KEY);
+        setAEMaxPower(stack, powerCapacity.getAsDouble());
     }
 
     @Override


### PR DESCRIPTION
If the new max power was lower than the current power, the clamping took only place if the new max power was larger than the default max power, i.e. it worked for any energy card but the last one.

Fixes AppliedEnergistics#7431

There is a potential for refactoring here, depending on whether the 3 functions setAEMaxPowerMultiplier, setAEMaxPower, and resetAEMaxPower are considered to be a stable API or not. I chose to not refactor for compatibility reasons. Deciding if that is the way to go is up to a reviewer in my opinion.

Be advised that this is my first time coding for any Minecraft mod, but the change should be small enough for a starter task.