### PR TITLE
check render before rendering it

### DIFF
--- a/src/main/java/appeng/client/guidebook/scene/GuidebookLevelRenderer.java
+++ b/src/main/java/appeng/client/guidebook/scene/GuidebookLevelRenderer.java
@@ -205,7 +205,7 @@ public class GuidebookLevelRenderer {
             MultiBufferSource buffers) {
         var dispatcher = Minecraft.getInstance().getBlockEntityRenderDispatcher();
         var renderer = dispatcher.getRenderer(blockEntity);
-        if (renderer != null) {
+        if (renderer != null && renderer.shouldRender(blockEntity, blockEntity.getBlockPos().getCenter())) {
             var pos = blockEntity.getBlockPos();
             stack.pushPose();
             stack.translate(pos.getX(), pos.getY(), pos.getZ());


### PR DESCRIPTION
some TESRs need `shouldRender` to check validity