### PR TITLE
FIx dense covered cable item model

### DIFF
--- a/src/main/resources/assets/ae2/models/item/covered_dense_cable_base.json
+++ b/src/main/resources/assets/ae2/models/item/covered_dense_cable_base.json
@@ -8,7 +8,7 @@
       "faces": {
         "north": {
           "texture": "#base",
-          "uv": [4.0, 4.0, 12.0, 11.0]
+          "uv": [6.0, 6.0, 10.0, 10.0]
         },
         "east": {
           "texture": "#base",
@@ -16,7 +16,7 @@
         },
         "south": {
           "texture": "#base",
-          "uv": [11.0, 4.0, 4.0, 12.0]
+          "uv": [10.0, 6.0, 6.0, 10.0]
         },
         "west": {
           "texture": "#base",


### PR DESCRIPTION
End textures (N/S) were improperly mapped for the item model

Old:
![image](https://github.com/AppliedEnergistics/Applied-Energistics-2/assets/10861407/30c50b47-6a6c-4bf0-900a-835382f07a1e)

New (don't mind the extra pixelation):
![image](https://github.com/AppliedEnergistics/Applied-Energistics-2/assets/10861407/facff10c-058f-443c-8c7c-c1e65e75a81a)
