### PR TITLE
Fix plane, p2p, terminal item models

### DIFF
--- a/src/main/resources/assets/ae2/models/item/annihilation_plane.json
+++ b/src/main/resources/assets/ae2/models/item/annihilation_plane.json
@@ -2,7 +2,8 @@
   "parent": "ae2:item/part_base",
   "textures": {
     "sides": "ae2:part/plane_sides",
-    "plane": "ae2:part/annihilation_plane"
+    "plane": "ae2:part/annihilation_plane",
+    "back": "ae2:part/transition_plane_back"
   },
   "elements": [
     {
@@ -10,24 +11,12 @@
       "from": [1, 1, 8],
       "to": [15, 15, 9],
       "faces": {
-        "north": {
-          "texture": "plane"
-        },
-        "south": {
-          "texture": "sides"
-        },
-        "east": {
-          "texture": "sides"
-        },
-        "west": {
-          "texture": "sides"
-        },
-        "up": {
-          "texture": "sides"
-        },
-        "down": {
-          "texture": "sides"
-        }
+        "north": { "uv": [1, 1, 15, 15], "texture": "plane" },
+        "east": { "uv": [15, 1, 16, 15], "texture": "sides" },
+        "south": { "uv": [1, 1, 15, 15], "texture": "back" },
+        "west": { "uv": [0, 1, 1, 15], "texture": "sides" },
+        "up": { "uv": [1, 0, 15, 1], "texture": "sides" },
+        "down": { "uv": [1, 15, 15, 16], "texture": "sides" }
       }
     },
     {
@@ -35,21 +24,11 @@
       "from": [5, 5, 9],
       "to": [11, 11, 10],
       "faces": {
-        "east": {
-          "texture": "sides"
-        },
-        "south": {
-          "texture": "sides"
-        },
-        "west": {
-          "texture": "sides"
-        },
-        "up": {
-          "texture": "sides"
-        },
-        "down": {
-          "texture": "sides"
-        }
+        "east": { "uv": [14, 5, 15, 11], "texture": "sides" },
+        "south": { "uv": [5, 5, 11, 11],"texture": "sides" },
+        "west": { "uv": [1, 5, 2, 11], "texture": "sides" },
+        "up": { "uv": [5, 1, 11, 2], "texture": "sides" },
+        "down": { "uv":[5, 14, 11, 15], "texture": "sides" }
       }
     }
   ]

--- a/src/main/resources/assets/ae2/models/item/display_base.json
+++ b/src/main/resources/assets/ae2/models/item/display_base.json
@@ -3,76 +3,66 @@
   "textures": {
     "sides": "ae2:part/monitor_sides",
     "back": "ae2:part/monitor_back",
+    "front_base": "ae2:part/monitor_front",
     "front_medium_bright": "ae2:part/monitor_colored"
   },
   "elements": [
     {
-      "name": "Front",
-      "from": [2, 2, 8],
+      "name": "Front Base",
+      "from": [2, 2, 7],
       "to": [14, 14, 9],
       "faces": {
-        "north": {
-          "texture": "#front"
-        },
-        "south": {
-          "texture": "#back"
-        },
-        "east": {
-          "texture": "#sides"
-        },
-        "west": {
-          "texture": "#sides"
-        },
-        "up": {
-          "texture": "#sides"
-        },
-        "down": {
-          "texture": "#sides"
-        }
+        "north": { "uv": [2, 2, 14, 14], "texture": "#front_base" },
+        "east": { "uv": [14, 2, 16, 14], "texture": "#sides" },
+        "south": { "uv": [2, 2, 14, 14], "texture": "#back" },
+        "west": { "uv": [0, 2, 2, 14], "texture": "#sides" },
+        "up": { "uv": [2, 0, 14, 2], "texture": "#sides" },
+        "down": { "uv": [2, 14, 14, 16], "texture": "#sides" }
+      }
+    },
+    {
+      "name": "Front",
+      "from": [3, 3, 7],
+      "to": [13, 13, 8],
+      "faces": {
+        "north": { "uv": [3, 3, 13, 13], "texture": "#front" },
+        "east": { "uv": [14, 3, 16, 13], "texture": "#sides" },
+        "south": { "uv": [3, 3, 13, 13], "texture": "#back" },
+        "west": { "uv": [0, 3, 2, 13], "texture": "#sides" },
+        "up": { "uv": [3, 0, 13, 2], "texture": "#sides" },
+        "down": { "uv": [3, 14, 13, 16], "texture": "#sides" }
       }
     },
     {
       "name": "Front Bright",
-      "from": [2, 2, 8],
-      "to": [14, 14, 9],
+      "from": [2, 2, 7],
+      "to": [14, 14, 8],
       "faces": {
-        "north": {
-          "texture": "#front_bright",
-          "tintindex": 3
-        }
+        "north": { "uv": [2, 2, 14, 14], "texture": "#front_bright", "tintindex": 3 }
       }
     },
     {
       "name": "Front Medium Bright",
-      "from": [2, 2, 8],
-      "to": [14, 14, 9],
+      "from": [2, 2, 7],
+      "to": [14, 14, 8],
       "faces": {
-        "north": {
-          "texture": "#front_medium_bright",
-          "tintindex": 4
-        }
+        "north": { "uv": [2, 2, 14, 14], "texture": "#front_medium_bright", "tintindex": 4 }
       }
     },
     {
       "name": "Front Medium",
-      "from": [2, 2, 8],
-      "to": [14, 14, 9],
+      "from": [2, 2, 7],
+      "to": [14, 14, 8],
       "faces": {
-        "north": {
-          "texture": "#front_medium",
-          "tintindex": 2
-        }
+        "north": { "uv": [2, 2, 14, 14], "texture": "#front_medium", "tintindex": 2 }
       }
     },
     {
       "name": "Front Dark",
-      "from": [2, 2, 8],
-      "to": [14, 14, 9],
+      "from": [2, 2, 7],
+      "to": [14, 14, 8],
       "faces": {
-        "north": {
-          "texture": "#front_dark",
-          "tintindex": 1
-        }
+        "north": { "uv": [2, 2, 14, 14], "texture": "#front_dark", "tintindex": 1 }
       }
     },
     {
@@ -80,21 +70,11 @@
       "from": [4, 4, 9],
       "to": [12, 12, 10],
       "faces": {
-        "east": {
-          "texture": "#sides"
-        },
-        "south": {
-          "texture": "#back"
-        },
-        "west": {
-          "texture": "#sides"
-        },
-        "up": {
-          "texture": "#sides"
-        },
-        "down": {
-          "texture": "#sides"
-        }
+        "east": { "uv": [6, 4, 7, 12], "texture": "#sides" },
+        "south": { "uv": [4, 4, 12, 12], "texture": "#back" },
+        "west": { "uv": [9, 4, 10, 12], "texture": "#sides" },
+        "up": { "uv": [4, 9, 12, 10], "texture": "#sides" },
+        "down": { "uv": [4, 6, 12, 7], "texture": "#sides" }
       }
     }
   ]

--- a/src/main/resources/assets/ae2/models/item/p2p_tunnel_base.json
+++ b/src/main/resources/assets/ae2/models/item/p2p_tunnel_base.json
@@ -20,24 +20,54 @@
       "from": [2, 2, 7],
       "to": [14, 14, 9],
       "faces": {
-        "north": {
-          "texture": "#front"
-        },
-        "south": {
-          "texture": "#back"
-        },
-        "east": {
-          "texture": "#sides"
-        },
-        "west": {
-          "texture": "#sides"
-        },
-        "up": {
-          "texture": "#sides"
-        },
-        "down": {
-          "texture": "#sides"
-        }
+        "north": { "uv": [2, 2, 14, 14], "texture": "#front" },
+        "east": { "uv": [14, 2, 16, 14], "texture": "#sides" },
+        "south": { "uv": [2, 2, 14, 14], "texture": "#back" },
+        "west": { "uv": [0, 2, 2, 14], "texture": "#sides" },
+        "up": { "uv": [2, 0, 14, 2], "texture": "#sides" },
+        "down": { "uv": [2, 14, 14, 16], "texture": "#sides" }
+      }
+    },
+    {
+      "from": [3, 3, 9],
+      "to": [13, 13, 10],
+      "faces": {
+        "east": { "uv" : [6, 3, 7, 13], "texture": "#sides" },
+        "south": { "uv": [3, 3, 13, 13], "texture": "#back" },
+        "west": { "uv": [9, 3, 10, 13], "texture": "#sides" },
+        "up": { "uv": [3, 9, 13, 10], "texture": "#sides" },
+        "down": { "uv": [3, 6, 13, 7], "texture": "#sides" }
+      }
+    },
+    {
+      "from": [6, 5, 10],
+      "to": [10, 11, 11],
+      "faces": {
+        "east": { "uv": [5, 5, 6, 11], "texture": "#sides" },
+        "south": { "uv": [6, 5, 10, 11], "texture": "#back" },
+        "west": { "uv": [5, 5, 10, 11], "texture": "#sides" },
+        "up": { "uv": [6, 3, 10, 4], "texture": "#sides" },
+        "down": { "uv": [6, 12, 10, 13], "texture": "#sides" }
+      }
+    },
+    {
+      "from": [5, 6, 10],
+      "to": [6, 10, 11],
+      "faces": {
+        "south": { "uv": [5, 6, 6, 10], "texture": "#back" },
+        "west": { "uv": [4, 7, 4, 11], "texture": "#sides" },
+        "up": { "uv": [3, 5, 4, 6], "texture": "#sides" },
+        "down": { "uv": [3, 10, 4, 11], "texture": "#sides" }
+      }
+    },
+    {
+      "from": [10, 6, 10],
+      "to": [11, 10, 11],
+      "faces": {
+        "east": { "uv" : [12, 7, 13, 11], "texture": "#sides" },
+        "south": { "uv": [10, 6, 11, 10], "texture": "#back" },
+        "up": { "uv": [12, 5, 13, 6], "texture": "#sides" },
+        "down": { "uv": [12, 10, 13, 11], "texture": "#sides" }
       }
     }
   ]


### PR DESCRIPTION
Several parts (Formation/Annihilation Planes, Terminals, P2Ps) had incorrect item models

## Some examples of old:
Side and front textures incorrect:
![image](https://github.com/AppliedEnergistics/Applied-Energistics-2/assets/10861407/ae351f14-1843-465f-8c1d-d7d18684e79b)

Formation plane with wrong back and side textures:
![image](https://github.com/AppliedEnergistics/Applied-Energistics-2/assets/10861407/ed635723-41f5-4635-87f0-7d66c9bf1c6f)

P2P with no backplate model:
![image](https://github.com/AppliedEnergistics/Applied-Energistics-2/assets/10861407/00f7d890-96fc-464f-93fa-43d227db529a)

Terminal with wrong thickness as item (in hand):
![2023-12-22_07 03 15](https://github.com/AppliedEnergistics/Applied-Energistics-2/assets/10861407/f30f1105-b433-464f-8e1b-8e4879d2ad50)

## Some examples of new:
Front and side textures corrected:
![image](https://github.com/AppliedEnergistics/Applied-Energistics-2/assets/10861407/307c40d1-98ee-4b49-b5f6-af6afc913122)|

Formation plane with proper back and side textures:
![image](https://github.com/AppliedEnergistics/Applied-Energistics-2/assets/10861407/e85b569b-bf69-4f25-a727-7fa1dea3db4b)

P2P with backplate model:
![image](https://github.com/AppliedEnergistics/Applied-Energistics-2/assets/10861407/7bcaa03e-70d8-40bc-b1ea-13944f299366)

Terminal with correct thickness and texturing (in hand):
![2023-12-22_01 07 00](https://github.com/AppliedEnergistics/Applied-Energistics-2/assets/10861407/8c239b9e-74de-4039-b80c-250bd0d524b5)