### PR TITLE
Make crafting unit recipies consistent

### DIFF
--- a/src/main/java/appeng/datagen/providers/recipes/CraftingRecipes.java
+++ b/src/main/java/appeng/datagen/providers/recipes/CraftingRecipes.java
@@ -577,13 +577,13 @@ public class CraftingRecipes extends AE2RecipeProvider {
                 .unlockedBy("has_crafting_unit", has(AEBlocks.CRAFTING_UNIT))
                 .save(consumer, AppEng.makeId("network/crafting/1k_cpu_crafting_storage"));
         ShapelessRecipeBuilder.shapeless(RecipeCategory.MISC, AEBlocks.CRAFTING_STORAGE_4K)
-                .requires(AEItems.CELL_COMPONENT_4K)
                 .requires(AEBlocks.CRAFTING_UNIT)
+                .requires(AEItems.CELL_COMPONENT_4K)
                 .unlockedBy("has_crafting_unit", has(AEBlocks.CRAFTING_UNIT))
                 .save(consumer, AppEng.makeId("network/crafting/4k_cpu_crafting_storage"));
         ShapelessRecipeBuilder.shapeless(RecipeCategory.MISC, AEBlocks.CRAFTING_STORAGE_16K)
-                .requires(AEItems.CELL_COMPONENT_16K)
                 .requires(AEBlocks.CRAFTING_UNIT)
+                .requires(AEItems.CELL_COMPONENT_16K)
                 .unlockedBy("has_crafting_unit", has(AEBlocks.CRAFTING_UNIT))
                 .save(consumer, AppEng.makeId("network/crafting/16k_cpu_crafting_storage"));
         ShapelessRecipeBuilder.shapeless(RecipeCategory.MISC, AEBlocks.CRAFTING_STORAGE_64K)
@@ -592,18 +592,18 @@ public class CraftingRecipes extends AE2RecipeProvider {
                 .unlockedBy("has_crafting_unit", has(AEBlocks.CRAFTING_UNIT))
                 .save(consumer, AppEng.makeId("network/crafting/64k_cpu_crafting_storage"));
         ShapelessRecipeBuilder.shapeless(RecipeCategory.MISC, AEBlocks.CRAFTING_STORAGE_256K)
-                .requires(AEItems.CELL_COMPONENT_256K)
                 .requires(AEBlocks.CRAFTING_UNIT)
+                .requires(AEItems.CELL_COMPONENT_256K)
                 .unlockedBy("has_crafting_unit", has(AEBlocks.CRAFTING_UNIT))
                 .save(consumer, AppEng.makeId("network/crafting/256k_cpu_crafting_storage"));
         ShapelessRecipeBuilder.shapeless(RecipeCategory.MISC, AEBlocks.CRAFTING_ACCELERATOR)
-                .requires(AEItems.ENGINEERING_PROCESSOR)
                 .requires(AEBlocks.CRAFTING_UNIT)
+                .requires(AEItems.ENGINEERING_PROCESSOR)
                 .unlockedBy("has_crafting_unit", has(AEBlocks.CRAFTING_UNIT))
                 .save(consumer, AppEng.makeId("network/crafting/cpu_crafting_accelerator"));
         ShapelessRecipeBuilder.shapeless(RecipeCategory.MISC, AEBlocks.CRAFTING_MONITOR)
-                .requires(AEParts.STORAGE_MONITOR)
                 .requires(AEBlocks.CRAFTING_UNIT)
+                .requires(AEParts.STORAGE_MONITOR)
                 .unlockedBy("has_crafting_unit", has(AEBlocks.CRAFTING_UNIT))
                 .save(consumer, AppEng.makeId("network/crafting/cpu_crafting_monitor"));
 


### PR DESCRIPTION
Make crafting unit recipies consistent in order [unit, additional item] this mainly serves to make the guide more visually appealing and readable.

Current status:
![image](https://github.com/AppliedEnergistics/Applied-Energistics-2/assets/11778108/9c04f034-5873-4569-b818-36da6b07d26e)
