### PR TITLE
Fix quantum bridge infinite update loop

### DIFF
--- a/src/main/java/appeng/me/cluster/implementations/QuantumCluster.java
+++ b/src/main/java/appeng/me/cluster/implementations/QuantumCluster.java
@@ -103,7 +103,7 @@ public class QuantumCluster implements IAECluster, IActionHost {
         if (myOtherSide instanceof QuantumCluster sideB) {
             var sideA = this;
 
-            if (sideA.isActive() && sideB.isActive()) {
+            if (sideA.isActive() && sideB.isActive() && sideA.getNode() != null && sideB.getNode() != null) {
                 if (this.connection != null && this.connection.getConnection() != null) {
                     final IGridNode a = this.connection.getConnection().a();
                     final IGridNode b = this.connection.getConnection().b();


### PR DESCRIPTION
Fixes #7491
Fixes #7342
Fixes #7337
Might be related to #7343, not confirmed.

The Cause
-----
This issue is actually caused by a NullPointerException here, where `sideA.getNode()` and `sideB.getNode()` return null:
https://github.com/AppliedEnergistics/Applied-Energistics-2/blob/5300718b535f2c883e85651c83e3d2ea3d7b0e66/src/main/java/appeng/me/cluster/implementations/QuantumCluster.java#L127-L128
The exception is caught here (the debug message won't be shown if debug log is not enabled in config):
https://github.com/AppliedEnergistics/Applied-Energistics-2/blob/5300718b535f2c883e85651c83e3d2ea3d7b0e66/src/main/java/appeng/me/cluster/MBCalculator.java#L148-L154
Where it calls `setModificationInProgress(null)`, which suppresses the update loop protection. Then it calls `this.disconnect()` which generates block updates causing further calls to `MBCalculator.calculateMultiblock()`, causing the update loop.

I didn't go into why the nodes are null, so I'm not sure if this simple check is the best way to fix it. But I did some testing and everything seems to be working fine, I also ran the Gametests and it's passing.