### PR TITLE
Invalidate capabilities when appropriate

### DIFF
--- a/src/main/java/appeng/blockentity/AEBaseBlockEntity.java
+++ b/src/main/java/appeng/blockentity/AEBaseBlockEntity.java
@@ -305,6 +305,7 @@ public class AEBaseBlockEntity extends BlockEntity
      */
     @ApiStatus.OverrideOnly
     protected void onOrientationChanged(BlockOrientation orientation) {
+        invalidateCapabilities();
     }
 
     /**

--- a/src/main/java/appeng/blockentity/misc/InscriberBlockEntity.java
+++ b/src/main/java/appeng/blockentity/misc/InscriberBlockEntity.java
@@ -454,9 +454,8 @@ public class InscriberBlockEntity extends AENetworkPowerBlockEntity
         }
 
         if (setting == Settings.INSCRIBER_SEPARATE_SIDES) {
-            // Send a block update since our exposed inventory changed...
-            // In theory this shouldn't be necessary, but we do it just in case...
-            markForUpdate();
+            // Our exposed inventory changed, invalidate caps!
+            invalidateCapabilities();
         }
 
         if (setting == Settings.INSCRIBER_BUFFER_SIZE) {

--- a/src/main/java/appeng/blockentity/storage/ChestBlockEntity.java
+++ b/src/main/java/appeng/blockentity/storage/ChestBlockEntity.java
@@ -81,7 +81,6 @@ import appeng.menu.MenuOpener;
 import appeng.menu.implementations.ChestMenu;
 import appeng.menu.locator.MenuLocators;
 import appeng.util.ConfigManager;
-import appeng.util.Platform;
 import appeng.util.inv.AppEngInternalInventory;
 import appeng.util.inv.CombinedInternalInventory;
 import appeng.util.inv.filter.IAEItemFilter;
@@ -433,7 +432,7 @@ public class ChestBlockEntity extends AENetworkPowerBlockEntity
 
             // update the neighbors
             if (this.level != null) {
-                Platform.notifyBlocksOfNeighbors(this.level, this.worldPosition);
+                invalidateCapabilities();
                 this.markForUpdate();
             }
         }

--- a/src/main/java/appeng/helpers/InterfaceLogic.java
+++ b/src/main/java/appeng/helpers/InterfaceLogic.java
@@ -31,7 +31,6 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.block.entity.BlockEntity;
 
 import appeng.api.config.Actionable;
 import appeng.api.config.FuzzyMode;
@@ -64,7 +63,6 @@ import appeng.me.helpers.MachineSource;
 import appeng.me.storage.DelegatingMEInventory;
 import appeng.util.ConfigInventory;
 import appeng.util.ConfigManager;
-import appeng.util.Platform;
 
 /**
  * Contains behavior for interface blocks and parts, which is independent of the storage channel.
@@ -207,10 +205,7 @@ public class InterfaceLogic implements ICraftingRequester, IUpgradeableObject, I
             });
         }
 
-        final BlockEntity te = this.host.getBlockEntity();
-        if (te != null && te.getLevel() != null) {
-            Platform.notifyBlocksOfNeighbors(te.getLevel(), te.getBlockPos());
-        }
+        this.host.getBlockEntity().invalidateCapabilities();
     }
 
     public void gridChanged() {

--- a/src/main/java/appeng/parts/CableBusContainer.java
+++ b/src/main/java/appeng/parts/CableBusContainer.java
@@ -293,6 +293,7 @@ public class CableBusContainer implements AEMultiBlockEntity, ICableBusContainer
         this.markForUpdate();
         this.markForSave();
         this.partChanged();
+        getBlockEntity().invalidateCapabilities();
 
         updateNeighborShapeOnSide(side);
     }

--- a/src/main/java/appeng/parts/p2p/CapabilityP2PTunnelPart.java
+++ b/src/main/java/appeng/parts/p2p/CapabilityP2PTunnelPart.java
@@ -24,7 +24,6 @@ import net.minecraft.core.Direction;
 import net.neoforged.neoforge.capabilities.BlockCapability;
 
 import appeng.api.parts.IPartItem;
-import appeng.hooks.ticking.TickHandler;
 import appeng.parts.PartAdjacentApi;
 
 /**
@@ -137,12 +136,9 @@ public abstract class CapabilityP2PTunnelPart<P extends CapabilityP2PTunnelPart<
 
     @Override
     public void onTunnelNetworkChange() {
-        // This might be invoked while the network is being unloaded and we don't want to send a block update then, so
-        // we delay it until the next tick.
-        TickHandler.instance().addCallable(getLevel(), () -> {
-            if (getMainNode().isReady()) { // Check that the p2p tunnel is still there.
-                getBlockEntity().invalidateCapabilities();
-            }
-        });
+        // This might be invoked while the network is being unloaded,
+        // however the capability system should handle this fine.
+        // (Not OK for block updates though, thankfully we don't need them anymore!)
+        getBlockEntity().invalidateCapabilities();
     }
 }


### PR DESCRIPTION
The invalidation on orientation changes is potentially overkill for many block entities (only condensers and inscribers really need it), but it doesn't matter.

(Note that `invalidateCapabilities()` should handle cycles, hence the simplifications in the capability P2P tunnel).