### PR TITLE
Fix to Divide by 0 Crash

### DIFF
--- a/src/main/java/appeng/client/gui/MathExpressionParser.java
+++ b/src/main/java/appeng/client/gui/MathExpressionParser.java
@@ -109,7 +109,7 @@ public class MathExpressionParser {
                                 number.push(left.subtract(right));
                             }
                             case '/' -> {
-                                if (right.equals(BigDecimal.ZERO)) {
+                                if (right.compareTo(BigDecimal.ZERO) == 0) {
                                     return Optional.empty(); // division by zeroes
                                 } else {
                                     number.push(left.divide(right, 8, RoundingMode.FLOOR));


### PR DESCRIPTION
Quick fix to the 0 check

Using BigDecimal.equals() method doesn't take account scale of the value, so comparing 0.0 to 0 would return false. 

The fix is to use BigDecimal.compareTo() which would return an Int which could then be compared to 0, with this, 0.0 to 0 would return as true