### PR TITLE
Fix #7522: Fix tiny TNT not passing blockentity to Block.dropResources

### DIFF
--- a/src/main/java/appeng/entity/TinyTNTPrimedEntity.java
+++ b/src/main/java/appeng/entity/TinyTNTPrimedEntity.java
@@ -174,8 +174,8 @@ public final class TinyTNTPrimedEntity extends PrimedTnt implements IEntityWithC
                             strength -= (resistance + 0.3F) * 0.11f;
 
                             if (strength > 0.01 && !state.isAir()) {
-                                if (block.dropFromExplosion(ex)) {
-                                    block.dropResources(state, this.level(), point);
+                                if (state.canDropFromExplosion(this.level(), point, ex)) {
+                                    Block.dropResources(state, this.level(), point, this.level().getBlockEntity(point));
                                 }
 
                                 level().setBlock(point, Blocks.AIR.defaultBlockState(), 3);


### PR DESCRIPTION
Should fix #7522 based on my analysis of the issue.