### PR TITLE
Number entry fixes: NaN & division with integer result handling

### DIFF
--- a/src/main/java/appeng/client/gui/MathExpressionParser.java
+++ b/src/main/java/appeng/client/gui/MathExpressionParser.java
@@ -26,8 +26,12 @@ public class MathExpressionParser {
 
             if (!wasNumberOrRightBracket || expression.charAt(i) != '-') {
                 var position = new ParsePosition(i);
-                BigDecimal decimal = (BigDecimal) decimalFormat.parse(expression, position);
+                Number parsedNumber = decimalFormat.parse(expression, position);
                 if (position.getErrorIndex() == -1) { // no error
+                    if (!(parsedNumber instanceof BigDecimal decimal)) {
+                        // NaN or infinity
+                        return Optional.empty();
+                    }
                     output.add(decimal);
                     i = position.getIndex();
                     wasNumberOrRightBracket = true;
@@ -136,7 +140,7 @@ public class MathExpressionParser {
         if (number.size() != 1) {
             return Optional.empty();
         } else {
-            return Optional.of(number.pop());
+            return Optional.of(number.pop().stripTrailingZeros());
         }
 
     }

--- a/src/main/java/appeng/client/gui/widgets/NumberEntryWidget.java
+++ b/src/main/java/appeng/client/gui/widgets/NumberEntryWidget.java
@@ -274,6 +274,11 @@ public class NumberEntryWidget implements ICompositeWidget {
             return OptionalLong.empty();
         }
 
+        // Reject decimal values if the unit is integral
+        if (type.amountPerUnit() == 1 && internalValue.get().scale() > 0) {
+            return OptionalLong.empty();
+        }
+
         var externalValue = convertToExternalValue(internalValue.get());
         if (externalValue < minValue) {
             return OptionalLong.empty();


### PR DESCRIPTION
- Fix #7492.
- Fix #7499 by adding `stripTrailingZeros()` before we check if the `BigDecimal` actually has a decimal part.
- Add integer validation to not allow clicking `Next` with integral units when the `BigDecimal` is not an integer.