### PR TITLE
use getLinkStatus() in WirelessTerminalMenuHost#insert

### DIFF
--- a/src/main/java/appeng/helpers/WirelessTerminalMenuHost.java
+++ b/src/main/java/appeng/helpers/WirelessTerminalMenuHost.java
@@ -249,7 +249,7 @@ public class WirelessTerminalMenuHost<T extends WirelessTerminalItem> extends It
             return 0;
         }
 
-        if (linkStatus.connected()) {
+        if (getLinkStatus().connected()) {
             var inv = getInventory();
             if (inv == null) {
                 return 0;
@@ -257,7 +257,7 @@ public class WirelessTerminalMenuHost<T extends WirelessTerminalItem> extends It
 
             return StorageHelper.poweredInsert(this, inv, what, amount, new PlayerSource(player), mode);
         } else {
-            var statusText = linkStatus.statusDescription();
+            var statusText = getLinkStatus().statusDescription();
             if (statusText != null && !mode.isSimulate()) {
                 player.displayClientMessage(statusText, false);
             }

--- a/src/main/java/appeng/items/contents/PortableCellMenuHost.java
+++ b/src/main/java/appeng/items/contents/PortableCellMenuHost.java
@@ -81,7 +81,7 @@ public class PortableCellMenuHost<T extends AbstractPortableCell> extends ItemMe
 
     @Override
     public long insert(Player player, AEKey what, long amount, Actionable mode) {
-        if (linkStatus.connected()) {
+        if (getLinkStatus().connected()) {
             var inv = getInventory();
             if (inv == null) {
                 return 0;
@@ -89,7 +89,7 @@ public class PortableCellMenuHost<T extends AbstractPortableCell> extends ItemMe
 
             return StorageHelper.poweredInsert(this, inv, what, amount, new PlayerSource(player), mode);
         } else {
-            var statusText = linkStatus.statusDescription();
+            var statusText = getLinkStatus().statusDescription();
             if (isClientSide() && statusText != null && !mode.isSimulate()) {
                 player.displayClientMessage(statusText, false);
             }


### PR DESCRIPTION
when inserting in the terminal item using right click, use getLinkStatus() instead of the variable directly, so that the correct value is obtained when addons override getLinkStatus()