### PR TITLE
Delay DebugItemGen Initialization

### DIFF
--- a/src/main/java/appeng/debug/ItemGenBlockEntity.java
+++ b/src/main/java/appeng/debug/ItemGenBlockEntity.java
@@ -48,6 +48,11 @@ public class ItemGenBlockEntity extends AEBaseBlockEntity implements InternalInv
 
     public ItemGenBlockEntity(BlockEntityType<?> blockEntityType, BlockPos pos, BlockState blockState) {
         super(blockEntityType, pos, blockState);
+    }
+
+    @Override
+    public void clearRemoved() {
+        super.clearRemoved();
         if (SHARED_POSSIBLE_ITEMS.isEmpty()) {
             initGlobalPossibleItems();
         }


### PR DESCRIPTION
Some mods will now construct every possible block entity type to attach capabilities. This causes the debug item generator to needlessly initialize a list of all potential items.