### PR TITLE
Fix rare QNB crash when leaving a single-player world

### DIFF
--- a/src/main/java/appeng/me/cluster/implementations/QuantumCluster.java
+++ b/src/main/java/appeng/me/cluster/implementations/QuantumCluster.java
@@ -61,7 +61,7 @@ public class QuantumCluster implements IAECluster, IActionHost {
 
     @SubscribeEvent
     public void onUnload(final LevelEvent.Unload e) {
-        if (this.center == null && this.center.getLevel() == e.getLevel()) {
+        if (this.center != null && this.center.getLevel() == e.getLevel()) {
             this.setUpdateStatus(false);
             this.destroy();
         }


### PR DESCRIPTION
Got an NPE when leaving a single player world because it was trying to destroy this QNB cluster (that had no center).