### PR TITLE
Pattern providers now only push ingredients for crafting patterns to molecular assemblers, not other inventories

### DIFF
--- a/src/main/java/appeng/api/crafting/IPatternDetails.java
+++ b/src/main/java/appeng/api/crafting/IPatternDetails.java
@@ -66,6 +66,16 @@ public interface IPatternDetails {
     GenericStack[] getOutputs();
 
     /**
+     * @return True if this pattern allows its inputs to be pushed to generic external inventories that would accept
+     *         those inputs. This would usually be true for custom processing patterns, but not true for patterns that
+     *         require custom machines or molecular assemblers (since those are pushed via
+     *         {@link ICraftingMachine#pushPattern}).
+     */
+    default boolean supportsPushInputsToExternalInventory() {
+        return true;
+    }
+
+    /**
      * Gives the pattern a chance to reorder its inputs for pushing to external inventories (i.e. NOT to
      * {@link ICraftingMachine}s).
      *

--- a/src/main/java/appeng/blockentity/crafting/IMolecularAssemblerSupportedPattern.java
+++ b/src/main/java/appeng/blockentity/crafting/IMolecularAssemblerSupportedPattern.java
@@ -22,6 +22,12 @@ public interface IMolecularAssemblerSupportedPattern extends IPatternDetails {
 
     void fillCraftingGrid(KeyCounter[] table, CraftingGridAccessor gridAccessor);
 
+    @Override
+    default boolean supportsPushInputsToExternalInventory() {
+        // Patterns crafted in a molecular assembler are usually pointless to craft in anything else
+        return false;
+    }
+
     @FunctionalInterface
     interface CraftingGridAccessor {
         void set(int slot, ItemStack stack);

--- a/src/main/java/appeng/helpers/patternprovider/PatternProviderLogic.java
+++ b/src/main/java/appeng/helpers/patternprovider/PatternProviderLogic.java
@@ -330,6 +330,12 @@ public class PatternProviderLogic implements InternalInventoryHost, ICraftingPro
             possibleTargets.add(new PushTarget(direction, adapter));
         }
 
+        // If no dedicated crafting machine could be found, and the pattern does not support
+        // generic external inventories, stop here.
+        if (!patternDetails.supportsPushInputsToExternalInventory()) {
+            return false;
+        }
+
         // Rearrange for round-robin
         rearrangeRoundRobin(possibleTargets);
 


### PR DESCRIPTION
Fixes #7688 