### PR TITLE
Sanitize item caps when an AEItemKey is loaded

### DIFF
--- a/src/main/java/appeng/api/stacks/AEItemKey.java
+++ b/src/main/java/appeng/api/stacks/AEItemKey.java
@@ -161,13 +161,13 @@ public final class AEItemKey extends AEKey {
             // This will trigger continuous error logs on every call to toStack(), killing performance
             if (extraCaps != null) {
                 var stack = new ItemStack(item, 1, extraCaps);
-                var sanitizezdCaps = stack.serializeAttachments();
-                if (!Objects.equals(extraCaps, sanitizezdCaps)) {
+                var sanitizedCaps = stack.serializeAttachments();
+                if (!Objects.equals(extraCaps, sanitizedCaps)) {
                     LOG.info("Sanitized item attachments for {} from {} -> {}", item.asItem(),
-                            extraCaps, sanitizezdCaps);
+                            extraCaps, sanitizedCaps);
                 }
 
-                extraCaps = sanitizezdCaps;
+                extraCaps = sanitizedCaps;
             }
 
             return of(item, extraTag, extraCaps);


### PR DESCRIPTION
When a mod is removed or a mod removes  the ability of an item to have a specific cap, we would currently continuously log errors, instead of stripping the cap from the cap NBT of the item key (and only logging once)