### PR TITLE
Move EncodedPatternItem to API

### DIFF
--- a/src/main/java/appeng/api/crafting/EncodedPatternItem.java
+++ b/src/main/java/appeng/api/crafting/EncodedPatternItem.java
@@ -16,7 +16,7 @@
  * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
  */
 
-package appeng.crafting.pattern;
+package appeng.api.crafting;
 
 import java.util.List;
 import java.util.Map;
@@ -39,13 +39,13 @@ import net.minecraft.world.level.Level;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.api.distmarker.OnlyIn;
 
-import appeng.api.crafting.IPatternDetails;
 import appeng.api.stacks.AEItemKey;
 import appeng.api.stacks.AmountFormat;
 import appeng.api.stacks.GenericStack;
 import appeng.core.AppEng;
 import appeng.core.definitions.AEItems;
 import appeng.core.localization.GuiText;
+import appeng.crafting.pattern.AECraftingPattern;
 import appeng.items.AEBaseItem;
 import appeng.items.misc.WrappedGenericStack;
 import appeng.util.InteractionUtil;
@@ -59,7 +59,7 @@ public abstract class EncodedPatternItem extends AEBaseItem {
     }
 
     @Override
-    public void addToMainCreativeTab(CreativeModeTab.Output output) {
+    public final void addToMainCreativeTab(CreativeModeTab.Output output) {
         // Don't show in creative mode, since it's not useful without NBT
     }
 

--- a/src/main/java/appeng/api/crafting/InvalidPatternHelper.java
+++ b/src/main/java/appeng/api/crafting/InvalidPatternHelper.java
@@ -16,7 +16,7 @@
  * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
  */
 
-package appeng.crafting.pattern;
+package appeng.api.crafting;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/appeng/client/gui/me/patternaccess/PatternSlot.java
+++ b/src/main/java/appeng/client/gui/me/patternaccess/PatternSlot.java
@@ -21,7 +21,7 @@ package appeng.client.gui.me.patternaccess;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 
-import appeng.crafting.pattern.EncodedPatternItem;
+import appeng.api.crafting.EncodedPatternItem;
 import appeng.menu.slot.AppEngSlot;
 
 /**

--- a/src/main/java/appeng/crafting/pattern/AEPatternDecoder.java
+++ b/src/main/java/appeng/crafting/pattern/AEPatternDecoder.java
@@ -23,6 +23,7 @@ import org.jetbrains.annotations.Nullable;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 
+import appeng.api.crafting.EncodedPatternItem;
 import appeng.api.crafting.IPatternDetails;
 import appeng.api.crafting.IPatternDetailsDecoder;
 import appeng.api.stacks.AEItemKey;

--- a/src/main/java/appeng/crafting/pattern/CraftingPatternItem.java
+++ b/src/main/java/appeng/crafting/pattern/CraftingPatternItem.java
@@ -15,6 +15,7 @@ import net.minecraft.world.item.crafting.RecipeManager;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.Level;
 
+import appeng.api.crafting.EncodedPatternItem;
 import appeng.api.stacks.AEItemKey;
 import appeng.core.AELog;
 import appeng.menu.AutoCraftingMenu;

--- a/src/main/java/appeng/crafting/pattern/ProcessingPatternItem.java
+++ b/src/main/java/appeng/crafting/pattern/ProcessingPatternItem.java
@@ -8,6 +8,7 @@ import org.jetbrains.annotations.Nullable;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 
+import appeng.api.crafting.EncodedPatternItem;
 import appeng.api.stacks.AEItemKey;
 import appeng.api.stacks.GenericStack;
 

--- a/src/main/java/appeng/crafting/pattern/SmithingTablePatternItem.java
+++ b/src/main/java/appeng/crafting/pattern/SmithingTablePatternItem.java
@@ -11,6 +11,7 @@ import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.item.crafting.SmithingRecipe;
 import net.minecraft.world.level.Level;
 
+import appeng.api.crafting.EncodedPatternItem;
 import appeng.api.stacks.AEItemKey;
 import appeng.core.AELog;
 

--- a/src/main/java/appeng/crafting/pattern/StonecuttingPatternItem.java
+++ b/src/main/java/appeng/crafting/pattern/StonecuttingPatternItem.java
@@ -11,6 +11,7 @@ import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.item.crafting.StonecutterRecipe;
 import net.minecraft.world.level.Level;
 
+import appeng.api.crafting.EncodedPatternItem;
 import appeng.api.stacks.AEItemKey;
 import appeng.core.AELog;
 

--- a/src/main/java/appeng/helpers/patternprovider/PatternContainer.java
+++ b/src/main/java/appeng/helpers/patternprovider/PatternContainer.java
@@ -2,13 +2,14 @@ package appeng.helpers.patternprovider;
 
 import org.jetbrains.annotations.Nullable;
 
+import appeng.api.crafting.EncodedPatternItem;
 import appeng.api.implementations.blockentities.PatternContainerGroup;
 import appeng.api.inventories.InternalInventory;
 import appeng.api.networking.IGrid;
 
 /**
- * Interface implemented by machines connected to the network if they support storing
- * {@link appeng.crafting.pattern.EncodedPatternItem}, such as the pattern provider.
+ * Interface implemented by machines connected to the network if they support storing {@link EncodedPatternItem}, such
+ * as the pattern provider.
  */
 public interface PatternContainer {
     /**

--- a/src/main/java/appeng/hooks/GuiGraphicsHooks.java
+++ b/src/main/java/appeng/hooks/GuiGraphicsHooks.java
@@ -27,10 +27,10 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 
 import appeng.api.client.AEKeyRendering;
+import appeng.api.crafting.EncodedPatternItem;
 import appeng.api.stacks.AmountFormat;
 import appeng.api.stacks.GenericStack;
 import appeng.client.gui.me.common.StackSizeRenderer;
-import appeng.crafting.pattern.EncodedPatternItem;
 
 public final class GuiGraphicsHooks {
     // Prevents recursion in the hook below

--- a/src/main/java/appeng/menu/slot/RestrictedInputSlot.java
+++ b/src/main/java/appeng/menu/slot/RestrictedInputSlot.java
@@ -24,6 +24,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
 
+import appeng.api.crafting.EncodedPatternItem;
 import appeng.api.crafting.PatternDetailsHelper;
 import appeng.api.features.GridLinkables;
 import appeng.api.features.IGridLinkableHandler;
@@ -40,7 +41,6 @@ import appeng.blockentity.misc.VibrationChamberBlockEntity;
 import appeng.blockentity.qnb.QuantumBridgeBlockEntity;
 import appeng.client.gui.Icon;
 import appeng.core.definitions.AEItems;
-import appeng.crafting.pattern.EncodedPatternItem;
 import appeng.util.Platform;
 
 /**


### PR DESCRIPTION
This PR moves `EncodedPatternItem` to API to avoid large amounts of copy-paste code for custom patterns in addons.
I previously discussed with @Technici4n to move large parts of that class to an API interface such that pattern item tooltips are uniform and to make the pattern preview work for custom encoded patterns. After thinking about it a bit more, I opted to move the entire class instead as moving "only" the relevant parts to an interface would effectively leave `EncodedPatternItem` as an almost empty class. If you prefer the interface approach despite that (i.e. to avoid indirectly exposing `AEBaseItem` in the API), please let me know and I'll adjust it accordingly.