### PR TITLE
Discover test plots based on a new annotation instead of listing them explicitly

### DIFF
--- a/src/main/java/appeng/server/testplots/AnnihilationPlaneTests.java
+++ b/src/main/java/appeng/server/testplots/AnnihilationPlaneTests.java
@@ -13,6 +13,7 @@ import appeng.core.definitions.AEParts;
 import appeng.server.testworld.PlotBuilder;
 import appeng.util.Platform;
 
+@TestPlotClass
 public class AnnihilationPlaneTests {
 
     @TestPlot("annihilation_plane_seed_farm")

--- a/src/main/java/appeng/server/testplots/AutoCraftingTestPlots.java
+++ b/src/main/java/appeng/server/testplots/AutoCraftingTestPlots.java
@@ -37,6 +37,7 @@ import appeng.server.testworld.SpawnExtraGridTestToolsChest;
 import appeng.server.testworld.TestCraftingJob;
 import appeng.util.inv.AppEngInternalInventory;
 
+@TestPlotClass
 public final class AutoCraftingTestPlots {
     private AutoCraftingTestPlots() {
     }

--- a/src/main/java/appeng/server/testplots/CrystalResonanceGeneratorTestPlots.java
+++ b/src/main/java/appeng/server/testplots/CrystalResonanceGeneratorTestPlots.java
@@ -14,6 +14,7 @@ import appeng.core.definitions.AEParts;
 import appeng.server.testworld.PlotBuilder;
 import appeng.server.testworld.PlotTestHelper;
 
+@TestPlotClass
 public class CrystalResonanceGeneratorTestPlots {
     @TestPlot("crg_charges_cell")
     public static void chargesCell(PlotBuilder plot) {

--- a/src/main/java/appeng/server/testplots/ExternalEnergyTestPlots.java
+++ b/src/main/java/appeng/server/testplots/ExternalEnergyTestPlots.java
@@ -14,6 +14,7 @@ import appeng.core.definitions.AEParts;
 import appeng.server.testworld.PlotBuilder;
 import appeng.server.testworld.PlotTestHelper;
 
+@TestPlotClass
 public class ExternalEnergyTestPlots {
     private static final BlockPos ORIGIN = BlockPos.ZERO;
 

--- a/src/main/java/appeng/server/testplots/GuidebookPlot.java
+++ b/src/main/java/appeng/server/testplots/GuidebookPlot.java
@@ -17,6 +17,7 @@ import appeng.server.testworld.PlotBuilder;
 /**
  * Test plot that sets up a working area for working on Guidebook structures.
  */
+@TestPlotClass
 public final class GuidebookPlot {
     private GuidebookPlot() {
     }

--- a/src/main/java/appeng/server/testplots/InscriberTestPlots.java
+++ b/src/main/java/appeng/server/testplots/InscriberTestPlots.java
@@ -13,6 +13,7 @@ import appeng.core.definitions.AEBlocks;
 import appeng.core.definitions.AEItems;
 import appeng.items.materials.NamePressItem;
 
+@TestPlotClass
 public final class InscriberTestPlots {
     private InscriberTestPlots() {
     }

--- a/src/main/java/appeng/server/testplots/InterfaceTestPlots.java
+++ b/src/main/java/appeng/server/testplots/InterfaceTestPlots.java
@@ -24,6 +24,7 @@ import appeng.me.helpers.BaseActionSource;
 import appeng.parts.misc.InterfacePart;
 import appeng.server.testworld.PlotBuilder;
 
+@TestPlotClass
 public class InterfaceTestPlots {
 
     /**

--- a/src/main/java/appeng/server/testplots/InvalidPatternTestPlot.java
+++ b/src/main/java/appeng/server/testplots/InvalidPatternTestPlot.java
@@ -8,6 +8,7 @@ import appeng.blockentity.storage.SkyChestBlockEntity;
 import appeng.core.definitions.AEBlocks;
 import appeng.server.testworld.PlotBuilder;
 
+@TestPlotClass
 public class InvalidPatternTestPlot {
 
     /**

--- a/src/main/java/appeng/server/testplots/ItemP2PTestPlots.java
+++ b/src/main/java/appeng/server/testplots/ItemP2PTestPlots.java
@@ -17,6 +17,7 @@ import appeng.core.definitions.AEParts;
 import appeng.parts.AEBasePart;
 import appeng.server.testworld.PlotBuilder;
 
+@TestPlotClass
 public class ItemP2PTestPlots {
 
     @TestPlot("p2p_items")

--- a/src/main/java/appeng/server/testplots/MemoryCardTestPlots.java
+++ b/src/main/java/appeng/server/testplots/MemoryCardTestPlots.java
@@ -36,6 +36,7 @@ import appeng.server.testworld.PlotBuilder;
 import appeng.server.testworld.PlotTestHelper;
 import appeng.util.SettingsFrom;
 
+@TestPlotClass
 public final class MemoryCardTestPlots {
     private MemoryCardTestPlots() {
     }

--- a/src/main/java/appeng/server/testplots/P2PTestPlots.java
+++ b/src/main/java/appeng/server/testplots/P2PTestPlots.java
@@ -26,6 +26,7 @@ import appeng.parts.reporting.AbstractPanelPart;
 import appeng.parts.reporting.PanelPart;
 import appeng.server.testworld.PlotBuilder;
 
+@TestPlotClass
 public class P2PTestPlots {
     @TestPlot("p2p_me")
     public static void me(PlotBuilder plot) {

--- a/src/main/java/appeng/server/testplots/PatternProviderLockModePlots.java
+++ b/src/main/java/appeng/server/testplots/PatternProviderLockModePlots.java
@@ -27,6 +27,7 @@ import appeng.server.testworld.SavedBlockEntity;
  * All plots are essentially the same: PP on Chest, powered by Creative Energy Cell. Use of the PP is via API, not
  * in-game tools.
  */
+@TestPlotClass
 public final class PatternProviderLockModePlots {
     private static final BlockPos LEVER_POS = BlockPos.ZERO.east();
     private static final BlockPos BUTTON_POS = BlockPos.ZERO.west();

--- a/src/main/java/appeng/server/testplots/PatternProviderPlots.java
+++ b/src/main/java/appeng/server/testplots/PatternProviderPlots.java
@@ -11,6 +11,7 @@ import appeng.core.definitions.AEBlocks;
 import appeng.core.definitions.AEParts;
 import appeng.server.testworld.PlotBuilder;
 
+@TestPlotClass
 public final class PatternProviderPlots {
     private PatternProviderPlots() {
     }

--- a/src/main/java/appeng/server/testplots/QnbTestPlots.java
+++ b/src/main/java/appeng/server/testplots/QnbTestPlots.java
@@ -12,6 +12,7 @@ import appeng.core.definitions.AEItems;
 import appeng.server.testworld.PlotBuilder;
 import appeng.server.testworld.PlotTestHelper;
 
+@TestPlotClass
 public final class QnbTestPlots {
     private QnbTestPlots() {
     }

--- a/src/main/java/appeng/server/testplots/SpatialTestPlots.java
+++ b/src/main/java/appeng/server/testplots/SpatialTestPlots.java
@@ -18,6 +18,7 @@ import appeng.server.testworld.PlotBuilder;
 import appeng.server.testworld.PlotTestHelper;
 import appeng.spatial.SpatialStoragePlotManager;
 
+@TestPlotClass
 public final class SpatialTestPlots {
     private SpatialTestPlots() {
     }

--- a/src/main/java/appeng/server/testplots/SpawnExtraGridTestTools.java
+++ b/src/main/java/appeng/server/testplots/SpawnExtraGridTestTools.java
@@ -9,6 +9,7 @@ import appeng.api.networking.IGrid;
 /**
  * Triggered to spawn additional testing tools into a container placed next to a spawned AE2 grid.
  */
+@TestPlotClass
 public class SpawnExtraGridTestTools extends Event {
     private final ResourceLocation plotId;
     private final InternalInventory inventory;

--- a/src/main/java/appeng/server/testplots/SubnetPlots.java
+++ b/src/main/java/appeng/server/testplots/SubnetPlots.java
@@ -17,6 +17,7 @@ import appeng.server.testworld.PlotBuilder;
 /**
  * Test plot that sets up a working area for working on Guidebook structures.
  */
+@TestPlotClass
 public final class SubnetPlots {
 
     private static final AEItemKey STICK = AEItemKey.of(Items.STICK);

--- a/src/main/java/appeng/server/testplots/TestPlotClass.java
+++ b/src/main/java/appeng/server/testplots/TestPlotClass.java
@@ -1,0 +1,8 @@
+package appeng.server.testplots;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestPlotClass {
+}


### PR DESCRIPTION
@Mari023 I think you were using the API to add test plots? I don't quite remember.
This adds the ability to use an annotation instead.