### PR TITLE
Pattern Access Terminal's search box will not auto focus

### DIFF
--- a/src/main/java/appeng/client/gui/me/patternaccess/PatternAccessTermScreen.java
+++ b/src/main/java/appeng/client/gui/me/patternaccess/PatternAccessTermScreen.java
@@ -171,9 +171,6 @@ public class PatternAccessTermScreen<C extends PatternAccessTermMenu> extends AE
 
         super.init();
 
-        // Auto focus search field
-        this.setInitialFocus(this.searchField);
-
         // numLines may have changed, recalculate scroll bar.
         this.resetScrollbar();
     }


### PR DESCRIPTION
Why don’t all terminals except Pattern Access Terminal auto focus?