### PR TITLE
Fix crafting job progress bar exceeding 100%

### DIFF
--- a/src/main/java/appeng/client/gui/widgets/CPUSelectionList.java
+++ b/src/main/java/appeng/client/gui/widgets/CPUSelectionList.java
@@ -215,7 +215,8 @@ public class CPUSelectionList implements ICompositeWidget {
                 infoBar.add(currentJob.what(), 0.6f);
 
                 // Draw a bar at the bottom of the button to indicate job progress
-                var progress = (int) (cpu.progress() * (buttonBg.getSrcWidth() - 1) / Math.max(1, cpu.totalItems()));
+                var totalItems = Math.max(1, cpu.totalItems());
+                var progress = (int) (Math.min(cpu.progress(), totalItems) * (buttonBg.getSrcWidth() - 1) / totalItems);
                 guiGraphics.fill(
                         x + 1,
                         y + buttonBg.getSrcHeight() - 2,


### PR DESCRIPTION
This fixes a progress bar rendering more than the maximum width by clamping the percentage if the crafting job makes heavy use of non-consumed items.

Note that this is merely a cosmetic fix for an overly long progress bar. The bar will still reach 100% much faster than completing the job. This is a more fundamental issue that still needs to be fixed separately.

Partial fix for #7468.

---

Note that I could not in fact verify that it does no longer occur, because I have no setup with mods using non-consumed items. I still think that a cosmetic fix is better than nothing.