### PR TITLE
Fix german translation of 256k storage cell

### DIFF
--- a/src/main/resources/assets/ae2/lang/de_de.json
+++ b/src/main/resources/assets/ae2/lang/de_de.json
@@ -806,7 +806,7 @@
   "item.ae2.item_p2p_tunnel": "Item P2P-Tunnel",
   "item.ae2.item_storage_cell_16k": "16k-ME-Speicherzelle",
   "item.ae2.item_storage_cell_1k": "1k-ME-Speicherzelle",
-  "item.ae2.item_storage_cell_256k": "16k-ME-Speicherzelle",
+  "item.ae2.item_storage_cell_256k": "256k-ME-Speicherzelle",
   "item.ae2.item_storage_cell_4k": "4k-ME-Speicherzelle",
   "item.ae2.item_storage_cell_64k": "64k-ME-Speicherzelle",
   "item.ae2.level_emitter": "ME-Füllstandsemitter",


### PR DESCRIPTION
The current translation indicates that it is a 64k cell, which is incorrect.