### PR TITLE
Make export storage implementation public

### DIFF
--- a/src/main/java/appeng/parts/automation/StorageExportStrategy.java
+++ b/src/main/java/appeng/parts/automation/StorageExportStrategy.java
@@ -21,7 +21,7 @@ public class StorageExportStrategy<T, S> implements StackExportStrategy {
     private final BlockCapabilityCache<T, Direction> cache;
     private final HandlerStrategy<T, S> handlerStrategy;
 
-    protected StorageExportStrategy(BlockCapability<T, Direction> capability,
+    public StorageExportStrategy(BlockCapability<T, Direction> capability,
             HandlerStrategy<T, S> handlerStrategy,
             ServerLevel level,
             BlockPos fromPos,


### PR DESCRIPTION
This will allow add-on makers to use the existing implementation of the export strategy instead of copying the whole thing over or instead of creating a dummy class that extends it just to make the constructor public.

Other strategy implementations such as importing and container storage are already public so this should be to.