### PR TITLE
Refer to page IDs rather than source pack for add-on guidebook pages

### DIFF
--- a/src/main/java/appeng/client/guidebook/screen/GuideScreen.java
+++ b/src/main/java/appeng/client/guidebook/screen/GuideScreen.java
@@ -292,29 +292,17 @@ public class GuideScreen extends Screen {
      */
     @Nullable
     private String getExternalSourceName() {
-        var sourcePackId = currentPage.sourcePack();
-        // If the pages came directly from a mod resource pack, we have to use the mod-list to resolve its name
-        if (sourcePackId.startsWith("mod:")) {
-            var modId = sourcePackId.substring("mod:".length());
-
-            // Only show the source marker for pages that are not native to the guides mod
-            if (guide.getDefaultNamespace().equals(modId)) {
-                return null;
-            }
-
-            return ModList.get().getModContainerById(modId)
+        var pageNamespace = currentPage.id().getNamespace();
+        // If the page had an ID under another mod's namespace, we have to use the mod-list to resolve its name
+        if (!guide.getDefaultNamespace().equals(pageNamespace)) {
+            return ModList.get().getModContainerById(pageNamespace)
                     .map(ModContainer::getModInfo)
                     .map(IModInfo::getDisplayName)
                     .orElse(null);
         }
 
-        // Only show the source marker for pages that are not native to the guides mod
-        if (guide.getDefaultNamespace().equals(sourcePackId)) {
-            return null;
-        }
-
-        var pack = Minecraft.getInstance().getResourcePackRepository().getPack(sourcePackId);
-        if (pack != null) {
+        var pack = Minecraft.getInstance().getResourcePackRepository().getPack(currentPage.sourcePack());
+        if (pack != null && !pack.getId().equals("mod_resources")) {
             return pack.getDescription().getString();
         }
 


### PR DESCRIPTION
In 1.20.1 [Neo]Forge, all mod assets are stuffed into a single `mod_resources` pack, making source pack checks ineffective for pages added by other add-on mods.