### PR TITLE
fix ingredient amount being ignored in non EmiStack instance

### DIFF
--- a/src/main/java/appeng/integration/modules/emi/EmiStackHelper.java
+++ b/src/main/java/appeng/integration/modules/emi/EmiStackHelper.java
@@ -61,6 +61,7 @@ public final class EmiStackHelper {
                 .stream()
                 .map(EmiStackHelper::toGenericStack)
                 .filter(Objects::nonNull)
+                .map(x -> new GenericStack(x.what(), emiIngredient.getAmount()))
                 .toList();
     }
 }


### PR DESCRIPTION
TagEmiIngredient wrap the amount in its own field, and the EmiStacks its contains don't have the amount data. It results in wrong amount of items being transferred to pattern terminal