### PR TITLE
fix charger not dropping charged items

### DIFF
--- a/src/main/java/appeng/block/misc/ChargerBlock.java
+++ b/src/main/java/appeng/block/misc/ChargerBlock.java
@@ -83,6 +83,10 @@ public class ChargerBlock extends AEBaseEntityBlock<ChargerBlockEntity> {
                     inv.setItemDirect(0, toInsert);
                     return ItemInteractionResult.sidedSuccess(level.isClientSide);
                 }
+            } else {
+                Platform.spawnDrops(player.level(), charger.getBlockPos().relative(charger.getFront()),
+                        List.of(chargingItem));
+                return ItemInteractionResult.sidedSuccess(level.isClientSide);
             }
         }
 


### PR DESCRIPTION
This fixes bug 7934 for me.

I'm still a bit confused as to why useItemOn() would be called in the first place rather than useWithoutItem()