### PR TITLE
Fix cables briefly connecting to incomplete Quantum Ring

### DIFF
--- a/src/main/java/appeng/blockentity/qnb/QuantumBridgeBlockEntity.java
+++ b/src/main/java/appeng/blockentity/qnb/QuantumBridgeBlockEntity.java
@@ -73,6 +73,7 @@ public class QuantumBridgeBlockEntity extends AENetworkInvBlockEntity
         super(blockEntityType, pos, blockState);
         this.getMainNode().setFlags(GridFlags.DENSE_CAPACITY);
         this.getMainNode().setIdlePowerUsage(22);
+        onGridConnectableSidesChanged();
     }
 
     @Override


### PR DESCRIPTION
Fix #7935.

I'm not sure if this is the correct way to do it, but it fixes the visual glitch of the split-second flash of a cable connecting to the newly placed, incomplete Quantum Ring.