### PR TITLE
Fix P2P Light output not updating when input is removed

### DIFF
--- a/src/main/java/appeng/parts/p2p/LightP2PTunnelPart.java
+++ b/src/main/java/appeng/parts/p2p/LightP2PTunnelPart.java
@@ -118,7 +118,7 @@ public class LightP2PTunnelPart extends P2PTunnelPart<LightP2PTunnelPart> implem
 
     @Override
     public int getLightLevel() {
-        if (this.isOutput() && this.isPowered()) {
+        if (this.isOutput() && this.isPowered() && this.getInput() != null) {
             return this.blockLight(this.lastValue);
         }
 


### PR DESCRIPTION
Found as an additional bug in #7936.

If the P2P Light input is removed, either by destroying or disconnecting it, the outputs would still emit the previous light level.

Please note that it does not fix the original bug report.