### PR TITLE
Switch to Biome for JSON formatting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -411,14 +411,18 @@ spotless {
             if (it.contains('*;\n')) {
                 throw new Error('No wildcard imports allowed')
             }
+
+            it
         }
         bumpThisNumberIfACustomStepChanges(1)
     }
 
-    format 'json', {
+   json {
         target 'src/*/resources/**/*.json'
         targetExclude 'src/generated/resources/**'
-        prettier().config(['parser': 'json'])
+        biome()
+        indentWithSpaces(2)
+        endWithNewline()
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,8 +17,8 @@ plugins {
 }
 
 dependencyResolutionManagement {
-    repositoriesMode = RepositoriesMode.FAIL_ON_PROJECT_REPOS
-    rulesMode = RulesMode.FAIL_ON_PROJECT_RULES
+    repositoriesMode = RepositoriesMode.PREFER_SETTINGS
+    rulesMode = RulesMode.PREFER_SETTINGS
     repositories {
         mavenLocal()
         maven {


### PR DESCRIPTION
Replaces the previous Prettier step which required a separate installation of npm to work at all. Biome no longer requires any extra dependencies as Spotless will simply grab a static binary to use from within `mavenLocal`.

Note that the `biome()` step also adds the `mavenLocal()` repository definition to the buildscript, which causes the project build to fail when using `RepositoriesMode.FAIL_ON_PROJECT_REPOS` in the settings file.