### PR TITLE
Fix GUI for formation plane, import bus and export bus

### DIFF
--- a/src/main/resources/assets/ae2/screens/formation_plane.json
+++ b/src/main/resources/assets/ae2/screens/formation_plane.json
@@ -7,7 +7,7 @@
   ],
   "background": {
     "texture": "guis/storagebus.png",
-    "srcRect": [0, 0, 176, 251]
+    "srcRect": [0, 0, 176, 253]
   },
   "slots": {
     "CONFIG": {

--- a/src/main/resources/assets/ae2/screens/io_bus.json
+++ b/src/main/resources/assets/ae2/screens/io_bus.json
@@ -7,7 +7,7 @@
   ],
   "background": {
     "texture": "guis/storagebus.png",
-    "srcRect": [0, 0, 176, 251]
+    "srcRect": [0, 0, 176, 253]
   },
   "slots": {
     "CONFIG": {


### PR DESCRIPTION
Fixes #7963.

All three use the storagebus.png but differ in the srcRect size. While storage_bus.json was updated during retexturing, the others were not leading to:
  - misaligned player inventory
  - missing a 2 pixel wide bottom border area