### PR TITLE
Fix crafting job progress bar exceeding 100%

### DIFF
--- a/src/main/java/appeng/crafting/execution/CraftingCpuHelper.java
+++ b/src/main/java/appeng/crafting/execution/CraftingCpuHelper.java
@@ -102,7 +102,8 @@ public class CraftingCpuHelper {
             IPatternDetails details,
             ICraftingInventory sourceInv,
             Level level,
-            KeyCounter expectedOutputs) {
+            KeyCounter expectedOutputs,
+            KeyCounter expectedContainerItems) {
 
         // Extract inputs into the container.
         var inputs = details.getInputs();
@@ -120,7 +121,7 @@ public class CraftingCpuHelper {
                 // Container items!
                 var containerItem = inputs[x].getRemainingKey(template.key());
                 if (containerItem != null) {
-                    expectedOutputs.add(containerItem, extracted);
+                    expectedContainerItems.add(containerItem, extracted);
                 }
 
                 remainingMultiplier -= extracted;

--- a/src/main/java/appeng/crafting/execution/ExecutingCraftingJob.java
+++ b/src/main/java/appeng/crafting/execution/ExecutingCraftingJob.java
@@ -45,6 +45,7 @@ public class ExecutingCraftingJob {
     private static final String NBT_PLAYER_ID = "playerId";
     private static final String NBT_FINAL_OUTPUT = "finalOutput";
     private static final String NBT_WAITING_FOR = "waitingFor";
+    private static final String NBT_WAITING_FOR_ADDITIONAL = "waitingForAdditional";
     private static final String NBT_TIME_TRACKER = "timeTracker";
     private static final String NBT_REMAINING_AMOUNT = "remainingAmount";
     private static final String NBT_TASKS = "tasks";
@@ -52,6 +53,7 @@ public class ExecutingCraftingJob {
 
     final CraftingLink link;
     final ListCraftingInventory waitingFor;
+    final ListCraftingInventory waitingForAdditional;
     final Map<IPatternDetails, TaskProgress> tasks = new HashMap<>();
     final ElapsedTimeTracker timeTracker;
     GenericStack finalOutput;
@@ -69,6 +71,7 @@ public class ExecutingCraftingJob {
         this.finalOutput = plan.finalOutput();
         this.remainingAmount = this.finalOutput.amount();
         this.waitingFor = new ListCraftingInventory(postCraftingDifference::onCraftingDifference);
+        this.waitingForAdditional = new ListCraftingInventory(postCraftingDifference::onCraftingDifference);
 
         // Fill waiting for and tasks
         long totalPending = 0;
@@ -99,6 +102,8 @@ public class ExecutingCraftingJob {
         this.remainingAmount = data.getLong(NBT_REMAINING_AMOUNT);
         this.waitingFor = new ListCraftingInventory(postCraftingDifference::onCraftingDifference);
         this.waitingFor.readFromNBT(data.getList(NBT_WAITING_FOR, Tag.TAG_COMPOUND), registries);
+        this.waitingForAdditional = new ListCraftingInventory(postCraftingDifference::onCraftingDifference);
+        this.waitingForAdditional.readFromNBT(data.getList(NBT_WAITING_FOR_ADDITIONAL, Tag.TAG_COMPOUND), registries);
         this.timeTracker = new ElapsedTimeTracker(data.getCompound(NBT_TIME_TRACKER));
         if (data.contains(NBT_PLAYER_ID, Tag.TAG_INT)) {
             this.playerId = data.getInt(NBT_PLAYER_ID);
@@ -129,6 +134,7 @@ public class ExecutingCraftingJob {
         data.put(NBT_FINAL_OUTPUT, GenericStack.writeTag(registries, finalOutput));
 
         data.put(NBT_WAITING_FOR, waitingFor.writeToNBT(registries));
+        data.put(NBT_WAITING_FOR_ADDITIONAL, waitingForAdditional.writeToNBT(registries));
         data.put(NBT_TIME_TRACKER, timeTracker.writeToNBT());
 
         final ListTag list = new ListTag();


### PR DESCRIPTION
Fix for 1.21 for the bug reported independently in #7468 for 1.20 and #7420 for 1.19.

The bug stems from the discrepancy between the initial calculation that only accounts for recipe outputs and the actual execution of the job which adds recipe outputs as well as any remaining items in the crafting grid, called container items. When decrementing the counter for the remaining items, these container items must not be counted to ensure the counter only decrements down to 0 and not beyond.

Fixing this side of the problem, rather than the initial calculation has two reasons:
  - more accurate progress bar, because recipes with container items don't decrease the counter multiple times per recipe execution, which will become important for more complex crafting jobs with a mix of normal recipes and those with additional container items.
  - the actual number of container items is determined only at the execution stage and not during the initial calculation.