### PR TITLE
add a getter for visible rows in terminal screens

### DIFF
--- a/src/main/java/appeng/client/gui/me/common/MEStorageScreen.java
+++ b/src/main/java/appeng/client/gui/me/common/MEStorageScreen.java
@@ -812,6 +812,10 @@ public class MEStorageScreen<C extends MEStorageMenu>
         this.repo.updateView();
     }
 
+    protected int getVisibleRows() {
+        return rows;
+    }
+
     private void toggleTerminalStyle(SettingToggleButton<appeng.api.config.TerminalStyle> btn, boolean backwards) {
         appeng.api.config.TerminalStyle next = btn.getNextValue(backwards);
         config.setTerminalStyle(next);

--- a/src/main/java/appeng/client/gui/me/patternaccess/PatternAccessTermScreen.java
+++ b/src/main/java/appeng/client/gui/me/patternaccess/PatternAccessTermScreen.java
@@ -619,6 +619,10 @@ public class PatternAccessTermScreen<C extends PatternAccessTermMenu> extends AE
                 srcRect.getHeight());
     }
 
+    protected int getVisibleRows() {
+        return visibleRows;
+    }
+
     sealed interface Row {
     }
 


### PR DESCRIPTION
In ae2wtlib, I want to use the row count for a widget that dynamically resized based on the amount of rows shown in the terminal. currently I have to redo a lot of that calculation.