### PR TITLE
Fix EMI recipe widgets

### DIFF
--- a/src/main/java/appeng/integration/modules/emi/EmiCondenserRecipe.java
+++ b/src/main/java/appeng/integration/modules/emi/EmiCondenserRecipe.java
@@ -37,7 +37,7 @@ class EmiCondenserRecipe extends BasicEmiRecipe {
     private final EmiStack output;
 
     public EmiCondenserRecipe(CondenserOutput type) {
-        super(CATEGORY, getRecipeId(type), 94, 48);
+        super(CATEGORY, getRecipeId(type), 96, 48);
         this.type = type;
         this.output = EmiStack.of(getOutput(type));
         this.outputs.add(this.output);
@@ -49,24 +49,24 @@ class EmiCondenserRecipe extends BasicEmiRecipe {
     public void addWidgets(WidgetHolder widgets) {
 
         var background = AppEng.makeId("textures/guis/condenser.png");
-        widgets.addTexture(background, 0, 0, 94, 48, 50, 25);
+        widgets.addTexture(background, 0, 0, 96, 48, 48, 25);
 
         var statesLocation = AppEng.makeId("textures/guis/states.png");
-        widgets.addTexture(statesLocation, 2, 28, 14, 14, 241, 81);
-        widgets.addTexture(statesLocation, 78, 28, 16, 16, 240, 240);
+        widgets.addTexture(statesLocation, 4, 28, 14, 14, 241, 81);
+        widgets.addTexture(statesLocation, 80, 28, 16, 16, 240, 240);
 
-        widgets.addAnimatedTexture(background, 70, 0, 6, 18, 178, 25,
+        widgets.addAnimatedTexture(background, 72, 0, 6, 18, 176, 0,
                 2000, false, true, false);
 
         if (type == CondenserOutput.MATTER_BALLS) {
-            widgets.addTexture(statesLocation, 78, 28, 14, 14, 16, 112);
+            widgets.addTexture(statesLocation, 80, 28, 14, 14, 16, 112);
         } else if (type == CondenserOutput.SINGULARITY) {
-            widgets.addTexture(statesLocation, 78, 28, 14, 14, 32, 112);
+            widgets.addTexture(statesLocation, 80, 28, 14, 14, 32, 112);
         }
-        widgets.addTooltipText(getTooltip(type), 78, 28, 16, 16);
+        widgets.addTooltipText(getTooltip(type), 80, 28, 16, 16);
 
-        widgets.addSlot(output, 54, 26).drawBack(false);
-        widgets.addSlot(viableStorageComponents, 50, 0).drawBack(false);
+        widgets.addSlot(output, 56, 26).drawBack(false);
+        widgets.addSlot(viableStorageComponents, 52, 0).drawBack(false);
 
     }
 

--- a/src/main/java/appeng/integration/modules/emi/EmiInscriberRecipe.java
+++ b/src/main/java/appeng/integration/modules/emi/EmiInscriberRecipe.java
@@ -20,7 +20,7 @@ class EmiInscriberRecipe extends BasicEmiRecipe {
     private final InscriberRecipe recipe;
 
     public EmiInscriberRecipe(RecipeHolder<InscriberRecipe> holder) {
-        super(CATEGORY, holder.id(), 97, 64);
+        super(CATEGORY, holder.id(), 105, 54);
 
         recipe = holder.value();
 
@@ -46,18 +46,18 @@ class EmiInscriberRecipe extends BasicEmiRecipe {
     public void addWidgets(WidgetHolder widgets) {
         ResourceLocation background = AppEng.makeId("textures/guis/inscriber.png");
 
-        widgets.addTexture(background, 0, 0, 97, 64, 44, 15);
+        widgets.addTexture(background, 0, 0, 105, 54, 36, 20);
 
-        widgets.addAnimatedTexture(background, 91, 24, 6, 18, 135, 177,
+        widgets.addAnimatedTexture(background, 100, 19, 6, 18, 177, 0,
                 2000, false, true, false);
 
-        widgets.addSlot(EmiIngredient.of(recipe.getTopOptional()), 0, 0)
+        widgets.addSlot(EmiIngredient.of(recipe.getTopOptional()), 2, 2)
                 .drawBack(false);
-        widgets.addSlot(EmiIngredient.of(recipe.getMiddleInput()), 18, 23)
+        widgets.addSlot(EmiIngredient.of(recipe.getMiddleInput()), 26, 18)
                 .drawBack(false);
-        widgets.addSlot(EmiIngredient.of(recipe.getBottomOptional()), 0, 46)
+        widgets.addSlot(EmiIngredient.of(recipe.getBottomOptional()), 2, 34)
                 .drawBack(false);
-        widgets.addSlot(EmiStack.of(recipe.getResultItem()), 68, 24)
+        widgets.addSlot(EmiStack.of(recipe.getResultItem()), 76, 19)
                 .drawBack(false);
     }
 }


### PR DESCRIPTION
The new textures moved some coordinates around. Since the textures are reused by the EMI recipe widgets they need to be adapted accordingly.