### PR TITLE
Fix "open guide" hotkey not working for items in Emi because they were changing each frame (#7965)

### DIFF
--- a/src/main/java/appeng/client/guidebook/hotkey/OpenGuideHotkey.java
+++ b/src/main/java/appeng/client/guidebook/hotkey/OpenGuideHotkey.java
@@ -1,6 +1,7 @@
 package appeng.client.guidebook.hotkey;
 
 import java.util.List;
+import java.util.Objects;
 
 import com.google.common.base.Strings;
 import com.mojang.blaze3d.platform.InputConstants;
@@ -51,8 +52,8 @@ public final class OpenGuideHotkey {
 
     private static boolean newTick = true;
 
-    // The last itemstack the tooltip was being shown for
-    private static ItemStack lastStack;
+    // The previous item the tooltip was being shown for
+    private static ResourceLocation previousItemId;
     @Nullable
     private static PageAnchor guidebookPage;
     // Full ticks since the button was held (reduces slowly when not held)
@@ -141,15 +142,16 @@ public final class OpenGuideHotkey {
     }
 
     private static void update(ItemStack itemStack) {
-        if (itemStack != lastStack) {
-            lastStack = itemStack;
+        var itemId = itemStack.getItemHolder()
+                .unwrapKey()
+                .map(ResourceKey::location)
+                .orElse(null);
+
+        if (!Objects.equals(itemId, previousItemId)) {
+            previousItemId = itemId;
             guidebookPage = null;
             ticksKeyHeld = 0;
 
-            var itemId = itemStack.getItemHolder()
-                    .unwrapKey()
-                    .map(ResourceKey::location)
-                    .orElse(null);
             if (itemId == null) {
                 return;
             }


### PR DESCRIPTION
Fixes #8059

(cherry picked from commit 40583e4c595b3ffae177098022125bd8c2032b55)