### PR TITLE
Fix annihilation planes working when the network is offline

### DIFF
--- a/src/main/java/appeng/parts/automation/AnnihilationPlanePart.java
+++ b/src/main/java/appeng/parts/automation/AnnihilationPlanePart.java
@@ -300,9 +300,13 @@ public class AnnihilationPlanePart extends AEBasePart implements IGridTickable {
 
     @Override
     public TickRateModulation tickingRequest(IGridNode node, int ticksSinceLastCall) {
+        if (!isActive()) {
+            return TickRateModulation.SLEEP;
+        }
+
         var grid = node.getGrid();
 
-        if (isActive() && continuousGeneration != null) {
+        if (continuousGeneration != null) {
             continuousGenerationTicks += ticksSinceLastCall;
             if (continuousGenerationTicks >= continuousGeneration.ticks) {
                 long amount = continuousGenerationTicks / continuousGeneration.ticks;


### PR DESCRIPTION
We could do the reset anyway even the plane is not active, but it doesn't seem useful.