### PR TITLE
Fix crafting job progress bar exceeding 100% with container items

### DIFF
--- a/src/main/java/appeng/crafting/execution/CraftingCpuHelper.java
+++ b/src/main/java/appeng/crafting/execution/CraftingCpuHelper.java
@@ -102,11 +102,11 @@ public class CraftingCpuHelper {
             IPatternDetails details,
             ICraftingInventory sourceInv,
             Level level,
-            KeyCounter expectedOutputs) {
+            KeyCounter expectedOutputs,
+            KeyCounter expectedContainerItems) {
 
         // Extract inputs into the container.
         var inputs = details.getInputs();
-        @SuppressWarnings("unchecked")
         KeyCounter[] inputHolder = new KeyCounter[inputs.length];
         boolean found = true;
 
@@ -120,7 +120,7 @@ public class CraftingCpuHelper {
                 // Container items!
                 var containerItem = inputs[x].getRemainingKey(template.key());
                 if (containerItem != null) {
-                    expectedOutputs.add(containerItem, extracted);
+                    expectedContainerItems.add(containerItem, extracted);
                 }
 
                 remainingMultiplier -= extracted;

--- a/src/main/java/appeng/crafting/execution/CraftingCpuLogic.java
+++ b/src/main/java/appeng/crafting/execution/CraftingCpuLogic.java
@@ -188,10 +188,11 @@ public class CraftingCpuLogic {
 
             var details = task.getKey();
             var expectedOutputs = new KeyCounter();
+            var expectedContainerItems = new KeyCounter();
             // Contains the inputs for the pattern.
             @Nullable
             var craftingContainer = CraftingCpuHelper.extractPatternInputs(
-                    details, inventory, level, expectedOutputs);
+                    details, inventory, level, expectedOutputs, expectedContainerItems);
 
             // Try to push to each provider.
             for (var provider : craftingService.getProviders(details)) {
@@ -214,6 +215,11 @@ public class CraftingCpuLogic {
                         job.waitingFor.insert(expectedOutput.getKey(), expectedOutput.getLongValue(),
                                 Actionable.MODULATE);
                     }
+                    for (var expectedContainerItem : expectedContainerItems) {
+                        job.waitingFor.insert(expectedContainerItem.getKey(), expectedContainerItem.getLongValue(),
+                                Actionable.MODULATE);
+                        job.timeTracker.addMaxItems(expectedContainerItem.getLongValue());
+                    }
 
                     cluster.markDirty();
 
@@ -229,8 +235,9 @@ public class CraftingCpuLogic {
 
                     // Prepare next inputs.
                     expectedOutputs.reset();
+                    expectedContainerItems.reset();
                     craftingContainer = CraftingCpuHelper.extractPatternInputs(details, inventory,
-                            level, expectedOutputs);
+                            level, expectedOutputs, expectedContainerItems);
                 }
             }
 

--- a/src/main/java/appeng/crafting/execution/ElapsedTimeTracker.java
+++ b/src/main/java/appeng/crafting/execution/ElapsedTimeTracker.java
@@ -27,7 +27,7 @@ public class ElapsedTimeTracker {
 
     private long lastTime = System.nanoTime();
     private long elapsedTime = 0;
-    private final long startItemCount;
+    private long startItemCount;
     private long remainingItemCount;
 
     public ElapsedTimeTracker(long startItemCount) {
@@ -49,11 +49,21 @@ public class ElapsedTimeTracker {
         return data;
     }
 
-    void decrementItems(long itemDiff) {
+    private void updateTime() {
         long currentTime = System.nanoTime();
         this.elapsedTime = this.elapsedTime + (currentTime - this.lastTime);
         this.lastTime = currentTime;
+    }
+
+    void decrementItems(long itemDiff) {
+        updateTime();
         this.remainingItemCount -= itemDiff;
+    }
+
+    void addMaxItems(long itemDiff) {
+        updateTime();
+        this.startItemCount += itemDiff;
+        this.remainingItemCount += itemDiff;
     }
 
     public long getElapsedTime() {

--- a/src/main/java/appeng/crafting/execution/ElapsedTimeTracker.java
+++ b/src/main/java/appeng/crafting/execution/ElapsedTimeTracker.java
@@ -27,6 +27,8 @@ public class ElapsedTimeTracker {
 
     private long lastTime = System.nanoTime();
     private long elapsedTime = 0;
+    // TODO 1.21 rename: "start item count" is not a good name:
+    // this item count can increase when container items are scheduled.
     private long startItemCount;
     private long remainingItemCount;
 


### PR DESCRIPTION
Alternative to https://github.com/AppliedEnergistics/Applied-Energistics-2/pull/8005. We simply add container items to the total number of items expected for the job.

Fixes #7468. Fixes #7420.