### PR TITLE
Fix #8020: Use up-to-date network contents for player-started crafting simulations

### DIFF
--- a/src/main/java/appeng/crafting/inv/NetworkCraftingSimulationState.java
+++ b/src/main/java/appeng/crafting/inv/NetworkCraftingSimulationState.java
@@ -44,7 +44,16 @@ public class NetworkCraftingSimulationState extends CraftingSimulationState {
             return;
         }
 
-        for (var stack : storage.getCachedInventory()) {
+        // We choose to re-query the available stacks every time a crafting simulation is started by a player.
+        // Using getCachedInventory causes issues with our "CTRL+click to craft" integration with EMI, which submits a
+        // job and then immediately starts a new simulation. We want that simulation to see the state of the network
+        // after the previous job was submitted in case of overlap between the recipes. More generally, having to replan
+        // is annoying, and we want to minimize the risk of that for player-started calculations.
+        // For non-player sources, it is fine to use the cached inventory: they will submit a new request eventually if
+        // this simulation or job fails.
+        var inventory = src.player().isEmpty() ? storage.getCachedInventory()
+                : storage.getInventory().getAvailableStacks();
+        for (var stack : inventory) {
             long networkAmount = stack.getLongValue();
             if (networkAmount > 0) {
                 this.list.add(stack.getKey(), networkAmount);


### PR DESCRIPTION
This fixes the annoyance expressed in #8020 with a straightforward solution. We want to make sure that the network state used by each simulation corresponds to a snapshot taken AFTER the submission of the previous job.