### PR TITLE
Fix flickering power bar

### DIFF
--- a/src/main/java/appeng/items/tools/powered/powersink/AEBasePoweredItem.java
+++ b/src/main/java/appeng/items/tools/powered/powersink/AEBasePoweredItem.java
@@ -77,7 +77,7 @@ public abstract class AEBasePoweredItem extends AEBaseItem implements IAEItemPow
     @Override
     public int getBarWidth(ItemStack stack) {
         double filled = getAECurrentPower(stack) / getAEMaxPower(stack);
-        return Mth.clamp((int) (filled * 13), 0, 13);
+        return Mth.clamp((int) Math.round(filled * 13), 0, 13);
     }
 
     @Override


### PR DESCRIPTION
In a scenario with wireless charging (in my case a Player Transmitter from Powah) you can run into situation where a Wireless Crafting Terminal when opened will show a flickering power bar when fully charged (and being regularly refilled wirelessly), which is somewhat noticable and distracting.

This is caused by the cast from `double` to `int` in `getBarWidth` which essentially chops off any fractional part of the value, where even the tiniest amount less than fully charged will show a bar that is not entirely full. When the wireless charging is done you have full power again and the bar is full, oscillating between the two states, causing the last pixel to flicker.

With this fix the threshold for the full bar shifts down to around 12.5/13 or 96.15% (rather than 13/13 or 100% as before) leading to a full power bar all the time if wireless charging keeps the Wireless Crafting Terminal topped off. On the other hand an empty bar is displayed only up until 0.5/13 or 3.85% (rather than 1/13 or 7.70% as before).

The benefit of the stopped flickering makes the change worthwhile in my eyes.

![power-new](https://github.com/user-attachments/assets/033c3d91-e516-4427-a8fb-fe85c23da564)
