### PR TITLE
[Fabric-1.20.1] p2p frequency tooltip fix

### DIFF
--- a/src/main/java/appeng/integration/modules/igtooltip/parts/P2PStateDataProvider.java
+++ b/src/main/java/appeng/integration/modules/igtooltip/parts/P2PStateDataProvider.java
@@ -1,5 +1,6 @@
 package appeng.integration.modules.igtooltip.parts;
 
+import net.minecraft.ChatFormatting;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
@@ -45,10 +46,10 @@ public final class P2PStateDataProvider implements BodyProvider<P2PTunnelPart>, 
             var freq = serverData.getShort(TAG_P2P_FREQUENCY);
 
             // Show the frequency and name of the frequency if it exists
-            var freqTooltip = Platform.p2p().toHexString(freq);
+            var freqTooltip = Platform.p2p().toColoredHexString(freq).withStyle(ChatFormatting.BOLD);
             if (serverData.contains(TAG_P2P_FREQUENCY_NAME, Tag.TAG_STRING)) {
                 var freqName = serverData.getString(TAG_P2P_FREQUENCY_NAME);
-                freqTooltip = freqName + " (" + freqTooltip + ")";
+                freqTooltip = Component.literal(freqName).append(" (").append(freqTooltip).append(")");
             }
 
             tooltip.addLine(InGameTooltip.P2PFrequency.text(freqTooltip));

--- a/src/main/java/appeng/items/tools/MemoryCardItem.java
+++ b/src/main/java/appeng/items/tools/MemoryCardItem.java
@@ -290,7 +290,7 @@ public class MemoryCardItem extends AEBaseItem implements IMemoryCard, AEToolIte
 
         if (data.contains("freq")) {
             final short freq = data.getShort("freq");
-            final String freqTooltip = ChatFormatting.BOLD + Platform.p2p().toHexString(freq);
+            var freqTooltip = Platform.p2p().toColoredHexString(freq).withStyle(ChatFormatting.BOLD);
 
             lines.add(Tooltips.of(Component.translatable("gui.tooltips.ae2.P2PFrequency", freqTooltip)));
         }

--- a/src/main/java/appeng/items/tools/MemoryCardItem.java
+++ b/src/main/java/appeng/items/tools/MemoryCardItem.java
@@ -56,6 +56,7 @@ import appeng.api.util.AEColor;
 import appeng.api.util.IConfigurableObject;
 import appeng.core.AELog;
 import appeng.core.localization.GuiText;
+import appeng.core.localization.InGameTooltip;
 import appeng.core.localization.PlayerMessages;
 import appeng.core.localization.Tooltips;
 import appeng.helpers.IConfigInvHost;
@@ -288,11 +289,11 @@ public class MemoryCardItem extends AEBaseItem implements IMemoryCard, AEToolIte
             lines.add(Tooltips.of(Component.translatable(tooltipKey)));
         }
 
-        if (data.contains("freq")) {
-            final short freq = data.getShort("freq");
+        if (data.contains("p2pFreq")) {
+            final short freq = data.getShort("p2pFreq");
             var freqTooltip = Platform.p2p().toColoredHexString(freq).withStyle(ChatFormatting.BOLD);
 
-            lines.add(Tooltips.of(Component.translatable("gui.tooltips.ae2.P2PFrequency", freqTooltip)));
+            lines.add(Tooltips.of(Component.translatable(InGameTooltip.P2PFrequency.getTranslationKey(), freqTooltip)));
         }
     }
 

--- a/src/main/java/appeng/util/helpers/P2PHelper.java
+++ b/src/main/java/appeng/util/helpers/P2PHelper.java
@@ -39,10 +39,9 @@ public class P2PHelper {
         return colors;
     }
 
-    private static int getFrequencyNibble(short frequency, int i){
+    private static int getFrequencyNibble(short frequency, int i) {
         return frequency >> 4 * (3 - i) & 0xF;
     }
-
 
     public short fromColors(AEColor[] colors) {
         Preconditions.checkArgument(colors.length == 4);
@@ -76,8 +75,7 @@ public class P2PHelper {
         for (var i = 0; i < 4; i++) {
             var nibble = getFrequencyNibble(frequency, i);
             var hex = Component.literal(HEX_DIGITS[nibble]);
-            parent.append(hex.setStyle
-                    (hex.getStyle().withColor(AEColor.values()[nibble].whiteVariant)));
+            parent.append(hex.setStyle(hex.getStyle().withColor(AEColor.values()[nibble].whiteVariant)));
         }
 
         return parent;

--- a/src/main/java/appeng/util/helpers/P2PHelper.java
+++ b/src/main/java/appeng/util/helpers/P2PHelper.java
@@ -20,6 +20,9 @@ package appeng.util.helpers;
 
 import com.google.common.base.Preconditions;
 
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
+
 import appeng.api.util.AEColor;
 
 public class P2PHelper {
@@ -28,13 +31,18 @@ public class P2PHelper {
         final AEColor[] colors = new AEColor[4];
 
         for (int i = 0; i < 4; i++) {
-            int nibble = frequency >> 4 * (3 - i) & 0xF;
+            int nibble = getFrequencyNibble(frequency, i);
 
             colors[i] = AEColor.values()[nibble];
         }
 
         return colors;
     }
+
+    private static int getFrequencyNibble(short frequency, int i){
+        return frequency >> 4 * (3 - i) & 0xF;
+    }
+
 
     public short fromColors(AEColor[] colors) {
         Preconditions.checkArgument(colors.length == 4);
@@ -56,6 +64,23 @@ public class P2PHelper {
 
     public String toHexString(short frequency) {
         return String.format("%04X", frequency);
+    }
+
+    private static final String[] HEX_DIGITS = {
+            "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B", "C", "D", "E", "F"
+    };
+
+    public MutableComponent toColoredHexString(short frequency) {
+        var parent = Component.empty();
+
+        for (var i = 0; i < 4; i++) {
+            var nibble = getFrequencyNibble(frequency, i);
+            var hex = Component.literal(HEX_DIGITS[nibble]);
+            parent.append(hex.setStyle
+                    (hex.getStyle().withColor(AEColor.values()[nibble].whiteVariant)));
+        }
+
+        return parent;
     }
 
 }

--- a/src/main/java/appeng/util/helpers/P2PHelper.java
+++ b/src/main/java/appeng/util/helpers/P2PHelper.java
@@ -75,7 +75,7 @@ public class P2PHelper {
         for (var i = 0; i < 4; i++) {
             var nibble = getFrequencyNibble(frequency, i);
             var hex = Component.literal(HEX_DIGITS[nibble]);
-            parent.append(hex.setStyle(hex.getStyle().withColor(AEColor.values()[nibble].whiteVariant)));
+            parent.append(hex.setStyle(hex.getStyle().withColor(AEColor.values()[nibble].mediumVariant)));
         }
 
         return parent;


### PR DESCRIPTION
This Pull Request contains two changes:
- Fix memory card tooltip not showing P2P frequency.
- Backport of the colorful frequency format. Show the P2P frequency in tooltips using the colors used on the P2P tunnels back.