### PR TITLE
Optimize ListCraftingInventory#extract

### DIFF
--- a/src/main/java/appeng/api/stacks/KeyCounter.java
+++ b/src/main/java/appeng/api/stacks/KeyCounter.java
@@ -94,8 +94,23 @@ public final class KeyCounter implements Iterable<Object2LongMap.Entry<AEKey>> {
         getSubIndex(key).add(key, amount);
     }
 
+    /**
+     * Subtracts the given amount from the value associated with the given key.
+     */
     public void remove(AEKey key, long amount) {
         add(key, -amount);
+    }
+
+    /**
+     * Removes the given key from this counter, and returns the old value (or 0).
+     */
+    public long remove(AEKey key) {
+        var subIndex = getSubIndex(key);
+        var ret = subIndex.remove(key);
+        if (subIndex.isEmpty()) {
+            lists.remove(key.getPrimaryKey());
+        }
+        return ret;
     }
 
     public void set(AEKey key, long amount) {

--- a/src/main/java/appeng/api/stacks/VariantCounter.java
+++ b/src/main/java/appeng/api/stacks/VariantCounter.java
@@ -42,6 +42,10 @@ abstract class VariantCounter implements Iterable<Object2LongMap.Entry<AEKey>> {
         }
     }
 
+    public long remove(AEKey key) {
+        return getRecords().removeLong(key);
+    }
+
     public void addAll(VariantCounter other) {
         for (var entry : other.getRecords().object2LongEntrySet()) {
             add(entry.getKey(), entry.getLongValue());

--- a/src/main/java/appeng/crafting/inv/ListCraftingInventory.java
+++ b/src/main/java/appeng/crafting/inv/ListCraftingInventory.java
@@ -54,10 +54,14 @@ public class ListCraftingInventory implements ICraftingInventory {
 
     @Override
     public long extract(AEKey what, long amount, Actionable mode) {
-        var extracted = Math.min(list.get(what), amount);
+        var available = list.get(what);
+        var extracted = Math.min(available, amount);
         if (mode == Actionable.MODULATE) {
-            list.remove(what, extracted);
-            list.removeZeros();
+            if (available > extracted) {
+                list.remove(what, extracted);
+            } else {
+                list.remove(what);
+            }
             listener.onChange(what);
         }
         return extracted;


### PR DESCRIPTION
`removeZeros` is an O(n) operation. Use the newly introduced remove(AEKey) instead.