### PR TITLE
Fix pulse unlock mode being broken by a constant redstone signal

### DIFF
--- a/src/main/java/appeng/helpers/patternprovider/PatternProviderLogic.java
+++ b/src/main/java/appeng/helpers/patternprovider/PatternProviderLogic.java
@@ -165,7 +165,7 @@ public class PatternProviderLogic implements InternalInventoryHost, ICraftingPro
         this.configManager.writeToNBT(tag, registries);
         this.patternInventory.writeToNBT(tag, NBT_MEMORY_CARD_PATTERNS, registries);
         tag.putInt(NBT_PRIORITY, this.priority);
-        if (unlockEvent == UnlockCraftingEvent.PULSE) {
+        if (unlockEvent == UnlockCraftingEvent.REDSTONE_POWER) {
             tag.putByte(NBT_UNLOCK_EVENT, (byte) 1);
         } else if (unlockEvent == UnlockCraftingEvent.RESULT) {
             if (unlockStack != null) {
@@ -174,6 +174,8 @@ public class PatternProviderLogic implements InternalInventoryHost, ICraftingPro
             } else {
                 LOGGER.error("Saving pattern provider {}, locked waiting for stack, but stack is null!", host);
             }
+        } else if (unlockEvent == UnlockCraftingEvent.REDSTONE_PULSE) {
+            tag.putByte(NBT_UNLOCK_EVENT, (byte) 3);
         }
 
         ListTag sendListTag = new ListTag();
@@ -196,8 +198,9 @@ public class PatternProviderLogic implements InternalInventoryHost, ICraftingPro
         var unlockEventType = tag.getByte(NBT_UNLOCK_EVENT);
         this.unlockEvent = switch (unlockEventType) {
             case 0 -> null;
-            case 1 -> UnlockCraftingEvent.PULSE;
+            case 1 -> UnlockCraftingEvent.REDSTONE_POWER;
             case 2 -> UnlockCraftingEvent.RESULT;
+            case 3 -> UnlockCraftingEvent.REDSTONE_PULSE;
             default -> {
                 LOGGER.error("Unknown unlock event type {} in NBT for pattern provider: {}", unlockEventType, tag);
                 yield null;
@@ -385,7 +388,13 @@ public class PatternProviderLogic implements InternalInventoryHost, ICraftingPro
         var lockMode = configManager.getSetting(Settings.LOCK_CRAFTING_MODE);
         switch (lockMode) {
             case LOCK_UNTIL_PULSE -> {
-                unlockEvent = UnlockCraftingEvent.PULSE;
+                if (getRedstoneState()) {
+                    // Already have signal, wait for no signal before switching to REDSTONE_POWER
+                    unlockEvent = UnlockCraftingEvent.REDSTONE_PULSE;
+                } else {
+                    // No signal, wait for signal
+                    unlockEvent = UnlockCraftingEvent.REDSTONE_POWER;
+                }
                 saveChanges();
             }
             case LOCK_UNTIL_RESULT -> {
@@ -411,7 +420,7 @@ public class PatternProviderLogic implements InternalInventoryHost, ICraftingPro
         } else if (unlockEvent != null) {
             // Crafting locked by waiting for unlock event
             switch (unlockEvent) {
-                case PULSE -> {
+                case REDSTONE_POWER, REDSTONE_PULSE -> {
                     return LockCraftingMode.LOCK_UNTIL_PULSE;
                 }
                 case RESULT -> {
@@ -768,8 +777,12 @@ public class PatternProviderLogic implements InternalInventoryHost, ICraftingPro
 
     public void updateRedstoneState() {
         // If we're waiting for a pulse, update immediately
-        if (unlockEvent == UnlockCraftingEvent.PULSE && getRedstoneState()) {
+        if (unlockEvent == UnlockCraftingEvent.REDSTONE_POWER && getRedstoneState()) {
             unlockEvent = null; // Unlocked!
+            saveChanges();
+        } else if (unlockEvent == UnlockCraftingEvent.REDSTONE_PULSE && !getRedstoneState()) {
+            unlockEvent = UnlockCraftingEvent.REDSTONE_POWER; // Wait for re-power
+            redstoneState = YesNo.UNDECIDED; // Need to re-check signal on next update
             saveChanges();
         } else {
             // Otherwise, just reset back to undecided

--- a/src/main/java/appeng/helpers/patternprovider/UnlockCraftingEvent.java
+++ b/src/main/java/appeng/helpers/patternprovider/UnlockCraftingEvent.java
@@ -4,6 +4,7 @@ package appeng.helpers.patternprovider;
  * The types of event that the pattern provider is waiting for to unlock crafting again.
  */
 public enum UnlockCraftingEvent {
-    PULSE,
-    RESULT
+    REDSTONE_POWER, // Waiting for redstone to be on (pulse blocking mode)
+    REDSTONE_PULSE, // Waiting for redstone to turn off and back on (pulse blocking mode, already powered when craft started)
+    RESULT // Waiting for result
 }


### PR DESCRIPTION
With this change pattern providers will check if they already have a redstone signal when locking, and if so they will wait for the signal to depower and then power again. This fixes odd behavior with a constant redstone signal and block updates leading to unlocking without a 'pulse'.

![2024-08-28_17 50 27](https://github.com/user-attachments/assets/f9725586-6202-42b8-bd6c-71414059f551)
