### PR TITLE
Allow enchanting annihilation planes with unbreaking and efficiency

### DIFF
--- a/src/generated/resources/data/minecraft/tags/item/enchantable/durability.json
+++ b/src/generated/resources/data/minecraft/tags/item/enchantable/durability.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "ae2:annihilation_plane"
+  ]
+}

--- a/src/generated/resources/data/minecraft/tags/item/enchantable/mining.json
+++ b/src/generated/resources/data/minecraft/tags/item/enchantable/mining.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "ae2:annihilation_plane"
+  ]
+}

--- a/src/main/java/appeng/datagen/providers/tags/ItemTagsProvider.java
+++ b/src/main/java/appeng/datagen/providers/tags/ItemTagsProvider.java
@@ -52,7 +52,9 @@ public class ItemTagsProvider extends net.minecraft.data.tags.ItemTagsProvider i
     protected void addTags(HolderLookup.Provider registries) {
         copyBlockTags();
 
-        // Allow the annihilation plane to be enchanted with silk touch & fortune
+        // Allow the annihilation plane to be enchanted with silk touch, fortune, efficiency & unbreaking
+        tag(ItemTags.DURABILITY_ENCHANTABLE).add(AEParts.ANNIHILATION_PLANE.asItem());
+        tag(ItemTags.MINING_ENCHANTABLE).add(AEParts.ANNIHILATION_PLANE.asItem());
         tag(ItemTags.MINING_LOOT_ENCHANTABLE).add(AEParts.ANNIHILATION_PLANE.asItem());
 
         // Forge is missing this tag right now


### PR DESCRIPTION
Fix #8173.

I have not checked if the enchanted planes do something useful, just that the enchantments can indeed be applied.