### PR TITLE
Fix wrong budding block tag

### DIFF
--- a/src/generated/resources/data/ae2/tags/block/growth_acceleratable.json
+++ b/src/generated/resources/data/ae2/tags/block/growth_acceleratable.json
@@ -20,6 +20,6 @@
       "id": "#minecraft:saplings",
       "required": false
     },
-    "#c:budding"
+    "#c:budding_blocks"
   ]
 }

--- a/src/generated/resources/data/c/tags/block/budding_blocks.json
+++ b/src/generated/resources/data/c/tags/block/budding_blocks.json
@@ -1,6 +1,5 @@
 {
   "values": [
-    "minecraft:budding_amethyst",
     "ae2:flawless_budding_quartz",
     "ae2:flawed_budding_quartz",
     "ae2:chipped_budding_quartz",

--- a/src/generated/resources/data/c/tags/item/budding_blocks.json
+++ b/src/generated/resources/data/c/tags/item/budding_blocks.json
@@ -1,6 +1,5 @@
 {
   "values": [
-    "minecraft:budding_amethyst",
     "ae2:flawless_budding_quartz",
     "ae2:flawed_budding_quartz",
     "ae2:chipped_budding_quartz",

--- a/src/generated/resources/data/c/tags/item/ingots/copper.json
+++ b/src/generated/resources/data/c/tags/item/ingots/copper.json
@@ -1,5 +1,0 @@
-{
-  "values": [
-    "minecraft:copper_ingot"
-  ]
-}

--- a/src/main/java/appeng/api/ids/AETags.java
+++ b/src/main/java/appeng/api/ids/AETags.java
@@ -78,8 +78,8 @@ public final class AETags {
 
     /**
      * Crystal growth accelerators will trigger additional random ticks for blocks in that tag, regardless of what the
-     * blocks are. By default, includes {@code c:budding_blocks} which includes budding amethyst
-     * and the various budding certus quartz blocks.
+     * blocks are. By default, includes {@code c:budding_blocks} which includes budding amethyst and the various budding
+     * certus quartz blocks.
      */
     public static final TagKey<Block> GROWTH_ACCELERATABLE = blockTag("ae2:growth_acceleratable");
 

--- a/src/main/java/appeng/api/ids/AETags.java
+++ b/src/main/java/appeng/api/ids/AETags.java
@@ -78,7 +78,7 @@ public final class AETags {
 
     /**
      * Crystal growth accelerators will trigger additional random ticks for blocks in that tag, regardless of what the
-     * blocks are. By default, includes {@code c:budding_blocks} / {@code forge:budding} which includes budding amethyst
+     * blocks are. By default, includes {@code c:budding_blocks} which includes budding amethyst
      * and the various budding certus quartz blocks.
      */
     public static final TagKey<Block> GROWTH_ACCELERATABLE = blockTag("ae2:growth_acceleratable");

--- a/src/main/java/appeng/datagen/providers/tags/BlockTagsProvider.java
+++ b/src/main/java/appeng/datagen/providers/tags/BlockTagsProvider.java
@@ -67,9 +67,7 @@ public class BlockTagsProvider extends IntrinsicHolderTagsProvider<Block> implem
                 .addOptionalTag(ConventionTags.SAPLINGS.location())
                 .addTag(ConventionTags.BUDDING_BLOCKS_BLOCKS);
 
-        // Only provide amethyst in the budding tag since that's the one we use; the other tags are for other mods
         tag(ConventionTags.BUDDING_BLOCKS_BLOCKS)
-                .add(Blocks.BUDDING_AMETHYST)
                 .add(AEBlocks.FLAWLESS_BUDDING_QUARTZ.block())
                 .add(AEBlocks.FLAWED_BUDDING_QUARTZ.block())
                 .add(AEBlocks.CHIPPED_BUDDING_QUARTZ.block())

--- a/src/main/java/appeng/datagen/providers/tags/ConventionTags.java
+++ b/src/main/java/appeng/datagen/providers/tags/ConventionTags.java
@@ -83,7 +83,7 @@ public final class ConventionTags {
     public static final TagKey<Item> FLUIX_DUST = tag("c:dusts/fluix");
     public static final TagKey<Item> FLUIX_CRYSTAL = tag("c:gems/fluix");
 
-    public static final TagKey<Item> COPPER_INGOT = tag("c:ingots/copper");
+    public static final TagKey<Item> COPPER_INGOT = Tags.Items.INGOTS_COPPER;
 
     public static final TagKey<Item> GOLD_NUGGET = Tags.Items.NUGGETS_GOLD;
     public static final TagKey<Item> GOLD_INGOT = Tags.Items.INGOTS_GOLD;
@@ -130,11 +130,11 @@ public final class ConventionTags {
 
     // Budding stuff
     public static final TagKey<Item> BUDDING_BLOCKS = Tags.Items.BUDDING_BLOCKS;
-    public static final TagKey<Item> BUDS = tag("c:buds");
-    public static final TagKey<Item> CLUSTERS = tag("c:clusters");
+    public static final TagKey<Item> BUDS = Tags.Items.BUDS;
+    public static final TagKey<Item> CLUSTERS = Tags.Items.CLUSTERS;
     public static final TagKey<Block> BUDDING_BLOCKS_BLOCKS = Tags.Blocks.BUDDING_BLOCKS;
-    public static final TagKey<Block> BUDS_BLOCKS = blockTag("c:buds");
-    public static final TagKey<Block> CLUSTERS_BLOCKS = blockTag("c:clusters");
+    public static final TagKey<Block> BUDS_BLOCKS = Tags.Blocks.BUDS;
+    public static final TagKey<Block> CLUSTERS_BLOCKS = Tags.Blocks.CLUSTERS;
 
     // For Growth Accelerator
     public static final TagKey<Block> CROPS = BlockTags.CROPS;
@@ -143,7 +143,7 @@ public final class ConventionTags {
     /**
      * Platform tags for blocks that should not be moved, i.e. some pipes, chunk loaders, etc...
      */
-    public static final TagKey<Block> IMMOVABLE_BLOCKS = blockTag("c:relocation_not_supported");
+    public static final TagKey<Block> IMMOVABLE_BLOCKS = Tags.Blocks.RELOCATION_NOT_SUPPORTED;
 
     /**
      * For Worldgen Biomes

--- a/src/main/java/appeng/datagen/providers/tags/ConventionTags.java
+++ b/src/main/java/appeng/datagen/providers/tags/ConventionTags.java
@@ -129,10 +129,10 @@ public final class ConventionTags {
     public static final TagKey<Item> CAN_REMOVE_COLOR = tag("ae2:can_remove_color");
 
     // Budding stuff
-    public static final TagKey<Item> BUDDING_BLOCKS = tag("c:budding");
+    public static final TagKey<Item> BUDDING_BLOCKS = Tags.Items.BUDDING_BLOCKS;
     public static final TagKey<Item> BUDS = tag("c:buds");
     public static final TagKey<Item> CLUSTERS = tag("c:clusters");
-    public static final TagKey<Block> BUDDING_BLOCKS_BLOCKS = blockTag("c:budding");
+    public static final TagKey<Block> BUDDING_BLOCKS_BLOCKS = Tags.Blocks.BUDDING_BLOCKS;
     public static final TagKey<Block> BUDS_BLOCKS = blockTag("c:buds");
     public static final TagKey<Block> CLUSTERS_BLOCKS = blockTag("c:clusters");
 

--- a/src/main/java/appeng/datagen/providers/tags/ItemTagsProvider.java
+++ b/src/main/java/appeng/datagen/providers/tags/ItemTagsProvider.java
@@ -62,9 +62,7 @@ public class ItemTagsProvider extends net.minecraft.data.tags.ItemTagsProvider i
         // Provide empty blacklist tags
         tag(AETags.ANNIHILATION_PLANE_ITEM_BLACKLIST);
 
-        // Only provide amethyst in the budding tag since that's the one we use; the other tags are for other mods
         tag(ConventionTags.BUDDING_BLOCKS)
-                .add(Items.BUDDING_AMETHYST)
                 .add(AEBlocks.FLAWLESS_BUDDING_QUARTZ.asItem())
                 .add(AEBlocks.FLAWED_BUDDING_QUARTZ.asItem())
                 .add(AEBlocks.CHIPPED_BUDDING_QUARTZ.asItem())

--- a/src/main/java/appeng/datagen/providers/tags/ItemTagsProvider.java
+++ b/src/main/java/appeng/datagen/providers/tags/ItemTagsProvider.java
@@ -55,10 +55,6 @@ public class ItemTagsProvider extends net.minecraft.data.tags.ItemTagsProvider i
         // Allow the annihilation plane to be enchanted with silk touch & fortune
         tag(ItemTags.MINING_LOOT_ENCHANTABLE).add(AEParts.ANNIHILATION_PLANE.asItem());
 
-        // Forge is missing this tag right now
-        tag(ConventionTags.COPPER_INGOT)
-                .add(Items.COPPER_INGOT);
-
         // Provide empty blacklist tags
         tag(AETags.ANNIHILATION_PLANE_ITEM_BLACKLIST);
 


### PR DESCRIPTION
Found during Soaryns stream, where Direwolfs new budding blocks didn't work with the the growth accelerator

removed some outdated javadoc, and some tags / tag content already provided by neoforge
also uses the code reference for tags where it makes sense
(the population of AETags.METAL_INGOTS still uses resource locations even where neoforge provides convention tags, but I've kept those for readability)