### PR TITLE
Add all viewable items in MEStorageMenus to Emi inventory

### DIFF
--- a/src/main/java/appeng/integration/modules/emi/AbstractRecipeHandler.java
+++ b/src/main/java/appeng/integration/modules/emi/AbstractRecipeHandler.java
@@ -51,6 +51,7 @@ abstract class AbstractRecipeHandler<T extends AEBaseMenu> implements StandardRe
         var slots = new ArrayList<Slot>();
         slots.addAll(menu.getSlots(SlotSemantics.PLAYER_INVENTORY));
         slots.addAll(menu.getSlots(SlotSemantics.PLAYER_HOTBAR));
+        slots.addAll(menu.getSlots(SlotSemantics.CRAFTING_GRID));
         return slots;
     }
 

--- a/src/main/java/appeng/integration/modules/emi/EmiUseCraftingRecipeHandler.java
+++ b/src/main/java/appeng/integration/modules/emi/EmiUseCraftingRecipeHandler.java
@@ -1,11 +1,14 @@
 package appeng.integration.modules.emi;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.core.NonNullList;
+import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.CraftingBookCategory;
 import net.minecraft.world.item.crafting.Ingredient;
@@ -14,11 +17,14 @@ import net.minecraft.world.item.crafting.RecipeHolder;
 import net.minecraft.world.item.crafting.ShapedRecipe;
 import net.minecraft.world.item.crafting.ShapedRecipePattern;
 
+import dev.emi.emi.api.recipe.EmiPlayerInventory;
 import dev.emi.emi.api.recipe.EmiRecipe;
 import dev.emi.emi.api.stack.EmiStack;
 
+import appeng.api.stacks.GenericStack;
 import appeng.core.localization.ItemModText;
 import appeng.integration.modules.itemlists.CraftingHelper;
+import appeng.menu.me.common.GridInventoryEntry;
 import appeng.menu.me.items.CraftingTermMenu;
 
 /**
@@ -39,6 +45,25 @@ public class EmiUseCraftingRecipeHandler<T extends CraftingTermMenu> extends Abs
 
     public EmiUseCraftingRecipeHandler(Class<T> containerClass) {
         super(containerClass);
+    }
+
+    @Override
+    public EmiPlayerInventory getInventory(AbstractContainerScreen<T> screen) {
+        List<EmiStack> list = new ArrayList<>();
+
+        for (Slot slot : getInputSources(screen.getMenu())) {
+            list.add(EmiStack.of(slot.getItem()));
+        }
+
+        var repo = screen.getMenu().getClientRepo();
+
+        if (repo != null) {
+            for (GridInventoryEntry entry : repo.getAllEntries()) {
+                list.add(EmiStackHelper.toEmiStack(new GenericStack(entry.getWhat(), entry.getStoredAmount())));
+            }
+        }
+
+        return new EmiPlayerInventory(list);
     }
 
     @Override


### PR DESCRIPTION
Also fixes a bug where items in the crafting terminal grid would disappear from the tree

Closes #8214 