### PR TITLE
(#8274) Optimize PathingService and GridConnection repath conditions

### DIFF
--- a/src/main/java/appeng/api/networking/IGrid.java
+++ b/src/main/java/appeng/api/networking/IGrid.java
@@ -106,6 +106,11 @@ public interface IGrid {
     Iterable<IGridNode> getNodes();
 
     /**
+     * @return true if the grid contains the provided node
+     */
+    boolean containsNode(IGridNode node);
+
+    /**
      * @return true if the last node has been removed from the grid.
      */
     boolean isEmpty();

--- a/src/main/java/appeng/api/networking/pathing/IPathingService.java
+++ b/src/main/java/appeng/api/networking/pathing/IPathingService.java
@@ -23,6 +23,7 @@
 
 package appeng.api.networking.pathing;
 
+import appeng.api.networking.IGridNode;
 import appeng.api.networking.IGridService;
 
 /**
@@ -63,4 +64,9 @@ public interface IPathingService extends IGridService {
      * @return The total number of channels currently used by this network.
      */
     int getUsedChannels();
+
+    /**
+     * Whether this PathingService is already aware of the provided node
+     */
+    boolean contains(IGridNode node);
 }

--- a/src/main/java/appeng/me/Grid.java
+++ b/src/main/java/appeng/me/Grid.java
@@ -202,6 +202,11 @@ public class Grid implements IGrid {
     }
 
     @Override
+    public boolean containsNode(IGridNode node) {
+        return this.machines.containsValue(node);
+    }
+
+    @Override
     public boolean isEmpty() {
         return this.pivot == null;
     }

--- a/src/main/java/appeng/me/GridMergeType.java
+++ b/src/main/java/appeng/me/GridMergeType.java
@@ -1,0 +1,14 @@
+package appeng.me;
+
+public enum GridMergeType {
+
+    /**
+     * The grid merge was non-trivial
+     */
+    COMPLEX,
+
+    /**
+     * The grid merge was a singular operation on an individual node
+     */
+    SIMPLE,
+}


### PR DESCRIPTION
There are several ways that a network can enter the "rebooting" state however only a few actually have consequence to the overall network state.

This change removes the need for the network to reboot during "simple" Grid merges while still enforcing rebooting for "complex" merges. A simple merge is one that has no bearing on the network pathing; imagine a long cable with no channel-consuming devices attached to it and then you add another cable. A complex network merge is everything else (combining grids, adding channel-consumers, removing channel-consumers, deleting grid connections).

Of note: half-items like P2P, Quartz Fiber, and all terminals (though not other cable types) always force a complex merge for some reason but seeing as the network needs to reboot to calculate their energy/channel consumption; this is preferred.

I performed testing using multiple networks both with and without controllers. using 1x and "infinite" channel modes.
I confirmed that power usage matched before and after this change by setting up identical networks, using the network tool to check both idle and channel consumption, and then adding more cables (old version triggers a reboot while this change does not); and then verified that both consumptions were identical.

I noticed some oddities around not needing to update pathing when placing AE powercells but I'm not sure these can pass channels and they don't consume one so I guess this is expected. EnergyService seemed to handle everything correctly.
`runGametest` also passes.