### PR TITLE
Allow filtering config stack slots with containers holding 0 of a stack

### DIFF
--- a/src/main/java/appeng/util/ConfigInventory.java
+++ b/src/main/java/appeng/util/ConfigInventory.java
@@ -210,7 +210,7 @@ public class ConfigInventory extends GenericStackInv {
                 // in stack mode, amounts of 0 or less will:
                 // - filter the slot to a minimum of 1 of that stack, if empty
                 // - clear the slot, if not empty
-                stack = getStack(slot) == null ? new GenericStack(stack.what(), 1) : null;
+                stack = getStack(slot) == null && mode == Mode.CONFIG_STACKS ? new GenericStack(stack.what(), 1) : null;
             }
         }
         super.setStack(slot, stack);

--- a/src/main/java/appeng/util/ConfigInventory.java
+++ b/src/main/java/appeng/util/ConfigInventory.java
@@ -207,8 +207,10 @@ public class ConfigInventory extends GenericStackInv {
                 // force amount to 0 in types-only mode
                 stack = new GenericStack(stack.what(), 0);
             } else if (!typesOnly && stack.amount() <= 0) {
-                // in stack mode, amounts of 0 or less clear the slot
-                stack = null;
+                // in stack mode, amounts of 0 or less will:
+                // - filter the slot to a minimum of 1 of that stack, if empty
+                // - clear the slot, if not empty
+                stack = getStack(slot) == null ? new GenericStack(stack.what(), 1) : null;
             }
         }
         super.setStack(slot, stack);

--- a/src/main/java/appeng/util/ConfigInventory.java
+++ b/src/main/java/appeng/util/ConfigInventory.java
@@ -207,10 +207,15 @@ public class ConfigInventory extends GenericStackInv {
                 // force amount to 0 in types-only mode
                 stack = new GenericStack(stack.what(), 0);
             } else if (!typesOnly && stack.amount() <= 0) {
-                // in stack mode, amounts of 0 or less will:
-                // - filter the slot to a minimum of 1 of that stack, if empty
-                // - clear the slot, if not empty
-                stack = getStack(slot) == null && mode == Mode.CONFIG_STACKS ? new GenericStack(stack.what(), 1) : null;
+                if (mode == Mode.CONFIG_STACKS && getStack(slot) == null) {
+                    // filter the slot to a minimum of 1 of that stack, if currently empty
+                    // This allows setting a filter using empty containers that are limited to one resource,
+                    // e.g. empty mana tablet.
+                    stack = new GenericStack(stack.what(), 1);
+                } else {
+                    // in stack mode, amounts of 0 or less clear the slot
+                    stack = null;
+                }
             }
         }
         super.setStack(slot, stack);

--- a/src/test/java/appeng/util/ConfigInventoryTest.java
+++ b/src/test/java/appeng/util/ConfigInventoryTest.java
@@ -77,15 +77,15 @@ public class ConfigInventoryTest {
         ConfigInventory inv = ConfigInventory.configStacks(1).supportedType(AEKeyType.items()).build();
 
         @Test
-        void stacksWithAmountZeroAreDropped() {
+        void stacksWithAmountZeroFilterToOne() {
             inv.setStack(0, ZERO_STICK);
-            assertNull(inv.getStack(0));
+            assertEquals(ONE_STICK, inv.getStack(0));
         }
 
         @Test
-        void stacksWithNegativeAmountsAreDropped() {
+        void stacksWithNegativeAmountsFilterToOne() {
             inv.setStack(0, new GenericStack(STICK_KEY, -1000));
-            assertNull(inv.getStack(0));
+            assertEquals(ONE_STICK, inv.getStack(0));
         }
 
         @Test

--- a/src/test/java/appeng/util/ConfigInventoryTest.java
+++ b/src/test/java/appeng/util/ConfigInventoryTest.java
@@ -89,6 +89,9 @@ public class ConfigInventoryTest {
         void stacksWithNegativeAmountsFilterToOne() {
             inv.setStack(0, new GenericStack(STICK_KEY, -1000));
             assertEquals(ONE_STICK, inv.getStack(0));
+            // Check that applying the same zero-filter to the same slot clears it
+            inv.setStack(0, new GenericStack(STICK_KEY, -1000));
+            assertNull(inv.getStack(0));
         }
 
         @Test

--- a/src/test/java/appeng/util/ConfigInventoryTest.java
+++ b/src/test/java/appeng/util/ConfigInventoryTest.java
@@ -80,6 +80,9 @@ public class ConfigInventoryTest {
         void stacksWithAmountZeroFilterToOne() {
             inv.setStack(0, ZERO_STICK);
             assertEquals(ONE_STICK, inv.getStack(0));
+            // Check that applying the same zero-filter to the same slot clears it
+            inv.setStack(0, ZERO_STICK);
+            assertNull(inv.getStack(0));
         }
 
         @Test


### PR DESCRIPTION
This PR allows config slots of `CONFIG_STACKS` mode to be filtered with a minimum of 1 of a given stack retrieved from a container, even if the container may have a zero amount of that stack.

The rationale for this comes from https://github.com/62832/ArsEnergistique/issues/17 and the [resulting Mixin](https://github.com/62832/ArsEnergistique/blob/master/src/main/java/gripe/_90/arseng/mixin/ConfigInventoryMixin.java) used to allow players to filter ME Interface slots to Source, even if the Source Jar being used to filter it is empty. As the Ars Énergistique add-on is designed around a key type for which only one possible resource exists (Source), it is wholly unambigious that any Source Jar may contain or make use of Source regardless of whether it currently doesn't contain any of it.

The same would apply, should it ever be updated to 1.21, to the Applied Botanics add-on and empty Mana Tablets as a result of this being included upstream, and has already applied as such, though only also in the presence of Ars Énergistique.