### PR TITLE
Remove a redundant `PatternProviderMenu` constructor

### DIFF
--- a/src/main/java/appeng/menu/implementations/PatternProviderMenu.java
+++ b/src/main/java/appeng/menu/implementations/PatternProviderMenu.java
@@ -41,8 +41,7 @@ import appeng.menu.slot.RestrictedInputSlot;
 public class PatternProviderMenu extends AEBaseMenu {
 
     public static final MenuType<PatternProviderMenu> TYPE = MenuTypeBuilder
-            .create((id, inv, host) -> new PatternProviderMenu(id, inv, host),
-                    PatternProviderLogicHost.class)
+            .create(PatternProviderMenu::new, PatternProviderLogicHost.class)
             .build("pattern_provider");
 
     protected final PatternProviderLogic logic;
@@ -58,11 +57,7 @@ public class PatternProviderMenu extends AEBaseMenu {
     @GuiSync(7)
     public GenericStack unlockStack = null;
 
-    public PatternProviderMenu(int id, Inventory playerInventory, PatternProviderLogicHost host) {
-        this(TYPE, id, playerInventory, host);
-    }
-
-    protected PatternProviderMenu(MenuType<? extends PatternProviderMenu> menuType, int id, Inventory playerInventory,
+    public PatternProviderMenu(MenuType<? extends PatternProviderMenu> menuType, int id, Inventory playerInventory,
             PatternProviderLogicHost host) {
         super(menuType, id, playerInventory, host);
         this.createPlayerInventorySlots(playerInventory);


### PR DESCRIPTION
Just for the sake of doing away with [more excessive add-on mixins](https://github.com/62832/MEGACells/blob/master/src/main/java/gripe/_90/megacells/mixin/PatternProviderMenuAccessor.java).