### PR TITLE
Prefix EMI "synthetic recipe" IDs with `/`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,7 +25,7 @@ neoForge.parchment.mappingsVersion=2024.07.07
 guideme_version=2.5.1
 top_minecraft_release=1.20
 top_version=1.20.4_neo-11.0.1-2
-emi_version=1.1.10+1.21
+emi_version=1.1.19+1.21.1
 # please learn how to use semver...
 top_version_range=[1.20.0,)
 jade_version_range=[15.0.0,)

--- a/src/main/java/appeng/integration/modules/emi/EmiAddItemUpgradeRecipe.java
+++ b/src/main/java/appeng/integration/modules/emi/EmiAddItemUpgradeRecipe.java
@@ -25,7 +25,7 @@ public class EmiAddItemUpgradeRecipe extends EmiCraftingRecipe {
     private static ResourceLocation makeId(IUpgradeableItem baseItem, Item upgrade) {
         var baseItemId = BuiltInRegistries.ITEM.getKey(baseItem.asItem());
         var upgradeId = BuiltInRegistries.ITEM.getKey(upgrade.asItem());
-        return AppEng.makeId("add_item_upgrade/" + baseItemId.getPath() + "/" + upgradeId.getPath());
+        return AppEng.makeId("/add_item_upgrade/" + baseItemId.getPath() + "/" + upgradeId.getPath());
     }
 
     private static EmiStack makeUpgraded(IUpgradeableItem baseItem, Item upgrade) {

--- a/src/main/java/appeng/integration/modules/emi/EmiCondenserRecipe.java
+++ b/src/main/java/appeng/integration/modules/emi/EmiCondenserRecipe.java
@@ -98,7 +98,7 @@ class EmiCondenserRecipe extends BasicEmiRecipe {
     }
 
     private static ResourceLocation getRecipeId(CondenserOutput type) {
-        return AppEng.makeId(type.name().toLowerCase(Locale.ROOT));
+        return AppEng.makeId("/" + type.name().toLowerCase(Locale.ROOT));
     }
 
     private List<Component> getTooltip(CondenserOutput type) {


### PR DESCRIPTION
Closes #8349.