### PR TITLE
Fix CraftingCPUCalculator allowing non-CraftingBlockEntities inside the multiblock

### DIFF
--- a/src/main/java/appeng/me/cluster/implementations/CraftingCPUCalculator.java
+++ b/src/main/java/appeng/me/cluster/implementations/CraftingCPUCalculator.java
@@ -65,11 +65,11 @@ public class CraftingCPUCalculator extends MBCalculator<CraftingBlockEntity, Cra
         for (BlockPos blockPos : BlockPos.betweenClosed(min, max)) {
             final IAEMultiBlock<?> te = (IAEMultiBlock<?>) level.getBlockEntity(blockPos);
 
-            if (te == null || !te.isValid()) {
+            if (te == null || !te.isValid() || !(te instanceof  CraftingBlockEntity)) {
                 return false;
             }
 
-            if (!storage && te instanceof CraftingBlockEntity) {
+            if (!storage) {
                 storage = ((CraftingBlockEntity) te).getStorageBytes() > 0;
             }
         }


### PR DESCRIPTION
This pull request fixes a crash that happens when users try to mix AE2 cpus with `IAEMultiBlock`s that aren't `CraftingBlockEntity`s, as reported [here](https://github.com/pedroksl/AdvancedAE/issues/108).

Testing for an instance of `CraftingBlockEntity` shouldn't be more restrictive than the current implementation since the `updateBlockEntities` method will force cast to that class, anyway.