### PR TITLE
Add support for Project Vibrant Journeys Cindercane

### DIFF
--- a/src/generated/resources/data/ae2/tags/block/growth_acceleratable.json
+++ b/src/generated/resources/data/ae2/tags/block/growth_acceleratable.json
@@ -13,6 +13,10 @@
     "minecraft:kelp",
     "minecraft:cocoa",
     {
+      "id": "projectvibrantjourneys:cindercane",
+      "required": false
+    },
+    {
       "id": "#minecraft:crops",
       "required": false
     },

--- a/src/main/java/appeng/datagen/providers/tags/BlockTagsProvider.java
+++ b/src/main/java/appeng/datagen/providers/tags/BlockTagsProvider.java
@@ -27,6 +27,7 @@ import net.minecraft.core.HolderLookup;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.data.PackOutput;
 import net.minecraft.data.tags.IntrinsicHolderTagsProvider;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.level.block.Block;
@@ -70,6 +71,7 @@ public class BlockTagsProvider extends IntrinsicHolderTagsProvider<Block> implem
                 .add(Blocks.BAMBOO_SAPLING, Blocks.BAMBOO, Blocks.SUGAR_CANE, Blocks.SUGAR_CANE, Blocks.VINE,
                         Blocks.TWISTING_VINES, Blocks.WEEPING_VINES, Blocks.CAVE_VINES, Blocks.SWEET_BERRY_BUSH,
                         Blocks.NETHER_WART, Blocks.KELP, Blocks.COCOA)
+                .addOptional(ResourceLocation.fromNamespaceAndPath("projectvibrantjourneys", "cindercane"))
                 .addOptionalTag(ConventionTags.CROPS.location())
                 .addOptionalTag(ConventionTags.SAPLINGS.location())
                 .addTag(ConventionTags.BUDDING_BLOCKS_BLOCKS);


### PR DESCRIPTION
As a player, I would like to be able to utilize the Growth Accelerator with Project Vibrant Journeys cindercane to speed up the growth process.
This adds cindercane to the "growth_acceleratable" tag so that it is applied random ticks.