### PR TITLE
Add support for global `ICraftingProvider`s independent of grid nodes

### DIFF
--- a/src/main/java/appeng/api/networking/crafting/ICraftingService.java
+++ b/src/main/java/appeng/api/networking/crafting/ICraftingService.java
@@ -65,6 +65,30 @@ public interface ICraftingService extends IGridService {
     void refreshNodeCraftingProvider(IGridNode node);
 
     /**
+     * Adds a {@link ICraftingProvider} that is not associated with a specific {@link IGridNode }. This is for providing
+     * crafting patterns and auto-crafting with {@link IGridService}s, for example.
+     * <p/>
+     * THIS IS NOT FOR USE BY {@link IGridNode NODES} THAT PROVIDE THE {@link ICraftingProvider} SERVICE. Those are
+     * automatically handled by the crafting system.
+     *
+     * @param cc to-be-added crafting pattern provider
+     */
+    void addGlobalCraftingProvider(ICraftingProvider cc);
+
+    /**
+     * Removes a provider added with {@link #addGlobalCraftingProvider(ICraftingProvider)}.
+     */
+    void removeGlobalCraftingProvider(ICraftingProvider cc);
+
+    /**
+     * Refreshes the storage mounts provided by a global storage provider.
+     *
+     * @throws IllegalArgumentException If the given provider has not been {@link #addGlobalCraftingProvider
+     *                                  registered}.
+     */
+    void refreshGlobalCraftingProvider(ICraftingProvider provider);
+
+    /**
      * Important: Never mutate the passed or returned stacks.
      *
      * @return another fuzzy equals stack that can be crafted and matches the filter, or null if none exists

--- a/src/main/java/appeng/me/service/CraftingService.java
+++ b/src/main/java/appeng/me/service/CraftingService.java
@@ -321,6 +321,22 @@ public class CraftingService implements ICraftingService, IGridServiceProvider {
         this.craftingProviders.addProvider(node);
     }
 
+    @Override
+    public void addGlobalCraftingProvider(ICraftingProvider cc) {
+        this.craftingProviders.addProvider(cc);
+    }
+
+    @Override
+    public void removeGlobalCraftingProvider(ICraftingProvider cc) {
+        this.craftingProviders.removeProvider(cc);
+    }
+
+    @Override
+    public void refreshGlobalCraftingProvider(ICraftingProvider cc) {
+        this.craftingProviders.removeProvider(cc);
+        this.craftingProviders.addProvider(cc);
+    }
+
     @Nullable
     @Override
     public AEKey getFuzzyCraftable(AEKey whatToCraft, AEKeyFilter filter) {

--- a/src/main/java/appeng/me/service/StorageService.java
+++ b/src/main/java/appeng/me/service/StorageService.java
@@ -208,7 +208,7 @@ public class StorageService implements IStorageService, IGridServiceProvider {
     public void addGlobalStorageProvider(IStorageProvider provider) {
         for (var state : globalProviders) {
             if (state.provider == provider) {
-                throw new IllegalArgumentException("Attempted to add duplicate global storage provider" + provider);
+                throw new IllegalArgumentException("Duplicate storage provider registration for " + provider);
             }
         }
 

--- a/src/main/java/appeng/me/service/StorageService.java
+++ b/src/main/java/appeng/me/service/StorageService.java
@@ -206,6 +206,12 @@ public class StorageService implements IStorageService, IGridServiceProvider {
 
     @Override
     public void addGlobalStorageProvider(IStorageProvider provider) {
+        for (var state : globalProviders) {
+            if (state.provider == provider) {
+                throw new IllegalArgumentException("Attempted to add duplicate global storage provider" + provider);
+            }
+        }
+
         var state = new ProviderState(provider);
         this.globalProviders.add(state);
         state.mount();
@@ -241,7 +247,7 @@ public class StorageService implements IStorageService, IGridServiceProvider {
             }
         }
 
-        throw new IllegalArgumentException("The given node is not part of this grid or has no storage provider.");
+        throw new IllegalArgumentException("Storage provider " + provider + " is not part of this grid.");
     }
 
     @Override

--- a/src/main/java/appeng/me/service/helpers/NetworkCraftingProviders.java
+++ b/src/main/java/appeng/me/service/helpers/NetworkCraftingProviders.java
@@ -66,7 +66,7 @@ public class NetworkCraftingProviders {
     public void addProvider(ICraftingProvider provider) {
         for (var state : globalProviders) {
             if (state.provider == provider) {
-                throw new IllegalArgumentException("Attempted to add duplicate global crafting provider" + provider);
+                throw new IllegalArgumentException("Duplicate crafting provider registration for " + provider);
             }
         }
 

--- a/src/test/java/appeng/crafting/simulation/helpers/SimulationEnv.java
+++ b/src/test/java/appeng/crafting/simulation/helpers/SimulationEnv.java
@@ -31,6 +31,7 @@ import appeng.api.networking.IGridNode;
 import appeng.api.networking.crafting.CalculationStrategy;
 import appeng.api.networking.crafting.ICraftingCPU;
 import appeng.api.networking.crafting.ICraftingPlan;
+import appeng.api.networking.crafting.ICraftingProvider;
 import appeng.api.networking.crafting.ICraftingRequester;
 import appeng.api.networking.crafting.ICraftingService;
 import appeng.api.networking.crafting.ICraftingSimulationRequester;
@@ -189,6 +190,21 @@ public class SimulationEnv {
 
             @Override
             public void refreshNodeCraftingProvider(IGridNode node) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void addGlobalCraftingProvider(ICraftingProvider cc) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void removeGlobalCraftingProvider(ICraftingProvider cc) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void refreshGlobalCraftingProvider(ICraftingProvider provider) {
                 throw new UnsupportedOperationException();
             }
         };


### PR DESCRIPTION
Recently, I had noticed that AE2's `IStorageService` allows for the ability to add "[global](https://github.com/AppliedEnergistics/Applied-Energistics-2/blob/main/src/main/java/appeng/api/networking/storage/IStorageService.java#L63)" instances of `IStorageProvider` with which to mount storage to a network which may not necessarily be provided by an individual device (via its `IGridNode`) but by e.g. another grid service entirely. Indeed, the crafting service [makes use of this](https://github.com/AppliedEnergistics/Applied-Energistics-2/blob/main/src/main/java/appeng/me/service/CraftingService.java#L137) in order to mount [its own storage](https://github.com/AppliedEnergistics/Applied-Energistics-2/blob/main/src/main/java/appeng/me/service/helpers/CraftingServiceStorage.java) that auto-crafting inputs are sent to to be forwarded to CPUs.

Analogously, this PR adds similar functionality for global `ICraftingProvider`s from which other grid services may be able to supply and process crafting patterns outside of a dedicated machine node. To give a few named examples, the MEGA Cells and AppliedE add-ons both make use of dedicated grid services through which a set of specialised crafting patterns is meant to be provided, i.e. to craft down compressed variants of items stored on a MEGA Bulk Cell or to "craft" items out of a ProjectE player's EMC stores respectively. So far these have both been handled by the individual "modules" used by these add-ons to enable the services, but this approach can be finicky and would require special casing in such a way that only one of these modules provides these patterns in case of any complications or that priorities set across multiple modules do not somehow clash.

As a proof-of-concept, [this commit](https://github.com/62832/MEGACells/commit/3cd7e70b29a77ddbc1bdab0cbe8011e40efae32c) in MEGA Cells illustrates how this system would be used, while also managing pattern priority from a single point within the relevant grid service but allowing any module to set it. With regards to priority, it may also be worth considering a follow-up to this PR in the future to allow grids to save their own persistent data outside of grid nodes, as this could eliminate the need for the locking logic in both the MEGA proof-of-concept and in AE2's own `PathingService` when keeping track of the channel mode for a network.