### PR TITLE
Allow `helpTopic` overrides in screen JSONs to use other namespaces' guide pages

### DIFF
--- a/src/main/java/appeng/client/gui/AEBaseScreen.java
+++ b/src/main/java/appeng/client/gui/AEBaseScreen.java
@@ -60,6 +60,7 @@ import net.neoforged.neoforge.network.PacketDistributor;
 import guideme.GuidesCommon;
 import guideme.PageAnchor;
 import guideme.color.SymbolicColor;
+import guideme.compiler.IdUtils;
 import guideme.document.DefaultStyles;
 import guideme.indices.ItemIndex;
 import guideme.style.ResolvedTextStyle;
@@ -1060,7 +1061,7 @@ public abstract class AEBaseScreen<T extends AEBaseMenu> extends AbstractContain
                 helpTopic = helpTopic.substring(0, sep);
             }
             try {
-                return new PageAnchor(AppEng.makeId(helpTopic), fragment);
+                return new PageAnchor(IdUtils.resolveId(helpTopic, AppEng.MOD_ID), fragment);
             } catch (Exception e) {
                 LOG.warn("Invalid helpTopic for screen {}: {}", this, helpTopic);
             }


### PR DESCRIPTION
Since I noticed earlier in add-on dev that trying to specify a help topic override for another add-on's guide pages proceeded to continuously spam the game log with the following:

`[Render thread/WARN] [ap.cl.gu.AEBaseScreen/]: Invalid helpTopic for screen gripe._90.appliede.client.screen.EMCInterfaceScreen@31e7f54: appliede:transmutation_devices.md`