### PR TITLE
Fix redstone P2P when deactivated

### DIFF
--- a/src/main/java/appeng/parts/p2p/RedstoneP2PTunnelPart.java
+++ b/src/main/java/appeng/parts/p2p/RedstoneP2PTunnelPart.java
@@ -63,6 +63,8 @@ public class RedstoneP2PTunnelPart extends P2PTunnelPart<RedstoneP2PTunnelPart> 
             final RedstoneP2PTunnelPart in = this.getInput();
             if (in != null) {
                 this.putInput(in.power);
+            } else {
+                this.putInput(0);
             }
         }
     }
@@ -73,8 +75,8 @@ public class RedstoneP2PTunnelPart extends P2PTunnelPart<RedstoneP2PTunnelPart> 
         }
 
         this.recursive = true;
-        if (this.isOutput() && this.getMainNode().isActive()) {
-            final int newPower = (Integer) o;
+        if (this.isOutput()) {
+            final int newPower = this.getMainNode().isActive() ? (Integer) o : 0;
             if (this.power != newPower) {
                 this.power = newPower;
                 this.notifyNeighbors();


### PR DESCRIPTION
Redstone P2P must emit a level of 0 if the input is no longer connected to the output or the P2P parts are offline.

Fixes #8476