### PR TITLE
Reduce collisions in AEItemKey hashing

### DIFF
--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -153,3 +153,7 @@ public net.minecraft.world.level.entity.PersistentEntitySectionManager chunkVisi
 
 # Poi listing for spatial IO
 public net.minecraft.world.level.chunk.storage.SectionStorage getOrLoad(J)Ljava/util/Optional;
+
+# Optimized hashCode implementation
+public net.minecraft.core.component.PatchedDataComponentMap prototype
+public net.minecraft.core.component.PatchedDataComponentMap patch


### PR DESCRIPTION
The main trick we play is how we hash the component patch map entries:
instead of XOR'ing the hash codes of the keys and the values,
we multiply the values by 31 ^ id, where id is the registered id of the data component.

Partially addresses https://github.com/AppliedEnergistics/Applied-Energistics-2/issues/8539 and https://github.com/AppliedEnergistics/Applied-Energistics-2/pull/8550.