### PR TITLE
Fix #6743: Shift-click insertion into the pattern access terminal

### DIFF
--- a/src/main/java/appeng/client/gui/me/patternaccess/PatternAccessTermScreen.java
+++ b/src/main/java/appeng/client/gui/me/patternaccess/PatternAccessTermScreen.java
@@ -23,6 +23,8 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
@@ -69,6 +71,7 @@ import appeng.core.AEConfig;
 import appeng.core.AppEng;
 import appeng.core.localization.GuiText;
 import appeng.core.network.serverbound.InventoryActionPacket;
+import appeng.core.network.serverbound.QuickMovePatternPacket;
 import appeng.helpers.InventoryAction;
 import appeng.menu.implementations.PatternAccessTermMenu;
 
@@ -346,6 +349,21 @@ public class PatternAccessTermScreen<C extends PatternAccessTermMenu> extends AE
                 PacketDistributor.sendToServer(p);
             }
 
+            return;
+        }
+
+        if (clickType == ClickType.QUICK_MOVE && slot.container == getPlayer().getInventory()) {
+            Set<Long> visiblePatternContainers = new LinkedHashSet<>();
+            for (var row : this.rows) {
+                if (row instanceof SlotsRow slotsRow) {
+                    visiblePatternContainers.add(slotsRow.container.getServerId());
+                }
+            }
+
+            int clickedSlot = slot.getContainerSlot();
+            var packet = new QuickMovePatternPacket(
+                    menu.containerId, clickedSlot, List.copyOf(visiblePatternContainers));
+            PacketDistributor.sendToServer(packet);
             return;
         }
 

--- a/src/main/java/appeng/core/network/InitNetwork.java
+++ b/src/main/java/appeng/core/network/InitNetwork.java
@@ -35,6 +35,7 @@ import appeng.core.network.serverbound.InventoryActionPacket;
 import appeng.core.network.serverbound.MEInteractionPacket;
 import appeng.core.network.serverbound.MouseWheelPacket;
 import appeng.core.network.serverbound.PartLeftClickPacket;
+import appeng.core.network.serverbound.QuickMovePatternPacket;
 import appeng.core.network.serverbound.RequestClosestMeteoritePacket;
 import appeng.core.network.serverbound.SelectKeyTypePacket;
 import appeng.core.network.serverbound.SwapSlotsPacket;
@@ -76,6 +77,7 @@ public class InitNetwork {
         serverbound(registrar, MEInteractionPacket.TYPE, MEInteractionPacket.STREAM_CODEC);
         serverbound(registrar, MouseWheelPacket.TYPE, MouseWheelPacket.STREAM_CODEC);
         serverbound(registrar, PartLeftClickPacket.TYPE, PartLeftClickPacket.STREAM_CODEC);
+        serverbound(registrar, QuickMovePatternPacket.TYPE, QuickMovePatternPacket.STREAM_CODEC);
         serverbound(registrar, SelectKeyTypePacket.TYPE, SelectKeyTypePacket.STREAM_CODEC);
         serverbound(registrar, SwapSlotsPacket.TYPE, SwapSlotsPacket.STREAM_CODEC);
         serverbound(registrar, SwitchGuisPacket.TYPE, SwitchGuisPacket.STREAM_CODEC);

--- a/src/main/java/appeng/core/network/serverbound/QuickMovePatternPacket.java
+++ b/src/main/java/appeng/core/network/serverbound/QuickMovePatternPacket.java
@@ -1,0 +1,46 @@
+package appeng.core.network.serverbound;
+
+import java.util.List;
+
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.server.level.ServerPlayer;
+
+import appeng.core.network.CustomAppEngPayload;
+import appeng.core.network.ServerboundPacket;
+import appeng.menu.implementations.PatternAccessTermMenu;
+
+/**
+ * Used for the pattern access terminal when the client shift-clicks an item in the player inventory.
+ */
+public record QuickMovePatternPacket(
+        int containerId,
+        int clickedSlot,
+        List<Long> allowedPatternContainers) implements ServerboundPacket {
+
+    public static final StreamCodec<RegistryFriendlyByteBuf, QuickMovePatternPacket> STREAM_CODEC = StreamCodec
+            .composite(
+                    ByteBufCodecs.VAR_INT,
+                    QuickMovePatternPacket::containerId,
+                    ByteBufCodecs.VAR_INT,
+                    QuickMovePatternPacket::clickedSlot,
+                    ByteBufCodecs.VAR_LONG.apply(ByteBufCodecs.list()),
+                    QuickMovePatternPacket::allowedPatternContainers,
+                    QuickMovePatternPacket::new);
+    public static final Type<QuickMovePatternPacket> TYPE = CustomAppEngPayload.createType("quick_move_pattern");
+
+    @Override
+    public void handleOnServer(ServerPlayer player) {
+        if (player.containerMenu.containerId == containerId
+                && player.containerMenu instanceof PatternAccessTermMenu menu) {
+            menu.quickMovePattern(player, clickedSlot, allowedPatternContainers);
+        }
+    }
+
+    @Override
+    public Type<? extends CustomPacketPayload> type() {
+        return TYPE;
+    }
+}

--- a/src/main/java/appeng/menu/implementations/PatternAccessTermMenu.java
+++ b/src/main/java/appeng/menu/implementations/PatternAccessTermMenu.java
@@ -18,8 +18,10 @@
 
 package appeng.menu.implementations;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.IdentityHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -29,6 +31,7 @@ import org.jetbrains.annotations.Nullable;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.inventory.MenuType;
+import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectArrayMap;
@@ -44,8 +47,10 @@ import appeng.api.inventories.InternalInventory;
 import appeng.api.networking.IGrid;
 import appeng.api.storage.ILinkStatus;
 import appeng.api.storage.IPatternAccessTermMenuHost;
+import appeng.blockentity.crafting.IMolecularAssemblerSupportedPattern;
 import appeng.client.gui.me.patternaccess.PatternAccessTermScreen;
 import appeng.core.AELog;
+import appeng.core.definitions.AEBlocks;
 import appeng.core.network.clientbound.ClearPatternAccessTerminalPacket;
 import appeng.core.network.clientbound.PatternAccessTerminalPacket;
 import appeng.core.network.clientbound.SetLinkStatusPacket;
@@ -283,6 +288,51 @@ public class PatternAccessTermMenu extends AEBaseMenu implements LinkStatusAware
                 if (player.getAbilities().instabuild && carried.isEmpty()) {
                     setCarried(is.isEmpty() ? ItemStack.EMPTY : is.copy());
                 }
+            }
+        }
+    }
+
+    public void quickMovePattern(ServerPlayer player, int clickedSlot, List<Long> allowedPatternContainers) {
+        if (clickedSlot >= Inventory.INVENTORY_SIZE) {
+            return;
+        }
+        Slot sourceSlot = getSlot(clickedSlot);
+        ItemStack sourceStack = sourceSlot.getItem();
+        if (sourceStack.getCount() != 1) {
+            return;
+        }
+        var pattern = PatternDetailsHelper.decodePattern(sourceStack, player.level());
+        if (pattern == null) {
+            return;
+        }
+        boolean molecularAssemblerPattern = pattern instanceof IMolecularAssemblerSupportedPattern;
+
+        // Collect possible targets
+        List<ContainerTracker> targets = new ArrayList<>();
+        for (var id : allowedPatternContainers) {
+            var inv = this.byId.get(id.longValue());
+            // Check pattern container exists and is visible
+            if (inv != null && isVisible(inv.container)) {
+                var icon = inv.group.icon();
+                // Keep molecular assembler iff pattern is supported by molecular assembler
+                boolean molecularAssembler = icon != null && icon.is(AEBlocks.MOLECULAR_ASSEMBLER);
+                if (molecularAssemblerPattern == molecularAssembler) {
+                    targets.add(inv);
+                }
+            }
+        }
+
+        // For now, limit to pattern containers in the same group
+        if (targets.stream().map(t -> t.group).distinct().count() != 1) {
+            return;
+        }
+
+        // Try to insert in each container until we succeed
+        for (var target : targets) {
+            var targetContainer = new FilteredInternalInventory(target.server, new PatternSlotFilter());
+            if (targetContainer.addItems(sourceStack).isEmpty()) {
+                sourceSlot.set(ItemStack.EMPTY);
+                return;
             }
         }
     }


### PR DESCRIPTION
Patterns are inserted into the pattern containers that are shown on the client side, search bar filtering included. If there are multiple groups, the pattern cannot be moved.

For crafting patterns, shift-clicking will typically put them in a molecular assembler. For processing patterns, search for the name of the target machine such that only one group of pattern containers is shown.