### PR TITLE
Mark all visible slots of processing pattern with their numbers

### DIFF
--- a/src/main/java/appeng/client/gui/me/items/ProcessingEncodingPanel.java
+++ b/src/main/java/appeng/client/gui/me/items/ProcessingEncodingPanel.java
@@ -1,5 +1,8 @@
 package appeng.client.gui.me.items;
 
+import appeng.client.gui.style.TextAlignment;
+import appeng.client.gui.widgets.Label;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.renderer.Rect2i;
 import net.minecraft.network.chat.Component;
@@ -20,6 +23,7 @@ public class ProcessingEncodingPanel extends EncodingModePanel {
     private final ActionButton clearBtn;
     private final ActionButton cycleOutputBtn;
     private final Scrollbar scrollbar;
+    private final Label[] inputLabels;
 
     public ProcessingEncodingPanel(PatternEncodingTermScreen<?> screen, WidgetContainer widgets) {
         super(screen, widgets);
@@ -42,6 +46,40 @@ public class ProcessingEncodingPanel extends EncodingModePanel {
         this.scrollbar.setRange(0, menu.getProcessingInputSlots().length / 3 - 3, 3);
         this.scrollbar.setCaptureMouseWheel(false);
 
+        var font = Minecraft.getInstance().font;
+
+        this.inputLabels = new Label[9];
+
+        var aligns = new TextAlignment[] {
+            TextAlignment.LEFT,
+            TextAlignment.CENTER,
+            TextAlignment.RIGHT,
+        };
+
+        var i = 0;
+        for (var vert: aligns)
+            for (var horiz: aligns) {
+                var label = new Label(Component.empty(), font);
+                var hLetter = switch(horiz) {
+                    case LEFT -> "L";
+                    case CENTER -> "C";
+                    case RIGHT -> "R";
+                };
+                var vLetter = switch(vert) {
+                    case LEFT -> "T";
+                    case CENTER -> "C";
+                    case RIGHT -> "B";
+                };
+                label
+                    .setDropShadow(false)
+                    .setAlignX(horiz)
+                    .setAlignY(vert);
+
+                widgets.add(String.format("slotLabel%s%s", hLetter, vLetter), label);
+
+                this.inputLabels[i] = label;
+                i += 1;
+        }
     }
 
     @Override
@@ -63,6 +101,12 @@ public class ProcessingEncodingPanel extends EncodingModePanel {
 
             slot.setActive(effectiveRow >= 0 && effectiveRow < 3);
             slot.y -= scrollbar.getCurrentScroll() * 18;
+        }
+
+        var slot = scrollbar.getCurrentScroll() * 3;
+        for (var label: inputLabels) {
+            label.setMessage(Component.literal(Integer.toString(slot)));
+            slot += 1;
         }
 
         updateTooltipVisibility();

--- a/src/main/java/appeng/client/gui/me/items/ProcessingEncodingPanel.java
+++ b/src/main/java/appeng/client/gui/me/items/ProcessingEncodingPanel.java
@@ -24,6 +24,7 @@ public class ProcessingEncodingPanel extends EncodingModePanel {
     private final ActionButton cycleOutputBtn;
     private final Scrollbar scrollbar;
     private final Label[] inputLabels;
+    private final Label[] outputLabels;
 
     public ProcessingEncodingPanel(PatternEncodingTermScreen<?> screen, WidgetContainer widgets) {
         super(screen, widgets);
@@ -50,35 +51,28 @@ public class ProcessingEncodingPanel extends EncodingModePanel {
 
         this.inputLabels = new Label[9];
 
-        var aligns = new TextAlignment[] {
-            TextAlignment.LEFT,
-            TextAlignment.CENTER,
-            TextAlignment.RIGHT,
-        };
+        for (var i = 0; i < this.inputLabels.length; i += 1) {
+            var label = new Label(Component.empty(), font);
+            label
+                .setDropShadow(false)
+                .setScale(0.5f);
 
-        var i = 0;
-        for (var vert: aligns)
-            for (var horiz: aligns) {
-                var label = new Label(Component.empty(), font);
-                var hLetter = switch(horiz) {
-                    case LEFT -> "L";
-                    case CENTER -> "C";
-                    case RIGHT -> "R";
-                };
-                var vLetter = switch(vert) {
-                    case LEFT -> "T";
-                    case CENTER -> "C";
-                    case RIGHT -> "B";
-                };
-                label
+            widgets.add(String.format("inputLabel%d", i), label);
+
+            this.inputLabels[i] = label;
+        }
+
+        this.outputLabels = new Label[3];
+
+        for (var i = 0; i < this.outputLabels.length; i += 1) {
+            var label = new Label(Component.empty(), font);
+            label
                     .setDropShadow(false)
-                    .setAlignX(horiz)
-                    .setAlignY(vert);
+                    .setScale(0.5f);
 
-                widgets.add(String.format("slotLabel%s%s", hLetter, vLetter), label);
+            widgets.add(String.format("outputLabel%d", i), label);
 
-                this.inputLabels[i] = label;
-                i += 1;
+            this.outputLabels[i] = label;
         }
     }
 
@@ -103,13 +97,19 @@ public class ProcessingEncodingPanel extends EncodingModePanel {
             slot.y -= scrollbar.getCurrentScroll() * 18;
         }
 
+        updateTooltipVisibility();
+
         var slot = scrollbar.getCurrentScroll() * 3;
         for (var label: inputLabels) {
             label.setMessage(Component.literal(Integer.toString(slot)));
             slot += 1;
         }
 
-        updateTooltipVisibility();
+        slot = scrollbar.getCurrentScroll();
+        for (var label: outputLabels) {
+            label.setMessage(Component.literal(Integer.toString(slot)));
+            slot += 1;
+        }
     }
 
     @Override
@@ -149,6 +149,12 @@ public class ProcessingEncodingPanel extends EncodingModePanel {
 
         screen.setSlotsHidden(SlotSemantics.PROCESSING_INPUTS, !visible);
         screen.setSlotsHidden(SlotSemantics.PROCESSING_OUTPUTS, !visible);
+
+        for (var label: inputLabels)
+            label.visible = visible;
+
+        for (var label: outputLabels)
+            label.visible = visible;
 
         updateTooltipVisibility();
     }

--- a/src/main/java/appeng/client/gui/widgets/Label.java
+++ b/src/main/java/appeng/client/gui/widgets/Label.java
@@ -102,39 +102,52 @@ public class Label extends AbstractStringWidget {
 
         var labelWidth = this.getWidth();
         var labelHeight = this.getHeight();
+
         var textWidth = font.width(message);
         var textHeight = font.lineHeight;
 
         var offsetX = alignToOffset(alignX);
         var offsetY = alignToOffset(alignY);
 
-        var drawX = this.getX() + Math.round(offsetX * (labelWidth - textWidth));
-        var drawY = this.getY() + Math.round(offsetY * (labelHeight - textHeight));
+        if (scale == 1) {
+            FormattedCharSequence drawText;
 
-        var drawText = clipWidth && textWidth > labelWidth
-            ? this.clipText(message, labelWidth)
-            : message.getVisualOrderText();
+            if (clipWidth && textWidth > labelWidth) {
+                drawText = this.clipText(message, labelWidth);
+                textWidth = labelWidth;
+            }
+            else {
+                drawText = message.getVisualOrderText();
+            }
 
-        guiGraphics.drawString(font, drawText, drawX, drawY, this.getColor(), dropShadow);
+            var drawX = this.getX() + Math.round(offsetX * (labelWidth - textWidth));
+            var drawY = this.getY() + Math.round(offsetY * (labelHeight - textHeight));
 
-//        if (scale == 1) {
-//            guiGraphics.drawString(font, drawText, drawX, drawY, this.getColor(), dropShadow);
-//        }
-//        else {
-//            guiGraphics.pose().pushPose();
-//
-//            guiGraphics.pose().translate(x, y, 0);
-//            guiGraphics.pose().scale(scale, scale, 1);
-//            guiGraphics.drawString(
-//                    font,
-//                    line,
-//                    0,
-//                    0,
-//                    color,
-//                    false);
-//
-//            guiGraphics.pose().popPose();
-//        }
+            guiGraphics.drawString(font, drawText, drawX, drawY, this.getColor(), dropShadow);
+        } else {
+            var labelLogicWidth = Math.round(labelWidth / scale);
+            FormattedCharSequence drawText;
+            if (clipWidth && textWidth > labelLogicWidth) {
+                drawText = this.clipText(message, labelLogicWidth);
+                textWidth = labelWidth;
+            }
+            else {
+                drawText = message.getVisualOrderText();
+                textWidth = Math.round(textWidth * scale);
+            }
+
+            textHeight = Math.round(textHeight * scale);
+
+            var drawX = this.getX() + Math.round(offsetX * (labelWidth - textWidth));
+            var drawY = this.getY() + Math.round(offsetY * (labelHeight - textHeight));
+
+            guiGraphics.pose().pushPose();
+
+            guiGraphics.pose().translate(drawX, drawY, 0);
+            guiGraphics.pose().scale(scale, scale, 1);
+            guiGraphics.drawString(font, drawText, 0, 0, this.getColor(), dropShadow);
+            guiGraphics.pose().popPose();
+        }
     }
 
     private FormattedCharSequence clipText(Component message, int width) {

--- a/src/main/java/appeng/client/gui/widgets/Label.java
+++ b/src/main/java/appeng/client/gui/widgets/Label.java
@@ -1,0 +1,153 @@
+package appeng.client.gui.widgets;
+
+import appeng.client.gui.style.TextAlignment;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.AbstractStringWidget;
+import net.minecraft.locale.Language;
+import net.minecraft.network.chat.CommonComponents;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.FormattedText;
+import net.minecraft.util.FormattedCharSequence;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Label widget, usable on any composite widget panel.
+ * Supports vertical and horizontal alignment, scaling, drop shadow and text clip
+ */
+public class Label extends AbstractStringWidget {
+    private boolean dropShadow;
+    private TextAlignment alignX;
+    private TextAlignment alignY;
+    private boolean clipWidth;
+    private float scale;
+
+    public Label(Component message, Font font) {
+        this(0, 0, font.width(message.getVisualOrderText()), font.lineHeight, message, font);
+    }
+
+    public Label(int width, int height, Component message, Font font) {
+        this(0, 0, width, height, message, font);
+    }
+
+    public Label(int x, int y, int width, int height, Component message, Font font) {
+        super(x, y, width, height, message, font);
+        this.active = false;
+        setDropShadow(false);
+        setAlignX(TextAlignment.LEFT);
+        setAlignY(TextAlignment.LEFT);
+        setClipWidth(false);
+        setScale(1.0f);
+    }
+
+    public boolean getDropShadow() {
+        return dropShadow;
+    }
+
+    public TextAlignment getAlignX() {
+        return alignX;
+    }
+
+    public TextAlignment getAlignY() {
+        return alignY;
+    }
+
+    public boolean getClipWidth() {
+        return clipWidth;
+    }
+
+    public float getScale() {
+        return scale;
+    }
+
+    public Label setDropShadow(boolean dropShadow) {
+        this.dropShadow = dropShadow;
+        return this;
+    }
+
+    public Label setAlignX(TextAlignment alignX) {
+        this.alignX = alignX;
+        return this;
+    }
+
+    /**
+     * @param alignY `LEFT` means `TOP`, `RIGHT` means `BOTTOM`
+     */
+    public Label setAlignY(TextAlignment alignY) {
+        this.alignY = alignY;
+        return this;
+    }
+
+    public Label setClipWidth(boolean clip) {
+        this.clipWidth = clip;
+        return this;
+    }
+
+    public Label setScale(float scale) {
+        if (!Float.isFinite(scale) || scale <= 0.0)
+            throw new IllegalArgumentException("`scale` must be finite positive value");
+        this.scale = scale;
+        return this;
+    }
+
+    public @NotNull Label setColor(int color) {
+        super.setColor(color);
+        return this;
+    }
+
+    @Override
+    public void renderWidget(@NotNull GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
+        var message = this.getMessage();
+        var font = this.getFont();
+
+        var labelWidth = this.getWidth();
+        var labelHeight = this.getHeight();
+        var textWidth = font.width(message);
+        var textHeight = font.lineHeight;
+
+        var offsetX = alignToOffset(alignX);
+        var offsetY = alignToOffset(alignY);
+
+        var drawX = this.getX() + Math.round(offsetX * (labelWidth - textWidth));
+        var drawY = this.getY() + Math.round(offsetY * (labelHeight - textHeight));
+
+        var drawText = clipWidth && textWidth > labelWidth
+            ? this.clipText(message, labelWidth)
+            : message.getVisualOrderText();
+
+        guiGraphics.drawString(font, drawText, drawX, drawY, this.getColor(), dropShadow);
+
+//        if (scale == 1) {
+//            guiGraphics.drawString(font, drawText, drawX, drawY, this.getColor(), dropShadow);
+//        }
+//        else {
+//            guiGraphics.pose().pushPose();
+//
+//            guiGraphics.pose().translate(x, y, 0);
+//            guiGraphics.pose().scale(scale, scale, 1);
+//            guiGraphics.drawString(
+//                    font,
+//                    line,
+//                    0,
+//                    0,
+//                    color,
+//                    false);
+//
+//            guiGraphics.pose().popPose();
+//        }
+    }
+
+    private FormattedCharSequence clipText(Component message, int width) {
+        var font = this.getFont();
+        var formattedtext = font.substrByWidth(message, width - font.width(CommonComponents.ELLIPSIS));
+        return Language.getInstance().getVisualOrder(FormattedText.composite(formattedtext, CommonComponents.ELLIPSIS));
+    }
+
+    private static float alignToOffset(TextAlignment alignment) {
+        return switch (alignment) {
+            case LEFT -> 0.0f;
+            case CENTER -> 0.5f;
+            case RIGHT -> 1.0f;
+        };
+    }
+}

--- a/src/main/resources/assets/ae2/screens/terminals/encoding/processing.json
+++ b/src/main/resources/assets/ae2/screens/terminals/encoding/processing.json
@@ -88,6 +88,60 @@
     "processingClearPattern": {
       "left": 79,
       "bottom": 159
+    },
+    "slotLabelLT": {
+      "left": 24,
+      "bottom": 158,
+      "width": 18,
+      "height": 18
+    },
+    "slotLabelCT": {
+      "left": 42,
+      "bottom": 158,
+      "width": 18,
+      "height": 18
+    },
+    "slotLabelRT": {
+      "left": 60,
+      "bottom": 158,
+      "width": 18,
+      "height": 18
+    },
+    "slotLabelLC": {
+      "left": 24,
+      "bottom": 140,
+      "width": 18,
+      "height": 18
+    },
+    "slotLabelCC": {
+      "left": 42,
+      "bottom": 140,
+      "width": 18,
+      "height": 18
+    },
+    "slotLabelRC": {
+      "left": 60,
+      "bottom": 140,
+      "width": 18,
+      "height": 18
+    },
+    "slotLabelLB": {
+      "left": 24,
+      "bottom": 122,
+      "width": 18,
+      "height": 18
+    },
+    "slotLabelCB": {
+      "left": 42,
+      "bottom": 122,
+      "width": 18,
+      "height": 18
+    },
+    "slotLabelRB": {
+      "left": 60,
+      "bottom": 122,
+      "width": 18,
+      "height": 18
     }
   }
 }

--- a/src/main/resources/assets/ae2/screens/terminals/encoding/processing.json
+++ b/src/main/resources/assets/ae2/screens/terminals/encoding/processing.json
@@ -89,56 +89,74 @@
       "left": 79,
       "bottom": 159
     },
-    "slotLabelLT": {
+    "inputLabel0": {
       "left": 24,
       "bottom": 158,
       "width": 18,
       "height": 18
     },
-    "slotLabelCT": {
+    "inputLabel1": {
       "left": 42,
       "bottom": 158,
       "width": 18,
       "height": 18
     },
-    "slotLabelRT": {
+    "inputLabel2": {
       "left": 60,
       "bottom": 158,
       "width": 18,
       "height": 18
     },
-    "slotLabelLC": {
+    "inputLabel3": {
       "left": 24,
       "bottom": 140,
       "width": 18,
       "height": 18
     },
-    "slotLabelCC": {
+    "inputLabel4": {
       "left": 42,
       "bottom": 140,
       "width": 18,
       "height": 18
     },
-    "slotLabelRC": {
+    "inputLabel5": {
       "left": 60,
       "bottom": 140,
       "width": 18,
       "height": 18
     },
-    "slotLabelLB": {
+    "inputLabel6": {
       "left": 24,
       "bottom": 122,
       "width": 18,
       "height": 18
     },
-    "slotLabelCB": {
+    "inputLabel7": {
       "left": 42,
       "bottom": 122,
       "width": 18,
       "height": 18
     },
-    "slotLabelRB": {
+    "inputLabel8": {
       "left": 60,
+      "bottom": 122,
+      "width": 18,
+      "height": 18
+    },
+    "outputLabel0": {
+      "left": 109,
+      "bottom": 158,
+      "width": 18,
+      "height": 18
+    },
+    "outputLabel1": {
+      "left": 109,
+      "bottom": 140,
+      "width": 18,
+      "height": 18
+    },
+    "outputLabel2": {
+      "left": 109,
       "bottom": 122,
       "width": 18,
       "height": 18


### PR DESCRIPTION
Implements one of the options for #8568 
Honestly doesn't look that well, yet was much simpler to do than row numbering.
The only thing I couldn't figure out is number on main output slot, seems to be caused by element draw order:
![зображення](https://github.com/user-attachments/assets/36a04a90-7c35-49cd-af7e-e9c4b867ea87)
