### PR TITLE
Fix potential class cast exception in recipe fill

### DIFF
--- a/src/main/java/appeng/core/network/serverbound/FillCraftingGridFromRecipePacket.java
+++ b/src/main/java/appeng/core/network/serverbound/FillCraftingGridFromRecipePacket.java
@@ -302,7 +302,7 @@ public record FillCraftingGridFromRecipePacket(
                 // While FuzzyMode.IGNORE_ALL will retrieve all stacks of the same Item which matches
                 // standard Vanilla Ingredient matching, there are NBT-matching Ingredient subclasses on Forge,
                 // and Mods might actually have mixed into Ingredient
-                .filter(e -> ((AEItemKey) e.getKey()).matches(ingredient))
+                .filter(e -> e.getKey() instanceof AEItemKey && ((AEItemKey) e.getKey()).matches(ingredient))
                 // Sort in descending order of availability
                 .sorted((a, b) -> Long.compare(b.getLongValue(), a.getLongValue()))//
                 .map(e -> (AEItemKey) e.getKey())//


### PR DESCRIPTION
`findBestMatchingItemStack` has an unchecked cast.

This causes a downstream bug [here with steps to reproduce](https://github.com/tom5454/Create-Stock-Bridge/issues/13), but to summarize, filling a recipe fails if the ingredients are a subclass of `AEKey` that is not `AEItemKey`. That project creates [`AERemoteItemKey`](https://github.com/tom5454/Create-Stock-Bridge/blob/main/NeoForge/src/platform-shared/java/com/tom/stockbridge/ae/AERemoteItemKey.java) to model items in Create's stock link system.

This change solves the downstream problem and seems just generally correct code. 