### PR TITLE
Balance annihilation plane enchantment energy cost

### DIFF
--- a/src/main/java/appeng/parts/automation/ItemPickupStrategy.java
+++ b/src/main/java/appeng/parts/automation/ItemPickupStrategy.java
@@ -271,8 +271,8 @@ public class ItemPickupStrategy implements PickupStrategy {
                 useEnergy = randomNumber == 0;
             }
             var levelSum = enchantments.entrySet().stream().map(Map.Entry::getValue).reduce(0, Integer::sum)
-                    - efficiencyLevel;
-            requiredEnergy *= 8 * levelSum * efficiencyFactor;
+                    - efficiencyLevel - unbreakingLevel;
+            requiredEnergy *= (levelSum > 0 ? 8 * levelSum : 1) * efficiencyFactor;
         }
 
         return useEnergy ? requiredEnergy : 0;


### PR DESCRIPTION
The current implementation had two problems:

Enchanting an annihilation plane with any level of efficiency (and nothing else) would reduce the required energy to zero due to multiplying with the 0 in levelSum directly.

Enchanting an annihilation plane with unbreaking would increase the energy cost by a factor of 8 per level of unbreaking, but only leading to an average saving of 50% (lv1), 33% (lv2), or 25% (lv3), effectively increasing the average cost rather than reducing it.

Fixes #8188