### PR TITLE
Close UIs of parts when they are removed from the world

### DIFF
--- a/src/main/java/appeng/menu/AEBaseMenu.java
+++ b/src/main/java/appeng/menu/AEBaseMenu.java
@@ -78,6 +78,7 @@ import appeng.menu.slot.CraftingTermSlot;
 import appeng.menu.slot.DisabledSlot;
 import appeng.menu.slot.FakeSlot;
 import appeng.menu.slot.RestrictedInputSlot;
+import appeng.parts.AEBasePart;
 import appeng.util.ConfigMenuInventory;
 
 public abstract class AEBaseMenu extends AbstractContainerMenu {
@@ -323,6 +324,12 @@ public abstract class AEBaseMenu extends AbstractContainerMenu {
             if (this.blockEntity != null
                     && this.blockEntity.getLevel().getBlockEntity(this.blockEntity.getBlockPos()) != this.blockEntity) {
                 this.setValidMenu(false);
+            }
+            if (this.part instanceof AEBasePart basePart) {
+                var host = basePart.getHost();
+                if (host == null || !host.isInWorld() || host.getPart(basePart.getSide()) != basePart) {
+                    setValidMenu(false);
+                }
             }
 
             if (dataSync.hasChanges()) {


### PR DESCRIPTION
The issue causes dupe problems because the menu will interact with the "ghost" Part object which will no longer affect the world.

Fixes #8614 