### PR TITLE
6865 - clean up fluid transform recipes

### DIFF
--- a/src/main/java/appeng/recipes/transform/TransformLogic.java
+++ b/src/main/java/appeng/recipes/transform/TransformLogic.java
@@ -64,7 +64,7 @@ public final class TransformLogic {
                 if (missingIngredients.stream().noneMatch(i -> i.test(entity.getItem())))
                     continue;
             } else {
-                if (!missingIngredients.getFirst().test(entity.getItem()))
+                if (!recipe.catalyst.test(entity.getItem()))
                     continue;
             }
 
@@ -133,11 +133,8 @@ public final class TransformLogic {
                 var recipe = holder.value();
                 if (!(recipe.circumstance.isFluid(fluid)))
                     continue;
-                for (var ingredient : recipe.ingredients) {
-                    for (var stack : ingredient.getItems()) {
-                        ret.add(stack.getItem());
-                    }
-                    break; // only process first ingredient (they're all required anyway)
+                for (var stack : recipe.catalyst.getItems()) {
+                    ret.add(stack.getItem());
                 }
             }
             return ret;
@@ -152,11 +149,8 @@ public final class TransformLogic {
                 var recipe = holder.value();
                 if (!recipe.circumstance.isFluid())
                     continue;
-                for (var ingredient : recipe.ingredients) {
-                    for (var stack : ingredient.getItems()) {
-                        ret.add(stack.getItem());
-                    }
-                    break; // only process first ingredient (they're all required anyway)
+                for (var stack : recipe.catalyst.getItems()) {
+                    ret.add(stack.getItem());
                 }
             }
             anyFluidCache = ret;
@@ -176,7 +170,8 @@ public final class TransformLogic {
                     for (var stack : ingredient.getItems()) {
                         ret.add(stack.getItem());
                     }
-                    // ingredients that aren't processed may be destroyed in the explosion, so process all of them.
+                    // ingredients that aren't processed may be destroyed in the explosion, so
+                    // process all of them.
                 }
             }
             explosionCache = ret;

--- a/src/main/java/appeng/recipes/transform/TransformLogic.java
+++ b/src/main/java/appeng/recipes/transform/TransformLogic.java
@@ -26,6 +26,8 @@ import net.neoforged.neoforge.event.server.ServerStartedEvent;
 import it.unimi.dsi.fastutil.objects.Reference2IntMap;
 import it.unimi.dsi.fastutil.objects.Reference2IntOpenHashMap;
 
+import appeng.recipes.AERecipeTypes;
+
 public final class TransformLogic {
     public static boolean canTransformInFluid(ItemEntity entity, FluidState fluid) {
         return getTransformableItems(entity.level(), fluid.getType()).contains(entity.getItem().getItem());
@@ -47,7 +49,7 @@ public final class TransformLogic {
         List<ItemEntity> itemEntities = level.getEntities(null, region).stream()
                 .filter(e -> e instanceof ItemEntity && !e.isRemoved()).map(e -> (ItemEntity) e).toList();
 
-        for (var holder : level.getRecipeManager().byType(TransformRecipe.TYPE)) {
+        for (var holder : level.getRecipeManager().byType(AERecipeTypes.TRANSFORM)) {
             var recipe = holder.value();
             if (!circumstancePredicate.test(recipe.circumstance))
                 continue;
@@ -127,7 +129,7 @@ public final class TransformLogic {
     private static Set<Item> getTransformableItems(Level level, Fluid fluid) {
         return fluidCache.computeIfAbsent(fluid, f -> {
             Set<Item> ret = Collections.newSetFromMap(new IdentityHashMap<>());
-            for (var holder : level.getRecipeManager().getAllRecipesFor(TransformRecipe.TYPE)) {
+            for (var holder : level.getRecipeManager().getAllRecipesFor(AERecipeTypes.TRANSFORM)) {
                 var recipe = holder.value();
                 if (!(recipe.circumstance.isFluid(fluid)))
                     continue;
@@ -146,7 +148,7 @@ public final class TransformLogic {
         Set<Item> ret = anyFluidCache;
         if (ret == null) {
             ret = Collections.newSetFromMap(new IdentityHashMap<>());
-            for (var holder : level.getRecipeManager().getAllRecipesFor(TransformRecipe.TYPE)) {
+            for (var holder : level.getRecipeManager().getAllRecipesFor(AERecipeTypes.TRANSFORM)) {
                 var recipe = holder.value();
                 if (!recipe.circumstance.isFluid())
                     continue;
@@ -166,7 +168,7 @@ public final class TransformLogic {
         Set<Item> ret = explosionCache;
         if (ret == null) {
             ret = Collections.newSetFromMap(new IdentityHashMap<>());
-            for (var holder : level.getRecipeManager().getAllRecipesFor(TransformRecipe.TYPE)) {
+            for (var holder : level.getRecipeManager().getAllRecipesFor(AERecipeTypes.TRANSFORM)) {
                 var recipe = holder.value();
                 if (!recipe.circumstance.isExplosion())
                     continue;

--- a/src/main/java/appeng/recipes/transform/TransformRecipe.java
+++ b/src/main/java/appeng/recipes/transform/TransformRecipe.java
@@ -58,12 +58,18 @@ public final class TransformRecipe implements Recipe<TransformRecipeInput> {
     public final NonNullList<Ingredient> ingredients;
     public final ItemStack output;
     public final TransformCircumstance circumstance;
+    public final Ingredient catalyst;
+
+    public Ingredient getCatalyst() {
+        return catalyst;
+    }
 
     public TransformRecipe(NonNullList<Ingredient> ingredients, ItemStack output,
             TransformCircumstance circumstance) {
         this.ingredients = ingredients;
         this.output = output;
         this.circumstance = circumstance;
+        this.catalyst = ingredients.getFirst();
     }
 
     @Override


### PR DESCRIPTION
This pull request adds a field on TransformRecipe named catalyst that stores the first ingredient of the recipe. This is later used in TransformLogic to make it clear that checks are made on the first ingredient of the recipe.

Also, the TransformRecipe.TYPE that has been deprecated has been changed to AERecipeTypes.TRANSFORM.