### PR TITLE
Fix Spatial Anchor overlay rendering in 1.20.1

### DIFF
--- a/src/main/java/appeng/client/render/overlay/OverlayManager.java
+++ b/src/main/java/appeng/client/render/overlay/OverlayManager.java
@@ -49,7 +49,7 @@ public class OverlayManager {
 
     @SubscribeEvent
     public void renderWorldLastEvent(RenderLevelStageEvent event) {
-        if (event.getStage() != RenderLevelStageEvent.Stage.AFTER_LEVEL) {
+        if (event.getStage() != RenderLevelStageEvent.Stage.AFTER_SOLID_BLOCKS) {
             return;
         }
 


### PR DESCRIPTION
Fixes #7880 by changing the render layer of the Spatial Anchor's overlay.
Tested and verified working on Forge version 47.4.6 alongside GuideME, building with dummy version number `15.123.123`.
This is not a direct backport of #7955, but instead references the Fabric implementation of the overlay, which is functional. Details are in #7880.
