### PR TITLE
Keep sky stone tank contents across saving and loading

### DIFF
--- a/src/main/java/appeng/blockentity/storage/SkyStoneTankBlockEntity.java
+++ b/src/main/java/appeng/blockentity/storage/SkyStoneTankBlockEntity.java
@@ -38,7 +38,7 @@ public class SkyStoneTankBlockEntity extends AEBaseBlockEntity {
         var tankNbt = new CompoundTag();
         tank.writeToNBT(registries, tankNbt);
         if (!tankNbt.isEmpty()) {
-            data.put("content", tankNbt);
+            data.put("tank", tankNbt);
         }
     }
 


### PR DESCRIPTION
Saving and loading must use the same name for the data. Previously loading would use "tank", whereas saving would use "content". Since the variable itself is called "tank" I've chosen this as the correct version for both.

Fixes #8634