### PR TITLE
Fix rare issue with cell not persisting when it is removed right after being changed

### DIFF
--- a/src/main/java/appeng/blockentity/inventory/AppEngCellInventory.java
+++ b/src/main/java/appeng/blockentity/inventory/AppEngCellInventory.java
@@ -36,6 +36,7 @@ public class AppEngCellInventory extends BaseInternalInventory {
     }
 
     public void setHandler(int slot, StorageCell handler) {
+        this.persist(slot);
         this.handlerForSlot[slot] = handler;
     }
 


### PR DESCRIPTION
The import bus will extract 2 cells in one tick, when it extracts the first, that will also reset the handler of the second.
The handler (BasicCellInventory) might still have unpersisted changes at that point, causing those changes to be voided.

Fixes #8682