### PR TITLE
EMI item pulling hotkey integration

### DIFF
--- a/src/main/java/appeng/core/network/InitNetwork.java
+++ b/src/main/java/appeng/core/network/InitNetwork.java
@@ -33,6 +33,7 @@ import appeng.core.network.serverbound.GuiActionPacket;
 import appeng.core.network.serverbound.HotkeyPacket;
 import appeng.core.network.serverbound.InventoryActionPacket;
 import appeng.core.network.serverbound.MEInteractionPacket;
+import appeng.core.network.serverbound.PullItemToPlayerPacket;
 import appeng.core.network.serverbound.MouseWheelPacket;
 import appeng.core.network.serverbound.PartLeftClickPacket;
 import appeng.core.network.serverbound.QuickMovePatternPacket;
@@ -82,6 +83,7 @@ public class InitNetwork {
         serverbound(registrar, SwapSlotsPacket.TYPE, SwapSlotsPacket.STREAM_CODEC);
         serverbound(registrar, SwitchGuisPacket.TYPE, SwitchGuisPacket.STREAM_CODEC);
         serverbound(registrar, UpdateHoldingCtrlPacket.TYPE, UpdateHoldingCtrlPacket.STREAM_CODEC);
+        serverbound(registrar, PullItemToPlayerPacket.TYPE, PullItemToPlayerPacket.STREAM_CODEC);
 
         // Bidirectional
         bidirectional(registrar, ConfigValuePacket.TYPE, ConfigValuePacket.STREAM_CODEC);

--- a/src/main/java/appeng/core/network/serverbound/PullItemToPlayerPacket.java
+++ b/src/main/java/appeng/core/network/serverbound/PullItemToPlayerPacket.java
@@ -1,0 +1,57 @@
+package appeng.core.network.serverbound;
+
+import net.minecraft.core.NonNullList;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.item.ItemStack;
+
+import appeng.core.network.CustomAppEngPayload;
+import appeng.core.network.ServerboundPacket;
+import appeng.menu.me.common.MEStorageMenu;
+
+public record PullItemToPlayerPacket(int containerId, NonNullList<ItemStack> stacks, long toPull) implements ServerboundPacket {
+
+    public static final StreamCodec<RegistryFriendlyByteBuf, PullItemToPlayerPacket> STREAM_CODEC = StreamCodec.ofMember(
+            PullItemToPlayerPacket::write,
+            PullItemToPlayerPacket::decode);
+
+    public static final Type<PullItemToPlayerPacket> TYPE = CustomAppEngPayload.createType("me_pull");
+
+    @Override
+    public Type<PullItemToPlayerPacket> type() {
+        return TYPE;
+    }
+
+    public static PullItemToPlayerPacket decode(RegistryFriendlyByteBuf buffer) {
+        int containerId = buffer.readInt();
+        NonNullList<ItemStack> stacks = NonNullList.withSize(buffer.readInt(), ItemStack.EMPTY);
+        for (int i = 0; i < stacks.size(); i++) {
+            stacks.set(i, ItemStack.OPTIONAL_STREAM_CODEC.decode(buffer));
+        }
+        long toPull = buffer.readVarLong();
+        return new PullItemToPlayerPacket(containerId, stacks, toPull);
+    }
+
+    public void write(RegistryFriendlyByteBuf data) {
+        data.writeInt(containerId);
+        data.writeInt(stacks.size());
+        for (ItemStack stack : stacks) {
+            ItemStack.OPTIONAL_STREAM_CODEC.encode(data, stack);
+        }
+        data.writeVarLong(toPull);
+    }
+
+    @Override
+    public void handleOnServer(ServerPlayer player) {
+        if (player.containerMenu instanceof MEStorageMenu aeMenu) {
+            // The open screen has changed since the client sent the packet
+            if (player.containerMenu.containerId != containerId) {
+                return;
+            }
+
+            aeMenu.transferMatchingStacksToPlayer(stacks, toPull);
+        }
+    }
+
+}

--- a/src/main/java/appeng/integration/modules/emi/AppEngEmiPlugin.java
+++ b/src/main/java/appeng/integration/modules/emi/AppEngEmiPlugin.java
@@ -62,6 +62,7 @@ public class AppEngEmiPlugin implements EmiPlugin {
         registry.addGenericExclusionArea(new EmiAeBaseScreenExclusionZones());
         registry.addGenericStackProvider(new EmiAeBaseScreenStackProvider());
         registry.addGenericDragDropHandler(new EmiAeBaseScreenDragDropHandler());
+        registry.addGenericStackPuller(new EmiAeBaseScreenStackPuller());
 
         // Additional Workstations
         registerWorkstations(registry);

--- a/src/main/java/appeng/integration/modules/emi/EmiAeBaseScreenStackPuller.java
+++ b/src/main/java/appeng/integration/modules/emi/EmiAeBaseScreenStackPuller.java
@@ -1,0 +1,31 @@
+package appeng.integration.modules.emi;
+
+import java.util.List;
+
+import net.minecraft.core.NonNullList;
+import dev.emi.emi.api.EmiStackPuller;
+import net.neoforged.neoforge.network.PacketDistributor;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.item.ItemStack;
+
+import appeng.menu.me.common.MEStorageMenu;
+import appeng.core.network.ServerboundPacket;
+import appeng.core.network.serverbound.PullItemToPlayerPacket;
+
+public class EmiAeBaseScreenStackPuller implements EmiStackPuller<AbstractContainerMenu> {
+
+    @Override
+    public boolean pullStack(AbstractContainerMenu menu, List<ItemStack> stacks, long toPull) {
+        if (!(menu instanceof MEStorageMenu aeMenu)) {
+            return false;
+        }
+
+        NonNullList<ItemStack> nonNullStacks = NonNullList.copyOf(stacks);
+
+        ServerboundPacket message = new PullItemToPlayerPacket(menu.containerId, nonNullStacks, toPull);
+        PacketDistributor.sendToServer(message);
+
+        return true;
+    }
+
+}


### PR DESCRIPTION
This PR integrates with a new feature within EMI that allows for automatically pulling items from any open inventory, see https://github.com/emilyploszaj/emi/pull/1062 for details about the functionality.

This will not function without the new API registry changes contained in the EMI PR, so I'll leave this as a draft for now until it is accepted and pushed into a build there. I tested this integration by building the changes in the above PR (built with `./gradlew neoforge:build`) and modifying `build.gradle` to use the updated API:
```gradle
compileOnly files('testing/emi-1.1.22-SNAPSHOT+1.21.1+neoforge-api.jar')
```
```gradle
localRuntimeOnly files('testing/emi-1.1.22-SNAPSHOT+1.21.1+neoforge.jar')
```