### PR TITLE
fix: remove the duplicate sugar cane block

### DIFF
--- a/src/main/java/appeng/datagen/providers/tags/BlockTagsProvider.java
+++ b/src/main/java/appeng/datagen/providers/tags/BlockTagsProvider.java
@@ -67,7 +67,7 @@ public class BlockTagsProvider extends IntrinsicHolderTagsProvider<Block> implem
                 .addOptionalTag(ConventionTags.GLASS_BLOCK.location());
         tag(AETags.GROWTH_ACCELERATABLE)
                 // TODO: Should all be in some conventional tag
-                .add(Blocks.BAMBOO_SAPLING, Blocks.BAMBOO, Blocks.SUGAR_CANE, Blocks.SUGAR_CANE, Blocks.VINE,
+                .add(Blocks.BAMBOO_SAPLING, Blocks.BAMBOO, Blocks.SUGAR_CANE, Blocks.VINE,
                         Blocks.TWISTING_VINES, Blocks.WEEPING_VINES, Blocks.CAVE_VINES, Blocks.SWEET_BERRY_BUSH,
                         Blocks.NETHER_WART, Blocks.KELP, Blocks.COCOA)
                 .addOptionalTag(ConventionTags.CROPS.location())


### PR DESCRIPTION
Hey, I'm sorry to bother you, but when I was browsing through the source code, I noticed that there seems to be a duplicate sugar cane block here. After browsing through other parts of the source code, I don't think it has any special effect, so I chose to delete this duplicate block. This is a small change, but I think it is still worth modifying.