### PR TITLE
Fix: Prevent Pattern Provider item loss on simultaneous slot insertions

### DIFF
--- a/src/main/java/appeng/helpers/externalstorage/GenericStackItemStorage.java
+++ b/src/main/java/appeng/helpers/externalstorage/GenericStackItemStorage.java
@@ -48,6 +48,19 @@ public class GenericStackItemStorage implements IItemHandler {
 
         var inserted = (int) inv.insert(slot, what, stack.getCount(), Actionable.ofSimulate(simulate));
 
+        if (inserted < stack.getCount()) {
+            var remaining = stack.getCount() - inserted;
+            for (int i = 0; i < inv.size() && remaining > 0; i++) {
+                if (i == slot) {
+                    continue;
+                }
+
+                var additionalInserted = (int) inv.insert(i, what, remaining, Actionable.ofSimulate(simulate));
+                inserted += additionalInserted;
+                remaining -= additionalInserted;
+            }
+        }
+
         return Platform.copyStackWithSize(stack, stack.getCount() - inserted);
     }
 


### PR DESCRIPTION
Modified GenericStackItemStorage.insertItem() to automatically search for available slots when the requested slot cannot accept the full stack. This prevents item loss when external mods (e.g., Industrial Upgrade ejector) insert multiple items targeting the same slot number.

The method now:
1. Attempts insertion into the specified slot first (maintains compatibility)
2. Iterates through remaining slots if insertion is incomplete
3. Distributes items across available slots automatically

Backward compatible - only enhances behavior in failure cases.