### PR TITLE
Fix: item duplication

### DIFF
--- a/src/main/java/appeng/me/storage/ExternalStorageFacade.java
+++ b/src/main/java/appeng/me/storage/ExternalStorageFacade.java
@@ -196,10 +196,13 @@ public abstract class ExternalStorageFacade implements MEStorage {
                     // size > maxSize, even if we request more. So even if it returns a valid stack, it might have more
                     // stuff.
                     int totalExtracted = 0;
-                    while (itemKey.matches(handler.getStackInSlot(slot))) {
+                    while (true) {
                         int extracted = wrapHandlerExtract(handler, slot, maxExtract - totalExtracted, false);
                         if (extracted > 0) {
                             totalExtracted += extracted;
+                            if (!itemKey.matches(handler.getStackInSlot(slot))) {
+                                break;
+                            }
                         } else {
                             break;
                         }

--- a/src/main/java/appeng/me/storage/ExternalStorageFacade.java
+++ b/src/main/java/appeng/me/storage/ExternalStorageFacade.java
@@ -196,7 +196,7 @@ public abstract class ExternalStorageFacade implements MEStorage {
                     // size > maxSize, even if we request more. So even if it returns a valid stack, it might have more
                     // stuff.
                     int totalExtracted = 0;
-                    while (true) {
+                    while (itemKey.matches(handler.getStackInSlot(slot))) {
                         int extracted = wrapHandlerExtract(handler, slot, maxExtract - totalExtracted, false);
                         if (extracted > 0) {
                             totalExtracted += extracted;


### PR DESCRIPTION
The `extractFromHandler` method currently assumes the item type in a given slot does not change between extractions. However, for some containers with auto-sorting or a dynamic number of slots, this can lead to item duplication.

This issue has already caused AE2 to duplicate items when import bus work for my mod’s container (see Frostbite-time/BeyondDimensions#19). It also caused the duplication reported in #8592.

This PR is a simple fix,  just one line,  and is very easy to review.