### PR TITLE
Improve pattern provider grouping

### DIFF
--- a/src/main/java/appeng/helpers/patternprovider/PatternProviderLogic.java
+++ b/src/main/java/appeng/helpers/patternprovider/PatternProviderLogic.java
@@ -746,12 +746,19 @@ public class PatternProviderLogic implements InternalInventoryHost, ICraftingPro
             return groups.iterator().next();
         }
 
+        // If nothing is adjacent, just use itself
+        var icon = this.host.getTerminalIcon();
         List<Component> tooltip = List.of();
         // If there are multiple groups, show that in the tooltip
         if (groups.size() > 1) {
             tooltip = new ArrayList<>();
             tooltip.add(GuiText.AdjacentToDifferentMachines.text().withStyle(ChatFormatting.BOLD));
+            // If all groups share the same icon use that
+            icon = groups.getFirst().icon();
             for (var group : groups) {
+                if (!icon.getId().equals(group.icon().getId())) {
+                    icon = this.host.getTerminalIcon();
+                }
                 tooltip.add(group.name());
                 for (var line : group.tooltip()) {
                     tooltip.add(Component.literal("  ").append(line));
@@ -759,11 +766,9 @@ public class PatternProviderLogic implements InternalInventoryHost, ICraftingPro
             }
         }
 
-        // If nothing is adjacent, just use itself
-        var hostIcon = this.host.getTerminalIcon();
         return new PatternContainerGroup(
-                hostIcon,
-                hostIcon.getDisplayName(),
+                icon,
+                icon.getDisplayName(),
                 tooltip);
     }
 

--- a/src/main/java/appeng/helpers/patternprovider/PatternProviderLogic.java
+++ b/src/main/java/appeng/helpers/patternprovider/PatternProviderLogic.java
@@ -747,12 +747,19 @@ public class PatternProviderLogic implements InternalInventoryHost, ICraftingPro
             return groups.iterator().next();
         }
 
+        // If nothing is adjacent, just use itself
+        var icon = this.host.getTerminalIcon();
         List<Component> tooltip = List.of();
         // If there are multiple groups, show that in the tooltip
         if (groups.size() > 1) {
             tooltip = new ArrayList<>();
             tooltip.add(GuiText.AdjacentToDifferentMachines.text().withStyle(ChatFormatting.BOLD));
+            // If all groups share the same icon use that
+            icon = groups.getFirst().icon();
             for (var group : groups) {
+                if (!icon.getId().equals(group.icon().getId())) {
+                    icon = this.host.getTerminalIcon();
+                }
                 tooltip.add(group.name());
                 for (var line : group.tooltip()) {
                     tooltip.add(Component.literal("  ").append(line));
@@ -760,11 +767,9 @@ public class PatternProviderLogic implements InternalInventoryHost, ICraftingPro
             }
         }
 
-        // If nothing is adjacent, just use itself
-        var hostIcon = this.host.getTerminalIcon();
         return new PatternContainerGroup(
-                hostIcon,
-                hostIcon.getDisplayName(),
+                icon,
+                icon.getDisplayName(),
                 tooltip);
     }
 


### PR DESCRIPTION
If different group entries are available still use the more specific icon if it is the same for all group entries.

Fixes #8732