### PR TITLE
Fix CPUSelectionList Tooltips.ofBytes(cpu.storage()) and formatStorage

### DIFF
--- a/src/main/java/appeng/client/gui/widgets/CPUSelectionList.java
+++ b/src/main/java/appeng/client/gui/widgets/CPUSelectionList.java
@@ -251,7 +251,8 @@ public class CPUSelectionList implements ICompositeWidget {
     }
 
     private String formatStorage(CraftingStatusMenu.CraftingCpuListEntry cpu) {
-        return (cpu.storage() / 1024) + "k";
+        Tooltips.Amount storageAmount = Tooltips.getByteAmount(cpu.storage());
+        return storageAmount.digit() + storageAmount.unit();
     }
 
     private Component getCpuName(CraftingStatusMenu.CraftingCpuListEntry cpu) {

--- a/src/main/java/appeng/client/gui/widgets/CPUSelectionList.java
+++ b/src/main/java/appeng/client/gui/widgets/CPUSelectionList.java
@@ -233,7 +233,8 @@ public class CPUSelectionList implements ICompositeWidget {
 
                 if (cpu.coProcessors() > 0) {
                     infoBar.add(Icon.BLOCKING_MODE_NO, 0.6f);
-                    String coProcessorCount = String.valueOf(cpu.coProcessors());
+                    Tooltips.Amount ProcessorCount = Tooltips.getAmount(cpu.coProcessors());
+                    String coProcessorCount = ProcessorCount.digit() + ProcessorCount.unit();
                     infoBar.add(coProcessorCount, textColor.toARGB(), 0.6f);
                     infoBar.addSpace(1);
                 }

--- a/src/main/java/appeng/core/localization/Tooltips.java
+++ b/src/main/java/appeng/core/localization/Tooltips.java
@@ -208,7 +208,9 @@ public final class Tooltips {
     public static final long[] DECIMAL_NUMS = new long[] { 1000L, 1000_000L, 1000_000_000L, 1000_000_000_000L,
             1000_000_000_000_000L,
             1000_000_000_000_000_000L };
-    public static final long[] BYTE_NUMS = new long[] { 1024L, 1024 * 1024L, 1024 * 1024 * 1024L, 1024 * 1024 * 1024L };
+    public static final long[] BYTE_NUMS = new long[] { 1024L, 1024 * 1024L, 1024 * 1024 * 1024L,
+            1024 * 1024 * 1024 * 1024L, 1024L * 1024L * 1024L * 1024L * 1024L,
+            1024L * 1024L * 1024L * 1024L * 1024L * 1024L };
 
     public static Component ofAmount(GenericStack stack) {
         return Component.literal(stack.what().formatAmount(stack.amount(), AmountFormat.FULL))


### PR DESCRIPTION
Fix the issue where tooltips crash when the CPUSelectionList's cpu  capacity is too large, and format the non-tooltips storage capacity numbers into smaller values with the correct units.