### PR TITLE
Secondary Outputs are now listed and available to craft

### DIFF
--- a/src/main/java/appeng/me/service/helpers/NetworkCraftingProviders.java
+++ b/src/main/java/appeng/me/service/helpers/NetworkCraftingProviders.java
@@ -200,7 +200,6 @@ public class NetworkCraftingProviders {
                 for (var output : outputs) {
                     methods.craftableItemsList.add(output.what(), 1);
 
-
                     methods.craftableItemsList.add(output.what(), 1);
 
                     var patternsForKey = methods.craftableItems.computeIfAbsent(output.what(),

--- a/src/main/java/appeng/me/service/helpers/NetworkCraftingProviders.java
+++ b/src/main/java/appeng/me/service/helpers/NetworkCraftingProviders.java
@@ -196,14 +196,18 @@ public class NetworkCraftingProviders {
             }
             for (var pattern : patterns) {
                 // output -> pattern (for simulation)
-                var primaryOutput = pattern.getPrimaryOutput();
+                var outputs = pattern.getOutputs();
+                for (var output : outputs) {
+                    methods.craftableItemsList.add(output.what(), 1);
 
-                methods.craftableItemsList.add(primaryOutput.what(), 1);
 
-                var patternsForKey = methods.craftableItems.computeIfAbsent(primaryOutput.what(),
-                        k -> new PatternsForKey());
-                patternsForKey.patterns.add(new PatternInfo(pattern, this));
-                patternsForKey.needsSorting = true;
+                    methods.craftableItemsList.add(output.what(), 1);
+
+                    var patternsForKey = methods.craftableItems.computeIfAbsent(output.what(),
+                            k -> new PatternsForKey());
+                    patternsForKey.patterns.add(new PatternInfo(pattern, this));
+                    patternsForKey.needsSorting = true;
+                }
 
                 // pattern -> method (for execution)
                 methods.craftingMethods.computeIfAbsent(pattern, d -> new CraftingProviderList()).add(provider);
@@ -215,15 +219,17 @@ public class NetworkCraftingProviders {
                 methods.emitableItems.compute(emitable, (key, cnt) -> cnt == 1 ? null : cnt - 1);
             }
             for (var pattern : patterns) {
-                var primaryOutput = pattern.getPrimaryOutput();
+                var outputs = pattern.getOutputs();
 
-                methods.craftableItemsList.remove(primaryOutput.what(), 1);
+                for (var output : outputs) {
+                    methods.craftableItemsList.remove(output.what(), 1);
 
-                methods.craftableItems.computeIfPresent(primaryOutput.what(), (key, patternsForKey) -> {
-                    patternsForKey.patterns.remove(new PatternInfo(pattern, this));
-                    patternsForKey.needsSorting = true;
-                    return patternsForKey.patterns.isEmpty() ? null : patternsForKey;
-                });
+                    methods.craftableItems.computeIfPresent(output.what(), (key, patternsForKey) -> {
+                        patternsForKey.patterns.remove(new PatternInfo(pattern, this));
+                        patternsForKey.needsSorting = true;
+                        return patternsForKey.patterns.isEmpty() ? null : patternsForKey;
+                    });
+                }
 
                 methods.craftingMethods.computeIfPresent(pattern, (pat, list) -> {
                     list.remove(provider);

--- a/src/test/java/appeng/crafting/simulation/helpers/SimulationEnv.java
+++ b/src/test/java/appeng/crafting/simulation/helpers/SimulationEnv.java
@@ -54,9 +54,11 @@ public class SimulationEnv {
     private final KeyCounter networkStorage = new KeyCounter();
 
     public IPatternDetails addPattern(IPatternDetails pattern) {
-        var output = pattern.getPrimaryOutput();
-        patterns.computeIfAbsent(output.what(), s -> new ArrayList<>()).add(pattern);
-        craftableItemsList.add(output.what(), 1);
+        var outputs = pattern.getOutputs();
+        for (var output : outputs) {
+            patterns.computeIfAbsent(output.what(), s -> new ArrayList<>()).add(pattern);
+            craftableItemsList.add(output.what(), 1);
+        }
         return pattern;
     }
 


### PR DESCRIPTION
This seems way too easy and simple, so I'm expecting something to be off that I'm not seeing as of writing this. I don't understand the entire machine that is AE2 to look for these bugs though.

Additionally, I imagine `PatternProviderLogic.onPushPatternSuccess` needs to be modified somehow to support this too, but I don't fully understand its purpose or how it needs to be reworked (if required) for this to work.


