### PR TITLE
Preserve NBT data for uninitialized ManagedGridNodes

### DIFF
--- a/src/main/java/appeng/me/ManagedGridNode.java
+++ b/src/main/java/appeng/me/ManagedGridNode.java
@@ -189,6 +189,11 @@ public class ManagedGridNode implements IManagedGridNode {
     public void saveToNBT(CompoundTag tag) {
         if (this.node != null) {
             this.node.saveToNBT(this.tagName, tag);
+        } else if (this.initData != null && this.initData.data != null) {
+            // Node not created yet, preserve initData
+            if (this.initData.data.contains(this.tagName)) {
+                tag.put(this.tagName, this.initData.data.getCompound(this.tagName));
+            }
         }
     }
 


### PR DESCRIPTION
When the world is loaded, `ManagedGridNodes.loadFromNBT(tag)` gets called and NBT data gets stored in `initData` because there is no actual Node yet to save it to. Later on `createNode(initData)` is called and loads the data fully.

The problem is that before `createNode` is actually called minecraft triggers another saveToNBT. (I believe this happens when it promotes the proto-chunks to full chunks during world load)
Currently that save cycle does not include the data in initData, so it gets lost when afterwards another loadFromNBT happens.

This PR saves the initData to the CompoundTag if there is no node but there is initData. (initData is wiped upon initialization, so this is safe)

--

I noticed this bug because SpatialIOPortBlockEntity objects would forget their owningPlayerId when logging out and back in, but it likely affects other data as well.