### PR TITLE
Logic error fix for CraftingCpuLogic.java

### DIFF
--- a/src/main/java/appeng/crafting/execution/CraftingCpuLogic.java
+++ b/src/main/java/appeng/crafting/execution/CraftingCpuLogic.java
@@ -235,6 +235,11 @@ public class CraftingCpuLogic {
                     task.getValue().value--;
                     if (task.getValue().value <= 0) {
                         it.remove();
+                        
+                        if (pushedPatterns == maxPatterns) {
+                            break taskLoop;
+                        }   
+                        
                         continue taskLoop;
                     }
 

--- a/src/main/java/appeng/crafting/execution/CraftingCpuLogic.java
+++ b/src/main/java/appeng/crafting/execution/CraftingCpuLogic.java
@@ -235,11 +235,11 @@ public class CraftingCpuLogic {
                     task.getValue().value--;
                     if (task.getValue().value <= 0) {
                         it.remove();
-                        
+
                         if (pushedPatterns == maxPatterns) {
                             break taskLoop;
-                        }   
-                        
+                        }
+
                         continue taskLoop;
                     }
 


### PR DESCRIPTION
This is an attempt to fix #8781 by adding an additional check to break before continuing.

Probably not the most elegant solution, as it simply repeats the second check within the first one (thus avoiding skipping the second check) but it is the simplest one I could think of.

After building and running AE2 with the change, this branch appears to fix the incorrect behavior.