### PR TITLE
Implement drive and chest cell LED blinking on storage activity

### DIFF
--- a/src/main/java/appeng/blockentity/storage/DriveBlockEntity.java
+++ b/src/main/java/appeng/blockentity/storage/DriveBlockEntity.java
@@ -80,6 +80,12 @@ public class DriveBlockEntity extends AENetworkedInvBlockEntity
     private final Item[] clientSideCellItems = new Item[getCellCount()];
     private final CellState[] clientSideCellState = new CellState[getCellCount()];
     private boolean clientSideOnline;
+    // Server-side: wall-clock ms of the most recent activity per slot
+    private final long[] lastBlinkTime = new long[getCellCount()];
+    // Client-side: wall-clock ms when we last received a blink notification per slot
+    private final long[] clientBlinkTimestamp = new long[getCellCount()];
+    // Rate-limiter: last time a blink triggered markForUpdate (server-side)
+    private long lastBlinkMarkForUpdateTime = 0L;
 
     public DriveBlockEntity(BlockEntityType<?> blockEntityType, BlockPos pos, BlockState blockState) {
         super(blockEntityType, pos, blockState);
@@ -115,6 +121,16 @@ public class DriveBlockEntity extends AENetworkedInvBlockEntity
         for (int i = 0; i < getCellCount(); i++) {
             data.writeVarInt(BuiltInRegistries.ITEM.getId(getCellItem(i)));
         }
+
+        // Write blink mask: one bit per slot, set if the slot had activity in the last 900ms
+        int blinkMask = 0;
+        long now = System.currentTimeMillis();
+        for (int i = 0; i < getCellCount(); i++) {
+            if (now - lastBlinkTime[i] < 900) {
+                blinkMask |= (1 << i);
+            }
+        }
+        data.writeShort(blinkMask);
     }
 
     @Override
@@ -165,6 +181,15 @@ public class DriveBlockEntity extends AENetworkedInvBlockEntity
             if (clientSideCellItems[i] != item) {
                 clientSideCellItems[i] = item;
                 changed = true;
+            }
+        }
+
+        // Read blink mask and stamp the local arrival time for any active slots
+        int blinkMask = data.readShort() & 0xFFFF;
+        long now = System.currentTimeMillis();
+        for (int i = 0; i < getCellCount(); i++) {
+            if ((blinkMask & (1 << i)) != 0) {
+                clientBlinkTimestamp[i] = now;
             }
         }
 
@@ -257,7 +282,7 @@ public class DriveBlockEntity extends AENetworkedInvBlockEntity
 
     @Override
     public boolean isCellBlinking(int slot) {
-        return false;
+        return System.currentTimeMillis() - clientBlinkTimestamp[slot] < 400;
     }
 
     @Override
@@ -410,7 +435,13 @@ public class DriveBlockEntity extends AENetworkedInvBlockEntity
     }
 
     private void blinkCell(int slot) {
-        this.updateVisualStateIfNeeded();
+        long now = System.currentTimeMillis();
+        lastBlinkTime[slot] = now;
+        // Rate-limit blink-triggered network updates to at most one per 100ms per drive
+        if (now - lastBlinkMarkForUpdateTime >= 100) {
+            lastBlinkMarkForUpdateTime = now;
+            this.markForUpdate();
+        }
     }
 
     /**

--- a/src/main/java/appeng/blockentity/storage/MEChestBlockEntity.java
+++ b/src/main/java/appeng/blockentity/storage/MEChestBlockEntity.java
@@ -123,6 +123,10 @@ public class MEChestBlockEntity extends AENetworkedPoweredBlockEntity
     private ChestMonitorHandler cellHandler;
     private IFluidHandler fluidHandler;
     private double idlePowerUsage;
+    // Server-side: wall-clock ms of the most recent cell activity
+    private long lastBlinkTime = Long.MIN_VALUE;
+    // Client-side: wall-clock ms when we last received a blink notification
+    private long clientBlinkTimestamp = Long.MIN_VALUE;
 
     public MEChestBlockEntity(BlockEntityType<?> blockEntityType, BlockPos pos, BlockState blockState) {
         super(blockEntityType, pos, blockState);
@@ -289,7 +293,7 @@ public class MEChestBlockEntity extends AENetworkedPoweredBlockEntity
 
     @Override
     public boolean isCellBlinking(int slot) {
-        return false;
+        return System.currentTimeMillis() - clientBlinkTimestamp < 400;
     }
 
     @Override
@@ -337,6 +341,9 @@ public class MEChestBlockEntity extends AENetworkedPoweredBlockEntity
         // empty->non-empty, so when the cell is changed, it should re-send the state
         // because of that
         data.writeVarInt(Item.getId(getCell().getItem()));
+
+        // Blink flag: true if there was cell activity in the last 900ms
+        data.writeBoolean(System.currentTimeMillis() - lastBlinkTime < 900);
     }
 
     @Override
@@ -352,6 +359,11 @@ public class MEChestBlockEntity extends AENetworkedPoweredBlockEntity
         clientPowered = data.readBoolean();
         paintedColor = data.readEnum(AEColor.class);
         cellItem = Item.byId(data.readVarInt());
+
+        // If the server reported recent activity, stamp the local arrival time
+        if (data.readBoolean()) {
+            clientBlinkTimestamp = System.currentTimeMillis();
+        }
 
         return c
                 || oldCellState != clientCellState
@@ -520,7 +532,8 @@ public class MEChestBlockEntity extends AENetworkedPoweredBlockEntity
     }
 
     private void blinkCell(int slot) {
-        this.recalculateDisplay();
+        this.lastBlinkTime = System.currentTimeMillis();
+        this.markForUpdate();
     }
 
     @Override

--- a/src/main/java/appeng/client/render/tesr/CellLedRenderer.java
+++ b/src/main/java/appeng/client/render/tesr/CellLedRenderer.java
@@ -44,8 +44,11 @@ public class CellLedRenderer {
     // Color to use if the cell is present but unpowered
     private static final Vector3f UNPOWERED_COLOR = new Vector3f(0, 0, 0);
 
-    // Color used for the cell indicator for blinking during recent activity
-    private static final Vector3f BLINK_COLOR = new Vector3f(1, 0.5f, 0.5f);
+    // Idle brightness multiplier for non-full cells. Blinking pulses from this up to full brightness
+    private static final float DIM_FACTOR = 0.55f;
+
+    // Duration of one full cosine pulse in milliseconds
+    private static final long PULSE_MS = 200;
 
     static {
         STATE_COLORS = new EnumMap<>(CellState.class);
@@ -113,21 +116,22 @@ public class CellLedRenderer {
             return UNPOWERED_COLOR;
         }
 
-        Vector3f col = STATE_COLORS.get(state);
-        if (drive.isCellBlinking(slot)) {
-            // 200 ms interval (100ms to get to red, then 100ms back)
-            long t = System.currentTimeMillis() % 200;
-            float f = (t - 100) / 200.0f + 0.5f;
-            f = easeInOutCubic(f);
-            col = new Vector3f(col);
-            col.lerp(BLINK_COLOR, f);
+        Vector3f bright = STATE_COLORS.get(state);
+
+        // Full cells stay at full brightness permanently — they are a constant warning
+        if (state == CellState.FULL) {
+            return bright;
         }
 
-        return col;
-    }
+        // All other states idle at a dimmer shade and pulse to full brightness on activity
+        Vector3f dim = new Vector3f(bright).mul(DIM_FACTOR);
+        if (drive.isCellBlinking(slot)) {
+            float phase = (System.currentTimeMillis() % PULSE_MS) / (float) PULSE_MS;
+            float f = 0.5f - 0.5f * (float) Math.cos(phase * 2 * Math.PI);
+            dim.lerp(bright, f);
+        }
 
-    private static float easeInOutCubic(float x) {
-        return x < 0.5f ? 4 * x * x * x : 1 - (float) Math.pow(-2 * x + 2, 3) / 2;
+        return dim;
     }
 
     private CellLedRenderer() {

--- a/src/main/java/appeng/me/storage/DriveWatcher.java
+++ b/src/main/java/appeng/me/storage/DriveWatcher.java
@@ -26,13 +26,11 @@ import appeng.api.storage.cells.StorageCell;
 
 public class DriveWatcher extends MEInventoryHandler {
 
-    private CellState oldStatus = CellState.EMPTY;
     private final Runnable activityCallback;
 
     public DriveWatcher(StorageCell i, Runnable activityCallback) {
         super(i);
         this.activityCallback = activityCallback;
-        this.oldStatus = getStatus();
     }
 
     public CellState getStatus() {
@@ -48,12 +46,7 @@ public class DriveWatcher extends MEInventoryHandler {
         var inserted = super.insert(what, amount, mode, source);
 
         if (mode == Actionable.MODULATE && inserted > 0) {
-            var newStatus = this.getStatus();
-
-            if (newStatus != this.oldStatus) {
-                this.activityCallback.run();
-                this.oldStatus = newStatus;
-            }
+            this.activityCallback.run();
         }
 
         return inserted;
@@ -64,12 +57,7 @@ public class DriveWatcher extends MEInventoryHandler {
         var extracted = super.extract(what, amount, mode, source);
 
         if (mode == Actionable.MODULATE && extracted > 0) {
-            var newStatus = this.getStatus();
-
-            if (newStatus != this.oldStatus) {
-                this.activityCallback.run();
-                this.oldStatus = newStatus;
-            }
+            this.activityCallback.run();
         }
 
         return extracted;


### PR DESCRIPTION
In this PR, I've tried to add back a functionality from AE1 where drives LEDs were blinking based on the activity. Looked to open issue #7439 the reason for removal, was the FPS drops if I understood correctly. That's the reason why I added the rate-limit for max. 10 network updates every second for each drive. The rate limiter caps markForUpdate() at 10 calls/second per drive regardless of throughput, so heavy automation won't spam packets.
I've also decreased the brightness of each LED. Previously, activity was shown by switching to a different color, now it brightens the existing state color instead (except red one, which indicates full cell).

I know it's most likely not priority on the list, but I always wanted this feature to see back from AE1. Because I'm still pretty new in Minecraft modding, I will appreciate any feedback.

Last thing. Maybe it would be a good idea to add it into config as well so it can be turned off/on as well?

This feature was also mentioned in #75 and #1993

This is how it looks in-game. (gif compression messed the red colour, but it was unchanged)

![ae](https://github.com/user-attachments/assets/1e9a6308-ca7c-4c7b-b682-5794ba256afa)
