### PR TITLE
Fix jade compat of remove FE and Fluid tooltip

### DIFF
--- a/src/main/java/appeng/integration/modules/jade/BodyProviderAdapter.java
+++ b/src/main/java/appeng/integration/modules/jade/BodyProviderAdapter.java
@@ -29,7 +29,6 @@ class BodyProviderAdapter<T extends BlockEntity> extends BaseProvider implements
     @Override
     public void appendTooltip(ITooltip tooltip, BlockAccessor accessor, IPluginConfig config) {
         tooltip.remove(JadeIds.UNIVERSAL_ENERGY_STORAGE);
-        tooltip.remove(JadeIds.UNIVERSAL_FLUID_STORAGE);
 
         var context = ContextHelper.getContext(accessor);
         var tooltipBuilder = new JadeTooltipBuilder(tooltip);

--- a/src/main/java/appeng/integration/modules/jade/BodyProviderAdapter.java
+++ b/src/main/java/appeng/integration/modules/jade/BodyProviderAdapter.java
@@ -28,8 +28,8 @@ class BodyProviderAdapter<T extends BlockEntity> extends BaseProvider implements
 
     @Override
     public void appendTooltip(ITooltip tooltip, BlockAccessor accessor, IPluginConfig config) {
-        tooltip.remove(JadeIds.UNIVERSAL_ENERGY_STORAGE_DETAILED);
-        tooltip.remove(JadeIds.UNIVERSAL_FLUID_STORAGE_DETAILED);
+        tooltip.remove(JadeIds.UNIVERSAL_ENERGY_STORAGE);
+        tooltip.remove(JadeIds.UNIVERSAL_FLUID_STORAGE);
 
         var context = ContextHelper.getContext(accessor);
         var tooltipBuilder = new JadeTooltipBuilder(tooltip);


### PR DESCRIPTION
The calls to `tooltip.remove(JadeIds.UNIVERSAL_ENERGY_STORAGE_DETAILED)` and `tooltip.remove(JadeIds.UNIVERSAL_FLUID_STORAGE_DETAILED)` currently have no effect. As a result, many block entities that extend `AEBaseBlockEntity` still display both FE and AE energy at the same time. This is especially noticeable for addon authors like myself.

In addition, even AE2’s own blocks can end up with inconsistent tooltips. For example, the Inscriber requires a direction to be provided when querying its energy capability; otherwise the query returns `null`. Because of that, Jade can’t obtain the information and ends up showing only AE energy. Meanwhile, blocks like the ME Controller will show both FE and AE energy.

I also adjusted the fluid-tooltip removal so that it actually takes effect. However, I’m not sure whether you intentionally wanted to remove the fluid tooltip in the first place, since fluid information doesn’t conflict with other tooltip lines. If that wasn’t the intention, you can simply remove that line.

before:
<img width="1272" height="1049" alt="bc3be7bfdc460126341c8167f82b5b74" src="https://github.com/user-attachments/assets/3280cdeb-317b-4d18-b1d1-38ab3a0c75ab" />
<img width="1469" height="1227" alt="b4238b5be771714107ca1774f7c90eeb" src="https://github.com/user-attachments/assets/d68875b5-3104-47eb-a2dc-86fe79ede39c" />

after:
<img width="1557" height="1104" alt="d45d17de22dc1db395ff72a51f679ace" src="https://github.com/user-attachments/assets/3a68add5-5a97-405c-adbc-af939608be68" />
<img width="1275" height="1200" alt="83ba99272b70c0619d749bb30faf711d" src="https://github.com/user-attachments/assets/dec1d687-50a0-41d8-846f-9789cd217d76" />