### PR TITLE
Fix getSelectedEnergyUnit being called in server environment

### DIFF
--- a/src/main/java/appeng/util/Platform.java
+++ b/src/main/java/appeng/util/Platform.java
@@ -54,6 +54,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.material.Fluid;
+import net.neoforged.api.distmarker.Dist;
 import net.neoforged.fml.ModList;
 import net.neoforged.fml.loading.FMLEnvironment;
 import net.neoforged.fml.util.thread.SidedThreadGroups;
@@ -142,8 +143,11 @@ public class Platform {
     }
 
     public static String formatPower(double p, boolean isRate) {
-        var displayUnits = AEConfig.instance().getSelectedEnergyUnit();
-        p = PowerUnit.AE.convertTo(displayUnits, p);
+        var displayUnits = PowerUnit.AE;
+        if (FMLEnvironment.dist == Dist.CLIENT) {
+            displayUnits = AEConfig.instance().getSelectedEnergyUnit();
+            p = PowerUnit.AE.convertTo(displayUnits, p);
+        }
 
         final String[] preFixes = { "k", "M", "G", "T", "P", "T", "P", "E", "Z", "Y" };
         var unitName = displayUnits.getSymbolName();


### PR DESCRIPTION
This change makes it so `Platform#formatPower` will use the AE power unit when it is being called from the server environment.
This was the easiest solution for this that I will use privately in order to fix this on my server and I thought maybe you would also want this little change.

It would probably be better to use the unit the client has selected instead by sending it to the server and caching it there per-client but I'm not really experienced how something like that would be done on NeoForge so I opted to do it this way.

fixes #8809