### PR TITLE
Fix crafting CPU inventory loss on chunk unload / server shutdown

### DIFF
--- a/src/main/java/appeng/blockentity/crafting/CraftingBlockEntity.java
+++ b/src/main/java/appeng/blockentity/crafting/CraftingBlockEntity.java
@@ -118,6 +118,17 @@ public class CraftingBlockEntity extends AENetworkedBlockEntity
 
     public void updateStatus(CraftingCPUCluster c) {
         if (this.cluster != null && this.cluster != c) {
+            // Persist the cluster's crafting state before releasing the reference.
+            // During chunk unload, onChunkUnloaded() → destroy() → updateStatus(null)
+            // runs BEFORE the chunk is saved to disk. If we null the cluster here,
+            // saveAdditional() will skip writing the inventory and in-progress crafting
+            // jobs are permanently lost. Saving to previousState ensures the data
+            // survives for the subsequent saveAdditional() call.
+            if (c == null && this.isCoreBlock()) {
+                var data = new net.minecraft.nbt.CompoundTag();
+                this.cluster.writeToNBT(data, this.level.registryAccess());
+                this.setPreviousState(data);
+            }
             this.cluster.breakCluster();
         }
 
@@ -173,8 +184,15 @@ public class CraftingBlockEntity extends AENetworkedBlockEntity
     public void saveAdditional(CompoundTag data, HolderLookup.Provider registries) {
         super.saveAdditional(data, registries);
         data.putBoolean("core", this.isCoreBlock());
-        if (this.isCoreBlock() && this.cluster != null) {
-            this.cluster.writeToNBT(data, registries);
+        if (this.isCoreBlock()) {
+            if (this.cluster != null) {
+                this.cluster.writeToNBT(data, registries);
+            } else if (this.previousState != null) {
+                // Cluster was destroyed (chunk unload / server shutdown) before save.
+                // Restore the snapshot taken in updateStatus() so the inventory and
+                // in-progress crafting job survive the round-trip.
+                data.merge(this.previousState);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes in-progress crafting CPU items being permanently voided when the server shuts down or the chunk containing the crafting CPU is unloaded.

**Root cause**: During chunk unload, `onChunkUnloaded()` destroys the grid node, which triggers `disconnect()` → `cluster.destroy()` → `updateStatus(null)`. This nulls the `cluster` reference on `CraftingBlockEntity` **before** `saveAdditional()` is called by the chunk serializer. With `cluster == null`, `saveAdditional()` skips writing the crafting inventory and job state entirely — all items extracted from the ME network for the in-progress job are permanently lost.

**The fix** (two changes in `CraftingBlockEntity.java`):

1. **`updateStatus(null)`**: Before releasing the cluster reference, snapshot the cluster's state (inventory + job) into `previousState` via the existing `setPreviousState()` mechanism.

2. **`saveAdditional()`**: When `cluster` is null but `previousState` is non-null, merge the snapshot into the save data. On reload, the existing `loadTag()` → `setPreviousState(data.copy())` path restores it, and when the cluster reforms the job resumes with all items intact.

This leverages AE2's existing `previousState` field, which was already designed for exactly this purpose (holding cluster data when the cluster isn't formed yet).

## Related issues

- #1944 — "Crafting pylons seems to loose inventory on server reboot" (closed without fix, 2020)
- #8450 — "Crafting CPUs frequently lock up completely and need manually resetting" (open, related symptom)

## Testing

1. Start a large crafting job (e.g. 64x of a multi-step recipe)
2. While the job is in progress, `/stop` the server
3. Restart the server
4. **Before fix**: crafting CPU is empty, job gone, items voided
5. **After fix**: crafting CPU retains its inventory and the job resumes

Also tested with chunk unload (walking far away from the crafting CPU and returning).

Tested on NeoForge 21.1.219 / MC 1.21.1 with a 200+ mod modpack (FTB Evolution).