### PR TITLE
[26.1] fix padding of scrollbars and other GUI textures on atlases

### DIFF
--- a/src/client/java/appeng/client/gui/AEBaseScreen.java
+++ b/src/client/java/appeng/client/gui/AEBaseScreen.java
@@ -502,11 +502,7 @@ public abstract class AEBaseScreen<T extends AEBaseMenu> extends AbstractContain
 
     @Override
     public void extractContents(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float a) {
-        super.extractContents(graphics, mouseX, mouseY, a);
-
         this.drawBG(graphics, leftPos, topPos, mouseX, mouseY, a);
-
-        graphics.nextStratum();
 
         widgets.drawBackgroundLayer(graphics, getBounds(true), new Point(mouseX - leftPos, mouseY - topPos));
 
@@ -515,6 +511,11 @@ public abstract class AEBaseScreen<T extends AEBaseMenu> extends AbstractContain
                 drawOptionalSlotBackground(graphics, (IOptionalSlot) slot, false);
             }
         }
+
+        // TODO 26.1 - Mithi83 - double-check the order of rendering in here
+        super.extractContents(graphics, mouseX, mouseY, a);
+
+        graphics.nextStratum();
     }
 
     private void drawOptionalSlotBackground(GuiGraphicsExtractor guiGraphics, IOptionalSlot slot, boolean alwaysDraw) {

--- a/src/client/java/appeng/client/gui/me/common/MEStorageScreen.java
+++ b/src/client/java/appeng/client/gui/me/common/MEStorageScreen.java
@@ -497,7 +497,10 @@ public class MEStorageScreen<C extends MEStorageMenu>
                     var sprite = minecraft.getAtlasManager().getAtlasOrThrow(AtlasIds.BLOCKS)
                             .getSprite(AppEng.makeId("block/molecular_assembler_lights"));
                     Blitter.sprite(sprite)
-                            .src(sprite.getX() + 2, sprite.getY() + 2, sprite.contents().width() - 4,
+                            // We only want the square part of the texture, which starts at the 3rd pixel.
+                            // Textures on atlases are padded by one pixel, we don't want the padding so move by one
+                            // additional pixel.
+                            .src(sprite.getX() + 3, sprite.getY() + 3, sprite.contents().width() - 4,
                                     sprite.contents().height() - 4)
                             .dest(slot.x - 1, slot.y - 1, 18, 18)
                             .blit(guiGraphics);

--- a/src/client/java/appeng/client/gui/style/Blitter.java
+++ b/src/client/java/appeng/client/gui/style/Blitter.java
@@ -111,10 +111,11 @@ public final class Blitter {
     public static Blitter sprite(TextureAtlasSprite sprite) {
         var atlas = (TextureAtlas) Minecraft.getInstance().getTextureManager().getTexture(sprite.atlasLocation());
 
+        // Textures on atlases are padded by one pixel, we don't want the padding so move by one pixel.
         return new Blitter(sprite.atlasLocation(), atlas.getWidth(), atlas.getHeight())
                 .src(
-                        sprite.getX(),
-                        sprite.getY(),
+                        sprite.getX() + 1,
+                        sprite.getY() + 1,
                         sprite.contents().width(),
                         sprite.contents().height());
     }

--- a/src/client/java/appeng/client/gui/widgets/VerticalButtonBar.java
+++ b/src/client/java/appeng/client/gui/widgets/VerticalButtonBar.java
@@ -127,7 +127,6 @@ public class VerticalButtonBar implements ICompositeWidget {
                 AppEng.makeId("vertical_buttons_bg"),
                 bounds.getX() + this.bounds.getX() - 2,
                 bounds.getY() + this.bounds.getY() - 1,
-                1,
                 this.bounds.getWidth() + 1,
                 this.bounds.getHeight() + 4);
     }


### PR DESCRIPTION
fix scrollbar, fluid rendering in GUI and the crafting marker (when pinned) being all offset by the one pixel of padding

based on / contains the changes from #8827 (without, they aren't visible at all)