### PR TITLE
adapt wthit and jade versions to 26.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,10 +19,10 @@ guideme_version=26.1.10-alpha
 jei_version=29.5.0.26
 jei_minecraft_version=26.1.2
 emi_version=1.1.19+1.21.1
-jade_version_range=[15.0.0,)
+jade_version_range=[26.0.0,)
 rei_version=21.9.812
-wthit_version=18.0.4
-jade_file_id=7313008
+wthit_version=19.0.1
+jade_file_id=7938398
 curios_version=7.1.0+1.20.4
 athena_version=4.2.0
 athena_file_id=6135647
@@ -37,7 +37,7 @@ runtime_itemlist_mod=jei
 
 # Set to wthit, jade or none to pick which tooltip mod gets picked at runtime
 # for the dev environment.
-runtime_tooltip_mod=none
+runtime_tooltip_mod=jade
 
 # Set to true to use Curio at runtime
 runtime_curio=false


### PR DESCRIPTION
I've chosen Jade as the default in this PR, adapt if you prefer another setting.