### PR TITLE
Fix: Low-localizable text of crafting status tooltip (#8833)

### DIFF
--- a/src/generated/resources/assets/ae2/lang/en_us.json
+++ b/src/generated/resources/assets/ae2/lang/en_us.json
@@ -561,7 +561,7 @@
   "gui.tooltips.ae2.CpuStatusCoProcessor": "%s Co-Processor",
   "gui.tooltips.ae2.CpuStatusCoProcessors": "%s Co-Processors",
   "gui.tooltips.ae2.CpuStatusCraftedIn": "Crafted %s in %s",
-  "gui.tooltips.ae2.CpuStatusCrafting": "Crafting %s",
+  "gui.tooltips.ae2.CpuStatusCrafting": "Crafting %s %s",
   "gui.tooltips.ae2.CpuStatusStorage": "%s Storage",
   "gui.tooltips.ae2.Craft": "Crafting Behavior",
   "gui.tooltips.ae2.CraftEither": "Use stocked items, or craft items while exporting.",

--- a/src/main/java/appeng/client/gui/widgets/CPUSelectionList.java
+++ b/src/main/java/appeng/client/gui/widgets/CPUSelectionList.java
@@ -111,7 +111,8 @@ public class CPUSelectionList implements ICompositeWidget {
             if (currentJob != null) {
                 tooltipLines.add(
                         ButtonToolTips.CpuStatusCrafting.text(
-                                Tooltips.ofAmount(currentJob)).append(" ").append(currentJob.what().getDisplayName()));
+                                Tooltips.ofAmount(currentJob),
+                                currentJob.what().getDisplayName()));
                 tooltipLines.add(
                         ButtonToolTips.CpuStatusCraftedIn.text(
                                 Tooltips.ofPercent(cpu.progress()),

--- a/src/main/java/appeng/core/localization/ButtonToolTips.java
+++ b/src/main/java/appeng/core/localization/ButtonToolTips.java
@@ -39,7 +39,7 @@ public enum ButtonToolTips implements LocalizationEnum {
     CpuStatusCoProcessor("%s Co-Processor"),
     CpuStatusCoProcessors("%s Co-Processors"),
     CpuStatusCraftedIn("Crafted %s in %s"),
-    CpuStatusCrafting("Crafting %s"),
+    CpuStatusCrafting("Crafting %s %s"),
     CpuStatusStorage("%s Storage"),
     LockCraftingMode("Lock Crafting"),
     LockCraftingModeNone("Never"),


### PR DESCRIPTION
close #8833