### PR TITLE
Added configs for newly placed terminals sort order and view mode (#8106)

### DIFF
--- a/src/main/java/appeng/core/AEConfig.java
+++ b/src/main/java/appeng/core/AEConfig.java
@@ -35,7 +35,10 @@ import appeng.api.config.CondenserOutput;
 import appeng.api.config.PowerMultiplier;
 import appeng.api.config.PowerUnit;
 import appeng.api.config.Settings;
+import appeng.api.config.SortDir;
+import appeng.api.config.SortOrder;
 import appeng.api.config.TerminalStyle;
+import appeng.api.config.ViewItems;
 import appeng.api.networking.pathing.ChannelMode;
 import appeng.core.settings.TickRates;
 import appeng.util.EnumCycler;
@@ -171,10 +174,43 @@ public final class AEConfig {
         return client.terminalStyle.get();
     }
 
+    public SortOrder getSortOrder() {
+        return common.sortOrder.get();
+    }
+
+    public SortDir getSortDir() {
+        return common.sortDir.get();
+    }
+
+    public ViewItems getViewItems() {
+        return common.viewItems.get();
+    }
+
     public void setTerminalStyle(TerminalStyle setting) {
         if (setting != client.terminalStyle.get()) {
             client.terminalStyle.set(setting);
             client.spec.save();
+        }
+    }
+
+    public void setSortOrder(SortOrder setting) {
+        if (setting != common.sortOrder.get()) {
+            common.sortOrder.set(setting);
+            common.spec.save();
+        }
+    }
+
+    public void setSortDir(SortDir setting) {
+        if (setting != common.sortDir.get()) {
+            common.sortDir.set(setting);
+            common.spec.save();
+        }
+    }
+
+    public void setViewItems(ViewItems setting) {
+        if (setting != common.viewItems.get()) {
+            common.viewItems.set(setting);
+            common.spec.save();
         }
     }
 
@@ -584,6 +620,10 @@ public final class AEConfig {
 
         public final Map<TickRates, IntValue> tickRateMin = new HashMap<>();
         public final Map<TickRates, IntValue> tickRateMax = new HashMap<>();
+        // Default terminal sorting
+        public EnumValue<SortOrder> sortOrder;
+        public EnumValue<SortDir> sortDir;
+        public EnumValue<ViewItems> viewItems;
 
         public CommonConfig() {
             var builder = new ModConfigSpec.Builder();
@@ -692,7 +732,14 @@ public final class AEConfig {
             vibrationChamberMaxEnergyPerTick = define(builder, "baseMaxEnergyPerGameTick", 40, 1, 1000,
                     "Maximum amount of AE/t the vibration chamber can speed up to when generated energy is being fully consumed.");
             builder.pop();
-
+            builder.comment("Default terminal sort settings");
+            builder.push("defaultTerminalSort");
+            sortOrder = defineEnum(builder, "sortOrder", SortOrder.NAME, "What to sort newly placed terminal by");
+            sortDir = defineEnum(builder, "sortDir", SortDir.ASCENDING,
+                    "What direction to sort newly placed terminals");
+            viewItems = defineEnum(builder, "viewItems", ViewItems.ALL, "What to show in newly placed terminals");
+            builder.pop();
+            
             spec = builder.build();
         }
 

--- a/src/main/java/appeng/parts/reporting/AbstractTerminalPart.java
+++ b/src/main/java/appeng/parts/reporting/AbstractTerminalPart.java
@@ -30,9 +30,6 @@ import net.minecraft.world.level.storage.ValueOutput;
 import net.minecraft.world.phys.Vec3;
 
 import appeng.api.config.Settings;
-import appeng.api.config.SortDir;
-import appeng.api.config.SortOrder;
-import appeng.api.config.ViewItems;
 import appeng.api.implementations.blockentities.IViewCellStorage;
 import appeng.api.inventories.InternalInventory;
 import appeng.api.parts.IPartItem;
@@ -44,6 +41,7 @@ import appeng.api.util.IConfigManager;
 import appeng.api.util.IConfigManagerBuilder;
 import appeng.api.util.KeyTypeSelection;
 import appeng.api.util.KeyTypeSelectionHost;
+import appeng.core.AEConfig;
 import appeng.menu.ISubMenu;
 import appeng.menu.MenuOpener;
 import appeng.menu.locator.MenuLocators;
@@ -79,9 +77,9 @@ public abstract class AbstractTerminalPart extends AbstractDisplayPart
 
     @MustBeInvokedByOverriders
     protected void registerSettings(IConfigManagerBuilder builder) {
-        builder.registerSetting(Settings.SORT_BY, SortOrder.NAME);
-        builder.registerSetting(Settings.VIEW_MODE, ViewItems.ALL);
-        builder.registerSetting(Settings.SORT_DIRECTION, SortDir.ASCENDING);
+        builder.registerSetting(Settings.SORT_BY, AEConfig.instance().getSortOrder());
+        builder.registerSetting(Settings.VIEW_MODE, AEConfig.instance().getViewItems());
+        builder.registerSetting(Settings.SORT_DIRECTION, AEConfig.instance().getSortDir());
     }
 
     @Override


### PR DESCRIPTION
Fixes #8106

This fix adds three config fields in the common config for newly placed terminals to use by default, one for which sorting mode you want to use, one for whether to go ascending or descending, and one whether to show stored/craftable (all), only stored, or only craftable. This is my first PR here so feel free to make any changes. I feel as if this would be a good feature, as otherwise every time you put a terminal down, you need to select your chosen sort manually each time. Thanks!