### PR TITLE
[26.1] Fix NeoForge API breaking changes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,8 +9,8 @@ java_version=25
 #########################################################
 minecraft_version=26.1.2
 # https://projects.neoforged.net/neoforged/neoforge
-neoforge_version=26.1.2.14-beta
-neoforge_version_range=[26.1.2.14-beta,)
+neoforge_version=26.1.2.21-beta
+neoforge_version_range=[26.1.2.21-beta,)
 
 #########################################################
 # Provided APIs                                         #

--- a/src/main/java/appeng/items/tools/powered/MatterCannonItem.java
+++ b/src/main/java/appeng/items/tools/powered/MatterCannonItem.java
@@ -57,7 +57,7 @@ import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.common.util.BlockSnapshot;
 import net.neoforged.neoforge.event.EventHooks;
-import net.neoforged.neoforge.event.level.BlockEvent;
+import net.neoforged.neoforge.event.level.block.BreakBlockEvent;
 
 import appeng.api.config.Actionable;
 import appeng.api.config.FuzzyMode;
@@ -387,7 +387,7 @@ public class MatterCannonItem extends AEBasePoweredItem implements IBasicCellIte
         }
 
         var state = level.getBlockState(pos);
-        var event = new BlockEvent.BreakEvent(level, pos, state, player);
+        var event = new BreakBlockEvent(level, pos, state, player);
         return !NeoForge.EVENT_BUS.post(event).isCanceled();
     }
 


### PR DESCRIPTION
In https://github.com/neoforged/NeoForge/pull/3064 (which is NF's `26.1.2.21-beta`)
> ▸ This PR moves BlockEvent.BreakEvent to a standalone top-level class BreakBlockEvent, and updates the firing logic to fire BreakBlockEvent on the client, instead of only firing it on the server. It still preserves the ability to send a packet when cancelled only on the server, but this is an opt-in behavior now.

There was breaking change in neoforge, so I updated neoforge version in gradle.properties and fix the event import. (which is only one)