### PR TITLE
Fix Curios integration breaking when Curios is not present

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,6 @@ dependencies {
             break
     }
 
-    compileOnly "top.theillusivec4.curios:curios-neoforge:${project.curios_version}:api"
     if (project.runtime_curio == "true") {
         localRuntimeOnly("top.theillusivec4.curios:curios-neoforge:${project.curios_version}")
     }

--- a/src/main/java/appeng/hotkeys/CuriosHotkeyAction.java
+++ b/src/main/java/appeng/hotkeys/CuriosHotkeyAction.java
@@ -6,9 +6,8 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.ItemLike;
 
-import top.theillusivec4.curios.api.CuriosCapability;
-
 import appeng.api.features.HotkeyAction;
+import appeng.integration.modules.curios.CuriosIntegration;
 import appeng.menu.locator.MenuLocators;
 
 public record CuriosHotkeyAction(Predicate<ItemStack> locatable,
@@ -20,7 +19,7 @@ public record CuriosHotkeyAction(Predicate<ItemStack> locatable,
 
     @Override
     public boolean run(Player player) {
-        var cap = player.getCapability(CuriosCapability.ITEM_HANDLER);
+        var cap = player.getCapability(CuriosIntegration.ITEM_HANDLER);
         if (cap == null)
             return false;
         for (int i = 0; i < cap.size(); i++) {

--- a/src/main/java/appeng/integration/modules/curios/CuriosIntegration.java
+++ b/src/main/java/appeng/integration/modules/curios/CuriosIntegration.java
@@ -1,0 +1,14 @@
+package appeng.integration.modules.curios;
+
+import net.minecraft.resources.Identifier;
+import net.neoforged.neoforge.capabilities.EntityCapability;
+import net.neoforged.neoforge.transfer.ResourceHandler;
+import net.neoforged.neoforge.transfer.item.ItemResource;
+
+public class CuriosIntegration {
+    // Create Curios capability ourselves instead of accessing it from the Curios API to avoid loading Curios classes.
+    public static final EntityCapability<ResourceHandler<ItemResource>, Void> ITEM_HANDLER = EntityCapability
+            .createVoid(
+                    Identifier.fromNamespaceAndPath("curios", "item_handler"),
+                    ResourceHandler.asClass());
+}

--- a/src/main/java/appeng/menu/locator/CuriosItemLocator.java
+++ b/src/main/java/appeng/menu/locator/CuriosItemLocator.java
@@ -9,14 +9,14 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.phys.BlockHitResult;
 
-import top.theillusivec4.curios.api.CuriosCapability;
+import appeng.integration.modules.curios.CuriosIntegration;
 
 /**
  * Implements {@link ItemMenuHostLocator} for items equipped in curios slots.
  */
 record CuriosItemLocator(int curioSlot, @Nullable BlockHitResult hitResult) implements ItemMenuHostLocator {
     public ItemStack locateItem(Player player) {
-        var cap = player.getCapability(CuriosCapability.ITEM_HANDLER);
+        var cap = player.getCapability(CuriosIntegration.ITEM_HANDLER);
         if (cap == null || curioSlot >= cap.size()) {
             return ItemStack.EMPTY;
         }

--- a/src/main/java/appeng/util/SearchInventoryEvent.java
+++ b/src/main/java/appeng/util/SearchInventoryEvent.java
@@ -8,7 +8,7 @@ import net.minecraft.world.item.ItemStack;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
 
-import top.theillusivec4.curios.api.CuriosCapability;
+import appeng.integration.modules.curios.CuriosIntegration;
 
 /**
  * Event fired when AE2 is looking for ItemStacks in a player inventory. By default, AE2 only looks at the 36 usual
@@ -32,7 +32,7 @@ public class SearchInventoryEvent extends PlayerEvent {
             event.getStacks().addAll(event.getEntity().getInventory().getNonEquipmentItems());
         });
         NeoForge.EVENT_BUS.addListener((SearchInventoryEvent event) -> {
-            var cap = event.getEntity().getCapability(CuriosCapability.ITEM_HANDLER);
+            var cap = event.getEntity().getCapability(CuriosIntegration.ITEM_HANDLER);
             if (cap == null)
                 return;
             for (int i = 0; i < cap.size(); i++) {


### PR DESCRIPTION
The `Open Wireless Terminal` keybinding breaks when curios is not present, due to the curios api 

Revert "remove duplicate curios capability implementation"
This reverts commit d47025097f9e3a84814eec8c27389ce7954e69d3, part of #8838 
I also added a comment explaining why it was done this way.

alternatively checking if curios is present before calling the api would work too, I implemented that in f01ec3a723a40b99347843223b1255bed4871089