### PR TITLE
add network stored energy to tooltip

### DIFF
--- a/src/generated/resources/assets/ae2/lang/en_us.json
+++ b/src/generated/resources/assets/ae2/lang/en_us.json
@@ -1015,6 +1015,7 @@
   "waila.ae2.P2PUnlinked": "Unlinked",
   "waila.ae2.Showing": "Showing",
   "waila.ae2.Stored": "Stored: %s / %s",
+  "waila.ae2.NetworkStored": "Network Stored: %s / %s",
   "waila.ae2.Suppressed": "Suppressed",
   "waila.ae2.Unlocked": "Unlocked"
 }

--- a/src/generated/resources/assets/ae2/lang/en_us.json
+++ b/src/generated/resources/assets/ae2/lang/en_us.json
@@ -1007,6 +1007,7 @@
   "waila.ae2.ErrorTooManyChannels": "Error: Too Many Channels",
   "waila.ae2.Locked": "Locked",
   "waila.ae2.NetworkBooting": "Network Booting",
+  "waila.ae2.NetworkStored": "Network Stored: %s / %s",
   "waila.ae2.P2PFrequency": "Frequency: %s",
   "waila.ae2.P2PInputManyOutputs": "Linked (Input Side) - %d Outputs",
   "waila.ae2.P2PInputOneOutput": "Linked (Input Side)",
@@ -1015,7 +1016,6 @@
   "waila.ae2.P2PUnlinked": "Unlinked",
   "waila.ae2.Showing": "Showing",
   "waila.ae2.Stored": "Stored: %s / %s",
-  "waila.ae2.NetworkStored": "Network Stored: %s / %s",
   "waila.ae2.Suppressed": "Suppressed",
   "waila.ae2.Unlocked": "Unlocked"
 }

--- a/src/main/java/appeng/core/localization/InGameTooltip.java
+++ b/src/main/java/appeng/core/localization/InGameTooltip.java
@@ -48,6 +48,7 @@ public enum InGameTooltip implements LocalizationEnum {
     P2PUnlinked("Unlinked"),
     Showing("Showing"),
     Stored("Stored: %s / %s"),
+    NetworkStored("Network Stored: %s / %s"),
     Suppressed("Suppressed"),
     Unlocked("Unlocked");
 

--- a/src/main/java/appeng/integration/modules/igtooltip/blocks/PowerStorageDataProvider.java
+++ b/src/main/java/appeng/integration/modules/igtooltip/blocks/PowerStorageDataProvider.java
@@ -10,6 +10,7 @@ import appeng.api.integrations.igtooltip.providers.BodyProvider;
 import appeng.api.integrations.igtooltip.providers.ServerDataProvider;
 import appeng.api.networking.energy.IAEPowerStorage;
 import appeng.core.localization.InGameTooltip;
+import appeng.me.helpers.IGridConnectedBlockEntity;
 import appeng.util.Platform;
 
 /**
@@ -22,6 +23,8 @@ public final class PowerStorageDataProvider implements BodyProvider<BlockEntity>
      */
     private static final String TAG_CURRENT_POWER = "currentPower";
     private static final String TAG_MAX_POWER = "maxPower";
+    private static final String TAG_GRID_CURRENT_POWER = "gridCurrentPower";
+    private static final String TAG_GRID_MAX_POWER = "gridMaxPower";
 
     @Override
     public void buildTooltip(BlockEntity object, TooltipContext context, TooltipBuilder tooltip) {
@@ -35,6 +38,16 @@ public final class PowerStorageDataProvider implements BodyProvider<BlockEntity>
 
             tooltip.addLine(InGameTooltip.Stored.text(formatCurrentPower, formatMaxPower));
         }
+
+        if (tag.contains(TAG_GRID_MAX_POWER)) {
+            var gridCurrentPower = tag.getDoubleOr(TAG_GRID_CURRENT_POWER, 0.0);
+            var gridMaxPower = tag.getDoubleOr(TAG_GRID_MAX_POWER, 0.0);
+
+            var formatGridCurrentPower = Platform.formatPower(gridCurrentPower, false);
+            var formatGridMaxPower = Platform.formatPower(gridMaxPower, false);
+
+            tooltip.addLine(InGameTooltip.NetworkStored.text(formatGridCurrentPower, formatGridMaxPower));
+        }
     }
 
     @Override
@@ -43,6 +56,16 @@ public final class PowerStorageDataProvider implements BodyProvider<BlockEntity>
             if (storage.getAEMaxPower() > 0) {
                 serverData.putDouble(TAG_CURRENT_POWER, storage.getAECurrentPower());
                 serverData.putDouble(TAG_MAX_POWER, storage.getAEMaxPower());
+            }
+        }
+
+        if (object instanceof IGridConnectedBlockEntity gridConnectedBlockEntity) {
+            var gridNode = gridConnectedBlockEntity.getActionableNode();
+            if (gridNode != null) {
+                var grid = gridNode.getGrid();
+                var energyService = grid.getEnergyService();
+                serverData.putDouble(TAG_GRID_CURRENT_POWER, energyService.getStoredPower());
+                serverData.putDouble(TAG_GRID_MAX_POWER, energyService.getMaxStoredPower());
             }
         }
     }


### PR DESCRIPTION
When you disconnect an AE2 machine from a larger network, you are creating a new network consisting of just that one machine. This network has a 25 AE buffer. The tooltip for that machine still says "device online" because there is power still lingering in the 25 AE buffer. This is very unintuitive.

https://github.com/user-attachments/assets/60a08880-3e20-4b36-9a88-6c1c7697b284

To remedy this, display network information in the tooltip:

<img width="871" height="526" alt="image" src="https://github.com/user-attachments/assets/d3ef1cbd-ef83-4a8e-a2a9-02ea72b4c859" />

Perhaps another solution would be for this network energy storage to transfer into the actual machine's energy storage?