### PR TITLE
Replace JLine static `Log` reference with SLF4J `Logger` instance

### DIFF
--- a/src/main/java/appeng/menu/locator/ItemMenuHostLocator.java
+++ b/src/main/java/appeng/menu/locator/ItemMenuHostLocator.java
@@ -1,7 +1,6 @@
 package appeng.menu.locator;
 
 import org.jetbrains.annotations.Nullable;
-import org.jline.utils.Log;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,11 +26,11 @@ public interface ItemMenuHostLocator extends MenuHostLocator {
             if (hostInterface.isInstance(menuHost)) {
                 return hostInterface.cast(menuHost);
             } else if (menuHost != null) {
-                Log.warn("Item in {} of {} did not create a compatible menu of type {}: {}",
+                LOG.warn("Item in {} of {} did not create a compatible menu of type {}: {}",
                         this, player, hostInterface, menuHost);
             }
         } else {
-            Log.warn("Item in {} of {} is not an IMenuItem: {}",
+            LOG.warn("Item in {} of {} is not an IMenuItem: {}",
                     this, player, it);
         }
 


### PR DESCRIPTION
The class declare a SLF4J `Logger LOG` field, but sometimes the JLine `Log` static class is referenced instead.

It makes no sense to swap logging implementations mid-class, _my assumption_ is that it's an error by referencing the class instead of the field.