### PR TITLE
perf: cache stack max damage for getFuzzySearchMaxValue (1.21.1)

### DIFF
--- a/src/main/java/appeng/api/stacks/AEItemKey.java
+++ b/src/main/java/appeng/api/stacks/AEItemKey.java
@@ -53,6 +53,7 @@ public final class AEItemKey extends AEKey {
     private final int hashCode;
     private final int maxStackSize;
     private final int damage;
+    private final int maxDamage;
 
     private AEItemKey(ItemStack stack) {
         Preconditions.checkArgument(!stack.isEmpty(), "stack is empty");
@@ -60,6 +61,7 @@ public final class AEItemKey extends AEKey {
         this.hashCode = ItemStack.hashItemAndComponents(stack);
         this.maxStackSize = stack.getMaxStackSize();
         this.damage = stack.getDamageValue();
+        this.maxDamage = stack.getMaxDamage();
     }
 
     @Nullable
@@ -184,7 +186,7 @@ public final class AEItemKey extends AEKey {
      */
     @Override
     public int getFuzzySearchMaxValue() {
-        return getReadOnlyStack().getMaxDamage();
+        return this.maxDamage;
     }
 
     @Override


### PR DESCRIPTION
Same patch is applicable to `main` branch.

Spark profile from official ATM10 server:
https://spark.lucko.me/lqT0gmYVY9?hl=3543%2C3966%2C5189%2C11105%2C11733%2C20200%2C20212%2C20235%2C20282%2C71215%2C71493%2C71698%2C71769%2C72300%2C72314%2C72328%2C72458%2C72515
<img width="1280" height="425" alt="image" src="https://github.com/user-attachments/assets/aefc7627-8569-4856-821d-f19c99f028c6" />
Flat, bottom-up view