### PR TITLE
[1.21.1][Feature] Add API for filtering storage terminal contents

### DIFF
--- a/API.md
+++ b/API.md
@@ -21,6 +21,7 @@ relevant during mod initialization:
 | `appeng.api.parts.PartModels` | For registering JSON block models used by custom cable bus parts.                                                |
 | `appeng.api.features.P2PTunnelAttunement` | For registering new items that attune P2P tunnels to specific types when right-clicked.                |
 | `appeng.api.client.StorageCellModels` | For customizing the models of storage cells when they're inserted into drives or ME chests.                      |
+| `appeng.api.implementations.menus.TerminalKeyFilters` | Allows addons to filter keys shown in ME storage terminals without changing storage access.                     |
 
 In general, these classes are thread-safe and may be used directly in a mod's constructor or thereafter.
 Once initialization of mods has completed however, changes to these registries result in undefined behavior.

--- a/src/main/java/appeng/api/implementations/menus/IStorageTerminalMenu.java
+++ b/src/main/java/appeng/api/implementations/menus/IStorageTerminalMenu.java
@@ -1,0 +1,51 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2026 TeamAppliedEnergistics
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.implementations.menus;
+
+import org.jetbrains.annotations.Nullable;
+
+import appeng.api.networking.IGrid;
+
+/**
+ * Exposes storage-terminal operations that are useful to addons without depending on AE2's concrete menu classes.
+ */
+public interface IStorageTerminalMenu {
+    /**
+     * @return The grid backing this terminal, or {@code null} on the client or if the terminal is not connected to a
+     *         grid.
+     */
+    @Nullable
+    IGrid getGrid();
+
+    /**
+     * Requests that the server resend the complete visible terminal inventory on the next menu update.
+     * <p>
+     * This is primarily useful after state used by a {@link TerminalKeyFilter} changes. Calling it does not modify ME
+     * storage or invalidate server-side key serials.
+     * <p>
+     * A full update can be expensive for large inventories and should only be requested when necessary. This method may
+     * only be called from the server thread.
+     */
+    void requestFullInventoryUpdate();
+}

--- a/src/main/java/appeng/api/implementations/menus/TerminalKeyFilter.java
+++ b/src/main/java/appeng/api/implementations/menus/TerminalKeyFilter.java
@@ -1,0 +1,52 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2026 TeamAppliedEnergistics
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.implementations.menus;
+
+import org.jetbrains.annotations.Nullable;
+
+import appeng.api.networking.IGrid;
+import appeng.api.stacks.AEKey;
+
+/**
+ * Controls whether keys are shown in ME storage terminals.
+ * <p>
+ * This is a presentation-only filter. Returning {@code false} does not prevent a key from being stored, inserted,
+ * extracted or otherwise accessed through the ME network. It must not be used as an access-control or security
+ * mechanism.
+ * <p>
+ * Filters are evaluated on the server and may be called frequently. Implementations should be fast, side-effect free
+ * and deterministic for their current state. When state that affects the result changes while a terminal is open, use
+ * {@link IStorageTerminalMenu#requestFullInventoryUpdate()} to refresh affected terminal menus.
+ */
+@FunctionalInterface
+public interface TerminalKeyFilter {
+    /**
+     * Tests whether a key should be shown in a storage terminal.
+     *
+     * @param grid The grid backing the terminal, or {@code null} for terminals that are not connected to a grid.
+     * @param key  The key being considered for display.
+     * @return {@code true} if the key should be shown.
+     */
+    boolean isVisible(@Nullable IGrid grid, AEKey key);
+}

--- a/src/main/java/appeng/api/implementations/menus/TerminalKeyFilters.java
+++ b/src/main/java/appeng/api/implementations/menus/TerminalKeyFilters.java
@@ -1,0 +1,70 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2026 TeamAppliedEnergistics
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.implementations.menus;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.jetbrains.annotations.Nullable;
+
+import appeng.api.networking.IGrid;
+import appeng.api.stacks.AEKey;
+
+/**
+ * Registry for additional {@link TerminalKeyFilter terminal key filters}.
+ * <p>
+ * All registered filters are combined using logical AND. Registration should happen during mod initialization. The
+ * filter implementations themselves may use dynamic state, but affected open terminals must be refreshed through
+ * {@link IStorageTerminalMenu#requestFullInventoryUpdate()} when that state changes.
+ */
+public final class TerminalKeyFilters {
+    private static final List<TerminalKeyFilter> FILTERS = new CopyOnWriteArrayList<>();
+
+    private TerminalKeyFilters() {
+    }
+
+    /**
+     * Registers an additional terminal key filter.
+     */
+    public static void register(TerminalKeyFilter filter) {
+        FILTERS.add(Objects.requireNonNull(filter, "filter"));
+    }
+
+    /**
+     * Tests a key against all registered terminal key filters.
+     * <p>
+     * Addon terminals may use this method to honor the same filters as AE2's storage terminals.
+     */
+    public static boolean isVisible(@Nullable IGrid grid, AEKey key) {
+        Objects.requireNonNull(key, "key");
+
+        for (var filter : FILTERS) {
+            if (!filter.isVisible(grid, key)) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/appeng/core/network/clientbound/MEInventoryUpdatePacket.java
+++ b/src/main/java/appeng/core/network/clientbound/MEInventoryUpdatePacket.java
@@ -195,6 +195,11 @@ public record MEInventoryUpdatePacket(
                 encodedEntries = null;
                 entryCount = 0;
                 fullUpdate = false; // Only the first packet in a chain is a full update
+            } else if (fullUpdate && packets.isEmpty()) {
+                // An empty full update still needs to reach the client to clear its previous contents. Keep an empty
+                // decoded entry list for the singleplayer path, where this packet instance is handled directly.
+                packets.add(new MEInventoryUpdatePacket(true, containerId, List.of(), 0, null));
+                fullUpdate = false;
             }
         }
 

--- a/src/main/java/appeng/menu/me/common/MEStorageMenu.java
+++ b/src/main/java/appeng/menu/me/common/MEStorageMenu.java
@@ -51,6 +51,8 @@ import appeng.api.config.SortOrder;
 import appeng.api.config.ViewItems;
 import appeng.api.implementations.blockentities.IViewCellStorage;
 import appeng.api.implementations.menuobjects.IPortableTerminal;
+import appeng.api.implementations.menus.IStorageTerminalMenu;
+import appeng.api.implementations.menus.TerminalKeyFilters;
 import appeng.api.networking.IGrid;
 import appeng.api.networking.IGridNode;
 import appeng.api.networking.energy.IEnergySource;
@@ -93,7 +95,7 @@ import appeng.util.Platform;
  * @see MEStorageScreen
  */
 public class MEStorageMenu extends AEBaseMenu
-        implements IConfigurableObject, IMEInteractionHandler, LinkStatusAwareMenu,
+        implements IConfigurableObject, IMEInteractionHandler, IStorageTerminalMenu, LinkStatusAwareMenu,
         KeyTypeSelectionMenu {
 
     public static final MenuType<MEStorageMenu> TYPE = MenuTypeBuilder
@@ -218,6 +220,17 @@ public class MEStorageMenu extends AEBaseMenu
         return null;
     }
 
+    @Override
+    @Nullable
+    public IGrid getGrid() {
+        if (!isServerSide()) {
+            return null;
+        }
+
+        var gridNode = getGridNode();
+        return gridNode != null ? gridNode.getGrid() : null;
+    }
+
     public boolean isKeyVisible(AEKey key) {
         // If the host is a basic item cell with a limited key space, account for this
         if (itemMenuHost != null && itemMenuHost.getItem() instanceof IBasicCellItem basicCellItem) {
@@ -225,6 +238,16 @@ public class MEStorageMenu extends AEBaseMenu
         }
 
         return true;
+    }
+
+    private boolean isKeyVisibleInTerminal(AEKey key) {
+        return isKeyVisible(key) && TerminalKeyFilters.isVisible(getGrid(), key);
+    }
+
+    @Override
+    public void requestFullInventoryUpdate() {
+        Platform.assertServerThread();
+        updateHelper.clear();
     }
 
     @Override
@@ -257,28 +280,34 @@ public class MEStorageMenu extends AEBaseMenu
             var requestables = new KeyCounter();
 
             try {
-                // Craftables
-                // Newly craftable
-                Sets.difference(previousCraftables, craftables).forEach(updateHelper::addChange);
-                // No longer craftable
-                Sets.difference(craftables, previousCraftables).forEach(updateHelper::addChange);
+                if (!updateHelper.isFullUpdate()) {
+                    // Craftables
+                    // Newly craftable
+                    Sets.difference(previousCraftables, craftables).forEach(updateHelper::addChange);
+                    // No longer craftable
+                    Sets.difference(craftables, previousCraftables).forEach(updateHelper::addChange);
 
-                // Available changes
-                previousAvailableStacks.removeAll(availableStacks);
-                previousAvailableStacks.removeZeros();
-                previousAvailableStacks.keySet().forEach(updateHelper::addChange);
+                    // Available changes
+                    previousAvailableStacks.removeAll(availableStacks);
+                    previousAvailableStacks.removeZeros();
+                    previousAvailableStacks.keySet().forEach(updateHelper::addChange);
+                }
 
                 if (updateHelper.hasChanges()) {
                     var builder = MEInventoryUpdatePacket
                             .builder(containerId, updateHelper.isFullUpdate(), getPlayer().registryAccess());
-                    builder.setFilter(this::isKeyVisible);
-                    builder.addChanges(updateHelper, availableStacks, craftables, requestables);
+                    builder.setFilter(this::isKeyVisibleInTerminal);
+                    if (updateHelper.isFullUpdate()) {
+                        builder.addFull(updateHelper, availableStacks, craftables, requestables);
+                    } else {
+                        builder.addChanges(updateHelper, availableStacks, craftables, requestables);
+                    }
                     builder.buildAndSend(this::sendPacketToClient);
                     updateHelper.commitChanges();
                 }
 
             } catch (Exception e) {
-                AELog.warn(e, "Failed to send incremental inventory update to client");
+                AELog.warn(e, "Failed to send inventory update to client");
             }
 
             previousCraftables = ImmutableSet.copyOf(craftables);

--- a/src/test/java/appeng/api/implementations/menus/TerminalKeyFiltersTest.java
+++ b/src/test/java/appeng/api/implementations/menus/TerminalKeyFiltersTest.java
@@ -1,0 +1,59 @@
+package appeng.api.implementations.menus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoSettings;
+
+import appeng.api.networking.IGrid;
+import appeng.api.stacks.AEKey;
+
+@MockitoSettings
+class TerminalKeyFiltersTest {
+    @Mock
+    IGrid grid;
+
+    @Mock
+    AEKey key;
+
+    private List<TerminalKeyFilter> filtersBefore;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void clearRegistry() throws Exception {
+        var filters = getFilters();
+        filtersBefore = List.copyOf(filters);
+        filters.clear();
+    }
+
+    @AfterEach
+    void restoreRegistry() throws Exception {
+        var filters = getFilters();
+        filters.clear();
+        filters.addAll(filtersBefore);
+    }
+
+    @Test
+    void combinesFiltersUsingLogicalAnd() {
+        assertThat(TerminalKeyFilters.isVisible(grid, key)).isTrue();
+
+        TerminalKeyFilters.register((grid, key) -> true);
+        assertThat(TerminalKeyFilters.isVisible(grid, key)).isTrue();
+
+        TerminalKeyFilters.register((grid, key) -> false);
+        assertThat(TerminalKeyFilters.isVisible(grid, key)).isFalse();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<TerminalKeyFilter> getFilters() throws NoSuchFieldException, IllegalAccessException {
+        Field field = TerminalKeyFilters.class.getDeclaredField("FILTERS");
+        field.setAccessible(true);
+        return (List<TerminalKeyFilter>) field.get(null);
+    }
+}

--- a/src/test/java/appeng/core/network/clientbound/MEInventoryUpdatePacketTest.java
+++ b/src/test/java/appeng/core/network/clientbound/MEInventoryUpdatePacketTest.java
@@ -1,0 +1,50 @@
+package appeng.core.network.clientbound;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import net.minecraft.core.RegistryAccess;
+
+import appeng.api.stacks.AEKey;
+import appeng.api.stacks.KeyCounter;
+import appeng.menu.me.common.IncrementalUpdateHelper;
+
+class MEInventoryUpdatePacketTest {
+    @Test
+    void fullUpdateIsSentWhenItContainsNoEntries() {
+        var packets = MEInventoryUpdatePacket.builder(42, true, RegistryAccess.EMPTY).build();
+
+        assertThat(packets).hasSize(1);
+        assertThat(packets.getFirst().fullUpdate()).isTrue();
+        assertThat(packets.getFirst().containerId()).isEqualTo(42);
+        assertThat(packets.getFirst().entries()).isEmpty();
+        assertThat(packets.getFirst().encodedEntryCount()).isZero();
+    }
+
+    @Test
+    void fullUpdateIsSentWhenAllEntriesAreFilteredOut() {
+        var key = mock(AEKey.class);
+        var storage = new KeyCounter();
+        storage.set(key, 1);
+
+        var builder = MEInventoryUpdatePacket.builder(42, true, RegistryAccess.EMPTY);
+        builder.setFilter(candidate -> false);
+        builder.addFull(new IncrementalUpdateHelper(), storage, Set.of(), new KeyCounter());
+
+        var packets = builder.build();
+        assertThat(packets).hasSize(1);
+        assertThat(packets.getFirst().fullUpdate()).isTrue();
+        assertThat(packets.getFirst().entries()).isEmpty();
+    }
+
+    @Test
+    void emptyIncrementalUpdateDoesNotSendAPacket() {
+        var packets = MEInventoryUpdatePacket.builder(42, false, RegistryAccess.EMPTY).build();
+
+        assertThat(packets).isEmpty();
+    }
+}


### PR DESCRIPTION
Add a terminal key filter API that allows add-ons to hide keys from storage terminal listings without affecting storage, insertion, extraction or automation.

Expose requestFullInventoryUpdate() on storage terminal menus so add-ons can refresh their contents when external filter state changes.

Also ensure empty full inventory updates still send a packet, allowing clients to clear previously visible entries when a filter hides everything.