### PR TITLE
(#8951) Fix AEKey.hasComponents() returning the inverse in AEItemKey and AEFluidKey

### DIFF
--- a/src/main/java/appeng/api/stacks/AEFluidKey.java
+++ b/src/main/java/appeng/api/stacks/AEFluidKey.java
@@ -166,7 +166,7 @@ public final class AEFluidKey extends AEKey {
 
     @Override
     public boolean hasComponents() {
-        return stack.getComponents().isEmpty();
+        return !stack.getComponentsPatch().isEmpty();
     }
 
     public FluidResource toResource() {
@@ -200,6 +200,6 @@ public final class AEFluidKey extends AEKey {
         var id = BuiltInRegistries.FLUID.getKey(getFluid());
         String idString = id != BuiltInRegistries.FLUID.getDefaultKey() ? id.toString()
                 : getFluid().getClass().getName() + "(unregistered)";
-        return stack.getComponents().isEmpty() ? idString : idString + " (+components)";
+        return stack.getComponentsPatch().isEmpty() ? idString : idString + " (+components)";
     }
 }

--- a/src/main/java/appeng/api/stacks/AEFluidKey.java
+++ b/src/main/java/appeng/api/stacks/AEFluidKey.java
@@ -166,7 +166,7 @@ public final class AEFluidKey extends AEKey {
 
     @Override
     public boolean hasComponents() {
-        return !stack.getComponentsPatch().isEmpty();
+        return !stack.isComponentsPatchEmpty();
     }
 
     public FluidResource toResource() {

--- a/src/main/java/appeng/api/stacks/AEItemKey.java
+++ b/src/main/java/appeng/api/stacks/AEItemKey.java
@@ -243,7 +243,7 @@ public final class AEItemKey extends AEKey {
 
     @Override
     public boolean hasComponents() {
-        return stack.getComponents().isEmpty();
+        return !stack.isComponentsPatchEmpty();
     }
 
     /**

--- a/src/test/java/appeng/api/stacks/AEItemKeyTest.java
+++ b/src/test/java/appeng/api/stacks/AEItemKeyTest.java
@@ -17,7 +17,9 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
 
 import net.minecraft.core.RegistryAccess;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.ProblemReporter;
 import net.minecraft.world.item.ItemStack;
@@ -204,9 +206,26 @@ class AEItemKeyTest {
         assertTrue(AEItemKey.of(stack).isDamaged());
     }
 
+    @Test
+    void testHasComponents() {
+        assertFalse(AEItemKey.of(Items.DIAMOND_PICKAXE).hasComponents());
+        assertFalse(AEItemKey.of(new ItemStack(Items.DIAMOND_PICKAXE)).hasComponents());
+
+        var undamagedPick = new ItemStack(Items.DIAMOND_PICKAXE);
+        assertFalse(AEItemKey.of(undamagedPick).hasComponents());
+
+        var namedStack = new ItemStack(Items.DIAMOND_PICKAXE);
+        namedStack.set(DataComponents.CUSTOM_NAME, Component.literal("variant"));
+        assertTrue(AEItemKey.of(namedStack).hasComponents());
+
+        namedStack.remove(DataComponents.CUSTOM_NAME);
+        assertFalse(AEItemKey.of(namedStack).hasComponents());
+    }
+
     /**
      * Regression test for {@link FuzzySearch#COMPARATOR} wrongly using AEKey identity comparison as a last resort.
      */
+
     @Test
     void testDifferentInstances(MinecraftServer server) {
         int testCount = 100;
@@ -237,4 +256,5 @@ class AEItemKeyTest {
 
         }
     }
+
 }


### PR DESCRIPTION
Fixes #8951

`AEItemKey.hasComponents()` and `AEFluidKey.hasComponents()` were both implemented as `stack.getComponents().isEmpty()`, which returns `true` when the stack has no components and `false` when it does — the inverse of the documented contract.

For `AEItemKey`, this let component-bearing item keys be treated as component-less by `AECraftingPattern`'s `isValidCache`, allowing one component variant's cached validation result to incorrectly apply to a different component variant of the same item.

## Fix

Both now check the attached component **patch** rather than the fully-resolved component map:
- `AEItemKey.hasComponents()` → `!stack.isComponentsPatchEmpty()`
- `AEFluidKey.hasComponents()` → `!stack.getComponentsPatch().isEmpty()`

This matches the pattern already used elsewhere in each class (`toString()`, the `MAP_CODEC`). The fully-resolved component map includes an item's or fluid's default components and is therefore rarely empty, so checking it
directly (as the original code did, just inverted) would have made `hasComponents()` return `true` for almost every stack — the exact trap flagged in the issue.

Also fixes the same inverted check in `AEFluidKey.toString()`, found while fixing the above.

`AECraftingPattern`'s cache gating (`getTestResult`/`setTestResult`) required no change, it already skips the shared cache whenever `hasComponents()` is `true`, which now correctly triggers for component-bearing keys.

## Testing

Added a regression test on `AEItemKey` covering an unmodified item, an item with an explicit component set (`CUSTOM_NAME`), and the same item after that component is removed. Full `AEItemKeyTest` suite passes locally (31/31, 0 failures).