### PR TITLE
Ignore crafting patterns without the requested output

### DIFF
--- a/src/main/java/appeng/api/crafting/IPatternDetails.java
+++ b/src/main/java/appeng/api/crafting/IPatternDetails.java
@@ -57,14 +57,16 @@ public interface IPatternDetails {
 
     /**
      * The primary output of this pattern. The pattern will only be used to craft the primary output; the others are
-     * just byproducts.
+     * just byproducts. The returned key must occur in {@link #getOutputs()} with a positive total amount that fits in a
+     * {@code long}.
      */
     default GenericStack getPrimaryOutput() {
         return getOutputs().get(0);
     }
 
     /**
-     * The outputs of this pattern.
+     * The outputs of this pattern. The list must not be empty and output amounts must not be negative. The returned
+     * output keys and amounts must remain stable for the lifetime of this pattern.
      */
     List<GenericStack> getOutputs();
 

--- a/src/main/java/appeng/crafting/CraftingTreeNode.java
+++ b/src/main/java/appeng/crafting/CraftingTreeNode.java
@@ -32,6 +32,7 @@ import appeng.api.networking.crafting.ICraftingService;
 import appeng.api.stacks.AEKey;
 import appeng.api.stacks.GenericStack;
 import appeng.api.stacks.KeyCounter;
+import appeng.core.AELog;
 import appeng.crafting.execution.CraftingCpuHelper;
 import appeng.crafting.execution.InputTemplate;
 import appeng.crafting.inv.ChildCraftingSimulationState;
@@ -125,7 +126,14 @@ public class CraftingTreeNode {
 
                 for (var details : craftingService.getCraftingFor(this.what)) {
                     if (this.parent == null || this.parent.notRecursive(details)) {
-                        this.nodes.add(new CraftingTreeProcess(craftingService, job, details, this));
+                        var process = new CraftingTreeProcess(craftingService, job, details, this);
+                        if (!process.hasValidOutputs(this.what)) {
+                            AELog.warn(
+                                    "Ignoring crafting pattern of type %s for %s because it has invalid outputs. Outputs: %s",
+                                    process.details.getClass().getName(), this.what, process.details.getOutputs());
+                            continue;
+                        }
+                        this.nodes.add(process);
                     }
                 }
             }

--- a/src/main/java/appeng/crafting/CraftingTreeProcess.java
+++ b/src/main/java/appeng/crafting/CraftingTreeProcess.java
@@ -155,6 +155,25 @@ public class CraftingTreeProcess {
         return tot;
     }
 
+    boolean hasValidOutputs(AEKey expectedOutput) {
+        long expectedOutputAmount = 0;
+
+        for (var output : this.details.getOutputs()) {
+            if (output.amount() < 0) {
+                return false;
+            }
+            if (expectedOutput.matches(output)) {
+                try {
+                    expectedOutputAmount = Math.addExact(expectedOutputAmount, output.amount());
+                } catch (ArithmeticException ignored) {
+                    return false;
+                }
+            }
+        }
+
+        return expectedOutputAmount > 0;
+    }
+
     boolean hasMultiplePaths() {
         for (var entry : nodes.entrySet()) {
             if (entry.getKey().hasMultiplePaths()) {

--- a/src/test/java/appeng/crafting/simulation/CraftingSimulationTest.java
+++ b/src/test/java/appeng/crafting/simulation/CraftingSimulationTest.java
@@ -2,6 +2,7 @@ package appeng.crafting.simulation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -280,6 +281,192 @@ public class CraftingSimulationTest {
                 .bytesMatch(2, 2, 0);
     }
 
+    @Test
+    public void testPatternWithNonPositivePrimaryOutputAmount() {
+        for (var invalidAmount : List.of(0L, -1L)) {
+            var env = new SimulationEnv();
+
+            var input = item(Items.COBBLESTONE);
+            var output = item(Items.DIAMOND);
+            env.addPattern(new ProcessingPatternBuilder(new GenericStack(output.what(), invalidAmount))
+                    .addPreciseInput(1, input)
+                    .build());
+
+            env.addStoredItem(input);
+
+            var plan = env.runSimulation(output, CalculationStrategy.REPORT_MISSING_ITEMS);
+            assertThatPlan(plan)
+                    .failed()
+                    .patternsMatch(Map.of())
+                    .emittedMatch()
+                    .missingMatch(output)
+                    .usedMatch();
+        }
+    }
+
+    @Test
+    public void testValidPatternIsUnaffectedByOutputValidation() {
+        var env = new SimulationEnv();
+
+        var input = item(Items.COBBLESTONE);
+        var output = item(Items.DIAMOND);
+        var pattern = env.addPattern(new ProcessingPatternBuilder(output)
+                .addPreciseInput(1, input)
+                .build());
+
+        env.addStoredItem(input);
+
+        var plan = env.runSimulation(output, CalculationStrategy.REPORT_MISSING_ITEMS);
+        assertThatPlan(plan)
+                .succeeded()
+                .patternsMatch(pattern, 1)
+                .emittedMatch()
+                .missingMatch()
+                .usedMatch(input);
+    }
+
+    @Test
+    public void testLimitedPatternWithZeroPrimaryOutputAmount() {
+        var env = new SimulationEnv();
+
+        var input = item(Items.WATER_BUCKET);
+        var output = item(Items.DIAMOND);
+        env.addPattern(new ProcessingPatternBuilder(new GenericStack(output.what(), 0))
+                .addPreciseInput(1, true, input)
+                .build());
+
+        env.addStoredItem(input);
+
+        var plan = env.runSimulation(output, CalculationStrategy.REPORT_MISSING_ITEMS);
+        assertThatPlan(plan)
+                .failed()
+                .patternsMatch(Map.of())
+                .emittedMatch()
+                .missingMatch(output)
+                .usedMatch();
+    }
+
+    @Test
+    public void testPatternWithNegativeByproductAmount() {
+        var env = new SimulationEnv();
+
+        var input = item(Items.COBBLESTONE);
+        var output = item(Items.DIAMOND);
+        var byproduct = item(Items.GOLD_INGOT);
+        env.addPattern(new ProcessingPatternBuilder(output, new GenericStack(byproduct.what(), -1))
+                .addPreciseInput(1, input)
+                .build());
+
+        env.addStoredItem(input);
+
+        var plan = env.runSimulation(output, CalculationStrategy.REPORT_MISSING_ITEMS);
+        assertThatPlan(plan)
+                .failed()
+                .patternsMatch(Map.of())
+                .emittedMatch()
+                .missingMatch(output)
+                .usedMatch();
+    }
+
+    @Test
+    public void testPatternWithZeroByproductAmount() {
+        var env = new SimulationEnv();
+
+        var input = item(Items.COBBLESTONE);
+        var output = item(Items.DIAMOND);
+        var byproduct = item(Items.GOLD_INGOT);
+        var pattern = env.addPattern(new ProcessingPatternBuilder(output, new GenericStack(byproduct.what(), 0))
+                .addPreciseInput(1, input)
+                .build());
+
+        env.addStoredItem(input);
+
+        var plan = env.runSimulation(output, CalculationStrategy.REPORT_MISSING_ITEMS);
+        assertThatPlan(plan)
+                .succeeded()
+                .patternsMatch(pattern, 1)
+                .emittedMatch()
+                .missingMatch()
+                .usedMatch(input);
+    }
+
+    @Test
+    public void testPatternWithOverflowingPrimaryOutputAmount() {
+        var env = new SimulationEnv();
+
+        var input = item(Items.COBBLESTONE);
+        var output = item(Items.DIAMOND);
+        env.addPattern(new ProcessingPatternBuilder(
+                new GenericStack(output.what(), Long.MAX_VALUE),
+                new GenericStack(output.what(), 1))
+                .addPreciseInput(1, input)
+                .build());
+
+        env.addStoredItem(input);
+
+        var plan = env.runSimulation(output, CalculationStrategy.REPORT_MISSING_ITEMS);
+        assertThatPlan(plan)
+                .failed()
+                .patternsMatch(Map.of())
+                .emittedMatch()
+                .missingMatch(output)
+                .usedMatch();
+    }
+
+    @Test
+    public void testCraftLessWithZeroPrimaryOutputAmount() {
+        var env = new SimulationEnv();
+
+        var input = item(Items.COBBLESTONE);
+        var output = item(Items.DIAMOND);
+        env.addPattern(new ProcessingPatternBuilder(new GenericStack(output.what(), 0))
+                .addPreciseInput(1, input)
+                .build());
+
+        env.addStoredItem(mult(input, 100));
+
+        var plan = env.runSimulation(mult(output, 100), CalculationStrategy.CRAFT_LESS);
+        assertThatPlan(plan)
+                .failed()
+                .patternsMatch(Map.of())
+                .emittedMatch()
+                .missingMatch(mult(output, 100))
+                .usedMatch()
+                .outputMatches(mult(output, 100));
+    }
+
+    @Test
+    public void testInvalidPatternDoesNotHideValidAlternative() {
+        var env = new SimulationEnv();
+
+        var zeroOutputInput = item(Items.COBBLESTONE);
+        var mismatchedOutputInput = item(Items.STONE);
+        var validInput = item(Items.OAK_PLANKS);
+        var output = item(Items.DIAMOND);
+        env.addPattern(withPrimaryOutput(output,
+                new ProcessingPatternBuilder(new GenericStack(output.what(), 0))
+                        .addPreciseInput(1, zeroOutputInput)
+                        .build()));
+        env.addPattern(withPrimaryOutput(output, new ProcessingPatternBuilder(item(Items.STONE))
+                .addPreciseInput(1, mismatchedOutputInput)
+                .build()));
+        var validPattern = env.addPattern(new ProcessingPatternBuilder(output)
+                .addPreciseInput(1, validInput)
+                .build());
+
+        env.addStoredItem(zeroOutputInput);
+        env.addStoredItem(mismatchedOutputInput);
+        env.addStoredItem(validInput);
+
+        var plan = env.runSimulation(output, CalculationStrategy.REPORT_MISSING_ITEMS);
+        assertThatPlan(plan)
+                .succeeded()
+                .patternsMatch(validPattern, 1)
+                .emittedMatch()
+                .missingMatch()
+                .usedMatch(validInput);
+    }
+
     /**
      * Basic test for multiple paths (multiple patterns that produce the same output).
      */
@@ -395,6 +582,30 @@ public class CraftingSimulationTest {
                 .succeeded()
                 .patternsMatch(mainPattern, 10, secondaryInputPattern, 10)
                 .emittedMatch(mult(secondaryInputSource, 10));
+    }
+
+    private static IPatternDetails withPrimaryOutput(GenericStack primaryOutput, IPatternDetails delegate) {
+        return new IPatternDetails() {
+            @Override
+            public AEItemKey getDefinition() {
+                return delegate.getDefinition();
+            }
+
+            @Override
+            public IInput[] getInputs() {
+                return delegate.getInputs();
+            }
+
+            @Override
+            public GenericStack getPrimaryOutput() {
+                return primaryOutput;
+            }
+
+            @Override
+            public List<GenericStack> getOutputs() {
+                return delegate.getOutputs();
+            }
+        };
     }
 
     private static GenericStack item(Item item) {


### PR DESCRIPTION
Closes #8938.

## Summary

Invalid third-party patterns no longer abort the entire autocrafting calculation.

- Invalid candidates are ignored and logged.
- Valid alternatives are still considered.
- If no valid candidate remains, the request follows the normal missing-items path.
- Rejected patterns do not consume inputs or add outputs to the plan.
- Existing valid patterns and zero-sized byproducts remain supported.
- The pattern output contract is documented without a binary API change.

## Covered cases

- Zero and negative requested-output amounts
- Normal and quantity-limited patterns
- Negative and zero-sized byproducts
- Overflowing requested-output totals
- `CRAFT_LESS` calculations
- Invalid candidates alongside a valid alternative

## Tests

- `./gradlew test --tests appeng.crafting.simulation.CraftingSimulationTest` (19 tests passed)
- `./gradlew spotlessCheck build --rerun-tasks --max-workers 1`
- `./gradlew runData` (no generated changes)
- `./gradlew runGametest` (all 68 required game tests passed)
- Full GitHub Actions build passed
